### PR TITLE
Fix: 打撃・投手成績が未記入の場合にcreate APIをスキップする

### DIFF
--- a/app/(app)/game-result/batting/page.tsx
+++ b/app/(app)/game-result/batting/page.tsx
@@ -446,38 +446,8 @@ export default function BattingRecord() {
       setIsSubmitting(false);
       return;
     }
-    const battingAverageData = {
-      batting_average: {
-        game_result_id: localStorageGameResultId,
-        user_id: currentUserId,
-        // plate_appearances: ,
-        times_at_bat: timesAtBat, // 打席数
-        at_bats: atBats,
-        hit: hit, // 安打数
-        two_base_hit: twoBaseHit, // 2塁打数
-        three_base_hit: threeBaseHit, // 3塁打数
-        home_run: homeRun, // 本塁打数
-        total_bases: totalBases, // 塁打数
-        runs_batted_in: existingRunsBattedIn
-          ? existingRunsBattedIn
-          : runsBattedIn,
-        run: existingRun ? existingRun : run,
-        strike_out: strikeOuts, // 三振数
-        base_on_balls: baseOnBalls, //四球
-        hit_by_pitch: hitByPitch, // 死球
-        sacrifice_hit: sacrificeHit, //犠打
-        sacrifice_fly: sacrificeFly, //犠飛
-        error: existingDefensiveError ? existingDefensiveError : defensiveError,
-        stealing_base: existingStealingBase
-          ? existingStealingBase
-          : stealingBase,
-        caught_stealing: existingCaughtStealing
-          ? existingCaughtStealing
-          : caughtStealing,
-      },
-    };
-    const filteredBattingBoxes = battingBoxes.filter((box) => box.result !== 0);
     // 未記入判定: 打席データも手動入力フィールドも全て空/0ならスキップ
+    const filteredBattingBoxes = battingBoxes.filter((box) => box.result !== 0);
     const rbi = existingRunsBattedIn ? existingRunsBattedIn : runsBattedIn;
     const r = existingRun ? existingRun : run;
     const err = existingDefensiveError
@@ -497,6 +467,31 @@ export default function BattingRecord() {
       router.push(`/game-result/pitching/`);
       return;
     }
+
+    const battingAverageData = {
+      batting_average: {
+        game_result_id: localStorageGameResultId,
+        user_id: currentUserId,
+        // plate_appearances: ,
+        times_at_bat: timesAtBat, // 打席数
+        at_bats: atBats,
+        hit: hit, // 安打数
+        two_base_hit: twoBaseHit, // 2塁打数
+        three_base_hit: threeBaseHit, // 3塁打数
+        home_run: homeRun, // 本塁打数
+        total_bases: totalBases, // 塁打数
+        runs_batted_in: rbi,
+        run: r,
+        strike_out: strikeOuts, // 三振数
+        base_on_balls: baseOnBalls, //四球
+        hit_by_pitch: hitByPitch, // 死球
+        sacrifice_hit: sacrificeHit, //犠打
+        sacrifice_fly: sacrificeFly, //犠飛
+        error: err,
+        stealing_base: sb,
+        caught_stealing: cs,
+      },
+    };
 
     for (let i = 0; i < filteredBattingBoxes.length; i++) {
       const battingBox = battingBoxes[i];

--- a/app/(app)/game-result/batting/page.tsx
+++ b/app/(app)/game-result/batting/page.tsx
@@ -477,6 +477,27 @@ export default function BattingRecord() {
       },
     };
     const filteredBattingBoxes = battingBoxes.filter((box) => box.result !== 0);
