### PR TITLE
Update: SentryのreleaseをVercel自動変数からフォールバック取得（#242）

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -6,7 +6,9 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   environment: process.env.NODE_ENV,
-  release: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
+  release:
+    process.env.NEXT_PUBLIC_SENTRY_RELEASE ||
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
   enabled: process.env.NODE_ENV === "production",
   sendDefaultPii: false,
   integrations: [

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -4,7 +4,10 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.1,
   environment: process.env.NODE_ENV,
-  release: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
+  release:
+    process.env.NEXT_PUBLIC_SENTRY_RELEASE ||
+    process.env.VERCEL_GIT_COMMIT_SHA ||
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
   enabled: process.env.NODE_ENV === "production",
   sendDefaultPii: false,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,7 +4,10 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.1,
   environment: process.env.NODE_ENV,
-  release: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
+  release:
+    process.env.NEXT_PUBLIC_SENTRY_RELEASE ||
+    process.env.VERCEL_GIT_COMMIT_SHA ||
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
   enabled: process.env.NODE_ENV === "production",
   sendDefaultPii: false,
 });


### PR DESCRIPTION
## 関連Issue

ippei-shimizu/buzzbase#242

## 概要

Vercel環境では \`NEXT_PUBLIC_SENTRY_RELEASE\` を手動設定する必要がないように、Vercelのビルド時に自動注入される \`VERCEL_GIT_COMMIT_SHA\` をフォールバックで参照するよう変更。

これによりVercelデプロイごとにcommit SHAが自動でSentryのreleaseタグになり、Source Mapマッチングの精度が向上する。

## 変更内容

- \`sentry.client.config.ts\`: \`NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\` をフォールバックに追加（クライアントバンドル用）
- \`sentry.server.config.ts\`: \`VERCEL_GIT_COMMIT_SHA\` をフォールバックに追加
- \`sentry.edge.config.ts\`: \`VERCEL_GIT_COMMIT_SHA\` をフォールバックに追加

## 確認手順

1. \`yarn typecheck\` — pass
2. \`yarn lint\` — pass
3. デプロイ後にVercelビルドログで以下を確認:
   - \`Created release: <commit-sha>\` のようなSentry release作成ログ
4. Sentry → buzzbase-frontend → Releases に commit SHA 名のリリースが表示される

## チェックリスト

- [x] \`yarn typecheck\` が通る
- [x] \`yarn lint\` が通る
- [ ] 本番動作確認（デプロイ後）