### PR TITLE
Add: Claude Code用のコーディングルールを追加

### DIFF
--- a/.claude/rules/component-design.md
+++ b/.claude/rules/component-design.md
@@ -1,0 +1,27 @@
+# コンポーネント設計ルール
+
+## 基本方針: Server Component優先
+
+- **よほどの理由がない限りServer Componentを使用する**
+- Client Componentが必要な場合は明確な理由を持つ（イベントハンドリング、useState、usePathname等）
+- `"use client"`は必要最小限のコンポーネントにのみ付与する
+
+## Container / Presentational パターン
+
+- page.tsxは薄く保つ（認証チェック + データ取得 + Presentationalへの委譲のみ）
+- Container役のClient Componentは`_components/`に配置（命名にContainerはつけない）
+- Presentationalコンポーネントはpropsのみ受け取り、データフェッチしない
+
+## コロケーション
+
+- 特定画面でのみ使用するコンポーネント: そのルートの`_components/`に配置
+- 複数画面で共通使用: ルートグループ直下の`_components/`に配置（例: `(admin)/_components/`）
+- 全体共通UI: `app/components/`に配置
+- ルーティングに関係しないディレクトリにはアンダーバーをつける（`_components/`, `_utils/`）
+
+## Vercelベストプラクティス
+
+- **booleanプロップの乱立を避ける** — Compound Componentパターンで構成するか、用途別にバリアントコンポーネントを作る
+- 条件レンダリングは `&&` ではなく三項演算子 `? :` を使う（`0 && <X/>`で"0"がレンダリングされる問題を防ぐ）
+- 静的なJSX要素はコンポーネント外に定数として切り出す
+- `forwardRef`は不要（React 19以降、refは通常のpropとして渡せる）

--- a/.claude/rules/data-fetching.md
+++ b/.claude/rules/data-fetching.md
@@ -1,0 +1,36 @@
+# データフェッチ / Server Actions ルール
+
+## 基本方針: Server Actions優先
+
+- **新機能のAPIリクエストはServer Actionsを使用する**
+- `services/`ディレクトリのAxios + useEffectパターンは旧来コード（新規では使わない）
+- `useEffect`でのデータフェッチは禁止
+
+## Server Actions (`actions.ts`)
+
+```typescript
+"use server";
+
+// 認証ヘッダー取得の共通パターン
+async function getAuthHeaders(): Promise<Record<string, string> | null> {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("access-token")?.value;
+  const client = cookieStore.get("client")?.value;
+  const uid = cookieStore.get("uid")?.value;
+  if (!accessToken || !client || !uid) return null;
+  return { "Content-Type": "application/json", "access-token": accessToken, client, uid };
+}
+```
+
+- actions.tsは責務ごとにファイルを分ける（`dashboard/actions.ts`, `seasons/actions.ts`）
+- 認証が必要なAPI: `cache: "no-store"`
+- 公開コンテンツ: `next: { revalidate: 60 }` でISR
+- エラー時は`null`や`[]`を返す（UI側でfallback表示）
+- `redirect()`を含む場合は`NEXT_REDIRECT`エラーを必ず再スロー
+- APIベースURL: `RAILS_API_URL`（`http://back:3000`、Docker内部通信）
+
+## パフォーマンス（Vercelベストプラクティス）
+
+- **独立したデータ取得は`Promise.all()`で並列実行する**（直列awaitしない）
+- `<Suspense>`で部分的にストリーミングし、ページ全体のレンダリングをブロックしない
+- propsにはソースデータだけ渡し、変換処理はクライアント側で行う（シリアライズの重複排除）