+    // 未記入判定: 打席データも手動入力フィールドも全て空/0ならスキップ
+    const rbi = existingRunsBattedIn ? existingRunsBattedIn : runsBattedIn;
+    const r = existingRun ? existingRun : run;
+    const err = existingDefensiveError
+      ? existingDefensiveError
+      : defensiveError;
+    const sb = existingStealingBase ? existingStealingBase : stealingBase;
+    const cs = existingCaughtStealing ? existingCaughtStealing : caughtStealing;
+    const isBattingEmpty =
+      filteredBattingBoxes.length === 0 &&
+      rbi === 0 &&
+      r === 0 &&
+      err === 0 &&
+      sb === 0 &&
+      cs === 0;
+
+    if (isBattingEmpty) {
+      router.push(`/game-result/pitching/`);
+      return;
+    }
+
     for (let i = 0; i < filteredBattingBoxes.length; i++) {
       const battingBox = battingBoxes[i];
       if (battingBox.text.replace("-", "") === "") continue;

--- a/app/(app)/game-result/pitching/page.tsx
+++ b/app/(app)/game-result/pitching/page.tsx
@@ -294,6 +294,47 @@ export default function PitchingRecord() {
       ? Number(existingSelectedInnings) + Number(changeExistingFractions)
       : Number(selectedInnings) + Number(selectedFractions);
     console.log(totalInnings);
+
+    // 未記入判定: 全フィールドが0/デフォルトならスキップ
+    const w = existingWin ? existingWin : win;
+    const l = existingLoss ? existingLoss : loss;
+    const h = existingHolds ? existingHolds : holds;
+    const sv = existingSaves ? existingSaves : saves;
+    const np = existingNumberOfPitches
+      ? existingNumberOfPitches
+      : numberOfPitches;
+    const gtd = existingGotToTheDistance
+      ? existingGotToTheDistance
+      : gotToTheDistance;
+    const ra = existingRunsAllowed ? existingRunsAllowed : runsAllowed;
+    const er = existingEarnedRuns ? existingEarnedRuns : earnedRuns;
+    const ha = existingHitsAllowed ? existingHitsAllowed : hitsAllowed;
+    const hr = existingHomeRuns ? existingHomeRuns : homeRuns;
+    const so = existingStrikeouts ? existingStrikeouts : strikeouts;
+    const bb = existingBasesOnBalls ? existingBasesOnBalls : basesOnBalls;
+    const hbp = existingHitByPitches ? existingHitByPitches : hitByPitches;
+
+    const isPitchingEmpty =
+      totalInnings === 0 &&
+      w === 0 &&
+      l === 0 &&
+      h === 0 &&
+      sv === 0 &&
+      np === 0 &&
+      !gtd &&
+      ra === 0 &&
+      er === 0 &&
+      ha === 0 &&
+      hr === 0 &&
+      so === 0 &&
+      bb === 0 &&
+      hbp === 0;
+
+    if (isPitchingEmpty) {
+      router.push(`/game-result/summary/`);
+      return;
+    }
+
     try {
       const pitchingResultData = {
         pitching_result: {

--- a/app/(app)/game-result/pitching/page.tsx
+++ b/app/(app)/game-result/pitching/page.tsx
@@ -293,8 +293,6 @@ export default function PitchingRecord() {
     const totalInnings = existingTotalInnings
       ? Number(existingSelectedInnings) + Number(changeExistingFractions)
       : Number(selectedInnings) + Number(selectedFractions);
-    console.log(totalInnings);
-
     // 未記入判定: 全フィールドが0/デフォルトならスキップ
     const w = existingWin ? existingWin : win;
     const l = existingLoss ? existingLoss : loss;


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#224

## 実装概要
打撃・投手成績の送信時に未記入判定を追加し、全フィールドがデフォルト値の場合はcreate APIをスキップして次画面に遷移するようにした。

## 背景
試合結果登録フローで、成績未記入のままでもBattingAverage/PitchingResultのレコードが作成されてしまう問題があった。フロントエンド側で事前にスキップすることで不要なAPIリクエストとレコード作成を防止する。

## やらなかったこと
- 編集モードでの全0クリア時のレコード削除

## 受入基準
- [ ] 打撃成績が未記入の場合、BattingAverage作成APIが呼ばれずpitching画面に遷移する
- [ ] 投手成績が未記入の場合、PitchingResult作成APIが呼ばれずsummary画面に遷移する
- [ ] 打撃のみ入力した場合、BattingAverageのみ作成される
- [ ] 投手のみ入力した場合、PitchingResultのみ作成される
- [ ] 両方入力した場合、既存動作と同じく両方作成される

## 実装詳細
### `app/(app)/game-result/batting/page.tsx`
- `handleSubmit`内でfilteredBattingBoxesの件数と手動入力フィールド（打点、得点、失策、盗塁、盗塁死）を判定
- 全て空/0なら `router.push('/game-result/pitching/')` で早期リターン

### `app/(app)/game-result/pitching/page.tsx`
- `handleSubmit`内で全フィールド（投球回数、勝敗、セーブ、ホールド、各種成績）を判定
- 全てデフォルト値なら `router.push('/game-result/summary/')` で早期リターン

## スクリーンショット
なし

## 確認手順
1. 試合結果登録画面で打撃成績を未入力のまま次へ進む → pitching画面に遷移、BattingAverageレコードが作られないことを確認
2. 投手成績を未入力のまま次へ進む → summary画面に遷移、PitchingResultレコードが作られないことを確認
3. 打撃成績のみ入力して投手成績は未入力 → BattingAverageのみ作成されることを確認
4. 両方入力 → 既存通り両方作成されることを確認

## 影響範囲
- 試合結果登録フロー（batting/pitching画面）

## コード上の懸念点
特になし

## その他
バックエンド側にもバリデーションを追加済み（buzzbase_back PR）で二重ガード。