### PR TITLE
fix: 四球が死球として記録されてしまう

### DIFF
--- a/app/game-result/batting/page.tsx
+++ b/app/game-result/batting/page.tsx
@@ -118,8 +118,8 @@ const useBattingStatistics = (battingBoxes: BattingBox[]) => {
       if (box.result === 10) totalBases += 4;
 
       if (box.result === 13 || box.result === 14) strikeOuts += 1;
-      if (box.result === 14) baseOnBalls += 1;
-      if (box.result === 15) hitByPitch += 1;
+      if (box.result === 15) baseOnBalls += 1;
+      if (box.result === 16) hitByPitch += 1;
       if (box.result === 11) sacrificeHit += 1;
       if (box.result === 12) sacrificeFly += 1;
     });


### PR DESCRIPTION
打撃成績で四球と登録しても、死球として記録されてしまう不具合を対応しました。