### PR TITLE
Feature: 代打・代走・途中出場・未出場の出場記録UI対応

### DIFF
--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -46,19 +46,19 @@ import {
 import { getCurrentUserId, getUserData } from "@app/services/userService";
 
 // 打順の選択肢。代打・代走・途中出場・未出場のケースで「なし」を選べるよう先頭に追加。
-// id: 0 は「なし」を示し、送信時は空文字に変換する（DB に "0" を保存しないため）。
+// 「なし」は id=""（空文字）として、state（matchBattingOrder）と Select の selectedKeys を一致させる。
 const battingOrder = [
-  { id: 0, turn: "なし" },
-  { id: 1, turn: "1番" },
-  { id: 2, turn: "2番" },
-  { id: 3, turn: "3番" },
-  { id: 4, turn: "4番" },
-  { id: 5, turn: "5番" },
-  { id: 6, turn: "6番" },
-  { id: 7, turn: "7番" },
-  { id: 8, turn: "8番" },
-  { id: 9, turn: "9番" },
-  { id: 10, turn: "-" },
+  { id: "", turn: "なし" },
+  { id: "1", turn: "1番" },
+  { id: "2", turn: "2番" },
+  { id: "3", turn: "3番" },
+  { id: "4", turn: "4番" },
+  { id: "5", turn: "5番" },
+  { id: "6", turn: "6番" },
+  { id: "7", turn: "7番" },
+  { id: "8", turn: "8番" },
+  { id: "9", turn: "9番" },
+  { id: "10", turn: "-" },
 ];
 
 type Team = {
@@ -193,15 +193,9 @@ export default function GameRecord() {
         ) {
           setInningFormat(existingMatchResult.inning_format);
         }
-        if (
-          existingMatchResult.appearance_type === "starter" ||
-          existingMatchResult.appearance_type === "substitute" ||
-          existingMatchResult.appearance_type === "pinch_hitter" ||
-          existingMatchResult.appearance_type === "pinch_runner" ||
-          existingMatchResult.appearance_type === "no_play"
-        ) {
-          setAppearanceType(existingMatchResult.appearance_type);
-        }
+        // appearance_type は MatchResultsData で AppearanceType として型付けされているため
+        // ランタイムガードは不要。inning_format と同様にそのまま反映する。
+        setAppearanceType(existingMatchResult.appearance_type);
       }
     } catch (error) {
       console.error("Error fetching existing match result:", error);
@@ -339,9 +333,9 @@ export default function GameRecord() {
     setOpponentTeamScore(Number(event.target.value));
   };
 
-  // 打順。「なし」を選んだとき (id=0) は空文字を保存して未指定として扱う。
+  // 打順。「なし」は id=""（空文字）なのでそのまま state に保存する。
   const handleBattingOrderChange = (event: { target: { value: string } }) => {
-    const order = event.target.value === "0" ? "" : event.target.value;
+    const order = event.target.value;
     setExistingMatchBattingOrder(order);
     setMatchBattingOrder(order);
   };
@@ -677,19 +671,13 @@ export default function GameRecord() {
                     wrapper: "flex-wrap",
                   }}
                   onValueChange={(value) => {
-                    if (
-                      value !== "starter" &&
-                      value !== "substitute" &&
-                      value !== "pinch_hitter" &&
-                      value !== "pinch_runner" &&
-                      value !== "no_play"
-                    ) {
-                      return;
-                    }
-                    setAppearanceType(value);
+                    // RadioGroup の選択肢は APPEARANCE_TYPE_OPTIONS から生成しているため、
+                    // value は必ず AppearanceType に絞られる。
+                    const next = value as AppearanceType;
+                    setAppearanceType(next);
                     // 代打／代走／未出場 を選んだ瞬間に打順／守備位置を「なし」（空文字）に
                     // 自動セットする。先発／途中出場のときは現状の値を維持。
-                    if (value !== "starter" && value !== "substitute") {
+                    if (next !== "starter" && next !== "substitute") {
                       setMatchBattingOrder("");
                       setExistingMatchBattingOrder("");
                       setDefensivePosition("");

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -1,5 +1,10 @@
 "use client";
-import type { InningFormat, SeasonData, TournamentData } from "@app/interface";
+import type {
+  AppearanceType,
+  InningFormat,
+  SeasonData,
+  TournamentData,
+} from "@app/interface";
 import {
   Autocomplete,
   AutocompleteItem,
@@ -18,6 +23,7 @@ import ErrorMessages from "@app/components/auth/ErrorMessages";
 import HeaderResult from "@app/components/header/HeaderResult";
 import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
+import { APPEARANCE_TYPE_OPTIONS } from "@app/constants/appearanceType";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import {
   createGameResult,
@@ -39,7 +45,10 @@ import {
 } from "@app/services/tournamentsService";
 import { getCurrentUserId, getUserData } from "@app/services/userService";
 
+// 打順の選択肢。代打・代走・途中出場・未出場のケースで「なし」を選べるよう先頭に追加。
+// id: 0 は「なし」を示し、送信時は空文字に変換する（DB に "0" を保存しないため）。
 const battingOrder = [
+  { id: 0, turn: "なし" },
   { id: 1, turn: "1番" },
   { id: 2, turn: "2番" },
   { id: 3, turn: "3番" },
@@ -107,6 +116,9 @@ export default function GameRecord() {
   const [matchMemo, setMatchMemo] = useState<string | null>(null);
   // 試合のイニング制（7 or 9）。初期値は新規作成時に直近試合の値、編集時は当該試合の値で上書きされる。
   const [inningFormat, setInningFormat] = useState<InningFormat>(9);
+  // 出場区分（先発 / 代打のみ / 代走のみ）。代打のみ・代走のみは打順／守備位置を任意に。
+  const [appearanceType, setAppearanceType] =
+    useState<AppearanceType>("starter");
   const [isMatchDate, setIsMatchDate] = useState(true);
   const [isMyTeamValid, setIsMyTeamValid] = useState(true);
   const [isOpponentTeamValid, setIsOpponentTeamValid] = useState(true);
@@ -180,6 +192,15 @@ export default function GameRecord() {
           existingMatchResult.inning_format === 9
         ) {
           setInningFormat(existingMatchResult.inning_format);
+        }
+        if (
+          existingMatchResult.appearance_type === "starter" ||
+          existingMatchResult.appearance_type === "substitute" ||
+          existingMatchResult.appearance_type === "pinch_hitter" ||
+          existingMatchResult.appearance_type === "pinch_runner" ||
+          existingMatchResult.appearance_type === "no_play"
+        ) {
+          setAppearanceType(existingMatchResult.appearance_type);
         }
       }
     } catch (error) {
@@ -318,9 +339,9 @@ export default function GameRecord() {
     setOpponentTeamScore(Number(event.target.value));
   };
 
-  // 打順
+  // 打順。「なし」を選んだとき (id=0) は空文字を保存して未指定として扱う。
   const handleBattingOrderChange = (event: { target: { value: string } }) => {
-    const order = event.target.value;
+    const order = event.target.value === "0" ? "" : event.target.value;
     setExistingMatchBattingOrder(order);
     setMatchBattingOrder(order);
   };
@@ -390,7 +411,12 @@ export default function GameRecord() {
       setIsOpponentTeamScoreValid(true);
     }
 
-    if (!matchBattingOrder && !existingMatchBattingOrder) {
+    // 先発／途中出場の場合のみ打順／守備位置を必須とする。
+    // 代打／代走／未出場は入力任意（出場区分切替時に自動で空文字がセットされる）。
+    const lineupRequired =
+      appearanceType === "starter" || appearanceType === "substitute";
+
+    if (lineupRequired && !matchBattingOrder && !existingMatchBattingOrder) {
       setIsBattingOrderValid(false);
       isValid = false;
       newErrors.push("打順が未入力です。");
@@ -398,7 +424,12 @@ export default function GameRecord() {
       setIsBattingOrderValid(true);
     }
 
-    if (!defensivePosition && !myPosition && !existingDefensivePosition) {
+    if (
+      lineupRequired &&
+      !defensivePosition &&
+      !myPosition &&
+      !existingDefensivePosition
+    ) {
       setIsDefensivePositionValid(false);
       isValid = false;
       newErrors.push("守備位置が未入力です。");
@@ -513,6 +544,7 @@ export default function GameRecord() {
           tournament_id: tournamentId,
           memo: matchMemo,
           inning_format: inningFormat,
+          appearance_type: appearanceType,
         },
       };
       const existingMatchResults = await checkExistingMatchResults(
@@ -548,7 +580,12 @@ export default function GameRecord() {
           );
         }
       }
-      router.push(`/game-result/batting/`);
+      // 未出場の場合は打撃・投手成績の入力をスキップして試合結果まとめへ。
+      const nextPath =
+        appearanceType === "no_play"
+          ? `/game-result/summary/`
+          : `/game-result/batting/`;
+      router.push(nextPath);
     } catch (error) {
       throw error;
     }
@@ -623,6 +660,49 @@ export default function GameRecord() {
                 >
                   <Radio value="9">9回制</Radio>
                   <Radio value="7">7回制</Radio>
+                </RadioGroup>
+                <Divider className="my-4" />
+                {/* 出場区分は選択肢が5つあるためラジオ側は折り返しを許可し、
+                    ラベル＋必須マーク部分は shrink-0 で縮まないようにする。 */}
+                <RadioGroup
+                  isRequired
+                  label="出場区分"
+                  orientation="horizontal"
+                  value={appearanceType}
+                  color="primary"
+                  size="sm"
+                  className="text-sm flex justify-between items-center flex-row [&>span]:text-white"
+                  classNames={{
+                    label: "shrink-0 whitespace-nowrap",
+                    wrapper: "flex-wrap",
+                  }}
+                  onValueChange={(value) => {
+                    if (
+                      value !== "starter" &&
+                      value !== "substitute" &&
+                      value !== "pinch_hitter" &&
+                      value !== "pinch_runner" &&
+                      value !== "no_play"
+                    ) {
+                      return;
+                    }
+                    setAppearanceType(value);
+                    // 代打／代走／未出場 を選んだ瞬間に打順／守備位置を「なし」（空文字）に
+                    // 自動セットする。先発／途中出場のときは現状の値を維持。
+                    if (value !== "starter" && value !== "substitute") {
+                      setMatchBattingOrder("");
+                      setExistingMatchBattingOrder("");
+                      setDefensivePosition("");
+                      setExistingDefensivePosition("");
+                      setMyPosition("");
+                    }
+                  }}
+                >
+                  {APPEARANCE_TYPE_OPTIONS.map((opt) => (
+                    <Radio key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </Radio>
+                  ))}
                 </RadioGroup>
                 <Divider className="my-4" />
                 <Autocomplete
@@ -752,14 +832,17 @@ export default function GameRecord() {
                 </div>
                 <Divider className="my-4" />
                 <Select
-                  isRequired
+                  isRequired={
+                    appearanceType === "starter" ||
+                    appearanceType === "substitute"
+                  }
                   variant="faded"
                   label="打順"
                   labelPlacement="outside-left"
                   size="md"
                   fullWidth={false}
                   color={isBattingOrderValid ? "default" : "danger"}
-                  className="grid justify-between items-center grid-cols-[auto_78px]"
+                  className="grid justify-between items-center grid-cols-[auto_96px]"
                   onChange={handleBattingOrderChange}
                   selectedKeys={
                     existingMatchBattingOrder !== undefined
@@ -775,7 +858,10 @@ export default function GameRecord() {
                 </Select>
                 <Divider className="my-4" />
                 <Select
-                  isRequired
+                  isRequired={
+                    appearanceType === "starter" ||
+                    appearanceType === "substitute"
+                  }
                   variant="faded"
                   label="守備位置"
                   labelPlacement="outside-left"
@@ -791,15 +877,20 @@ export default function GameRecord() {
                       : myPosition
                   }
                 >
-                  {positionData.map((position) => (
-                    <SelectItem
-                      key={position.id}
-                      textValue={position.name}
-                      className="text-white"
-                    >
-                      {position.name}
-                    </SelectItem>
-                  ))}
+                  {[
+                    <SelectItem key="" textValue="なし" className="text-white">
+                      なし
+                    </SelectItem>,
+                    ...positionData.map((position) => (
+                      <SelectItem
+                        key={position.id}
+                        textValue={position.name}
+                        className="text-white"
+                      >
+                        {position.name}
+                      </SelectItem>
+                    )),
+                  ]}
                 </Select>
                 <Divider className="my-4" />
                 <Textarea
@@ -823,7 +914,7 @@ export default function GameRecord() {
                   endContent={<NextArrowIcon stroke="#F4F4F4" />}
                   isDisabled={isSubmitting}
                 >
-                  打撃結果
+                  {appearanceType === "no_play" ? "試合結果まとめ" : "打撃結果"}
                 </Button>
               </div>
             </form>

--- a/app/(app)/game-result/summary/[slug]/page.tsx
+++ b/app/(app)/game-result/summary/[slug]/page.tsx
@@ -26,6 +26,7 @@ import HeaderGameDetail from "@app/components/header/HeaderGameDetail";
 import SummaryResultHeader from "@app/components/header/SummaryHeader";
 import ResultShareComponent from "@app/components/share/ResultShareComponent";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
+import { getAppearanceTypeBadgeLabel } from "@app/constants/appearanceType";
 import { useAuthContext } from "@app/contexts/useAuthContext";
 import { getUserBattingAverage } from "@app/services/battingAveragesService";
 import { deleteGameResult } from "@app/services/gameResultsService";
@@ -347,7 +348,7 @@ export default function ResultsSummary() {
               {matchResult ? (
                 matchResult.map((match: MatchResultDisplay) => (
                   <div key={match.id}>
-                    <div className="flex items-center gap-x-2">
+                    <div className="flex items-center gap-x-2 flex-wrap">
                       <Chip
                         variant="faded"
                         classNames={{
@@ -361,6 +362,22 @@ export default function ResultsSummary() {
                             ? "オープン戦"
                             : ""}
                       </Chip>
+                      {(() => {
+                        const badge = getAppearanceTypeBadgeLabel(
+                          match.appearance_type,
+                        );
+                        return badge ? (
+                          <Chip
+                            variant="faded"
+                            classNames={{
+                              base: "border-small border-zic-500 px-2",
+                              content: "text-blue-300 text-xs",
+                            }}
+                          >
+                            {badge}
+                          </Chip>
+                        ) : null;
+                      })()}
                       <p className="text-sm font-normal">
                         {new Date(match.date_and_time).toLocaleDateString()}
                       </p>

--- a/app/(app)/game-result/summary/[slug]/page.tsx
+++ b/app/(app)/game-result/summary/[slug]/page.tsx
@@ -22,11 +22,11 @@ import { useEffect, useState } from "react";
 import { adSlots } from "@app/components/ad/adConfig";
 import AdInFeed from "@app/components/ad/AdInFeed";
 import AuthRequiredOverlay from "@app/components/auth/AuthRequiredOverlay";
+import AppearanceTypeBadge from "@app/components/chip/AppearanceTypeBadge";
 import HeaderGameDetail from "@app/components/header/HeaderGameDetail";
 import SummaryResultHeader from "@app/components/header/SummaryHeader";
 import ResultShareComponent from "@app/components/share/ResultShareComponent";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
-import { getAppearanceTypeBadgeLabel } from "@app/constants/appearanceType";
 import { useAuthContext } from "@app/contexts/useAuthContext";
 import { getUserBattingAverage } from "@app/services/battingAveragesService";
 import { deleteGameResult } from "@app/services/gameResultsService";
@@ -362,22 +362,9 @@ export default function ResultsSummary() {
                             ? "オープン戦"
                             : ""}
                       </Chip>
-                      {(() => {
-                        const badge = getAppearanceTypeBadgeLabel(
-                          match.appearance_type,
-                        );
-                        return badge ? (
-                          <Chip
-                            variant="faded"
-                            classNames={{
-                              base: "border-small border-zic-500 px-2",
-                              content: "text-blue-300 text-xs",
-                            }}
-                          >
-                            {badge}
-                          </Chip>
-                        ) : null;
-                      })()}
+                      <AppearanceTypeBadge
+                        appearanceType={match.appearance_type}
+                      />
                       <p className="text-sm font-normal">
                         {new Date(match.date_and_time).toLocaleDateString()}
                       </p>

--- a/app/(app)/game-result/summary/page.tsx
+++ b/app/(app)/game-result/summary/page.tsx
@@ -13,6 +13,7 @@ import { adSlots } from "@app/components/ad/adConfig";
 import AdInFeed from "@app/components/ad/AdInFeed";
 import SummaryResultHeader from "@app/components/header/SummaryHeader";
 import ResultShareComponent from "@app/components/share/ResultShareComponent";
+import { getAppearanceTypeBadgeLabel } from "@app/constants/appearanceType";
 import { getCurrentBattingAverage } from "@app/services/battingAveragesService";
 import { getCurrentMatchResult } from "@app/services/matchResultsService";
 import { getCurrentPitchingResult } from "@app/services/pitchingResultsService";
@@ -281,7 +282,7 @@ export default function ResultsSummary() {
               {matchResult ? (
                 matchResult.map((match: MatchResultDisplay) => (
                   <div key={match.id}>
-                    <div className="flex items-center gap-x-2">
+                    <div className="flex items-center gap-x-2 flex-wrap">
                       <Chip
                         variant="faded"
                         classNames={{
@@ -295,6 +296,22 @@ export default function ResultsSummary() {
                             ? "オープン戦"
                             : ""}
                       </Chip>
+                      {(() => {
+                        const badge = getAppearanceTypeBadgeLabel(
+                          match.appearance_type,
+                        );
+                        return badge ? (
+                          <Chip
+                            variant="faded"
+                            classNames={{
+                              base: "border-small border-zic-500 px-2",
+                              content: "text-blue-300 text-xs",
+                            }}
+                          >
+                            {badge}
+                          </Chip>
+                        ) : null;
+                      })()}
                       <p className="text-sm font-normal">
                         {new Date(match.date_and_time).toLocaleDateString()}
                       </p>

--- a/app/(app)/game-result/summary/page.tsx
+++ b/app/(app)/game-result/summary/page.tsx
@@ -11,9 +11,9 @@ import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { adSlots } from "@app/components/ad/adConfig";
 import AdInFeed from "@app/components/ad/AdInFeed";
+import AppearanceTypeBadge from "@app/components/chip/AppearanceTypeBadge";
 import SummaryResultHeader from "@app/components/header/SummaryHeader";
 import ResultShareComponent from "@app/components/share/ResultShareComponent";
-import { getAppearanceTypeBadgeLabel } from "@app/constants/appearanceType";
 import { getCurrentBattingAverage } from "@app/services/battingAveragesService";
 import { getCurrentMatchResult } from "@app/services/matchResultsService";
 import { getCurrentPitchingResult } from "@app/services/pitchingResultsService";
@@ -296,22 +296,9 @@ export default function ResultsSummary() {
                             ? "オープン戦"
                             : ""}
                       </Chip>
-                      {(() => {
-                        const badge = getAppearanceTypeBadgeLabel(
-                          match.appearance_type,
-                        );
-                        return badge ? (
-                          <Chip
-                            variant="faded"
-                            classNames={{
-                              base: "border-small border-zic-500 px-2",
-                              content: "text-blue-300 text-xs",
-                            }}
-                          >
-                            {badge}
-                          </Chip>
-                        ) : null;
-                      })()}
+                      <AppearanceTypeBadge
+                        appearanceType={match.appearance_type}
+                      />
                       <p className="text-sm font-normal">
                         {new Date(match.date_and_time).toLocaleDateString()}
                       </p>

--- a/app/components/chip/AppearanceTypeBadge.tsx
+++ b/app/components/chip/AppearanceTypeBadge.tsx
@@ -1,0 +1,25 @@
+import type { AppearanceType } from "@app/interface";
+import { Chip } from "@heroui/react";
+import { getAppearanceTypeBadgeLabel } from "@app/constants/appearanceType";
+
+// 試合一覧・サマリー・詳細で先発以外の出場区分（代打・代走・途中出場）を強調表示するバッジ。
+// 強調対象でないとき（先発・未出場・未指定）は何もレンダリングしない。
+export default function AppearanceTypeBadge({
+  appearanceType,
+}: {
+  appearanceType?: AppearanceType | null;
+}) {
+  const label = getAppearanceTypeBadgeLabel(appearanceType);
+  if (!label) return null;
+  return (
+    <Chip
+      variant="faded"
+      classNames={{
+        base: "border-small border-zinc-500 px-2",
+        content: "text-blue-300 text-xs",
+      }}
+    >
+      {label}
+    </Chip>
+  );
+}

--- a/app/components/listItem/MatchResultsItem.tsx
+++ b/app/components/listItem/MatchResultsItem.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { AppearanceType } from "@app/interface";
 import {
   Button,
   Card,
@@ -9,6 +10,7 @@ import {
   Divider,
 } from "@heroui/react";
 import { useRouter } from "next/navigation";
+import { getAppearanceTypeBadgeLabel } from "@app/constants/appearanceType";
 
 type GameResultItem = {
   game_result_id: number;
@@ -22,6 +24,7 @@ type GameResultItem = {
     tournament_name?: string;
     my_team_score: number;
     opponent_team_score: number;
+    appearance_type?: AppearanceType;
   };
   plate_appearances?: PlateAppearance[];
   pitching_result?: {
@@ -163,7 +166,7 @@ export default function MatchResultsItem(props: MatchResultsItemProps) {
               詳細
             </Button>
             <CardHeader className="p-0 flex-col items-start">
-              <div className="flex items-center gap-x-2">
+              <div className="flex items-center gap-x-2 flex-wrap">
                 {game.match_result?.match_type ? (
                   <>
                     <Chip
@@ -179,6 +182,22 @@ export default function MatchResultsItem(props: MatchResultsItemProps) {
                           ? "オープン戦"
                           : ""}
                     </Chip>
+                    {(() => {
+                      const badge = getAppearanceTypeBadgeLabel(
+                        game.match_result.appearance_type,
+                      );
+                      return badge ? (
+                        <Chip
+                          variant="faded"
+                          classNames={{
+                            base: "border-small border-zic-500 px-2",
+                            content: "text-blue-300 text-xs",
+                          }}
+                        >
+                          {badge}
+                        </Chip>
+                      ) : null;
+                    })()}
                     <p className="text-sm font-normal text-zinc-400">
                       {new Date(
                         game.match_result.date_and_time,

--- a/app/components/listItem/MatchResultsItem.tsx
+++ b/app/components/listItem/MatchResultsItem.tsx
@@ -10,7 +10,7 @@ import {
   Divider,
 } from "@heroui/react";
 import { useRouter } from "next/navigation";
-import { getAppearanceTypeBadgeLabel } from "@app/constants/appearanceType";
+import AppearanceTypeBadge from "@app/components/chip/AppearanceTypeBadge";
 
 type GameResultItem = {
   game_result_id: number;
@@ -182,22 +182,9 @@ export default function MatchResultsItem(props: MatchResultsItemProps) {
                           ? "オープン戦"
                           : ""}
                     </Chip>
-                    {(() => {
-                      const badge = getAppearanceTypeBadgeLabel(
-                        game.match_result.appearance_type,
-                      );
-                      return badge ? (
-                        <Chip
-                          variant="faded"
-                          classNames={{
-                            base: "border-small border-zic-500 px-2",
-                            content: "text-blue-300 text-xs",
-                          }}
-                        >
-                          {badge}
-                        </Chip>
-                      ) : null;
-                    })()}
+                    <AppearanceTypeBadge
+                      appearanceType={game.match_result.appearance_type}
+                    />
                     <p className="text-sm font-normal text-zinc-400">
                       {new Date(
                         game.match_result.date_and_time,

--- a/app/constants/appearanceType.ts
+++ b/app/constants/appearanceType.ts
@@ -1,0 +1,44 @@
+import type { AppearanceType } from "@app/interface";
+
+// 試合の出場区分（先発 / 途中出場 / 代打 / 代走 / 未出場）の表示ラベル単一ソース。
+// フォーム選択肢や試合一覧バッジ等で参照する。
+
+export const APPEARANCE_TYPE_LABELS: Readonly<Record<AppearanceType, string>> =
+  {
+    starter: "先発",
+    substitute: "途中出場",
+    pinch_hitter: "代打",
+    pinch_runner: "代走",
+    no_play: "未出場",
+  };
+
+export const APPEARANCE_TYPE_OPTIONS: ReadonlyArray<{
+  value: AppearanceType;
+  label: string;
+}> = [
+  { value: "starter", label: APPEARANCE_TYPE_LABELS.starter },
+  { value: "substitute", label: APPEARANCE_TYPE_LABELS.substitute },
+  { value: "pinch_hitter", label: APPEARANCE_TYPE_LABELS.pinch_hitter },
+  { value: "pinch_runner", label: APPEARANCE_TYPE_LABELS.pinch_runner },
+  { value: "no_play", label: APPEARANCE_TYPE_LABELS.no_play },
+];
+
+// 試合一覧・詳細・サマリーで強調表示したい出場区分（先発以外の出場系）。
+// "未出場" はバッジを出さない方針（試合に出ていないので試合バッジとして強調する意味が薄い）。
+const HIGHLIGHTED_APPEARANCE_TYPES: ReadonlyArray<AppearanceType> = [
+  "substitute",
+  "pinch_hitter",
+  "pinch_runner",
+];
+
+/**
+ * 試合一覧 / 詳細 / サマリーでバッジ表示すべき場合のラベルを返す。
+ * 強調対象でない（先発・未出場・未指定）場合は null を返す。
+ */
+export const getAppearanceTypeBadgeLabel = (
+  appearanceType?: AppearanceType | null,
+): string | null => {
+  if (!appearanceType) return null;
+  if (!HIGHLIGHTED_APPEARANCE_TYPES.includes(appearanceType)) return null;
+  return APPEARANCE_TYPE_LABELS[appearanceType];
+};

--- a/app/interface/index.ts
+++ b/app/interface/index.ts
@@ -221,10 +221,17 @@ export interface MatchResultsData {
     tournament_id: number | null;
     memo: string | null;
     inning_format: InningFormat;
+    appearance_type: AppearanceType;
   };
 }
 
 export type InningFormat = 7 | 9;
+export type AppearanceType =
+  | "starter"
+  | "substitute"
+  | "pinch_hitter"
+  | "pinch_runner"
+  | "no_play";
 
 export interface BattingAverageData {
   batting_average: {
@@ -276,6 +283,7 @@ export interface MatchResult {
   opponent_team_name: string;
   my_team_score: number;
   opponent_team_score: number;
+  appearance_type?: AppearanceType;
 }
 
 export interface BattingAverage {


### PR DESCRIPTION
## issue
close #304

## 実装概要
試合作成・編集フォームに「出場区分」セレクタ（先発／途中出場／代打／代走／未出場）を追加。先発／途中出場のときだけ打順／守備位置を必須にし、それ以外を選んだ瞬間に打順／守備位置を「なし」へ自動セット。未出場時は打撃・投手成績の入力をスキップして試合結果まとめへ直接遷移。試合一覧・サマリー・詳細では先発以外の出場区分を青色バッジで表示。

## 背景
バックエンドで `match_results.appearance_type` が追加されたことに対応。代打・代走のみで出場した試合や、途中出場、未出場（試合記録のみ）も Web 側で記録できるようにする。

## やらなかったこと
- 試合一覧の絞り込み条件に出場区分を追加（別途検討）
- 出場区分別のレーダーチャート／集計グラフ

## 受入基準
- [x] 試合作成フォームに出場区分ラジオを追加（先発・途中出場・代打・代走・未出場）
- [x] 先発／途中出場のときだけ打順／守備位置が必須（必須マーク＋バリデーション）
- [x] 代打／代走／未出場を選択した瞬間に打順／守備位置を「なし」（空文字）に自動セット
- [x] 打順 Select の選択肢先頭に「なし」を追加
- [x] 守備位置 Select の選択肢先頭に「なし」を追加
- [x] 未出場のとき送信ボタンが「試合結果まとめ」に変わり、保存後に `/game-result/summary/` に直接遷移
- [x] 試合一覧／サマリー／詳細に出場区分バッジ（代打・代走・途中出場のみ）
- [x] フォームの並び順を 試合種類 → イニング制 → 出場区分 に統一
- [x] yarn typecheck / lint / test 全パス

## 実装詳細
- `app/interface/index.ts`: `AppearanceType` 型と `MatchResult.appearance_type` を追加
- `app/constants/appearanceType.ts` (新規): ラベル定数 + バッジ表示判定 `getAppearanceTypeBadgeLabel`
- `app/(app)/game-result/record/page.tsx`: 出場区分ラジオ、必須切替、自動「なし」化、未出場スキップ、ボタンラベル切替、打順 Select 幅 96px
- `app/components/listItem/MatchResultsItem.tsx`: 一覧アイテムに出場区分バッジ
- `app/(app)/game-result/summary/page.tsx`: 試合まとめ画面にバッジ
- `app/(app)/game-result/summary/[slug]/page.tsx`: 試合詳細画面にバッジ

## スクリーンショット
（出場区分ラジオ・バッジ表示・未出場スキップ動作）

## 確認手順
1. `/game-result/record` で出場区分「先発」を選択 → 打順・守備位置が必須
2. 「代打」を選択 → 打順・守備位置が「なし」に自動セット、必須マーク非表示
3. 「未出場」を選択 → ボタンが「試合結果まとめ」、保存後に `/game-result/summary/` に直接遷移
4. 試合一覧で代打・代走・途中出場の試合に青色バッジが表示される
5. 試合詳細・サマリーでも同様にバッジ表示

## 影響範囲
- 試合作成・編集フォーム
- 試合一覧／詳細／まとめ画面
- 既存試合（appearance_type 未指定 → バックエンドが `'starter'` でフォールバック）は挙動変化なし

## コード上の懸念点
- Web の summary 画面では未出場時にも打撃・投手セクションを「成績はありません」と表示。Mobile では完全非表示にしているが本対応では Web 側を据え置き

## その他
特になし