--- a/.claude/rules/data-fetching.md
+++ b/.claude/rules/data-fetching.md
@@ -18,7 +18,12 @@ async function getAuthHeaders(): Promise<Record<string, string> | null> {
   const client = cookieStore.get("client")?.value;
   const uid = cookieStore.get("uid")?.value;
   if (!accessToken || !client || !uid) return null;
-  return { "Content-Type": "application/json", "access-token": accessToken, client, uid };
+  return {
+    "Content-Type": "application/json",
+    "access-token": accessToken,
+    client,
+    uid,
+  };
 }
 ```
 

--- a/.claude/rules/general.md
+++ b/.claude/rules/general.md
@@ -1,0 +1,35 @@
+# フロントエンド 全般ルール
+
+## 技術スタック
+
+- Next.js 16 / React 19 / TypeScript
+- UIライブラリ: HeroUI（旧NextUI）+ Mantine
+- スタイリング: TailwindCSS
+- 状態管理: SWR（旧来）/ Server Actions（新規）
+- パスエイリアス: `@app/*` → `app/*`
+
+## コーディング規約
+
+- すべての新しいファイルにはTypeScriptを使用
+- ESLint + Prettierに準拠（`yarn lint`, `yarn format`）
+- 型定義は`app/interface/index.ts`に集約
+
+## 認証
+
+- 一般ユーザー: `access-token` / `client` / `uid`の3つのCookie（DeviseTokenAuth形式）
+- 管理者: JWT認証（`admin-access-token` + `admin-refresh-token`）
+- 認証ガードは`proxy.ts`で実施（Next.js 16で`middleware.ts`から`proxy.ts`にリネーム）
+- Server Actions内での認証チェック: `cookies()`から3トークンを取得
+
+## テーマ / デザイン
+
+- ダークテーマ基調（`buzz-dark`テーマ）
+- プライマリカラー: `#d08000`（ゴールド）
+- 背景: `#2E2E2E`（main）/ `#424242`（sub）
+
+## 開発コマンド
+
+- `yarn dev` — 開発サーバー
+- `yarn build` — ビルド
+- `yarn lint` / `yarn typecheck` — 品質チェック
+- `yarn test` — Jestテスト

--- a/.claude/rules/performance.md
+++ b/.claude/rules/performance.md
@@ -1,0 +1,20 @@
+# パフォーマンスルール（Vercelベストプラクティス準拠）
+
+## バンドルサイズ（CRITICAL）
+
+- **バレルインポートを避ける** — `import { X } from 'library'`ではなく直接ファイルからインポート
+- 初回レンダリングに不要な重いコンポーネントは`next/dynamic`で遅延ロード（`ssr: false`）
+- `next.config.js`の`optimizePackageImports`を活用
+
+## 再レンダリング最適化
+
+- **useEffectでstateを同期しない** — propsやstateから計算できる値はレンダリング中に直接計算する
+- `useState` + `useEffect`で派生値を管理するのはアンチパターン
+- state更新は関数形式を使う: `setItems(prev => [...prev, newItem])`（stale closure防止）
+- `useEffect`の依存配列にオブジェクト全体ではなく、使うprimitive値を指定（`[user.id]` not `[user]`）
+- 連続的な値（px幅等）ではなく導出boolean（`isMobile`）をsubscribeする
+
+## サーバーサイド
+
+- `React.cache()`でリクエスト内のデータフェッチを重複排除する（Prisma等DB直接アクセス向け）
+- 非同期Server Componentは互いに依存させず並列実行させる

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,5 @@ next-env.d.ts
 
 .serena
 
-# Claude Code settings
-.claude/
-
 # Ruby LSP cache
 .ruby-lsp/


### PR DESCRIPTION
## issue
なし

## 実装概要
Claude Codeがフロントエンドのコードを書く際に参照するコーディングルール（`.claude/rules/`）を追加。

## 背景
Claude Codeでコード生成する際に、プロジェクト固有の設計パターンや規約に沿ったコードが生成されるよう、ルールファイルを整備する。Vercelのベストプラクティス（vercel-react-best-practices, vercel-composition-patterns）と既存コードベースのパターンを融合して作成。

## やらなかったこと
- skillsの追加（rulesとは異なり常時読み込みではないため別対応）

## 受入基準
- [ ] `.claude/rules/`配下に4ファイルが存在する
- [ ] 既存のコードパターンと矛盾するルールがない
- [ ] `.gitignore`の変更で`.claude/`ディレクトリのrulesが追跡可能になっている

## 実装詳細
### 新規ファイル（`.claude/rules/`）
- `component-design.md` — Server Component優先、Container/Presentationalパターン、コロケーション、booleanプロップ排除
- `data-fetching.md` — Server Actions優先（旧Axios+useEffectパターン禁止）、Promise.all並列実行、Suspenseストリーミング
- `performance.md` — バレルインポート回避、dynamic import、useEffectでのstate同期禁止、関数形式setState
- `general.md` — 技術スタック（Next.js 16/React 19）、認証方式、テーマ/デザイン、開発コマンド

### 変更ファイル
- `.gitignore` — `.claude/`の除外を削除し、rulesファイルをgit管理対象に変更

## スクリーンショット
なし

## 確認手順
1. `.claude/rules/`配下の各ファイルの内容を確認
2. 既存のCLAUDE.mdと矛盾がないことを確認

## 影響範囲
Claude Codeの動作のみ。アプリケーションコードへの影響なし。

## コード上の懸念点
- `.gitignore`から`.claude/`の除外を完全に削除している。settings.json等のClaude Code設定ファイルもgit管理対象になるが、現時点では問題なし。

## その他
特になし