### PR TITLE
Fix: 試合結果削除の404を成功扱いにし連打ループを解消

### DIFF
--- a/app/(app)/game-result/summary/[slug]/page.tsx
+++ b/app/(app)/game-result/summary/[slug]/page.tsx
@@ -16,6 +16,7 @@ import {
   ModalHeader,
   useDisclosure,
 } from "@heroui/react";
+import axios from "axios";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { adSlots } from "@app/components/ad/adConfig";
@@ -282,13 +283,20 @@ export default function ResultsSummary() {
     setIsLoading(true);
     try {
       await deleteGameResult(id);
-      setTimeout(() => {
-        router.push(`/mypage/${currentUsersUserId}`);
+    } catch (error) {
+      // 404 は既に削除済みなので成功扱い（クライアント側のキャッシュ等に古い id が
+      // 残るケースで「削除できません」状態を起こさないため）。それ以外は失敗扱い。
+      const isNotFound =
+        axios.isAxiosError(error) && error.response?.status === 404;
+      if (!isNotFound) {
         setIsLoading(false);
-      }, 1000);
-    } catch {
-      setIsLoading(false);
+        return;
+      }
     }
+    setTimeout(() => {
+      router.push(`/mypage/${currentUsersUserId}`);
+      setIsLoading(false);
+    }, 1000);
   };
 
   if (authLoading) {

--- a/app/(app)/game-result/summary/[slug]/page.tsx
+++ b/app/(app)/game-result/summary/[slug]/page.tsx
@@ -293,10 +293,7 @@ export default function ResultsSummary() {
         return;
       }
     }
-    setTimeout(() => {
-      router.push(`/mypage/${currentUsersUserId}`);
-      setIsLoading(false);
-    }, 1000);
+    router.push(`/mypage/${currentUsersUserId}`);
   };
 
   if (authLoading) {


### PR DESCRIPTION
## Summary
試合結果サマリー画面の削除ハンドラで、404 を成功扱いに変更。サーバ側冪等化（buzzbase_back PR #196）の保険として実装。

## Background
モバイル Sentry [BUZZBASE-MOBILE-8](https://0dd1e9c639d9.sentry.io/issues/BUZZBASE-MOBILE-8) で観測された 404 連打ループは主にモバイル経路だが、Web 版でも同じ `deleteGameResult` を使う `app/(app)/game-result/summary/[slug]/page.tsx` で同種の問題が起き得るため、念のため対応。

## Changes
- `handleDeleteGameResult`: 404 は既に削除済みなので成功扱い → mypage に遷移
- 404 以外は従来通り loading 解除のみ

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [ ] サーバ側冪等化と合わせて動作確認（404 はそもそも来なくなる想定）

refs #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)