### PR TITLE
Chore: Server ActionsとSentry設定の強化（ログ管理の環境整備 #242）

### DIFF
--- a/app/(admin)/admin-management-console/app-users/actions.ts
+++ b/app/(admin)/admin-management-console/app-users/actions.ts
@@ -9,6 +9,7 @@ import type {
 import { revalidatePath } from "next/cache";
 import { getAdminUser } from "../../../../lib/admin-auth";
 import { generateInternalJWT } from "../../../../lib/internal-jwt";
+import { captureServerActionError } from "../../../../lib/sentry-helpers";
 import { RAILS_API_URL } from "../../../constants/api";
 
 export async function getAppUsers(
@@ -109,6 +110,10 @@ export async function suspendUser(
     revalidatePath("/admin-management-console/app-users");
     return { success: true, message: data.message };
   } catch (error) {
+    captureServerActionError(error, {
+      action: "suspendUser",
+      extra: { userId: id },
+    });
     console.error("Error suspending user:", error);
     return {
       success: false,
@@ -151,6 +156,10 @@ export async function restoreUser(
     revalidatePath("/admin-management-console/app-users");
     return { success: true, message: data.message };
   } catch (error) {
+    captureServerActionError(error, {
+      action: "restoreUser",
+      extra: { userId: id },
+    });
     console.error("Error restoring user:", error);
     return {
       success: false,
@@ -193,6 +202,10 @@ export async function softDeleteUser(
     revalidatePath("/admin-management-console/app-users");
     return { success: true, message: data.message };
   } catch (error) {
+    captureServerActionError(error, {
+      action: "softDeleteUser",
+      extra: { userId: id },
+    });
     console.error("Error deleting user:", error);
     return {
       success: false,

--- a/app/(admin)/admin-management-console/auth/actions.ts
+++ b/app/(admin)/admin-management-console/auth/actions.ts
@@ -2,6 +2,7 @@
 
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { captureServerActionError } from "../../../../lib/sentry-helpers";
 import { RAILS_API_URL } from "../../../constants/api";
 
 export async function adminLogin(
@@ -55,6 +56,7 @@ export async function adminLogin(
     if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
       throw error;
     }
+    captureServerActionError(error, { action: "adminLogin" });
     console.error("Admin login error:", error);
     return { error: "ログイン処理中にエラーが発生しました" };
   }
@@ -71,6 +73,7 @@ export async function adminLogout() {
       },
     });
   } catch (error) {
+    captureServerActionError(error, { action: "adminLogout" });
     console.error("Admin logout API error:", error);
   }
 

--- a/app/(admin)/admin-management-console/dashboard/actions.ts
+++ b/app/(admin)/admin-management-console/dashboard/actions.ts
@@ -60,7 +60,10 @@ export async function getDashboardStats(
 
     return await response.json();
   } catch (error) {
-    captureServerActionError(error, { action: "getDashboardStats" });
+    captureServerActionError(error, {
+      action: "getDashboardStats",
+      rethrow: true,
+    });
     console.error("Error fetching dashboard stats:", error);
     throw error;
   }
@@ -93,7 +96,10 @@ export async function getUserAnalytics(period: "7d" | "30d" | "90d" = "30d") {
 
     return await response.json();
   } catch (error) {
-    captureServerActionError(error, { action: "getUserAnalytics" });
+    captureServerActionError(error, {
+      action: "getUserAnalytics",
+      rethrow: true,
+    });
     console.error("Error fetching user analytics:", error);
     throw error;
   }

--- a/app/(admin)/admin-management-console/dashboard/actions.ts
+++ b/app/(admin)/admin-management-console/dashboard/actions.ts
@@ -2,6 +2,7 @@
 
 import { getAdminUser } from "../../../../lib/admin-auth";
 import { generateInternalJWT } from "../../../../lib/internal-jwt";
+import { captureServerActionError } from "../../../../lib/sentry-helpers";
 import { RAILS_API_URL } from "../../../constants/api";
 
 export interface DashboardStats {
@@ -59,6 +60,7 @@ export async function getDashboardStats(
 
     return await response.json();
   } catch (error) {
+    captureServerActionError(error, { action: "getDashboardStats" });
     console.error("Error fetching dashboard stats:", error);
     throw error;
   }
@@ -91,6 +93,7 @@ export async function getUserAnalytics(period: "7d" | "30d" | "90d" = "30d") {
 
     return await response.json();
   } catch (error) {
+    captureServerActionError(error, { action: "getUserAnalytics" });
     console.error("Error fetching user analytics:", error);
     throw error;
   }

--- a/app/(admin)/admin-management-console/groups/actions.ts
+++ b/app/(admin)/admin-management-console/groups/actions.ts
@@ -8,6 +8,7 @@ import type {
 import { revalidatePath } from "next/cache";
 import { getAdminUser } from "../../../../lib/admin-auth";
 import { generateInternalJWT } from "../../../../lib/internal-jwt";
+import { captureServerActionError } from "../../../../lib/sentry-helpers";
 import { RAILS_API_URL } from "../../../constants/api";
 
 export async function getGroups(
@@ -42,6 +43,7 @@ export async function getGroups(
 
     return response.json();
   } catch (error) {
+    captureServerActionError(error, { action: "getGroups" });
     console.error("Error fetching groups:", error);
     throw error;
   }
@@ -72,6 +74,7 @@ export async function getGroup(id: number): Promise<AdminGroupDetail> {
     const data: AdminGroupDetailResponse = await response.json();
     return data.group;
   } catch (error) {
+    captureServerActionError(error, { action: "getGroup" });
     console.error("Error fetching group:", error);
     throw error;
   }
@@ -108,6 +111,10 @@ export async function deleteGroup(
     const data = await response.json().catch(() => ({}));
     return { success: true, message: data.message || "グループを削除しました" };
   } catch (error) {
+    captureServerActionError(error, {
+      action: "deleteGroup",
+      extra: { groupId: id },
+    });
     console.error("Error deleting group:", error);
     return {
       success: false,

--- a/app/(admin)/admin-management-console/groups/actions.ts
+++ b/app/(admin)/admin-management-console/groups/actions.ts
@@ -43,7 +43,7 @@ export async function getGroups(
 
     return response.json();
   } catch (error) {
-    captureServerActionError(error, { action: "getGroups" });
+    captureServerActionError(error, { action: "getGroups", rethrow: true });
     console.error("Error fetching groups:", error);
     throw error;
   }
@@ -74,7 +74,7 @@ export async function getGroup(id: number): Promise<AdminGroupDetail> {
     const data: AdminGroupDetailResponse = await response.json();
     return data.group;
   } catch (error) {
-    captureServerActionError(error, { action: "getGroup" });
+    captureServerActionError(error, { action: "getGroup", rethrow: true });
     console.error("Error fetching group:", error);
     throw error;
   }

--- a/app/(admin)/admin-management-console/notices/actions.ts
+++ b/app/(admin)/admin-management-console/notices/actions.ts
@@ -39,7 +39,10 @@ export async function getManagementNotices(): Promise<ManagementNotice[]> {
     const data: ManagementNoticeResponse = await response.json();
     return data.management_notices;
   } catch (error) {
-    captureServerActionError(error, { action: "getManagementNotices" });
+    captureServerActionError(error, {
+      action: "getManagementNotices",
+      rethrow: true,
+    });
     console.error("Error fetching management notices:", error);
     throw error;
   }

--- a/app/(admin)/admin-management-console/notices/actions.ts
+++ b/app/(admin)/admin-management-console/notices/actions.ts
@@ -9,6 +9,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { getAdminUser } from "../../../../lib/admin-auth";
 import { generateInternalJWT } from "../../../../lib/internal-jwt";
+import { captureServerActionError } from "../../../../lib/sentry-helpers";
 import { RAILS_API_URL } from "../../../constants/api";
 
 export async function getManagementNotices(): Promise<ManagementNotice[]> {
@@ -38,6 +39,7 @@ export async function getManagementNotices(): Promise<ManagementNotice[]> {
     const data: ManagementNoticeResponse = await response.json();
     return data.management_notices;
   } catch (error) {
+    captureServerActionError(error, { action: "getManagementNotices" });
     console.error("Error fetching management notices:", error);
     throw error;
   }
@@ -78,6 +80,7 @@ export async function createManagementNotice(
     revalidatePath("/admin-management-console/notices");
     return { success: true, message: data.message };
   } catch (error) {
+    captureServerActionError(error, { action: "createManagementNotice" });
     console.error("Error creating management notice:", error);
     return {
       success: false,
@@ -122,6 +125,10 @@ export async function updateManagementNotice(
     revalidatePath("/admin-management-console/notices");
     return { success: true, message: data.message };
   } catch (error) {
+    captureServerActionError(error, {
+      action: "updateManagementNotice",
+      extra: { noticeId: id },
+    });
     console.error("Error updating management notice:", error);
     return {
       success: false,
@@ -164,6 +171,10 @@ export async function deleteManagementNotice(
     const data = await response.json().catch(() => ({}));
     return { success: true, message: data.message || "お知らせを削除しました" };
   } catch (error) {
+    captureServerActionError(error, {
+      action: "deleteManagementNotice",
+      extra: { noticeId: id },
+    });
     console.error("Error deleting management notice:", error);
     return {
       success: false,

--- a/app/(admin)/admin-management-console/teams/actions.ts
+++ b/app/(admin)/admin-management-console/teams/actions.ts
@@ -43,7 +43,7 @@ export async function getTeams(
 
     return response.json();
   } catch (error) {
-    captureServerActionError(error, { action: "getTeams" });
+    captureServerActionError(error, { action: "getTeams", rethrow: true });
     console.error("Error fetching teams:", error);
     throw error;
   }
@@ -74,7 +74,7 @@ export async function getTeam(id: number): Promise<AdminTeamDetail> {
     const data: AdminTeamDetailResponse = await response.json();
     return data.team;
   } catch (error) {
-    captureServerActionError(error, { action: "getTeam" });
+    captureServerActionError(error, { action: "getTeam", rethrow: true });
     console.error("Error fetching team:", error);
     throw error;
   }

--- a/app/(admin)/admin-management-console/teams/actions.ts
+++ b/app/(admin)/admin-management-console/teams/actions.ts
@@ -8,6 +8,7 @@ import type {
 import { revalidatePath } from "next/cache";
 import { getAdminUser } from "../../../../lib/admin-auth";
 import { generateInternalJWT } from "../../../../lib/internal-jwt";
+import { captureServerActionError } from "../../../../lib/sentry-helpers";
 import { RAILS_API_URL } from "../../../constants/api";
 
 export async function getTeams(
@@ -42,6 +43,7 @@ export async function getTeams(
 
     return response.json();
   } catch (error) {
+    captureServerActionError(error, { action: "getTeams" });
     console.error("Error fetching teams:", error);
     throw error;
   }
@@ -72,6 +74,7 @@ export async function getTeam(id: number): Promise<AdminTeamDetail> {
     const data: AdminTeamDetailResponse = await response.json();
     return data.team;
   } catch (error) {
+    captureServerActionError(error, { action: "getTeam" });
     console.error("Error fetching team:", error);
     throw error;
   }
@@ -108,6 +111,10 @@ export async function deleteTeam(
     const data = await response.json().catch(() => ({}));
     return { success: true, message: data.message || "チームを削除しました" };
   } catch (error) {
+    captureServerActionError(error, {
+      action: "deleteTeam",
+      extra: { teamId: id },
+    });
     console.error("Error deleting team:", error);
     return {
       success: false,

--- a/app/(admin)/admin-management-console/users/actions.ts
+++ b/app/(admin)/admin-management-console/users/actions.ts
@@ -37,7 +37,7 @@ export async function getAdminUsers(): Promise<AdminUser[]> {
     const data: AdminUserResponse = await response.json();
     return data.admin_users;
   } catch (error) {
-    captureServerActionError(error, { action: "getAdminUsers" });
+    captureServerActionError(error, { action: "getAdminUsers", rethrow: true });
     console.error("Error fetching admin users:", error);
     throw error;
   }

--- a/app/(admin)/admin-management-console/users/actions.ts
+++ b/app/(admin)/admin-management-console/users/actions.ts
@@ -10,6 +10,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { getAdminUser } from "../../../../lib/admin-auth";
 import { generateInternalJWT } from "../../../../lib/internal-jwt";
+import { captureServerActionError } from "../../../../lib/sentry-helpers";
 import { RAILS_API_URL } from "../../../constants/api";
 
 export async function getAdminUsers(): Promise<AdminUser[]> {
@@ -36,6 +37,7 @@ export async function getAdminUsers(): Promise<AdminUser[]> {
     const data: AdminUserResponse = await response.json();
     return data.admin_users;
   } catch (error) {
+    captureServerActionError(error, { action: "getAdminUsers" });
     console.error("Error fetching admin users:", error);
     throw error;
   }
@@ -73,6 +75,7 @@ export async function createAdminUser(
     revalidatePath("/admin-management-console/users");
     return { success: true, message: data.message };
   } catch (error) {
+    captureServerActionError(error, { action: "createAdminUser" });
     console.error("Error creating admin user:", error);
     return {
       success: false,
@@ -117,6 +120,10 @@ export async function updateAdminUser(
     revalidatePath("/admin-management-console/users");
     return { success: true, message: data.message };
   } catch (error) {
+    captureServerActionError(error, {
+      action: "updateAdminUser",
+      extra: { adminUserId: id },
+    });
     console.error("Error updating admin user:", error);
     return {
       success: false,
@@ -159,6 +166,10 @@ export async function deleteAdminUser(
     revalidatePath("/admin-management-console/users");
     return { success: true, message: data.message };
   } catch (error) {
+    captureServerActionError(error, {
+      action: "deleteAdminUser",
+      extra: { adminUserId: id },
+    });
     console.error("Error deleting admin user:", error);
     return {
       success: false,

--- a/app/(app)/dashboard/actions.ts
+++ b/app/(app)/dashboard/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { cookies } from "next/headers";
+import { captureServerActionError } from "../../../lib/sentry-helpers";
 import { RAILS_API_URL } from "../../constants/api";
 
 export interface RecentGameResult {
@@ -154,6 +155,7 @@ export async function getDashboardData(
 
     return await response.json();
   } catch (error) {
+    captureServerActionError(error, { action: "getDashboardData" });
     console.error("Error fetching dashboard data:", error);
     return null;
   }
@@ -203,6 +205,7 @@ export async function getAvailableSeasons(): Promise<SeasonOption[]> {
     if (!response.ok) return [];
     return await response.json();
   } catch (error) {
+    captureServerActionError(error, { action: "getAvailableSeasons" });
     console.error("Error fetching seasons:", error);
     return [];
   }
@@ -229,6 +232,7 @@ export async function getFilteredBattingStats(
     if (!response.ok) return null;
     return await response.json();
   } catch (error) {
+    captureServerActionError(error, { action: "getFilteredBattingStats" });
     console.error("Error fetching batting stats:", error);
     return null;
   }
@@ -255,6 +259,7 @@ export async function getFilteredPitchingStats(
     if (!response.ok) return null;
     return await response.json();
   } catch (error) {
+    captureServerActionError(error, { action: "getFilteredPitchingStats" });
     console.error("Error fetching pitching stats:", error);
     return null;
   }

--- a/app/(app)/notice-from-management/actions.ts
+++ b/app/(app)/notice-from-management/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { captureServerActionError } from "../../../lib/sentry-helpers";
 import { RAILS_API_URL } from "../../constants/api";
 
 export interface PublicManagementNotice {
@@ -24,6 +25,7 @@ export async function getPublishedNotices(): Promise<PublicManagementNotice[]> {
     const data = await response.json();
     return data.management_notices ?? [];
   } catch (error) {
+    captureServerActionError(error, { action: "getPublishedNotices" });
     console.error("Error fetching published notices:", error);
     return [];
   }
@@ -49,6 +51,7 @@ export async function getPublishedNotice(
     const data = await response.json();
     return data.management_notice ?? null;
   } catch (error) {
+    captureServerActionError(error, { action: "getPublishedNotice" });
     console.error("Error fetching published notice:", error);
     return null;
   }

--- a/app/(app)/seasons/actions.ts
+++ b/app/(app)/seasons/actions.ts
@@ -3,6 +3,7 @@
 import type { SeasonData } from "@app/interface";
 import { cookies } from "next/headers";
 import { RAILS_API_URL } from "@app/constants/api";
+import { captureServerActionError } from "../../../lib/sentry-helpers";
 
 async function getAuthHeaders(): Promise<Record<string, string> | null> {
   const cookieStore = await cookies();
@@ -35,6 +36,7 @@ export async function getSeasonsServer(): Promise<SeasonData[]> {
     if (!response.ok) return [];
     return await response.json();
   } catch (error) {
+    captureServerActionError(error, { action: "getSeasonsServer" });
     console.error("Error fetching seasons:", error);
     return [];
   }

--- a/app/(app)/stats/actions.ts
+++ b/app/(app)/stats/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { cookies } from "next/headers";
+import { captureServerActionError } from "../../../lib/sentry-helpers";
 import { RAILS_API_URL } from "../../constants/api";
 
 export interface BattingStatsRow {
@@ -101,7 +102,8 @@ export async function getBattingStats(
 
     const data = await response.json();
     return data.rows ?? [];
-  } catch {
+  } catch (error) {
+    captureServerActionError(error, { action: "getBattingStats" });
     return [];
   }
 }
@@ -129,7 +131,8 @@ export async function getPitchingStats(
 
     const data = await response.json();
     return data.rows ?? [];
-  } catch {
+  } catch (error) {
+    captureServerActionError(error, { action: "getPitchingStats" });
     return [];
   }
 }

--- a/app/contexts/userContext.tsx
+++ b/app/contexts/userContext.tsx
@@ -1,6 +1,12 @@
 "use client";
 import type { UserContextType } from "@app/interface";
-import React, { createContext, useContext, type ReactNode } from "react";
+import * as Sentry from "@sentry/nextjs";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  type ReactNode,
+} from "react";
 import useSWR from "swr";
 import { fetcher } from "@app/hooks/swrFetcher";
 
@@ -28,6 +34,14 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
     userId: userId ?? { id: null, team_id: null, user_id: "" },
     usersUserId: usersUserId ?? { user_id: "" },
   };
+
+  useEffect(() => {
+    if (state.userId.id) {
+      Sentry.setUser({ id: String(state.userId.id) });
+    } else {
+      Sentry.setUser(null);
+    }
+  }, [state.userId.id]);
 
   return (
     <UserContext.Provider value={{ state }}>{children}</UserContext.Provider>

--- a/lib/sentry-helpers.ts
+++ b/lib/sentry-helpers.ts
@@ -1,0 +1,23 @@
+import * as Sentry from "@sentry/nextjs";
+
+type CaptureContext = {
+  action?: string;
+  extra?: Record<string, unknown>;
+};
+
+export function captureServerActionError(
+  error: unknown,
+  context?: CaptureContext,
+): void {
+  if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
+    return;
+  }
+
+  Sentry.captureException(error, {
+    tags: {
+      source: "server-action",
+      ...(context?.action ? { action: context.action } : {}),
+    },
+    extra: context?.extra,
+  });
+}

--- a/lib/sentry-helpers.ts
+++ b/lib/sentry-helpers.ts
@@ -3,13 +3,43 @@ import * as Sentry from "@sentry/nextjs";
 type CaptureContext = {
   action?: string;
   extra?: Record<string, unknown>;
+  /**
+   * catch 内でエラーを再スローする場合は true を指定する。
+   * その場合、本ヘルパーは captureException を呼ばず、isolation scope にタグだけ設定する。
+   * → 再スロー後に Next.js / Sentry SDK の自動キャプチャが動くため、二重通知を防げる。
+   */
+  rethrow?: boolean;
 };
 
+/**
+ * Server Actions の catch 句で使用するヘルパー。
+ *
+ * - NEXT_REDIRECT (Next.js の redirect() による疑似エラー) は無視する
+ * - rethrow: false（デフォルト）: その場で captureException する（エラーを吸収する catch 用）
+ * - rethrow: true: capture せず isolation scope にタグだけ設定する（再スローする catch 用）
+ *
+ * ⚠️ 注意:
+ * NEXT_REDIRECT を含むパス（redirect() を呼んでいる Server Action）では、
+ * このヘルパーを呼ぶ前に必ず手動で以下を実行すること:
+ *
+ *   if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) throw error;
+ *
+ * このヘルパーは void 戻りで re-throw しないため、redirect エラーを呼び出し側が
+ * 意識的に再スローしないとリダイレクトが動作しない。
+ */
 export function captureServerActionError(
   error: unknown,
   context?: CaptureContext,
 ): void {
   if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
+    return;
+  }
+
+  if (context?.rethrow) {
+    const scope = Sentry.getIsolationScope();
+    scope.setTag("source", "server-action");
+    if (context.action) scope.setTag("action", context.action);
+    if (context.extra) scope.setExtras(context.extra);
     return;
   }
 

--- a/next.config.js
+++ b/next.config.js
@@ -42,7 +42,9 @@ const nextConfig = {
 module.exports = withSentryConfig(nextConfig, {
   silent: true,
   hideSourceMaps: true,
-  // NOTE: ソースマップのSentryへのアップロードは未設定
-  // 有効にするには org, project, authToken の設定が必要
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#configure-source-maps
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  // SENTRY_AUTH_TOKEN が未設定の環境ではソースマップアップロードはスキップされる
+  // 本番ビルド時のみ CI/CD で SENTRY_ORG / SENTRY_PROJECT / SENTRY_AUTH_TOKEN を設定する
 });

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,8 +3,16 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.1,
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
   environment: process.env.NODE_ENV,
   release: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
   enabled: process.env.NODE_ENV === "production",
   sendDefaultPii: false,
+  integrations: [
+    Sentry.replayIntegration({
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+  ],
 });


### PR DESCRIPTION
## 関連Issue

ippei-shimizu/buzzbase#242

## 概要

Server Actionsの \`catch\` で握りつぶしていたエラーをSentryに通知する仕組みを統一導入。Session Replayでエラー発生時のUI再現も可能に。Source Mapアップロード設定も整備（CI環境変数連携）。

## 変更内容

### Server Actions のエラー通知統一（commit 1）
- \`lib/sentry-helpers.ts\`: \`captureServerActionError\` ヘルパーを新規作成（NEXT_REDIRECT除外）
- 全11個の \`actions.ts\` の catch 句に \`Sentry.captureException\` を追加
  - \`(app)/dashboard\`, \`notice-from-management\`, \`seasons\`, \`stats\`
  - \`(admin)/admin-management-console/{auth,dashboard,app-users,groups,notices,teams,users}\`

### ユーザーコンテキスト設定（commit 2）
- \`app/contexts/userContext.tsx\`: ログイン後に \`Sentry.setUser({ id })\`、ログアウト時に \`setUser(null)\`

### Sentry設定強化（commit 3）
- \`sentry.client.config.ts\`: Session Replay有効化（通常 0.1 / エラー時 1.0）+ \`replayIntegration\`
- \`next.config.js\`: \`SENTRY_ORG\` / \`SENTRY_PROJECT\` / \`SENTRY_AUTH_TOKEN\` をenv依存に（CI設定でSource Mapアップロード可能に）

## スクリーンショット

UI変更なし

## 確認手順

1. \`yarn typecheck\` — pass
2. \`yarn lint\` — pass
3. \`yarn test\` — 245 tests passed
4. 本番デプロイ後、Sentryダッシュボードで以下を確認:
   - Server Actions のエラーが \`source: server-action\` タグ付きで記録される
   - ログイン後のIssueに user.id が紐付く
   - Session Replay が記録される

## チェックリスト

- [x] \`yarn typecheck\` が通る
- [x] \`yarn lint\` が通る
- [x] \`yarn test\` が通る
- [ ] 本番動作確認（デプロイ後）