### PR TITLE
Remove: front CI から Codecov アップロードステップを削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,16 +37,8 @@ jobs:
       - name: Prettier check
         run: yarn format:check
 
-      - name: Run tests with coverage
+      - name: Run tests
         run: yarn test:ci
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage/lcov.info
-          flags: frontend
-          name: front-coverage
-          fail_ci_if_error: false
 
   build:
     name: Build Check


### PR DESCRIPTION
## issue
（直接の関連issueなし。モバイルCI構築（buzzbase #154）の議論で「Codecov を BUZZ BASE では採用しない」方針が決まったため、front 側の CI からも該当ステップを削除する。）

## 実装概要

`.github/workflows/ci.yml` から Codecov アップロードステップを削除。

## 背景

CI 実行ログを確認したところ、Codecov アップロードは長期間「Token required - not valid tokenless upload」エラーで失敗していた。`fail_ci_if_error: false` のためCI自体は緑のまま、Codecov 上にデータも届いておらず、PR コメントなどの恩恵も得られていなかった。

個人開発スコープでは外部サービス依存のメンテナンスコストに見合う恩恵が薄いと判断し、front / back / mobile のすべてで Codecov を採用しない方針に揃える（back は元から未採用）。

## やらなかったこと

- 別サービス（Coveralls 等）への移行 — 今回は導入しない
- カバレッジ計測自体の停止 — `yarn test:ci` は引き続き `--coverage` 付きで実行（CI ログ上で確認可能）
- `test:ci` スクリプト名・内容の変更 — 互換性維持のため変更なし

## 受入基準

- [ ] CI が緑で通る
- [ ] `Run tests` ステップが正常に走る（カバレッジ計算も含む）
- [ ] Codecov upload ステップが実行されないこと

## 実装詳細

`.github/workflows/ci.yml`:

- `Run tests with coverage` → `Run tests` に名称変更
- `Upload coverage to Codecov` ステップ（`codecov/codecov-action@v4` ブロック）を削除

ステップは `lint-and-test` ジョブ内のみで、`build` ジョブは無変更。

## スクリーンショット

なし

## 確認手順

1. このPRをopenにする
2. GitHub Actions タブで `Front CI` ワークフローが緑で完了することを確認
3. ジョブログで `Run tests` ステップが実行され、`Upload coverage to Codecov` ステップが**存在しない**ことを確認

## 影響範囲

- `buzzbase_front` の CI 実行のみ
- アプリケーションコード・ビルド成果物には影響なし

## コード上の懸念点

特になし

## その他

mobile 側の関連 PR（CI 新規構築）は `buzzbase_mobile` リポジトリで別途作成。