### PR TITLE
未ログイン時に成績・試合情報の閲覧を制限しログインCTAを表示

### DIFF
--- a/app/(app)/game-result/summary/[slug]/page.tsx
+++ b/app/(app)/game-result/summary/[slug]/page.tsx
@@ -20,10 +20,12 @@ import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { adSlots } from "@app/components/ad/adConfig";
 import AdInFeed from "@app/components/ad/AdInFeed";
+import AuthRequiredOverlay from "@app/components/auth/AuthRequiredOverlay";
 import HeaderGameDetail from "@app/components/header/HeaderGameDetail";
 import SummaryResultHeader from "@app/components/header/SummaryHeader";
 import ResultShareComponent from "@app/components/share/ResultShareComponent";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
+import { useAuthContext } from "@app/contexts/useAuthContext";
 import { getUserBattingAverage } from "@app/services/battingAveragesService";
 import { deleteGameResult } from "@app/services/gameResultsService";
 import { getUserMatchResult } from "@app/services/matchResultsService";
@@ -63,6 +65,7 @@ const battingOrder = [
 ];
 
 export default function ResultsSummary() {
+  const { isLoggedIn, loading: authLoading } = useAuthContext();
   const [matchResult, setMatchResult] = useState<MatchResultDisplay[]>([]);
   const [plateAppearance, setPlateAppearance] = useState<
     PlateAppearanceSummary[]
@@ -287,6 +290,34 @@ export default function ResultsSummary() {
       setIsLoading(false);
     }
   };
