### PR TITLE
Admin グループメンバー一覧に作成者バッジを表示

### DIFF
--- a/app/(admin)/admin-management-console/groups/[id]/_components/GroupMembersList.tsx
+++ b/app/(admin)/admin-management-console/groups/[id]/_components/GroupMembersList.tsx
@@ -42,12 +42,19 @@ export default function GroupMembersList({ members }: GroupMembersListProps) {
                   className="hover:bg-gray-50 transition-colors"
                 >
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <Link
-                      href={`/admin-management-console/app-users/${member.id}`}
-                      className="text-sm font-medium text-indigo-600 hover:text-indigo-900"
-                    >
-                      {member.name || "-"}
-                    </Link>
+                    <div className="flex items-center gap-2">
+                      <Link
+                        href={`/admin-management-console/app-users/${member.id}`}
+                        className="text-sm font-medium text-indigo-600 hover:text-indigo-900"
+                      >
+                        {member.name || "-"}
+                      </Link>
+                      {member.is_creator ? (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800">
+                          作成者
+                        </span>
+                      ) : null}
+                    </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                     {member.email}

--- a/app/types/admin.ts
+++ b/app/types/admin.ts
@@ -187,6 +187,7 @@ export interface AdminGroupMember {
   email: string;
   user_id: string | null;
   image_url: string | null;
+  is_creator: boolean;
   joined_at: string;
 }
 


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#240

## 実装概要
Admin画面のグループ詳細ページで、メンバー一覧のユーザー名の横にグループ作成者を示す「作成者」バッジを表示するようにした。

## 背景
バックエンドの修正でメンバー一覧が承認済みユーザー全員を返すように変更され、各メンバーに `is_creator` フラグが追加された。フロントエンドでこのフラグを利用してバッジを表示する。

## やらなかったこと
特になし

## 受入基準
- [ ] グループ作成者の名前の横に紫色の「作成者」バッジが表示される
- [ ] 作成者以外のメンバーにはバッジが表示されない
- [ ] TypeScript型チェックが通る

## 実装詳細

### 型定義 (`app/types/admin.ts`)
- `AdminGroupMember` に `is_creator: boolean` フィールドを追加

### メンバー一覧 (`groups/[id]/_components/GroupMembersList.tsx`)
- `member.is_creator` が true の場合、ユーザー名の横に `bg-indigo-100 text-indigo-800` のバッジ「作成者」を表示

## スクリーンショット
なし

## 確認手順
1. Admin画面にログイン
2. グループ管理 → 任意のグループの「詳細」をクリック
3. グループ作成者のユーザー名の横に「作成者」バッジが表示されることを確認

## 影響範囲
- Admin画面のグループ詳細ページのメンバー一覧のみ

## コード上の懸念点
特になし

## その他
- バックエンドPR: ippei-shimizu/buzzbase_back#180