### PR TITLE
Add: Dependabotの設定ファイルを追加 (closes #297)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    target-branch: "stg"
+    open-pull-requests-limit: 5
+    assignees:
+      - "ippei-shimizu"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "Update"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    target-branch: "stg"
+    open-pull-requests-limit: 5
+    assignees:
+      - "ippei-shimizu"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "Update"
+      include: "scope"


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#297

## 概要

Dependabotを導入し、依存パッケージとGitHub Actionsの定期自動更新PRを毎週月曜09:00 (JST) に作成できるようにする。

## 変更内容

- \`.github/dependabot.yml\` を新規追加
  - \`npm\` ecosystem: yarn.lockの依存パッケージを weekly で更新
  - \`github-actions\` ecosystem: \`.github/workflows/\` 配下のActionを weekly で更新
- target-branch は \`stg\` に設定し、既存の \`stg → main\` リリースフローに乗せる
- コミットメッセージのプレフィックスは \`Update\` でプロジェクト規約 (\`Update: ...\`) に揃える
- ラベル \`dependencies\`、assignee \`ippei-shimizu\`、open PR上限は5件

## 確認手順

1. マージ後、リポジトリの **Insights → Dependency graph → Dependabot** タブで \`Last checked\` が表示されることを確認
2. **Check for updates** から手動トリガし、PRが \`stg\` ブランチに対して作成されることを確認
3. 生成されたPRで \`Front CI\` が起動し、lint / typecheck / test が走ることを確認

## チェックリスト

- [x] yamlの記法が正しい
- [x] target-branch が \`stg\` になっている
- [x] commit-message.prefix が規約に沿っている