+
+  if (authLoading) {
+    return (
+      <>
+        <HeaderGameDetail />
+        <main className="h-full">
+          <div className="pb-20 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+            <LoadingSpinner />
+          </div>
+        </main>
+      </>
+    );
+  }
+
+  if (isLoggedIn === false) {
+    return (
+      <>
+        <HeaderGameDetail />
+        <main className="h-full">
+          <div className="pb-20 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+            <div className="pt-20 px-4 lg:px-6">
+              <AuthRequiredOverlay message="試合結果を閲覧するにはログインが必要です" />
+            </div>
+          </div>
+        </main>
+      </>
+    );
+  }
 
   return (
     <>

--- a/app/(app)/game-result/summary/layout.tsx
+++ b/app/(app)/game-result/summary/layout.tsx
@@ -4,6 +4,7 @@ export const metadata: Metadata = {
   title: "試合結果まとめ",
   description:
     "この試合についての試合結果・打撃成績・投手成績をまとめて表示します。SNSなどで成績をシェアすることもできます。",
+  robots: { index: false },
 };
 export default function SummaryLayout({
   children,

--- a/app/(app)/mypage/[slug]/page.tsx
+++ b/app/(app)/mypage/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import React, { useState } from "react";
 import { adSlots } from "@app/components/ad/adConfig";
 import AdInFeed from "@app/components/ad/AdInFeed";
+import AuthRequiredOverlay from "@app/components/auth/AuthRequiredOverlay";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import FollowButton from "@app/components/button/FollowButton";
 import Header from "@app/components/header/Header";
@@ -250,6 +251,10 @@ export default function MyPage() {
                   <p className="text-sm text-zinc-400 text-center">
                     このアカウントは非公開です
                   </p>
+                </div>
+              ) : isLoggedIn === false ? (
+                <div className="mt-8">
+                  <AuthRequiredOverlay message="成績・試合情報を閲覧するにはログインが必要です" />
                 </div>
               ) : (
                 <>

--- a/app/(app)/mypage/[slug]/page.tsx
+++ b/app/(app)/mypage/[slug]/page.tsx
@@ -28,7 +28,7 @@ type Position = {
 };
 
 export default function MyPage() {
-  const { isLoggedIn } = useAuthContext();
+  const { isLoggedIn, loading: authLoading } = useAuthContext();
   const [errors, setErrors] = useState<string[]>([]);
 
   const { userData, isLoadingUsers, isErrorUser } = getUserIdData();
@@ -252,6 +252,8 @@ export default function MyPage() {
                     このアカウントは非公開です
                   </p>
                 </div>
+              ) : authLoading ? (
+                <div className="mt-8" />
               ) : isLoggedIn === false ? (
                 <div className="mt-8">
                   <AuthRequiredOverlay message="成績・試合情報を閲覧するにはログインが必要です" />

--- a/app/(app)/stats/actions.ts
+++ b/app/(app)/stats/actions.ts
@@ -73,6 +73,11 @@ async function getAuthHeaders(): Promise<Record<string, string> | null> {
   };
 }
 
+export async function getIsAuthenticated(): Promise<boolean> {
+  const headers = await getAuthHeaders();
+  return headers !== null;
+}
+
 export async function getBattingStats(
   period: StatsPeriod,
   year?: string,

--- a/app/(app)/stats/page.tsx
+++ b/app/(app)/stats/page.tsx
@@ -1,11 +1,17 @@
 import type { StatsPeriod } from "./actions";
+import AuthRequiredOverlay from "@app/components/auth/AuthRequiredOverlay";
 import Header from "@app/components/header/Header";
 import StatsContainer from "./_components/StatsContainer";
-import { getBattingStats, getPitchingStats } from "./actions";
+import {
+  getBattingStats,
+  getIsAuthenticated,
+  getPitchingStats,
+} from "./actions";
 
 export const metadata = {
   title: "成績 | BUZZ BASE",
   description: "打撃成績・投手成績を年別・月別・日別で確認できます。",
+  robots: { index: false },
 };
 
 type ActiveTab = "batting" | "pitching";
@@ -15,6 +21,21 @@ export default async function StatsPage({
 }: {
   searchParams: Promise<{ tab?: string; period?: string }>;
 }) {
+  const isAuthenticated = await getIsAuthenticated();
+
+  if (!isAuthenticated) {
+    return (
+      <>
+        <Header />
+        <main className="min-h-full max-w-[720px] mx-auto w-full lg:m-[0_auto_0_28%]">
+          <div className="pt-20 px-4">
+            <AuthRequiredOverlay message="成績を閲覧するにはログインが必要です" />
+          </div>
+        </main>
+      </>
+    );
+  }
+
   const params = await searchParams;
   const tab: ActiveTab = params.tab === "pitching" ? "pitching" : "batting";
   const period: StatsPeriod =

--- a/app/components/auth/AuthRequiredOverlay.tsx
+++ b/app/components/auth/AuthRequiredOverlay.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { Button } from "@heroui/react";
+import Image from "next/image";
+import Link from "next/link";
+import { LockIcon } from "@app/components/icon/LockIcon";
+import { APP_STORE_URL } from "@app/constants/app";
+
+interface AuthRequiredOverlayProps {
+  message?: string;
+}
+
+export default function AuthRequiredOverlay({
+  message = "この情報を閲覧するにはログインが必要です",
+}: AuthRequiredOverlayProps) {
+  return (
+    <div className="flex flex-col items-center gap-y-4 py-12">
+      <LockIcon fill="#a1a1aa" width="40" height="40" />
+      <p className="text-sm text-zinc-400 text-center">{message}</p>
+      <div className="flex items-center gap-x-3 mt-2">
+        <Link href="/signin">
+          <Button
+            color="default"
+            size="lg"
+            radius="sm"
+            className="bg-white text-zinc-800 font-medium py-3"
+          >
+            ログイン
+          </Button>
+        </Link>
+        <Link href="/signup">
+          <Button
+            color="primary"
+            size="lg"
+            radius="sm"
+            className="font-medium py-2"
+          >
+            新規登録
+          </Button>
+        </Link>
+      </div>
+      <div className="mt-3">
+        <p className="text-xs text-zinc-400 mb-2 text-center">
+          iOSアプリはこちら
+        </p>
+        <a href={APP_STORE_URL} target="_blank" rel="noopener noreferrer">
+          <Image
+            src="/images/download_app_store_badge_jp.svg"
+            alt="App Storeからダウンロード"
+            width={150}
+            height={50}
+            className="h-[44px] w-auto"
+          />
+        </a>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#238

## 実装概要
未ログインユーザーがマイページの成績・試合タブ、試合詳細ページ、成績ページにアクセスした際に、データの代わりにログイン/新規登録CTAを表示するようにした。プロフィール基本情報（名前、チーム、ポジション等）は引き続き公開。

## 背景
未ログイン状態で他ユーザーの成績・試合情報が閲覧できてしまうため、ログイン必須にする。未ログイン時にはログイン・新規登録への導線を表示し、ユーザー登録へのコンバージョンを促す。バックエンドAPI側の認証必須化と合わせた二重防御。

## やらなかったこと
- モバイルアプリの変更（現状で全画面ログイン必須のため対応不要）
- プロフィール基本情報の非公開化（SEO・共有リンクからの流入導線として維持）

## 受入基準
- [ ] 未ログインで `/mypage/<user_id>` にアクセスすると、プロフィール基本情報は表示されるが、成績・試合タブの代わりにログインCTAが表示される
- [ ] 未ログインで `/game-result/summary/<slug>` にアクセスすると、ログインCTAが表示される
- [ ] 未ログインで `/stats` にアクセスすると、ログインCTAが表示される
- [ ] ログイン済みで上記すべてが従来通り正常に表示される
- [ ] CTAのログイン/新規登録ボタンが正しいリンク先に遷移する

## 実装詳細

### 新規コンポーネント
- **`AuthRequiredOverlay`** (`app/components/auth/AuthRequiredOverlay.tsx`)
  - Presentationalコンポーネント（`useAuthContext`を使わず、親が表示制御）
  - ロックアイコン + メッセージ + ログイン/新規登録ボタン + App Storeバッジ
  - `message` propsでコンテキストに応じたメッセージを表示

### ページ変更
| ページ | 変更内容 |
|---|---|
| `/mypage/[slug]/page.tsx` | `isLoggedIn === false` 時に成績・試合タブの代わりに `AuthRequiredOverlay` を表示 |
| `/game-result/summary/[slug]/page.tsx` | `useAuthContext` を追加し、未ログイン時はCTA表示（APIコールをスキップ） |
| `/stats/page.tsx` | Server Actionで `getIsAuthenticated()` を追加し、未認証時はCTA表示 |

### SEO
| ファイル | 変更 |
|---|---|
| `game-result/summary/layout.tsx` | `robots: { index: false }` を追加 |
| `stats/page.tsx` | `metadata` に `robots: { index: false }` を追加 |

## スクリーンショット
なし（ブラウザでの動作確認推奨）

## 確認手順
1. `yarn typecheck` がパスすることを確認
2. ブラウザでCookieを削除して未ログイン状態にする
3. `/mypage/<他ユーザーのuser_id>` にアクセス → プロフィール情報は表示、成績・試合タブの代わりにCTAが表示される
4. `/game-result/summary/<slug>` にアクセス → CTAが表示される
5. `/stats` にアクセス → CTAが表示される
6. ログイン後、上記3ページすべてが従来通り正常に表示される

## 影響範囲
- `/mypage/[slug]` — 成績・試合タブエリアのみ（プロフィールヘッダーは影響なし）
- `/game-result/summary/[slug]` — ページ全体
- `/stats` — ページ全体
- SEO: 試合詳細・成績ページがnoindexに

## コード上の懸念点
- `game-result/summary/[slug]/page.tsx` は旧パターン（useEffect + axiosInstance）のため、`useAuthContext` を追加する形で対応。新規実装ではServer Actionsパターンを推奨。
- `stats/page.tsx` はServer Componentのため、`getIsAuthenticated()` サーバーアクションで認証チェックを行い、Client Componentの `AuthRequiredOverlay` をレンダリングする構成。

## その他
バックエンドAPI側の認証必須化は `buzzbase_back` リポジトリのPRで対応。