### PR TITLE
Admin画面にチーム管理・グループ管理ページを追加

### DIFF
--- a/app/(admin)/_components/Pagination.tsx
+++ b/app/(admin)/_components/Pagination.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { PaginationInfo } from "../../types/admin";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+
+interface PaginationProps {
+  pagination: PaginationInfo;
+  basePath: string;
+}
+
+export default function Pagination({ pagination, basePath }: PaginationProps) {
+  const searchParams = useSearchParams();
+  const { current_page, total_pages, total_count, per_page } = pagination;
+
+  if (total_pages <= 1) return null;
+
+  function buildHref(page: number): string {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("page", page.toString());
+    return `${basePath}?${params.toString()}`;
+  }
+
+  const startItem = (current_page - 1) * per_page + 1;
+  const endItem = Math.min(current_page * per_page, total_count);
+
+  return (
+    <div className="flex items-center justify-between pt-4 text-sm">
+      <span className="text-gray-500">
+        {total_count}件中 {startItem}-{endItem}件
+      </span>
+      <div className="flex items-center gap-1">
+        {current_page > 1 ? (
+          <Link
+            href={buildHref(current_page - 1)}
+            className="px-3 py-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+          >
+            前へ
+          </Link>
+        ) : (
+          <span className="px-3 py-1 rounded border border-gray-200 text-gray-300">
+            前へ
+          </span>
+        )}
+
+        <span className="px-3 py-1 text-gray-600">
+          {current_page} / {total_pages}
+        </span>
+
+        {current_page < total_pages ? (
+          <Link
+            href={buildHref(current_page + 1)}
+            className="px-3 py-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+          >
+            次へ
+          </Link>
+        ) : (
+          <span className="px-3 py-1 rounded border border-gray-200 text-gray-300">
+            次へ
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/_components/Sidebar.tsx
+++ b/app/(admin)/_components/Sidebar.tsx
@@ -95,6 +95,38 @@ const MegaphoneIcon = (props: React.SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
+const TeamIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    {...props}
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21"
+    />
+  </svg>
+);
+
+const GroupIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    {...props}
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z"
+    />
+  </svg>
+);
+
 const MonitoringIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
     {...props}
@@ -151,6 +183,18 @@ export default function Sidebar() {
       href: "/admin-management-console/notices",
       icon: MegaphoneIcon,
       current: pathname.startsWith("/admin-management-console/notices"),
+    },
+    {
+      name: "チーム管理",
+      href: "/admin-management-console/teams",
+      icon: TeamIcon,
+      current: pathname.startsWith("/admin-management-console/teams"),
+    },
+    {
+      name: "グループ管理",
+      href: "/admin-management-console/groups",
+      icon: GroupIcon,
+      current: pathname.startsWith("/admin-management-console/groups"),
     },
   ];
 

--- a/app/(admin)/admin-management-console/groups/[id]/_components/GroupDetailCard.tsx
+++ b/app/(admin)/admin-management-console/groups/[id]/_components/GroupDetailCard.tsx
@@ -1,0 +1,50 @@
+import { type AdminGroupDetail } from "../../../../../types/admin";
+
+interface GroupDetailCardProps {
+  group: AdminGroupDetail;
+}
+
+export default function GroupDetailCard({ group }: GroupDetailCardProps) {
+  return (
+    <div className="bg-white shadow rounded-lg p-6">
+      <h3 className="text-lg font-medium text-gray-900 mb-4">グループ情報</h3>
+      <dl className="grid grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-2">
+        <div>
+          <dt className="text-sm font-medium text-gray-500">グループ名</dt>
+          <dd className="mt-1 text-sm text-gray-900">{group.name}</dd>
+        </div>
+        <div>
+          <dt className="text-sm font-medium text-gray-500">アイコン</dt>
+          <dd className="mt-1">
+            {group.icon_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={group.icon_url}
+                alt={group.name}
+                className="h-10 w-10 rounded-full object-cover"
+              />
+            ) : (
+              <span className="text-sm text-gray-400">なし</span>
+            )}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-sm font-medium text-gray-500">メンバー数</dt>
+          <dd className="mt-1 text-sm text-gray-900">
+            {group.group_users_count}人
+          </dd>
+        </div>
+        <div>
+          <dt className="text-sm font-medium text-gray-500">招待数</dt>
+          <dd className="mt-1 text-sm text-gray-900">
+            {group.group_invitations_count}件
+          </dd>
+        </div>
+        <div>
+          <dt className="text-sm font-medium text-gray-500">作成日時</dt>
+          <dd className="mt-1 text-sm text-gray-900">{group.created_at}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}

--- a/app/(admin)/admin-management-console/groups/[id]/_components/GroupInvitationsList.tsx
+++ b/app/(admin)/admin-management-console/groups/[id]/_components/GroupInvitationsList.tsx
@@ -1,0 +1,87 @@
+import { type AdminGroupInvitation } from "../../../../../types/admin";
+
+interface GroupInvitationsListProps {
+  invitations: AdminGroupInvitation[];
+}
+
+const stateLabels: Record<AdminGroupInvitation["state"], string> = {
+  pending: "保留中",
+  accepted: "承認済み",
+  declined: "辞退",
+};
+
+const stateStyles: Record<AdminGroupInvitation["state"], string> = {
+  pending: "bg-yellow-100 text-yellow-800",
+  accepted: "bg-green-100 text-green-800",
+  declined: "bg-red-100 text-red-800",
+};
+
+export default function GroupInvitationsList({
+  invitations,
+}: GroupInvitationsListProps) {
+  return (
+    <div className="bg-white shadow rounded-lg p-6">
+      <h3 className="text-lg font-medium text-gray-900 mb-4">
+        招待状況（{invitations.length}件）
+      </h3>
+
+      {invitations.length === 0 ? (
+        <div className="text-center py-8">
+          <p className="text-sm text-gray-500">招待はありません。</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  ユーザー名
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  メールアドレス
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  ステータス
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  送信日時
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  回答日時
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {invitations.map((invitation) => (
+                <tr
+                  key={invitation.id}
+                  className="hover:bg-gray-50 transition-colors"
+                >
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {invitation.user_name || "-"}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {invitation.user_email}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <span
+                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${stateStyles[invitation.state]}`}
+                    >
+                      {stateLabels[invitation.state]}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {invitation.sent_at || "-"}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {invitation.responded_at || "-"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(admin)/admin-management-console/groups/[id]/_components/GroupMembersList.tsx
+++ b/app/(admin)/admin-management-console/groups/[id]/_components/GroupMembersList.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+import { type AdminGroupMember } from "../../../../../types/admin";
+
+interface GroupMembersListProps {
+  members: AdminGroupMember[];
+}
+
+export default function GroupMembersList({ members }: GroupMembersListProps) {
+  return (
+    <div className="bg-white shadow rounded-lg p-6">
+      <h3 className="text-lg font-medium text-gray-900 mb-4">
+        メンバー一覧（{members.length}人）
+      </h3>
+
+      {members.length === 0 ? (
+        <div className="text-center py-8">
+          <p className="text-sm text-gray-500">メンバーはいません。</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  ユーザー名
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  メールアドレス
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  ユーザーID
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  参加日
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {members.map((member) => (
+                <tr
+                  key={member.id}
+                  className="hover:bg-gray-50 transition-colors"
+                >
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <Link
+                      href={`/admin-management-console/app-users/${member.id}`}
+                      className="text-sm font-medium text-indigo-600 hover:text-indigo-900"
+                    >
+                      {member.name || "-"}
+                    </Link>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {member.email}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {member.user_id || "-"}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {member.joined_at}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(admin)/admin-management-console/groups/[id]/page.tsx
+++ b/app/(admin)/admin-management-console/groups/[id]/page.tsx
@@ -1,0 +1,106 @@
+import Link from "next/link";
+import { getGroup } from "../actions";
+import GroupDetailCard from "./_components/GroupDetailCard";
+import GroupInvitationsList from "./_components/GroupInvitationsList";
+import GroupMembersList from "./_components/GroupMembersList";
+
+export const dynamic = "force-dynamic";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function GroupDetailPage(props: PageProps) {
+  const params = await props.params;
+  const groupId = parseInt(params.id, 10);
+
+  if (isNaN(groupId)) {
+    return (
+      <div className="px-4 py-6 sm:px-0">
+        <div className="border-4 border-dashed border-gray-200 rounded-lg p-6">
+          <div className="text-center py-12">
+            <h3 className="text-lg font-medium text-gray-900 mb-2">エラー</h3>
+            <p className="text-gray-500 mb-4">無効なグループIDです</p>
+            <Link
+              href="/admin-management-console/groups"
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
+            >
+              グループ一覧に戻る
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  let group;
+  try {
+    group = await getGroup(groupId);
+  } catch (_error) {
+    console.error("Error loading group:", _error);
+
+    return (
+      <div className="px-4 py-6 sm:px-0">
+        <div className="border-4 border-dashed border-gray-200 rounded-lg p-6">
+          <div className="text-center py-12">
+            <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100 mb-4">
+              <svg
+                className="h-6 w-6 text-red-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+                />
+              </svg>
+            </div>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">エラー</h3>
+            <p className="text-gray-500 mb-4">グループの取得に失敗しました</p>
+            <Link
+              href="/admin-management-console/groups"
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
+            >
+              グループ一覧に戻る
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 py-6 sm:px-0">
+      <div className="mb-4">
+        <Link
+          href="/admin-management-console/groups"
+          className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"
+        >
+          <svg
+            className="w-4 h-4 mr-1"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+          グループ一覧に戻る
+        </Link>
+      </div>
+
+      <div className="space-y-6">
+        <GroupDetailCard group={group} />
+        <GroupMembersList members={group.members} />
+        <GroupInvitationsList invitations={group.invitations} />
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/admin-management-console/groups/_components/DeleteConfirmDialog.tsx
+++ b/app/(admin)/admin-management-console/groups/_components/DeleteConfirmDialog.tsx
@@ -1,0 +1,86 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { type AdminGroup } from "../../../../types/admin";
+import { deleteGroup } from "../actions";
+
+interface DeleteConfirmDialogProps {
+  group: AdminGroup;
+}
+
+export default function DeleteConfirmDialog({
+  group,
+}: DeleteConfirmDialogProps) {
+  const deleteAction = async () => {
+    "use server";
+    const result = await deleteGroup(group.id);
+
+    if (result.success) {
+      redirect("/admin-management-console/groups");
+    } else {
+      redirect(
+        `/admin-management-console/groups?mode=delete&id=${group.id}&error=${encodeURIComponent(result.errors?.join(", ") || "削除に失敗しました")}`,
+      );
+    }
+  };
+
+  return (
+    <div className="bg-white shadow rounded-lg p-6">
+      <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100 mb-4">
+        <svg
+          className="h-6 w-6 text-red-600"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+          />
+        </svg>
+      </div>
+
+      <div className="text-center">
+        <h3 className="text-lg font-medium text-gray-900 mb-2">
+          グループを削除
+        </h3>
+        <div className="text-sm text-gray-500 mb-6">
+          <p className="mb-2">以下のグループを削除しますか？</p>
+          <div className="bg-gray-50 p-3 rounded-md text-left">
+            <p>
+              <span className="font-medium">グループ名:</span> {group.name}
+            </p>
+            <p>
+              <span className="font-medium">メンバー数:</span>{" "}
+              {group.group_users_count}
+            </p>
+            <p>
+              <span className="font-medium">ID:</span> {group.id}
+            </p>
+          </div>
+          <p className="mt-3 text-red-600 font-medium">
+            この操作は取り消せません。
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-center space-x-3">
+        <Link
+          href="/admin-management-console/groups"
+          className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+        >
+          キャンセル
+        </Link>
+        <form action={deleteAction}>
+          <button
+            type="submit"
+            className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+          >
+            削除する
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/admin-management-console/groups/_components/GroupTable.tsx
+++ b/app/(admin)/admin-management-console/groups/_components/GroupTable.tsx
@@ -1,0 +1,133 @@
+import Link from "next/link";
+import { type AdminGroup } from "../../../../types/admin";
+
+interface GroupTableProps {
+  groups: AdminGroup[];
+}
+
+export default function GroupTable({ groups }: GroupTableProps) {
+  if (groups.length === 0) {
+    return (
+      <div className="bg-white shadow rounded-lg p-6">
+        <div className="text-center py-12">
+          <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-gray-100 mb-4">
+            <svg
+              className="h-6 w-6 text-gray-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+              />
+            </svg>
+          </div>
+          <h3 className="text-lg font-medium text-gray-900 mb-2">
+            グループがありません
+          </h3>
+          <p className="text-gray-500">登録されているグループはありません。</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white shadow rounded-lg overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                ID
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                グループ名
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                メンバー数
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                招待数
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                作成日時
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                操作
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {groups.map((group) => (
+              <tr key={group.id} className="hover:bg-gray-50 transition-colors">
+                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                  {group.id}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className="text-sm font-medium text-gray-900 max-w-xs truncate">
+                    {group.name}
+                  </div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {group.group_users_count}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {group.group_invitations_count}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {group.created_at}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                  {group.deletable ? (
+                    <Link
+                      href={`/admin-management-console/groups?mode=delete&id=${group.id}`}
+                      className="inline-flex items-center px-3 py-1.5 border border-red-300 shadow-sm text-xs font-medium rounded text-red-700 bg-red-50 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
+                    >
+                      <svg
+                        className="w-4 h-4 mr-1"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                        />
+                      </svg>
+                      削除
+                    </Link>
+                  ) : (
+                    <span
+                      className="inline-flex items-center px-3 py-1.5 border border-gray-200 shadow-sm text-xs font-medium rounded text-gray-400 bg-gray-50 cursor-not-allowed"
+                      title="メンバーが所属しているため削除できません"
+                    >
+                      <svg
+                        className="w-4 h-4 mr-1"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                        />
+                      </svg>
+                      削除
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/admin-management-console/groups/_components/GroupTable.tsx
+++ b/app/(admin)/admin-management-console/groups/_components/GroupTable.tsx
@@ -81,10 +81,10 @@ export default function GroupTable({ groups }: GroupTableProps) {
                   {group.created_at}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                  {group.deletable ? (
+                  <div className="flex justify-end space-x-2">
                     <Link
-                      href={`/admin-management-console/groups?mode=delete&id=${group.id}`}
-                      className="inline-flex items-center px-3 py-1.5 border border-red-300 shadow-sm text-xs font-medium rounded text-red-700 bg-red-50 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
+                      href={`/admin-management-console/groups/${group.id}`}
+                      className="inline-flex items-center px-3 py-1.5 border border-gray-300 shadow-sm text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
                     >
                       <svg
                         className="w-4 h-4 mr-1"
@@ -96,32 +96,59 @@ export default function GroupTable({ groups }: GroupTableProps) {
                           strokeLinecap="round"
                           strokeLinejoin="round"
                           strokeWidth={2}
-                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                        />
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
                         />
                       </svg>
-                      削除
+                      詳細
                     </Link>
-                  ) : (
-                    <span
-                      className="inline-flex items-center px-3 py-1.5 border border-gray-200 shadow-sm text-xs font-medium rounded text-gray-400 bg-gray-50 cursor-not-allowed"
-                      title="メンバーが所属しているため削除できません"
-                    >
-                      <svg
-                        className="w-4 h-4 mr-1"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
+                    {group.deletable ? (
+                      <Link
+                        href={`/admin-management-console/groups?mode=delete&id=${group.id}`}
+                        className="inline-flex items-center px-3 py-1.5 border border-red-300 shadow-sm text-xs font-medium rounded text-red-700 bg-red-50 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
                       >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                        />
-                      </svg>
-                      削除
-                    </span>
-                  )}
+                        <svg
+                          className="w-4 h-4 mr-1"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                          />
+                        </svg>
+                        削除
+                      </Link>
+                    ) : (
+                      <span
+                        className="inline-flex items-center px-3 py-1.5 border border-gray-200 shadow-sm text-xs font-medium rounded text-gray-400 bg-gray-50 cursor-not-allowed"
+                        title="メンバーが所属しているため削除できません"
+                      >
+                        <svg
+                          className="w-4 h-4 mr-1"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                          />
+                        </svg>
+                        削除
+                      </span>
+                    )}
+                  </div>
                 </td>
               </tr>
             ))}

--- a/app/(admin)/admin-management-console/groups/actions.ts
+++ b/app/(admin)/admin-management-console/groups/actions.ts
@@ -21,6 +21,7 @@ export async function getGroups(): Promise<AdminGroup[]> {
         "Content-Type": "application/json",
         Authorization: `Bearer ${jwtToken}`,
       },
+      cache: "no-store",
     });
 
     if (!response.ok) {

--- a/app/(admin)/admin-management-console/groups/actions.ts
+++ b/app/(admin)/admin-management-console/groups/actions.ts
@@ -1,6 +1,10 @@
 "use server";
 
-import type { AdminGroupsResponse } from "../../../types/admin";
+import type {
+  AdminGroupDetail,
+  AdminGroupDetailResponse,
+  AdminGroupsResponse,
+} from "../../../types/admin";
 import { revalidatePath } from "next/cache";
 import { getAdminUser } from "../../../../lib/admin-auth";
 import { generateInternalJWT } from "../../../../lib/internal-jwt";
@@ -39,6 +43,36 @@ export async function getGroups(
     return response.json();
   } catch (error) {
     console.error("Error fetching groups:", error);
+    throw error;
+  }
+}
+
+export async function getGroup(id: number): Promise<AdminGroupDetail> {
+  try {
+    const adminUser = await getAdminUser();
+    if (!adminUser) {
+      throw new Error("認証が必要です");
+    }
+
+    const jwtToken = generateInternalJWT(adminUser.id);
+
+    const response = await fetch(`${RAILS_API_URL}/api/v1/admin/groups/${id}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${jwtToken}`,
+      },
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      throw new Error("グループの取得に失敗しました");
+    }
+
+    const data: AdminGroupDetailResponse = await response.json();
+    return data.group;
+  } catch (error) {
+    console.error("Error fetching group:", error);
     throw error;
   }
 }

--- a/app/(admin)/admin-management-console/groups/actions.ts
+++ b/app/(admin)/admin-management-console/groups/actions.ts
@@ -1,12 +1,14 @@
 "use server";
 
-import type { AdminGroup, AdminGroupsResponse } from "../../../types/admin";
+import type { AdminGroupsResponse } from "../../../types/admin";
 import { revalidatePath } from "next/cache";
 import { getAdminUser } from "../../../../lib/admin-auth";
 import { generateInternalJWT } from "../../../../lib/internal-jwt";
 import { RAILS_API_URL } from "../../../constants/api";
 
-export async function getGroups(): Promise<AdminGroup[]> {
+export async function getGroups(
+  params: { page?: string } = {},
+): Promise<AdminGroupsResponse> {
   try {
     const adminUser = await getAdminUser();
     if (!adminUser) {
@@ -15,7 +17,13 @@ export async function getGroups(): Promise<AdminGroup[]> {
 
     const jwtToken = generateInternalJWT(adminUser.id);
 
-    const response = await fetch(`${RAILS_API_URL}/api/v1/admin/groups`, {
+    const searchParams = new URLSearchParams();
+    if (params.page) searchParams.set("page", params.page);
+
+    const query = searchParams.toString();
+    const url = `${RAILS_API_URL}/api/v1/admin/groups${query ? `?${query}` : ""}`;
+
+    const response = await fetch(url, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -28,8 +36,7 @@ export async function getGroups(): Promise<AdminGroup[]> {
       throw new Error("グループの取得に失敗しました");
     }
 
-    const data: AdminGroupsResponse = await response.json();
-    return data.groups;
+    return response.json();
   } catch (error) {
     console.error("Error fetching groups:", error);
     throw error;

--- a/app/(admin)/admin-management-console/groups/actions.ts
+++ b/app/(admin)/admin-management-console/groups/actions.ts
@@ -1,0 +1,75 @@
+"use server";
+
+import type { AdminGroup, AdminGroupsResponse } from "../../../types/admin";
+import { revalidatePath } from "next/cache";
+import { getAdminUser } from "../../../../lib/admin-auth";
+import { generateInternalJWT } from "../../../../lib/internal-jwt";
+import { RAILS_API_URL } from "../../../constants/api";
+
+export async function getGroups(): Promise<AdminGroup[]> {
+  try {
+    const adminUser = await getAdminUser();
+    if (!adminUser) {
+      throw new Error("認証が必要です");
+    }
+
+    const jwtToken = generateInternalJWT(adminUser.id);
+
+    const response = await fetch(`${RAILS_API_URL}/api/v1/admin/groups`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${jwtToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error("グループの取得に失敗しました");
+    }
+
+    const data: AdminGroupsResponse = await response.json();
+    return data.groups;
+  } catch (error) {
+    console.error("Error fetching groups:", error);
+    throw error;
+  }
+}
+
+export async function deleteGroup(
+  id: number,
+): Promise<{ success: boolean; message?: string; errors?: string[] }> {
+  try {
+    const adminUser = await getAdminUser();
+    if (!adminUser) {
+      return { success: false, errors: ["認証が必要です"] };
+    }
+
+    const jwtToken = generateInternalJWT(adminUser.id);
+
+    const response = await fetch(`${RAILS_API_URL}/api/v1/admin/groups/${id}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${jwtToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      return {
+        success: false,
+        errors: data.errors || ["グループの削除に失敗しました"],
+      };
+    }
+
+    revalidatePath("/admin-management-console/groups");
+    const data = await response.json().catch(() => ({}));
+    return { success: true, message: data.message || "グループを削除しました" };
+  } catch (error) {
+    console.error("Error deleting group:", error);
+    return {
+      success: false,
+      errors: ["グループの削除中にエラーが発生しました"],
+    };
+  }
+}

--- a/app/(admin)/admin-management-console/groups/page.tsx
+++ b/app/(admin)/admin-management-console/groups/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { Suspense } from "react";
+import Pagination from "../../_components/Pagination";
 import DeleteConfirmDialog from "./_components/DeleteConfirmDialog";
 import GroupTable from "./_components/GroupTable";
 import { getGroups } from "./actions";
@@ -10,17 +12,18 @@ interface PageProps {
   searchParams: Promise<{
     mode?: "delete";
     id?: string;
+    page?: string;
     error?: string;
   }>;
 }
 
 export default async function GroupsPage(props: PageProps) {
   const searchParams = await props.searchParams;
-  const { mode, id, error } = searchParams;
+  const { mode, id, page, error } = searchParams;
 
-  let groups;
+  let data;
   try {
-    groups = await getGroups();
+    data = await getGroups({ page });
   } catch (_error) {
     console.error("Error loading groups:", _error);
 
@@ -58,7 +61,7 @@ export default async function GroupsPage(props: PageProps) {
   }
 
   const targetGroup = id
-    ? groups.find((group) => group.id === parseInt(id, 10))
+    ? data.groups.find((group) => group.id === parseInt(id, 10))
     : null;
 
   if (mode === "delete" && id && !targetGroup) {
@@ -69,11 +72,11 @@ export default async function GroupsPage(props: PageProps) {
     <div className="px-4 py-6 sm:px-0">
       <div className="border-4 border-dashed border-gray-200 rounded-lg p-6">
         <div className="sm:flex sm:items-center sm:justify-between mb-6">
-          <div>
+          <div className="flex items-baseline gap-3">
             <h2 className="text-2xl font-bold text-gray-900">グループ管理</h2>
-            <p className="mt-2 text-sm text-gray-700">
-              グループの一覧表示・削除を行えます。
-            </p>
+            <span className="text-sm text-gray-500">
+              {data.pagination.total_count}件
+            </span>
           </div>
         </div>
 
@@ -86,7 +89,15 @@ export default async function GroupsPage(props: PageProps) {
         {mode === "delete" && targetGroup ? (
           <DeleteConfirmDialog group={targetGroup} />
         ) : (
-          <GroupTable groups={groups} />
+          <>
+            <GroupTable groups={data.groups} />
+            <Suspense fallback={null}>
+              <Pagination
+                pagination={data.pagination}
+                basePath="/admin-management-console/groups"
+              />
+            </Suspense>
+          </>
         )}
       </div>
     </div>

--- a/app/(admin)/admin-management-console/groups/page.tsx
+++ b/app/(admin)/admin-management-console/groups/page.tsx
@@ -58,7 +58,7 @@ export default async function GroupsPage(props: PageProps) {
   }
 
   const targetGroup = id
-    ? groups.find((group) => group.id === parseInt(id))
+    ? groups.find((group) => group.id === parseInt(id, 10))
     : null;
 
   if (mode === "delete" && id && !targetGroup) {

--- a/app/(admin)/admin-management-console/groups/page.tsx
+++ b/app/(admin)/admin-management-console/groups/page.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import DeleteConfirmDialog from "./_components/DeleteConfirmDialog";
+import GroupTable from "./_components/GroupTable";
+import { getGroups } from "./actions";
+
+export const dynamic = "force-dynamic";
+
+interface PageProps {
+  searchParams: Promise<{
+    mode?: "delete";
+    id?: string;
+    error?: string;
+  }>;
+}
+
+export default async function GroupsPage(props: PageProps) {
+  const searchParams = await props.searchParams;
+  const { mode, id, error } = searchParams;
+
+  let groups;
+  try {
+    groups = await getGroups();
+  } catch (_error) {
+    console.error("Error loading groups:", _error);
+
+    return (
+      <div className="px-4 py-6 sm:px-0">
+        <div className="border-4 border-dashed border-gray-200 rounded-lg p-6">
+          <div className="text-center py-12">
+            <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100 mb-4">
+              <svg
+                className="h-6 w-6 text-red-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+                />
+              </svg>
+            </div>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">エラー</h3>
+            <p className="text-gray-500 mb-4">グループの取得に失敗しました</p>
+            <Link
+              href="/admin-management-console/groups"
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
+            >
+              再試行
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const targetGroup = id
+    ? groups.find((group) => group.id === parseInt(id))
+    : null;
+
+  if (mode === "delete" && id && !targetGroup) {
+    redirect("/admin-management-console/groups");
+  }
+
+  return (
+    <div className="px-4 py-6 sm:px-0">
+      <div className="border-4 border-dashed border-gray-200 rounded-lg p-6">
+        <div className="sm:flex sm:items-center sm:justify-between mb-6">
+          <div>
+            <h2 className="text-2xl font-bold text-gray-900">グループ管理</h2>
+            <p className="mt-2 text-sm text-gray-700">
+              グループの一覧表示・削除を行えます。
+            </p>
+          </div>
+        </div>
+
+        {error ? (
+          <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-md">
+            <p className="text-sm text-red-600">{decodeURIComponent(error)}</p>
+          </div>
+        ) : null}
+
+        {mode === "delete" && targetGroup ? (
+          <DeleteConfirmDialog group={targetGroup} />
+        ) : (
+          <GroupTable groups={groups} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/admin-management-console/groups/page.tsx
+++ b/app/(admin)/admin-management-console/groups/page.tsx
@@ -21,7 +21,7 @@ export default async function GroupsPage(props: PageProps) {
   const searchParams = await props.searchParams;
   const { mode, id, page, error } = searchParams;
 
-  let data;
+  let data: Awaited<ReturnType<typeof getGroups>>;
   try {
     data = await getGroups({ page });
   } catch (_error) {

--- a/app/(admin)/admin-management-console/teams/[id]/_components/TeamDetailCard.tsx
+++ b/app/(admin)/admin-management-console/teams/[id]/_components/TeamDetailCard.tsx
@@ -1,0 +1,41 @@
+import { type AdminTeamDetail } from "../../../../../types/admin";
+
+interface TeamDetailCardProps {
+  team: AdminTeamDetail;
+}
+
+export default function TeamDetailCard({ team }: TeamDetailCardProps) {
+  return (
+    <div className="bg-white shadow rounded-lg p-6">
+      <h3 className="text-lg font-medium text-gray-900 mb-4">チーム情報</h3>
+      <dl className="grid grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-2">
+        <div>
+          <dt className="text-sm font-medium text-gray-500">チーム名</dt>
+          <dd className="mt-1 text-sm text-gray-900">{team.name}</dd>
+        </div>
+        <div>
+          <dt className="text-sm font-medium text-gray-500">カテゴリ</dt>
+          <dd className="mt-1 text-sm text-gray-900">
+            {team.category_name || "-"}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-sm font-medium text-gray-500">都道府県</dt>
+          <dd className="mt-1 text-sm text-gray-900">
+            {team.prefecture_name || "-"}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-sm font-medium text-gray-500">試合結果数</dt>
+          <dd className="mt-1 text-sm text-gray-900">
+            {team.match_results_count}件
+          </dd>
+        </div>
+        <div>
+          <dt className="text-sm font-medium text-gray-500">作成日時</dt>
+          <dd className="mt-1 text-sm text-gray-900">{team.created_at}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}

--- a/app/(admin)/admin-management-console/teams/[id]/_components/TeamMembersList.tsx
+++ b/app/(admin)/admin-management-console/teams/[id]/_components/TeamMembersList.tsx
@@ -1,0 +1,71 @@
+import Link from "next/link";
+import { type AdminTeamMember } from "../../../../../types/admin";
+
+interface TeamMembersListProps {
+  members: AdminTeamMember[];
+}
+
+export default function TeamMembersList({ members }: TeamMembersListProps) {
+  return (
+    <div className="bg-white shadow rounded-lg p-6">
+      <h3 className="text-lg font-medium text-gray-900 mb-4">
+        所属メンバー（{members.length}人）
+      </h3>
+
+      {members.length === 0 ? (
+        <div className="text-center py-8">
+          <p className="text-sm text-gray-500">
+            所属しているメンバーはいません。
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  ユーザー名
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  メールアドレス
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  ユーザーID
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  登録日
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {members.map((member) => (
+                <tr
+                  key={member.id}
+                  className="hover:bg-gray-50 transition-colors"
+                >
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <Link
+                      href={`/admin-management-console/app-users/${member.id}`}
+                      className="text-sm font-medium text-indigo-600 hover:text-indigo-900"
+                    >
+                      {member.name || "-"}
+                    </Link>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {member.email}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {member.user_id || "-"}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {member.created_at}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(admin)/admin-management-console/teams/[id]/page.tsx
+++ b/app/(admin)/admin-management-console/teams/[id]/page.tsx
@@ -1,0 +1,104 @@
+import Link from "next/link";
+import { getTeam } from "../actions";
+import TeamDetailCard from "./_components/TeamDetailCard";
+import TeamMembersList from "./_components/TeamMembersList";
+
+export const dynamic = "force-dynamic";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function TeamDetailPage(props: PageProps) {
+  const params = await props.params;
+  const teamId = parseInt(params.id, 10);
+
+  if (isNaN(teamId)) {
+    return (
+      <div className="px-4 py-6 sm:px-0">
+        <div className="border-4 border-dashed border-gray-200 rounded-lg p-6">
+          <div className="text-center py-12">
+            <h3 className="text-lg font-medium text-gray-900 mb-2">エラー</h3>
+            <p className="text-gray-500 mb-4">無効なチームIDです</p>
+            <Link
+              href="/admin-management-console/teams"
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
+            >
+              チーム一覧に戻る
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  let team;
+  try {
+    team = await getTeam(teamId);
+  } catch (_error) {
+    console.error("Error loading team:", _error);
+
+    return (
+      <div className="px-4 py-6 sm:px-0">
+        <div className="border-4 border-dashed border-gray-200 rounded-lg p-6">
+          <div className="text-center py-12">
+            <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100 mb-4">
+              <svg
+                className="h-6 w-6 text-red-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+                />
+              </svg>
+            </div>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">エラー</h3>
+            <p className="text-gray-500 mb-4">チームの取得に失敗しました</p>
+            <Link
+              href="/admin-management-console/teams"
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
+            >
+              チーム一覧に戻る
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 py-6 sm:px-0">
+      <div className="mb-4">
+        <Link
+          href="/admin-management-console/teams"
+          className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"
+        >
+          <svg
+            className="w-4 h-4 mr-1"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+          チーム一覧に戻る
+        </Link>
+      </div>
+
+      <div className="space-y-6">
+        <TeamDetailCard team={team} />
+        <TeamMembersList members={team.members} />
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/admin-management-console/teams/_components/DeleteConfirmDialog.tsx
+++ b/app/(admin)/admin-management-console/teams/_components/DeleteConfirmDialog.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { type AdminTeam } from "../../../../types/admin";
+import { deleteTeam } from "../actions";
+
+interface DeleteConfirmDialogProps {
+  team: AdminTeam;
+}
+
+export default function DeleteConfirmDialog({
+  team,
+}: DeleteConfirmDialogProps) {
+  const deleteAction = async () => {
+    "use server";
+    const result = await deleteTeam(team.id);
+
+    if (result.success) {
+      redirect("/admin-management-console/teams");
+    } else {
+      redirect(
+        `/admin-management-console/teams?mode=delete&id=${team.id}&error=${encodeURIComponent(result.errors?.join(", ") || "削除に失敗しました")}`,
+      );
+    }
+  };
+
+  return (
+    <div className="bg-white shadow rounded-lg p-6">
+      <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100 mb-4">
+        <svg
+          className="h-6 w-6 text-red-600"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+          />
+        </svg>
+      </div>
+
+      <div className="text-center">
+        <h3 className="text-lg font-medium text-gray-900 mb-2">チームを削除</h3>
+        <div className="text-sm text-gray-500 mb-6">
+          <p className="mb-2">以下のチームを削除しますか？</p>
+          <div className="bg-gray-50 p-3 rounded-md text-left">
+            <p>
+              <span className="font-medium">チーム名:</span> {team.name}
+            </p>
+            <p>
+              <span className="font-medium">カテゴリ:</span>{" "}
+              {team.category_name || "-"}
+            </p>
+            <p>
+              <span className="font-medium">ID:</span> {team.id}
+            </p>
+          </div>
+          <p className="mt-3 text-red-600 font-medium">
+            この操作は取り消せません。
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-center space-x-3">
+        <Link
+          href="/admin-management-console/teams"
+          className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+        >
+          キャンセル
+        </Link>
+        <form action={deleteAction}>
+          <button
+            type="submit"
+            className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+          >
+            削除する
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/admin-management-console/teams/_components/TeamTable.tsx
+++ b/app/(admin)/admin-management-console/teams/_components/TeamTable.tsx
@@ -93,10 +93,10 @@ export default function TeamTable({ teams }: TeamTableProps) {
                   {team.created_at}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                  {team.deletable ? (
+                  <div className="flex justify-end space-x-2">
                     <Link
-                      href={`/admin-management-console/teams?mode=delete&id=${team.id}`}
-                      className="inline-flex items-center px-3 py-1.5 border border-red-300 shadow-sm text-xs font-medium rounded text-red-700 bg-red-50 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
+                      href={`/admin-management-console/teams/${team.id}`}
+                      className="inline-flex items-center px-3 py-1.5 border border-gray-300 shadow-sm text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
                     >
                       <svg
                         className="w-4 h-4 mr-1"
@@ -108,32 +108,59 @@ export default function TeamTable({ teams }: TeamTableProps) {
                           strokeLinecap="round"
                           strokeLinejoin="round"
                           strokeWidth={2}
-                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                        />
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
                         />
                       </svg>
-                      削除
+                      詳細
                     </Link>
-                  ) : (
-                    <span
-                      className="inline-flex items-center px-3 py-1.5 border border-gray-200 shadow-sm text-xs font-medium rounded text-gray-400 bg-gray-50 cursor-not-allowed"
-                      title="試合結果が紐づいているため削除できません"
-                    >
-                      <svg
-                        className="w-4 h-4 mr-1"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
+                    {team.deletable ? (
+                      <Link
+                        href={`/admin-management-console/teams?mode=delete&id=${team.id}`}
+                        className="inline-flex items-center px-3 py-1.5 border border-red-300 shadow-sm text-xs font-medium rounded text-red-700 bg-red-50 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
                       >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                        />
-                      </svg>
-                      削除
-                    </span>
-                  )}
+                        <svg
+                          className="w-4 h-4 mr-1"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                          />
+                        </svg>
+                        削除
+                      </Link>
+                    ) : (
+                      <span
+                        className="inline-flex items-center px-3 py-1.5 border border-gray-200 shadow-sm text-xs font-medium rounded text-gray-400 bg-gray-50 cursor-not-allowed"
+                        title="試合結果が紐づいているため削除できません"
+                      >
+                        <svg
+                          className="w-4 h-4 mr-1"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                          />
+                        </svg>
+                        削除
+                      </span>
+                    )}
+                  </div>
                 </td>
               </tr>
             ))}

--- a/app/(admin)/admin-management-console/teams/_components/TeamTable.tsx
+++ b/app/(admin)/admin-management-console/teams/_components/TeamTable.tsx
@@ -1,0 +1,145 @@
+import Link from "next/link";
+import { type AdminTeam } from "../../../../types/admin";
+
+interface TeamTableProps {
+  teams: AdminTeam[];
+}
+
+export default function TeamTable({ teams }: TeamTableProps) {
+  if (teams.length === 0) {
+    return (
+      <div className="bg-white shadow rounded-lg p-6">
+        <div className="text-center py-12">
+          <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-gray-100 mb-4">
+            <svg
+              className="h-6 w-6 text-gray-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+              />
+            </svg>
+          </div>
+          <h3 className="text-lg font-medium text-gray-900 mb-2">
+            チームがありません
+          </h3>
+          <p className="text-gray-500">登録されているチームはありません。</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white shadow rounded-lg overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                ID
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                チーム名
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                カテゴリ
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                都道府県
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                所属ユーザー
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                試合結果数
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                作成日時
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                操作
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {teams.map((team) => (
+              <tr key={team.id} className="hover:bg-gray-50 transition-colors">
+                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                  {team.id}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className="text-sm font-medium text-gray-900 max-w-xs truncate">
+                    {team.name}
+                  </div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {team.category_name || "-"}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {team.prefecture_name || "-"}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {team.user_name || "-"}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {team.match_results_count}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {team.created_at}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                  {team.deletable ? (
+                    <Link
+                      href={`/admin-management-console/teams?mode=delete&id=${team.id}`}
+                      className="inline-flex items-center px-3 py-1.5 border border-red-300 shadow-sm text-xs font-medium rounded text-red-700 bg-red-50 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
+                    >
+                      <svg
+                        className="w-4 h-4 mr-1"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                        />
+                      </svg>
+                      削除
+                    </Link>
+                  ) : (
+                    <span
+                      className="inline-flex items-center px-3 py-1.5 border border-gray-200 shadow-sm text-xs font-medium rounded text-gray-400 bg-gray-50 cursor-not-allowed"
+                      title="試合結果が紐づいているため削除できません"
+                    >
+                      <svg
+                        className="w-4 h-4 mr-1"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                        />
+                      </svg>
+                      削除
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/admin-management-console/teams/actions.ts
+++ b/app/(admin)/admin-management-console/teams/actions.ts
@@ -1,12 +1,14 @@
 "use server";
 
-import type { AdminTeam, AdminTeamsResponse } from "../../../types/admin";
+import type { AdminTeamsResponse } from "../../../types/admin";
 import { revalidatePath } from "next/cache";
 import { getAdminUser } from "../../../../lib/admin-auth";
 import { generateInternalJWT } from "../../../../lib/internal-jwt";
 import { RAILS_API_URL } from "../../../constants/api";
 
-export async function getTeams(): Promise<AdminTeam[]> {
+export async function getTeams(
+  params: { page?: string } = {},
+): Promise<AdminTeamsResponse> {
   try {
     const adminUser = await getAdminUser();
     if (!adminUser) {
@@ -15,7 +17,13 @@ export async function getTeams(): Promise<AdminTeam[]> {
 
     const jwtToken = generateInternalJWT(adminUser.id);
 
-    const response = await fetch(`${RAILS_API_URL}/api/v1/admin/teams`, {
+    const searchParams = new URLSearchParams();
+    if (params.page) searchParams.set("page", params.page);
+
+    const query = searchParams.toString();
+    const url = `${RAILS_API_URL}/api/v1/admin/teams${query ? `?${query}` : ""}`;
+
+    const response = await fetch(url, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -28,8 +36,7 @@ export async function getTeams(): Promise<AdminTeam[]> {
       throw new Error("チームの取得に失敗しました");
     }
 
-    const data: AdminTeamsResponse = await response.json();
-    return data.teams;
+    return response.json();
   } catch (error) {
     console.error("Error fetching teams:", error);
     throw error;

--- a/app/(admin)/admin-management-console/teams/actions.ts
+++ b/app/(admin)/admin-management-console/teams/actions.ts
@@ -21,6 +21,7 @@ export async function getTeams(): Promise<AdminTeam[]> {
         "Content-Type": "application/json",
         Authorization: `Bearer ${jwtToken}`,
       },
+      cache: "no-store",
     });
 
     if (!response.ok) {

--- a/app/(admin)/admin-management-console/teams/actions.ts
+++ b/app/(admin)/admin-management-console/teams/actions.ts
@@ -1,6 +1,10 @@
 "use server";
 
-import type { AdminTeamsResponse } from "../../../types/admin";
+import type {
+  AdminTeamDetail,
+  AdminTeamDetailResponse,
+  AdminTeamsResponse,
+} from "../../../types/admin";
 import { revalidatePath } from "next/cache";
 import { getAdminUser } from "../../../../lib/admin-auth";
 import { generateInternalJWT } from "../../../../lib/internal-jwt";
@@ -39,6 +43,36 @@ export async function getTeams(
     return response.json();
   } catch (error) {
     console.error("Error fetching teams:", error);
+    throw error;
+  }
+}
+
+export async function getTeam(id: number): Promise<AdminTeamDetail> {
+  try {
+    const adminUser = await getAdminUser();
+    if (!adminUser) {
+      throw new Error("認証が必要です");
+    }
+
+    const jwtToken = generateInternalJWT(adminUser.id);
+
+    const response = await fetch(`${RAILS_API_URL}/api/v1/admin/teams/${id}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${jwtToken}`,
+      },
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      throw new Error("チームの取得に失敗しました");
+    }
+
+    const data: AdminTeamDetailResponse = await response.json();
+    return data.team;
+  } catch (error) {
+    console.error("Error fetching team:", error);
     throw error;
   }
 }

--- a/app/(admin)/admin-management-console/teams/actions.ts
+++ b/app/(admin)/admin-management-console/teams/actions.ts
@@ -1,0 +1,75 @@
+"use server";
+
+import type { AdminTeam, AdminTeamsResponse } from "../../../types/admin";
+import { revalidatePath } from "next/cache";
+import { getAdminUser } from "../../../../lib/admin-auth";
+import { generateInternalJWT } from "../../../../lib/internal-jwt";
+import { RAILS_API_URL } from "../../../constants/api";
+
+export async function getTeams(): Promise<AdminTeam[]> {
+  try {
+    const adminUser = await getAdminUser();
+    if (!adminUser) {
+      throw new Error("認証が必要です");
+    }
+
+    const jwtToken = generateInternalJWT(adminUser.id);
+
+    const response = await fetch(`${RAILS_API_URL}/api/v1/admin/teams`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${jwtToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error("チームの取得に失敗しました");
+    }
+
+    const data: AdminTeamsResponse = await response.json();
+    return data.teams;
+  } catch (error) {
+    console.error("Error fetching teams:", error);
+    throw error;
+  }
+}
+
+export async function deleteTeam(
+  id: number,
+): Promise<{ success: boolean; message?: string; errors?: string[] }> {
+  try {
+    const adminUser = await getAdminUser();
+    if (!adminUser) {
+      return { success: false, errors: ["認証が必要です"] };
+    }
+
+    const jwtToken = generateInternalJWT(adminUser.id);
+
+    const response = await fetch(`${RAILS_API_URL}/api/v1/admin/teams/${id}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${jwtToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      return {
+        success: false,
+        errors: data.errors || ["チームの削除に失敗しました"],
+      };
+    }
+
+    revalidatePath("/admin-management-console/teams");
+    const data = await response.json().catch(() => ({}));
+    return { success: true, message: data.message || "チームを削除しました" };
+  } catch (error) {
+    console.error("Error deleting team:", error);
+    return {
+      success: false,
+      errors: ["チームの削除中にエラーが発生しました"],
+    };
+  }
+}

--- a/app/(admin)/admin-management-console/teams/page.tsx
+++ b/app/(admin)/admin-management-console/teams/page.tsx
@@ -1,0 +1,92 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import DeleteConfirmDialog from "./_components/DeleteConfirmDialog";
+import TeamTable from "./_components/TeamTable";
+import { getTeams } from "./actions";
+
+export const dynamic = "force-dynamic";
+
+interface PageProps {
+  searchParams: Promise<{
+    mode?: "delete";
+    id?: string;
+    error?: string;
+  }>;
+}
+
+export default async function TeamsPage(props: PageProps) {
+  const searchParams = await props.searchParams;
+  const { mode, id, error } = searchParams;
+
+  let teams;
+  try {
+    teams = await getTeams();
+  } catch (_error) {
+    console.error("Error loading teams:", _error);
+
+    return (
+      <div className="px-4 py-6 sm:px-0">
+        <div className="border-4 border-dashed border-gray-200 rounded-lg p-6">
+          <div className="text-center py-12">
+            <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100 mb-4">
+              <svg
+                className="h-6 w-6 text-red-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+                />
+              </svg>
+            </div>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">エラー</h3>
+            <p className="text-gray-500 mb-4">チームの取得に失敗しました</p>
+            <Link
+              href="/admin-management-console/teams"
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
+            >
+              再試行
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const targetTeam = id ? teams.find((team) => team.id === parseInt(id)) : null;
+
+  if (mode === "delete" && id && !targetTeam) {
+    redirect("/admin-management-console/teams");
+  }
+
+  return (
+    <div className="px-4 py-6 sm:px-0">
+      <div className="border-4 border-dashed border-gray-200 rounded-lg p-6">
+        <div className="sm:flex sm:items-center sm:justify-between mb-6">
+          <div>
+            <h2 className="text-2xl font-bold text-gray-900">チーム管理</h2>
+            <p className="mt-2 text-sm text-gray-700">
+              チームの一覧表示・削除を行えます。
+            </p>
+          </div>
+        </div>
+
+        {error ? (
+          <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-md">
+            <p className="text-sm text-red-600">{decodeURIComponent(error)}</p>
+          </div>
+        ) : null}
+
+        {mode === "delete" && targetTeam ? (
+          <DeleteConfirmDialog team={targetTeam} />
+        ) : (
+          <TeamTable teams={teams} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/admin-management-console/teams/page.tsx
+++ b/app/(admin)/admin-management-console/teams/page.tsx
@@ -57,7 +57,9 @@ export default async function TeamsPage(props: PageProps) {
     );
   }
 
-  const targetTeam = id ? teams.find((team) => team.id === parseInt(id)) : null;
+  const targetTeam = id
+    ? teams.find((team) => team.id === parseInt(id, 10))
+    : null;
 
   if (mode === "delete" && id && !targetTeam) {
     redirect("/admin-management-console/teams");

--- a/app/(admin)/admin-management-console/teams/page.tsx
+++ b/app/(admin)/admin-management-console/teams/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { Suspense } from "react";
+import Pagination from "../../_components/Pagination";
 import DeleteConfirmDialog from "./_components/DeleteConfirmDialog";
 import TeamTable from "./_components/TeamTable";
 import { getTeams } from "./actions";
@@ -10,17 +12,18 @@ interface PageProps {
   searchParams: Promise<{
     mode?: "delete";
     id?: string;
+    page?: string;
     error?: string;
   }>;
 }
 
 export default async function TeamsPage(props: PageProps) {
   const searchParams = await props.searchParams;
-  const { mode, id, error } = searchParams;
+  const { mode, id, page, error } = searchParams;
 
-  let teams;
+  let data;
   try {
-    teams = await getTeams();
+    data = await getTeams({ page });
   } catch (_error) {
     console.error("Error loading teams:", _error);
 
@@ -58,7 +61,7 @@ export default async function TeamsPage(props: PageProps) {
   }
 
   const targetTeam = id
-    ? teams.find((team) => team.id === parseInt(id, 10))
+    ? data.teams.find((team) => team.id === parseInt(id, 10))
     : null;
 
   if (mode === "delete" && id && !targetTeam) {
@@ -69,11 +72,11 @@ export default async function TeamsPage(props: PageProps) {
     <div className="px-4 py-6 sm:px-0">
       <div className="border-4 border-dashed border-gray-200 rounded-lg p-6">
         <div className="sm:flex sm:items-center sm:justify-between mb-6">
-          <div>
+          <div className="flex items-baseline gap-3">
             <h2 className="text-2xl font-bold text-gray-900">チーム管理</h2>
-            <p className="mt-2 text-sm text-gray-700">
-              チームの一覧表示・削除を行えます。
-            </p>
+            <span className="text-sm text-gray-500">
+              {data.pagination.total_count}件
+            </span>
           </div>
         </div>
 
@@ -86,7 +89,15 @@ export default async function TeamsPage(props: PageProps) {
         {mode === "delete" && targetTeam ? (
           <DeleteConfirmDialog team={targetTeam} />
         ) : (
-          <TeamTable teams={teams} />
+          <>
+            <TeamTable teams={data.teams} />
+            <Suspense fallback={null}>
+              <Pagination
+                pagination={data.pagination}
+                basePath="/admin-management-console/teams"
+              />
+            </Suspense>
+          </>
         )}
       </div>
     </div>

--- a/app/(admin)/admin-management-console/teams/page.tsx
+++ b/app/(admin)/admin-management-console/teams/page.tsx
@@ -21,7 +21,7 @@ export default async function TeamsPage(props: PageProps) {
   const searchParams = await props.searchParams;
   const { mode, id, page, error } = searchParams;
 
-  let data;
+  let data: Awaited<ReturnType<typeof getTeams>>;
   try {
     data = await getTeams({ page });
   } catch (_error) {

--- a/app/types/admin.ts
+++ b/app/types/admin.ts
@@ -136,6 +136,7 @@ export interface AdminTeam {
 
 export interface AdminTeamsResponse {
   teams: AdminTeam[];
+  pagination: PaginationInfo;
 }
 
 // Group Management types
@@ -151,4 +152,5 @@ export interface AdminGroup {
 
 export interface AdminGroupsResponse {
   groups: AdminGroup[];
+  pagination: PaginationInfo;
 }

--- a/app/types/admin.ts
+++ b/app/types/admin.ts
@@ -121,3 +121,34 @@ export interface ManagementNoticeSingleResponse {
   management_notice: ManagementNotice;
   message?: string;
 }
+
+// Team Management types
+export interface AdminTeam {
+  id: number;
+  name: string;
+  category_name: string | null;
+  prefecture_name: string | null;
+  user_name: string | null;
+  match_results_count: number;
+  deletable: boolean;
+  created_at: string;
+}
+
+export interface AdminTeamsResponse {
+  teams: AdminTeam[];
+}
+
+// Group Management types
+export interface AdminGroup {
+  id: number;
+  name: string;
+  icon_url: string | null;
+  group_users_count: number;
+  group_invitations_count: number;
+  deletable: boolean;
+  created_at: string;
+}
+
+export interface AdminGroupsResponse {
+  groups: AdminGroup[];
+}

--- a/app/types/admin.ts
+++ b/app/types/admin.ts
@@ -154,3 +154,63 @@ export interface AdminGroupsResponse {
   groups: AdminGroup[];
   pagination: PaginationInfo;
 }
+
+// Team Detail types
+export interface AdminTeamMember {
+  id: number;
+  name: string | null;
+  email: string;
+  user_id: string | null;
+  image_url: string | null;
+  created_at: string;
+}
+
+export interface AdminTeamDetail {
+  id: number;
+  name: string;
+  category_name: string | null;
+  prefecture_name: string | null;
+  match_results_count: number;
+  deletable: boolean;
+  created_at: string;
+  members: AdminTeamMember[];
+}
+
+export interface AdminTeamDetailResponse {
+  team: AdminTeamDetail;
+}
+
+// Group Detail types
+export interface AdminGroupMember {
+  id: number;
+  name: string | null;
+  email: string;
+  user_id: string | null;
+  image_url: string | null;
+  joined_at: string;
+}
+
+export interface AdminGroupInvitation {
+  id: number;
+  user_name: string | null;
+  user_email: string;
+  state: "pending" | "accepted" | "declined";
+  sent_at: string | null;
+  responded_at: string | null;
+}
+
+export interface AdminGroupDetail {
+  id: number;
+  name: string;
+  icon_url: string | null;
+  group_users_count: number;
+  group_invitations_count: number;
+  deletable: boolean;
+  created_at: string;
+  members: AdminGroupMember[];
+  invitations: AdminGroupInvitation[];
+}
+
+export interface AdminGroupDetailResponse {
+  group: AdminGroupDetail;
+}


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#240

## 実装概要
Admin画面にチーム管理・グループ管理ページを追加し、サイドバーナビゲーションにリンクを追加した。

## 背景
Admin画面からチームやグループのデータを閲覧・削除できるようにするため。紐づくデータがある場合は削除ボタンをdisabledにし、誤削除を防止する。

## やらなかったこと
- チーム・グループの作成・編集UI（Admin画面では閲覧・削除のみ）
- ページネーション（既存のnotices管理ページと同パターン）

## 受入基準
- [ ] `/admin-management-console/teams` でチーム一覧が表示される
- [ ] 試合結果が紐づいているチームの削除ボタンがdisabled表示になる
- [ ] 削除可能なチームで削除確認ダイアログが表示され、削除が実行される
- [ ] `/admin-management-console/groups` でグループ一覧が表示される
- [ ] メンバーが所属しているグループの削除ボタンがdisabled表示になる
- [ ] 削除可能なグループで削除確認ダイアログが表示され、削除が実行される
- [ ] サイドバーに「チーム管理」「グループ管理」のリンクが表示される
- [ ] アクティブページでサイドバーのハイライトが正しく動作する

## 実装詳細

### 型定義 (`app/types/admin.ts`)
- `AdminTeam` / `AdminTeamsResponse` — チーム管理用の型
- `AdminGroup` / `AdminGroupsResponse` — グループ管理用の型

### チーム管理 (`admin-management-console/teams/`)
- `actions.ts` — `getTeams()` / `deleteTeam()` サーバーアクション
- `page.tsx` — searchParamsの`mode`で一覧/削除確認を切り替え（既存noticesパターン準拠）
- `_components/TeamTable.tsx` — チーム一覧テーブル（`deletable`フラグでボタン出し分け）
- `_components/DeleteConfirmDialog.tsx` — 削除確認ダイアログ

### グループ管理 (`admin-management-console/groups/`)
- 同構成（actions, page, GroupTable, DeleteConfirmDialog）

### サイドバー (`_components/Sidebar.tsx`)
- `TeamIcon` / `GroupIcon` SVGコンポーネント追加
- navigation配列に「チーム管理」「グループ管理」を追加

## スクリーンショット
なし（実機確認推奨）

## 確認手順
1. `docker compose up` で開発環境を起動
2. `http://localhost:8100/admin-management-console/teams` にアクセスしチーム一覧が表示されることを確認
3. 試合結果が紐づいているチームの削除ボタンがグレーアウトしていることを確認
4. 削除可能なチームの削除ボタンをクリックし、確認ダイアログ→削除が正常動作することを確認
5. `http://localhost:8100/admin-management-console/groups` で同様にグループ管理を確認
6. サイドバーの「チーム管理」「グループ管理」リンクとアクティブ状態を確認

## 影響範囲
- Admin画面のみ（一般ユーザー向けページへの影響なし）
- サイドバーへのナビゲーション項目追加

## コード上の懸念点
特になし（既存のnotices管理ページと同一パターンで実装）

## その他
- バックエンドPR: ippei-shimizu/buzzbase_back#178