### PR TITLE
Add: Pro Gate / Paywall コンポーネント (#317)

### DIFF
--- a/app/(app)/pro/actions.ts
+++ b/app/(app)/pro/actions.ts
@@ -1,0 +1,108 @@
+"use server";
+
+import type {
+  EntitlementCheck,
+  EntitlementsResponse,
+  ProStatus,
+} from "../../types/pro";
+import { cookies } from "next/headers";
+import { captureServerActionError } from "../../../lib/sentry-helpers";
+import { RAILS_API_URL } from "../../constants/api";
+
+async function getAuthHeaders(): Promise<Record<string, string> | null> {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("access-token")?.value;
+  const client = cookieStore.get("client")?.value;
+  const uid = cookieStore.get("uid")?.value;
+
+  if (!accessToken || !client || !uid) return null;
+
+  return {
+    "Content-Type": "application/json",
+    "access-token": accessToken,
+    client,
+    uid,
+  };
+}
+
+/**
+ * 現在ユーザーの Pro 加入状態と保有 entitlement を取得する。
+ * 未認証・API 失敗時は null を返す。UI 側で DEFAULT_PRO_STATUS にフォールバックする想定。
+ */
+export async function getProStatus(): Promise<ProStatus | null> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return null;
+
+    const response = await fetch(`${RAILS_API_URL}/api/v1/pro/status`, {
+      method: "GET",
+      headers,
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      console.error("Pro status API error:", response.status);
+      return null;
+    }
+
+    return (await response.json()) as ProStatus;
+  } catch (error) {
+    captureServerActionError(error, { action: "getProStatus" });
+    return null;
+  }
+}
+
+/**
+ * 全 entitlement キーごとの granted フラグを取得する。
+ * 個別画面で「この機能が利用可能か」のチェックリスト的に使う。
+ */
+export async function getEntitlements(): Promise<EntitlementCheck[] | null> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return null;
+
+    const response = await fetch(`${RAILS_API_URL}/api/v1/pro/entitlements`, {
+      method: "GET",
+      headers,
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      console.error("Pro entitlements API error:", response.status);
+      return null;
+    }
+
+    const body = (await response.json()) as EntitlementsResponse;
+    return body.entitlements;
+  } catch (error) {
+    captureServerActionError(error, { action: "getEntitlements" });
+    return null;
+  }
+}
+
+/**
+ * RevenueCat と Rails の Pro 状態を再同期する。
+ * 本Issueはスタブで last_synced_at の更新のみ。実同期ロジックは #318 で実装する。
+ */
+export async function syncProStatus(): Promise<ProStatus | null> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return null;
+
+    const response = await fetch(`${RAILS_API_URL}/api/v1/pro/sync`, {
+      method: "POST",
+      headers,
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      console.error("Pro sync API error:", response.status);
+      return null;
+    }
+
+    return (await response.json()) as ProStatus;
+  } catch (error) {
+    captureServerActionError(error, { action: "syncProStatus" });
+    return null;
+  }
+}

--- a/app/(app)/pro/actions.ts
+++ b/app/(app)/pro/actions.ts
@@ -89,10 +89,10 @@ export async function syncProStatus(): Promise<ProStatus | null> {
     const headers = await getAuthHeaders();
     if (!headers) return null;
 
+    // POST はそもそも Next.js のフェッチキャッシュ対象外。cache: "no-store" は不要。
     const response = await fetch(`${RAILS_API_URL}/api/v1/pro/sync`, {
       method: "POST",
       headers,
-      cache: "no-store",
     });
 
     if (!response.ok) {

--- a/app/components/pro/PaywallModal.tsx
+++ b/app/components/pro/PaywallModal.tsx
@@ -9,7 +9,7 @@ import {
   ModalHeader,
   Button,
 } from "@heroui/react";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 interface PaywallCopy {
   title: string;
@@ -96,14 +96,8 @@ export default function PaywallModal({
   onClose,
   feature,
 }: PaywallModalProps) {
-  const router = useRouter();
   const copy =
     (PRO_PAYWALL_COPY as Record<string, PaywallCopy>)[feature] ?? DEFAULT_COPY;
-
-  const handleUpgrade = () => {
-    onClose();
-    router.push("/pro");
-  };
 
   return (
     <Modal
@@ -128,7 +122,8 @@ export default function PaywallModal({
           >
             閉じる
           </Button>
-          <Button color="primary" onPress={handleUpgrade}>
+          {/* Link を Button の中身として使うことで、Next.js の prefetch を効かせる。 */}
+          <Button color="primary" as={Link} href="/pro" onPress={onClose}>
             Pro プランを見る
           </Button>
         </ModalFooter>

--- a/app/components/pro/PaywallModal.tsx
+++ b/app/components/pro/PaywallModal.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import type { Feature, ProFeature } from "@app/types/pro";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Button,
+} from "@heroui/react";
+import { useRouter } from "next/navigation";
+
+interface PaywallCopy {
+  title: string;
+  description: string;
+}
+
+// Pro 機能ごとの paywall コピー。各機能 Issue で文言を最終調整する想定。
+const PRO_PAYWALL_COPY: Record<ProFeature, PaywallCopy> = {
+  no_ads: {
+    title: "広告を非表示にして集中する",
+    description:
+      "Pro プランに加入すると、アプリ内のすべての広告が非表示になります。",
+  },
+  season_transition_graph: {
+    title: "シーズンを跨いだ成長を可視化",
+    description:
+      "過去複数シーズンの成績を折れ線グラフで比較して、長期的な成長を確認できます。",
+  },
+  grass_full_history: {
+    title: "練習履歴を全期間で確認",
+    description:
+      "草機能のヒートマップを全期間で表示。継続の積み重ねを実感できます。",
+  },
+  unlimited_practice_menus: {
+    title: "練習メニューを無制限に登録",
+    description:
+      "Pro プランなら4つ目以降の練習メニューも自由に登録・編集できます。",
+  },
+  unlimited_media_uploads: {
+    title: "動画・画像を無制限にアップロード",
+    description: "月3点までの制限を撤廃。練習映像をいくらでも保存できます。",
+  },
+  media_long_term_storage: {
+    title: "動画・画像を長期保管",
+    description: "31日以上前にアップロードしたメディアもいつでも閲覧可能です。",
+  },
+  unlimited_schedules: {
+    title: "自主練スケジュールを無制限に作成",
+    description: "複数のメニューを並行管理して、計画的に練習できます。",
+  },
+  unlimited_monthly_goals: {
+    title: "月次目標を複数管理",
+    description: "打撃・投手・走塁など複数の目標を同時に追跡できます。",
+  },
+  season_goals: {
+    title: "シーズン目標を設定",
+    description:
+      "1シーズンを通した中長期目標を設定し、月次目標と紐づけて追跡できます。",
+  },
+  custom_notification_messages: {
+    title: "通知メッセージをカスタマイズ",
+    description: "練習リマインドや目標達成通知の文言を自分好みに編集できます。",
+  },
+  advanced_goal_tracking: {
+    title: "目標達成度を詳細に追跡",
+    description:
+      "達成率の推移グラフや改善ポイントの提示で、目標到達を後押しします。",
+  },
+  detailed_condition_log: {
+    title: "コンディションを詳しく記録",
+    description:
+      "体調・気分・睡眠などを細かく記録し、調子の良し悪しの傾向を把握できます。",
+  },
+};
+
+const DEFAULT_COPY: PaywallCopy = {
+  title: "Pro 加入で BUZZ BASE をフル活用",
+  description: "Pro プランで全機能のロックを解除できます。",
+};
+
+interface PaywallModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  feature: Feature;
+}
+
+/**
+ * Pro 機能への加入を促すモーダル。
+ * Pro 機能の feature を渡すと、その機能に最適化された訴求コピーを表示する。
+ * 無料機能を誤って渡された場合は汎用コピーで表示する。
+ */
+export default function PaywallModal({
+  isOpen,
+  onClose,
+  feature,
+}: PaywallModalProps) {
+  const router = useRouter();
+  const copy =
+    (PRO_PAYWALL_COPY as Record<string, PaywallCopy>)[feature] ?? DEFAULT_COPY;
+
+  const handleUpgrade = () => {
+    onClose();
+    router.push("/pro");
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      placement="center"
+      className="buzz-dark"
+    >
+      <ModalContent>
+        <ModalHeader className="flex flex-col gap-1 text-white">
+          {copy.title}
+        </ModalHeader>
+        <ModalBody>
+          <p className="text-sm text-gray-200">{copy.description}</p>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            color="default"
+            variant="light"
+            onPress={onClose}
+            className="text-white"
+          >
+            閉じる
+          </Button>
+          <Button color="primary" onPress={handleUpgrade}>
+            Pro プランを見る
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/app/components/pro/ProGate.tsx
+++ b/app/components/pro/ProGate.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import type { Feature } from "@app/types/pro";
+import { useState, type ReactNode } from "react";
+import PaywallModal from "@app/components/pro/PaywallModal";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+
+interface ProGateProps {
+  feature: Feature;
+  children: ReactNode;
+  /**
+   * Pro 未加入時に children の代わりに表示するノード。
+   * 未指定の場合は何も表示せず、locked ハンドラを呼んだタイミングで Paywall が開く想定。
+   */
+  fallback?: ReactNode;
+  /**
+   * fallback と Paywall モーダル両方を有効化する場合のラッパー。
+   * 「タップ時に Paywall を開く」UX を提供するために使う。
+   * 未指定の場合、fallback がそのまま表示されるだけ。
+   */
+  renderLockedTrigger?: (open: () => void) => ReactNode;
+}
+
+/**
+ * Pro 機能をラップし、Pro 加入時のみ children を表示する。
+ * 未加入時は fallback or 何も表示しない、もしくは renderLockedTrigger 経由で
+ * クリックすると PaywallModal が立ち上がる構造を提供する。
+ */
+export default function ProGate({
+  feature,
+  children,
+  fallback,
+  renderLockedTrigger,
+}: ProGateProps) {
+  const { hasEntitlement } = useEntitlement();
+  const [isPaywallOpen, setPaywallOpen] = useState(false);
+
+  if (hasEntitlement(feature)) return <>{children}</>;
+
+  return (
+    <>
+      {renderLockedTrigger
+        ? renderLockedTrigger(() => setPaywallOpen(true))
+        : (fallback ?? null)}
+      <PaywallModal
+        isOpen={isPaywallOpen}
+        onClose={() => setPaywallOpen(false)}
+        feature={feature}
+      />
+    </>
+  );
+}

--- a/app/components/pro/ProGate.tsx
+++ b/app/components/pro/ProGate.tsx
@@ -9,22 +9,20 @@ interface ProGateProps {
   feature: Feature;
   children: ReactNode;
   /**
-   * Pro 未加入時に children の代わりに表示するノード。
-   * 未指定の場合は何も表示せず、locked ハンドラを呼んだタイミングで Paywall が開く想定。
+   * Pro 未加入時に children の代わりに表示する静的ノード。
+   * renderLockedTrigger と排他で使う想定（同時指定なら renderLockedTrigger を優先）。
    */
   fallback?: ReactNode;
   /**
-   * fallback と Paywall モーダル両方を有効化する場合のラッパー。
-   * 「タップ時に Paywall を開く」UX を提供するために使う。
-   * 未指定の場合、fallback がそのまま表示されるだけ。
+   * タップで PaywallModal を開けるロックトリガーをレンダリングする関数。
+   * 指定された場合のみ PaywallModal を DOM 上に用意する。
    */
   renderLockedTrigger?: (open: () => void) => ReactNode;
 }
 
 /**
- * Pro 機能をラップし、Pro 加入時のみ children を表示する。
- * 未加入時は fallback or 何も表示しない、もしくは renderLockedTrigger 経由で
- * クリックすると PaywallModal が立ち上がる構造を提供する。
+ * Pro 機能をラップし、entitlement を持つときのみ children を表示する。
+ * 未許可時の代替表示は renderLockedTrigger / fallback / なし の3パターン。
  */
 export default function ProGate({
   feature,
@@ -37,16 +35,18 @@ export default function ProGate({
 
   if (hasEntitlement(feature)) return <>{children}</>;
 
-  return (
-    <>
-      {renderLockedTrigger
-        ? renderLockedTrigger(() => setPaywallOpen(true))
-        : (fallback ?? null)}
-      <PaywallModal
-        isOpen={isPaywallOpen}
-        onClose={() => setPaywallOpen(false)}
-        feature={feature}
-      />
-    </>
-  );
+  if (renderLockedTrigger) {
+    return (
+      <>
+        {renderLockedTrigger(() => setPaywallOpen(true))}
+        <PaywallModal
+          isOpen={isPaywallOpen}
+          onClose={() => setPaywallOpen(false)}
+          feature={feature}
+        />
+      </>
+    );
+  }
+
+  return <>{fallback ?? null}</>;
 }

--- a/app/components/pro/ProStatusProvider.tsx
+++ b/app/components/pro/ProStatusProvider.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useMemo,
+  useState,
+  useTransition,
+  type ReactNode,
+} from "react";
+import { getProStatus } from "@app/(app)/pro/actions";
+import { DEFAULT_PRO_STATUS, type ProStatus } from "@app/types/pro";
+
+interface ProStatusContextValue {
+  proStatus: ProStatus;
+  isRefreshing: boolean;
+  refresh: () => void;
+}
+
+export const ProStatusContext = createContext<ProStatusContextValue | null>(
+  null,
+);
+
+interface ProStatusProviderProps {
+  initialValue: ProStatus | null;
+  children: ReactNode;
+}
+
+/**
+ * Pro 状態をアプリ配下に配布する Context Provider。
+ * Server Component で getProStatus() の戻り値を initialValue として渡し、
+ * クライアント側では refresh() でサーバーアクションを再実行できる。
+ * initialValue が null（未認証や API 失敗）なら無料状態として扱う。
+ */
+export function ProStatusProvider({
+  initialValue,
+  children,
+}: ProStatusProviderProps) {
+  const [proStatus, setProStatus] = useState<ProStatus>(
+    initialValue ?? DEFAULT_PRO_STATUS,
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const refresh = useCallback(() => {
+    startTransition(async () => {
+      const next = await getProStatus();
+      if (next) setProStatus(next);
+    });
+  }, []);
+
+  const value = useMemo<ProStatusContextValue>(
+    () => ({ proStatus, isRefreshing: isPending, refresh }),
+    [proStatus, isPending, refresh],
+  );
+
+  return (
+    <ProStatusContext.Provider value={value}>
+      {children}
+    </ProStatusContext.Provider>
+  );
+}

--- a/app/components/pro/__tests__/PaywallModal.test.tsx
+++ b/app/components/pro/__tests__/PaywallModal.test.tsx
@@ -1,27 +1,11 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { useRouter } from "next/navigation";
 import PaywallModal from "../PaywallModal";
 
-jest.mock("next/navigation", () => ({
-  useRouter: jest.fn(),
-}));
-
-const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
-
 describe("PaywallModal", () => {
-  const mockPush = jest.fn();
   const mockOnClose = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseRouter.mockReturnValue({
-      push: mockPush,
-      replace: jest.fn(),
-      refresh: jest.fn(),
-      back: jest.fn(),
-      forward: jest.fn(),
-      prefetch: jest.fn(),
-    });
   });
 
   it("Pro 機能を渡すと、その機能に対応したコピーが表示される", () => {
@@ -64,13 +48,16 @@ describe("PaywallModal", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("「Pro プランを見る」ボタンで /pro へ遷移し onClose も呼ばれる", () => {
+  it("「Pro プランを見る」ボタンが /pro への Link になっていて、押下で onClose が呼ばれる", () => {
     render(<PaywallModal isOpen onClose={mockOnClose} feature="no_ads" />);
 
-    fireEvent.click(screen.getByText("Pro プランを見る"));
+    // HeroUI の Button は as={Link} を渡しても role=button のままで、
+    // 内部要素が <a href> を持つ。href の検証は closest("a") で行う。
+    const upgradeButton = screen.getByText("Pro プランを見る");
+    expect(upgradeButton.closest("a")).toHaveAttribute("href", "/pro");
 
+    fireEvent.click(upgradeButton);
     expect(mockOnClose).toHaveBeenCalledTimes(1);
-    expect(mockPush).toHaveBeenCalledWith("/pro");
   });
 
   it("「閉じる」ボタンで onClose が呼ばれる", () => {

--- a/app/components/pro/__tests__/PaywallModal.test.tsx
+++ b/app/components/pro/__tests__/PaywallModal.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useRouter } from "next/navigation";
+import PaywallModal from "../PaywallModal";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+
+describe("PaywallModal", () => {
+  const mockPush = jest.fn();
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRouter.mockReturnValue({
+      push: mockPush,
+      replace: jest.fn(),
+      refresh: jest.fn(),
+      back: jest.fn(),
+      forward: jest.fn(),
+      prefetch: jest.fn(),
+    });
+  });
+
+  it("Pro 機能を渡すと、その機能に対応したコピーが表示される", () => {
+    render(
+      <PaywallModal
+        isOpen
+        onClose={mockOnClose}
+        feature="season_transition_graph"
+      />,
+    );
+
+    expect(
+      screen.getByText("シーズンを跨いだ成長を可視化"),
+    ).toBeInTheDocument();
+  });
+
+  it("別の Pro 機能では別のコピーが表示される", () => {
+    render(
+      <PaywallModal
+        isOpen
+        onClose={mockOnClose}
+        feature="unlimited_practice_menus"
+      />,
+    );
+
+    expect(screen.getByText("練習メニューを無制限に登録")).toBeInTheDocument();
+  });
+
+  it("isOpen が false のときは表示されない", () => {
+    render(
+      <PaywallModal
+        isOpen={false}
+        onClose={mockOnClose}
+        feature="season_transition_graph"
+      />,
+    );
+
+    expect(
+      screen.queryByText("シーズンを跨いだ成長を可視化"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("「Pro プランを見る」ボタンで /pro へ遷移し onClose も呼ばれる", () => {
+    render(<PaywallModal isOpen onClose={mockOnClose} feature="no_ads" />);
+
+    fireEvent.click(screen.getByText("Pro プランを見る"));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith("/pro");
+  });
+
+  it("「閉じる」ボタンで onClose が呼ばれる", () => {
+    render(<PaywallModal isOpen onClose={mockOnClose} feature="no_ads" />);
+
+    fireEvent.click(screen.getByText("閉じる"));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/pro/__tests__/ProGate.test.tsx
+++ b/app/components/pro/__tests__/ProGate.test.tsx
@@ -6,17 +6,6 @@ jest.mock("@app/hooks/pro/useEntitlement", () => ({
   useEntitlement: jest.fn(),
 }));
 
-jest.mock("next/navigation", () => ({
-  useRouter: jest.fn(() => ({
-    push: jest.fn(),
-    replace: jest.fn(),
-    refresh: jest.fn(),
-    back: jest.fn(),
-    forward: jest.fn(),
-    prefetch: jest.fn(),
-  })),
-}));
-
 const mockUseEntitlement = useEntitlement as jest.MockedFunction<
   typeof useEntitlement
 >;
@@ -47,7 +36,7 @@ describe("ProGate", () => {
     expect(screen.getByText("Pro Content")).toBeInTheDocument();
   });
 
-  it("entitlement を持たない場合、children を表示しない", () => {
+  it("entitlement を持たない場合、children も PaywallModal も DOM に存在しない", () => {
     mockEntitlement(false);
 
     render(
@@ -57,6 +46,10 @@ describe("ProGate", () => {
     );
 
     expect(screen.queryByText("Pro Content")).not.toBeInTheDocument();
+    // renderLockedTrigger / fallback どちらも無いので、Paywall コピーは描画されない
+    expect(
+      screen.queryByText("シーズンを跨いだ成長を可視化"),
+    ).not.toBeInTheDocument();
   });
 
   it("entitlement を持たない場合、fallback を表示する", () => {

--- a/app/components/pro/__tests__/ProGate.test.tsx
+++ b/app/components/pro/__tests__/ProGate.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import ProGate from "../ProGate";
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    refresh: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    prefetch: jest.fn(),
+  })),
+}));
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+
+function mockEntitlement(granted: boolean) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: granted,
+    inTrial: false,
+    inGracePeriod: false,
+    hasEntitlement: jest.fn(() => granted),
+  });
+}
+
+describe("ProGate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("entitlement を持つ場合、children をそのまま表示する", () => {
+    mockEntitlement(true);
+
+    render(
+      <ProGate feature="season_transition_graph">
+        <div>Pro Content</div>
+      </ProGate>,
+    );
+
+    expect(screen.getByText("Pro Content")).toBeInTheDocument();
+  });
+
+  it("entitlement を持たない場合、children を表示しない", () => {
+    mockEntitlement(false);
+
+    render(
+      <ProGate feature="season_transition_graph">
+        <div>Pro Content</div>
+      </ProGate>,
+    );
+
+    expect(screen.queryByText("Pro Content")).not.toBeInTheDocument();
+  });
+
+  it("entitlement を持たない場合、fallback を表示する", () => {
+    mockEntitlement(false);
+
+    render(
+      <ProGate
+        feature="season_transition_graph"
+        fallback={<div>Locked Notice</div>}
+      >
+        <div>Pro Content</div>
+      </ProGate>,
+    );
+
+    expect(screen.getByText("Locked Notice")).toBeInTheDocument();
+    expect(screen.queryByText("Pro Content")).not.toBeInTheDocument();
+  });
+
+  it("renderLockedTrigger 経由でクリックすると PaywallModal が開く", () => {
+    mockEntitlement(false);
+
+    render(
+      <ProGate
+        feature="season_transition_graph"
+        renderLockedTrigger={(open) => (
+          <button type="button" onClick={open}>
+            ロック解除
+          </button>
+        )}
+      >
+        <div>Pro Content</div>
+      </ProGate>,
+    );
+
+    fireEvent.click(screen.getByText("ロック解除"));
+
+    // PaywallModal の Pro 機能特有の文言が表示される
+    expect(
+      screen.getByText("シーズンを跨いだ成長を可視化"),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/hooks/pro/__tests__/useEntitlement.test.tsx
+++ b/app/hooks/pro/__tests__/useEntitlement.test.tsx
@@ -1,0 +1,149 @@
+import { renderHook } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { ProStatusProvider } from "@app/components/pro/ProStatusProvider";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { DEFAULT_PRO_STATUS, type ProStatus } from "@app/types/pro";
+
+// Server Action はテストでは呼ばれないが、モジュール解決のためにモック
+jest.mock("@app/(app)/pro/actions", () => ({
+  getProStatus: jest.fn(),
+}));
+
+function makeProActiveStatus(): ProStatus {
+  return {
+    subscription: {
+      status: "active",
+      plan_type: "monthly",
+      platform: "ios",
+      started_at: "2026-04-01T00:00:00+09:00",
+      expires_at: "2026-06-01T00:00:00+09:00",
+      in_trial: false,
+      in_grace_period: false,
+      days_remaining: 14,
+      is_early_subscriber: false,
+      has_used_trial: true,
+    },
+    entitlements: [
+      ...DEFAULT_PRO_STATUS.entitlements,
+      "no_ads",
+      "season_transition_graph",
+      "unlimited_practice_menus",
+    ],
+  };
+}
+
+function wrapperWith(initialValue: ProStatus | null) {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <ProStatusProvider initialValue={initialValue}>
+      {children}
+    </ProStatusProvider>
+  );
+  Wrapper.displayName = "TestProStatusWrapper";
+  return Wrapper;
+}
+
+describe("useEntitlement", () => {
+  describe("Provider が無い場合", () => {
+    it("無料機能には true、Pro 機能には false を返す", () => {
+      const { result } = renderHook(() => useEntitlement());
+
+      expect(result.current.hasEntitlement("basic_game_record")).toBe(true);
+      expect(result.current.hasEntitlement("season_transition_graph")).toBe(
+        false,
+      );
+      expect(result.current.isPro).toBe(false);
+    });
+  });
+
+  describe("無料ユーザー (status: free)", () => {
+    it("無料機能には true、Pro 機能には false を返す", () => {
+      const { result } = renderHook(() => useEntitlement(), {
+        wrapper: wrapperWith(null),
+      });
+
+      expect(result.current.hasEntitlement("basic_game_record")).toBe(true);
+      expect(result.current.hasEntitlement("calculation_tools")).toBe(true);
+      expect(result.current.hasEntitlement("no_ads")).toBe(false);
+      expect(result.current.hasEntitlement("unlimited_practice_menus")).toBe(
+        false,
+      );
+      expect(result.current.isPro).toBe(false);
+    });
+  });
+
+  describe("Pro ユーザー (status: active)", () => {
+    const proStatus = makeProActiveStatus();
+
+    it("無料機能・Pro 機能のいずれも true を返す", () => {
+      const { result } = renderHook(() => useEntitlement(), {
+        wrapper: wrapperWith(proStatus),
+      });
+
+      expect(result.current.hasEntitlement("basic_game_record")).toBe(true);
+      expect(result.current.hasEntitlement("no_ads")).toBe(true);
+      expect(result.current.hasEntitlement("season_transition_graph")).toBe(
+        true,
+      );
+      expect(result.current.hasEntitlement("unlimited_practice_menus")).toBe(
+        true,
+      );
+      expect(result.current.isPro).toBe(true);
+    });
+
+    it("entitlements に含まれない Pro 機能には false を返す", () => {
+      const { result } = renderHook(() => useEntitlement(), {
+        wrapper: wrapperWith(proStatus),
+      });
+
+      // proStatus.entitlements には 'detailed_condition_log' が含まれていない
+      expect(result.current.hasEntitlement("detailed_condition_log")).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("トライアル中ユーザー", () => {
+    it("inTrial: true、isPro: true を返す", () => {
+      const trialStatus: ProStatus = {
+        subscription: {
+          ...DEFAULT_PRO_STATUS.subscription,
+          status: "trial",
+          in_trial: true,
+          expires_at: "2026-06-01T00:00:00+09:00",
+          days_remaining: 7,
+        },
+        entitlements: [...DEFAULT_PRO_STATUS.entitlements, "no_ads"],
+      };
+
+      const { result } = renderHook(() => useEntitlement(), {
+        wrapper: wrapperWith(trialStatus),
+      });
+
+      expect(result.current.isPro).toBe(true);
+      expect(result.current.inTrial).toBe(true);
+      expect(result.current.inGracePeriod).toBe(false);
+    });
+  });
+
+  describe("グレースピリオド中ユーザー (cancelled)", () => {
+    it("inGracePeriod: true、isPro: true を返す", () => {
+      const cancelledStatus: ProStatus = {
+        subscription: {
+          ...DEFAULT_PRO_STATUS.subscription,
+          status: "cancelled",
+          in_grace_period: true,
+          expires_at: "2026-06-01T00:00:00+09:00",
+          days_remaining: 5,
+        },
+        entitlements: [...DEFAULT_PRO_STATUS.entitlements, "no_ads"],
+      };
+
+      const { result } = renderHook(() => useEntitlement(), {
+        wrapper: wrapperWith(cancelledStatus),
+      });
+
+      expect(result.current.isPro).toBe(true);
+      expect(result.current.inGracePeriod).toBe(true);
+    });
+  });
+});

--- a/app/hooks/pro/__tests__/useEntitlement.test.tsx
+++ b/app/hooks/pro/__tests__/useEntitlement.test.tsx
@@ -17,6 +17,7 @@ function makeProActiveStatus(): ProStatus {
       platform: "ios",
       started_at: "2026-04-01T00:00:00+09:00",
       expires_at: "2026-06-01T00:00:00+09:00",
+      pro_active: true,
       in_trial: false,
       in_grace_period: false,
       days_remaining: 14,
@@ -108,6 +109,7 @@ describe("useEntitlement", () => {
         subscription: {
           ...DEFAULT_PRO_STATUS.subscription,
           status: "trial",
+          pro_active: true,
           in_trial: true,
           expires_at: "2026-06-01T00:00:00+09:00",
           days_remaining: 7,
@@ -131,6 +133,7 @@ describe("useEntitlement", () => {
         subscription: {
           ...DEFAULT_PRO_STATUS.subscription,
           status: "cancelled",
+          pro_active: true,
           in_grace_period: true,
           expires_at: "2026-06-01T00:00:00+09:00",
           days_remaining: 5,

--- a/app/hooks/pro/useEntitlement.ts
+++ b/app/hooks/pro/useEntitlement.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useCallback } from "react";
+import { useProStatus } from "@app/hooks/pro/useProStatus";
+import { FREE_FEATURES, type Feature } from "@app/types/pro";
+
+interface UseEntitlementReturn {
+  isPro: boolean;
+  inTrial: boolean;
+  inGracePeriod: boolean;
+  hasEntitlement: (feature: Feature) => boolean;
+}
+
+/**
+ * 機能アクセス権（Entitlement）をクライアント側で判定するフック。
+ * 無料機能は常に true、Pro 機能は subscription.entitlements に含まれていれば true。
+ * back の Entitlement#has_entitlement? と同じロジックを表現する。
+ */
+export function useEntitlement(): UseEntitlementReturn {
+  const { proStatus, isPro } = useProStatus();
+
+  const hasEntitlement = useCallback(
+    (feature: Feature): boolean => {
+      if ((FREE_FEATURES as readonly string[]).includes(feature)) return true;
+      return proStatus.entitlements.includes(feature);
+    },
+    [proStatus.entitlements],
+  );
+
+  return {
+    isPro,
+    inTrial: proStatus.subscription.in_trial,
+    inGracePeriod: proStatus.subscription.in_grace_period,
+    hasEntitlement,
+  };
+}

--- a/app/hooks/pro/useProStatus.ts
+++ b/app/hooks/pro/useProStatus.ts
@@ -28,9 +28,9 @@ export function useProStatus(): UseProStatusReturn {
   }
 
   const { proStatus, isRefreshing, refresh } = ctx;
-  const isPro = ["trial", "active", "cancelled", "billing_issue"].includes(
-    proStatus.subscription.status,
-  );
+  // サーバー側で「期限内かつ Pro 扱いの status」を判定済みのフラグを単一の真実とする。
+  // 期限切れの cancelled / billing_issue で誤って true にならないようにするため。
+  const isPro = proStatus.subscription.pro_active;
 
   return { proStatus, isPro, isRefreshing, refresh };
 }

--- a/app/hooks/pro/useProStatus.ts
+++ b/app/hooks/pro/useProStatus.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useContext } from "react";
+import { ProStatusContext } from "@app/components/pro/ProStatusProvider";
+import { DEFAULT_PRO_STATUS, type ProStatus } from "@app/types/pro";
+
+interface UseProStatusReturn {
+  proStatus: ProStatus;
+  isPro: boolean;
+  isRefreshing: boolean;
+  refresh: () => void;
+}
+
+/**
+ * Pro 状態を取得する。ProStatusProvider 配下では実際の状態を、
+ * Provider が無いコンポーネント階層では DEFAULT_PRO_STATUS（無料状態）を返す。
+ */
+export function useProStatus(): UseProStatusReturn {
+  const ctx = useContext(ProStatusContext);
+
+  if (!ctx) {
+    return {
+      proStatus: DEFAULT_PRO_STATUS,
+      isPro: false,
+      isRefreshing: false,
+      refresh: () => {},
+    };
+  }
+
+  const { proStatus, isRefreshing, refresh } = ctx;
+  const isPro = ["trial", "active", "cancelled", "billing_issue"].includes(
+    proStatus.subscription.status,
+  );
+
+  return { proStatus, isPro, isRefreshing, refresh };
+}

--- a/app/types/pro.ts
+++ b/app/types/pro.ts
@@ -1,0 +1,95 @@
+/**
+ * Pro 加入状態と Entitlement の型定義。
+ * back/app/models/concerns/entitlement.rb の定数と一致させる必要がある。
+ * 同期の自動化は将来 Issue で対応する（現状は手動同期）。
+ */
+
+// 無料プランで利用可能な機能キー。Pro 加入の有無に関わらず常に許可される。
+export const FREE_FEATURES = [
+  "basic_game_record", // 試合記録(基本): 試合結果・打撃成績の入力と表示
+  "basic_stats", // 基本成績集計: 打率・防御率などの基本指標
+  "group_ranking", // グループ内ランキング機能
+  "calculation_tools", // 打率・防御率などの計算ツール
+  "baseball_note_basic", // 野球ノート(基本): 練習・試合の振り返りメモ
+  "shadow_swing_basic", // 素振りカウンター(基本): スイング回数の記録
+  "practice_log_basic", // 練習記録(基本): 練習内容のログ
+  "grass_recent_30days", // 草機能: 直近30日分のヒートマップ表示
+  "monthly_goal_single", // 月次目標: 1つまで作成可
+  "schedule_single", // 自主練スケジュール: 1つまで作成可
+] as const;
+
+// Pro 加入時のみ利用可能な機能キー。subscription.entitlements に含まれていれば許可。
+export const PRO_FEATURES = [
+  "no_ads", // 広告非表示
+  "season_transition_graph", // シーズン跨ぎ成績推移グラフ(複数シーズン比較)
+  "grass_full_history", // 草機能: 全期間ヒートマップ表示
+  "unlimited_practice_menus", // 練習メニュー無制限(無料は3件まで)
+  "unlimited_media_uploads", // 動画・画像アップロード無制限(無料は月3件)
+  "media_long_term_storage", // メディア長期保管(31日以上前も閲覧可)
+  "unlimited_schedules", // 自主練スケジュール無制限(無料は1件まで)
+  "unlimited_monthly_goals", // 月次目標無制限(無料は1件まで)
+  "season_goals", // シーズン目標(無料は利用不可)
+  "custom_notification_messages", // カスタム通知メッセージの設定
+  "advanced_goal_tracking", // 高度な目標トラッキング(達成率の詳細推移)
+  "detailed_condition_log", // 詳細コンディションログ(体調・気分の詳細記録)
+] as const;
+
+export type FreeFeature = (typeof FREE_FEATURES)[number];
+export type ProFeature = (typeof PRO_FEATURES)[number];
+export type Feature = FreeFeature | ProFeature;
+
+export type SubscriptionStatus =
+  | "free"
+  | "trial"
+  | "active"
+  | "cancelled"
+  | "billing_issue"
+  | "expired"
+  | "pending";
+
+export type PlanType = "monthly" | "yearly";
+export type Platform = "ios" | "web" | "android";
+
+export interface ProSubscription {
+  status: SubscriptionStatus;
+  plan_type: PlanType | null;
+  platform: Platform | null;
+  started_at: string | null;
+  expires_at: string | null;
+  in_trial: boolean;
+  in_grace_period: boolean;
+  days_remaining: number | null;
+  is_early_subscriber: boolean;
+  has_used_trial: boolean;
+}
+
+export interface ProStatus {
+  subscription: ProSubscription;
+  entitlements: string[];
+}
+
+export interface EntitlementCheck {
+  key: Feature;
+  granted: boolean;
+}
+
+export interface EntitlementsResponse {
+  entitlements: EntitlementCheck[];
+}
+
+// 未認証や API 失敗時のフォールバック値。
+export const DEFAULT_PRO_STATUS: ProStatus = {
+  subscription: {
+    status: "free",
+    plan_type: null,
+    platform: null,
+    started_at: null,
+    expires_at: null,
+    in_trial: false,
+    in_grace_period: false,
+    days_remaining: null,
+    is_early_subscriber: false,
+    has_used_trial: false,
+  },
+  entitlements: [...FREE_FEATURES],
+};

--- a/app/types/pro.ts
+++ b/app/types/pro.ts
@@ -68,7 +68,7 @@ export interface ProSubscription {
 
 export interface ProStatus {
   subscription: ProSubscription;
-  entitlements: string[];
+  entitlements: Feature[];
 }
 
 export interface EntitlementCheck {
@@ -95,5 +95,5 @@ export const DEFAULT_PRO_STATUS: ProStatus = {
     is_early_subscriber: false,
     has_used_trial: false,
   },
-  entitlements: [...FREE_FEATURES],
+  entitlements: [...FREE_FEATURES] as Feature[],
 };

--- a/app/types/pro.ts
+++ b/app/types/pro.ts
@@ -56,6 +56,9 @@ export interface ProSubscription {
   platform: Platform | null;
   started_at: string | null;
   expires_at: string | null;
+  // Server 側で期限と status を合わせて判定した Pro 加入可否。
+  // クライアントはこれを単一の真実として参照する（status からの再計算は不要）。
+  pro_active: boolean;
   in_trial: boolean;
   in_grace_period: boolean;
   days_remaining: number | null;
@@ -85,6 +88,7 @@ export const DEFAULT_PRO_STATUS: ProStatus = {
     platform: null,
     started_at: null,
     expires_at: null,
+    pro_active: false,
     in_trial: false,
     in_grace_period: false,
     days_remaining: null,


### PR DESCRIPTION
## 概要

BUZZ BASE Pro リリースに必要な「Pro 加入状態の取得」「機能アクセス権 (Entitlement) 判定」「Paywall 表示」のクライアント基盤を front に追加する。
ref: ippei-shimizu/buzzbase#317  
back 側 PR: ippei-shimizu/buzzbase_back#222

## 変更内容

### 型定義

- `app/types/pro.ts`
  - `FREE_FEATURES` 10 種 + `PRO_FEATURES` 12 種 (各キーに説明コメント)
  - `Feature` / `SubscriptionStatus` / `ProStatus` 等の型
  - `DEFAULT_PRO_STATUS` (未認証時の fallback 値)

### Server Action

- `app/(app)/pro/actions.ts`
  - `getProStatus()` → \`GET /api/v1/pro/status\`
  - `getEntitlements()` → \`GET /api/v1/pro/entitlements\`
  - `syncProStatus()` → \`POST /api/v1/pro/sync\`

### Context Provider と Hook

- `app/components/pro/ProStatusProvider.tsx`
  - Server Component で取得した初期値を Context で配布
  - `useTransition` + `refresh()` で再取得可能
- `app/hooks/pro/useProStatus.ts`: 状態 + `isPro` + `refresh`
- `app/hooks/pro/useEntitlement.ts`: `hasEntitlement(feature)` を提供

### コンポーネント

- `app/components/pro/ProGate.tsx`
  - feature が許可されていれば children、未許可なら fallback / renderLockedTrigger
- `app/components/pro/PaywallModal.tsx`
  - HeroUI Modal ベース。\`PRO_PAYWALL_COPY\` で feature ごとの訴求コピー
  - 「Pro プランを見る」で /pro へ遷移

### テスト (15 例追加・既存 260 例も全パス)

- \`app/hooks/pro/__tests__/useEntitlement.test.tsx\`
- \`app/components/pro/__tests__/ProGate.test.tsx\`
- \`app/components/pro/__tests__/PaywallModal.test.tsx\`

## 使い方の想定

```tsx
// page.tsx (Server Component)
const proStatus = await getProStatus();
return (
  <ProStatusProvider initialValue={proStatus}>
    <DashboardContent />
  </ProStatusProvider>
);

// 任意の Client Component
<ProGate feature="season_transition_graph"
  renderLockedTrigger={(open) => (
    <button onClick={open}>シーズン跨ぎグラフを見る</button>
  )}
>
  <SeasonTransitionGraph />
</ProGate>
```

## 本 Issue で対象外 (別 Issue へ委譲)

- RevenueCat Web SDK の導入: #318 (課金フロー実装) に委譲
- /pro ページの実装: 別 Issue (Pro 加入ページ自体は本 Issue のスコープ外)
- 既存画面への ProGate 組み込み: 各 Pro 機能 Issue (#319〜#325)
- back 側 entitlement キーとの自動同期: 将来 Issue (現状は手動同期)

## Test plan

- [x] \`docker compose exec front yarn typecheck\` (Done)
- [x] \`docker compose exec front yarn lint\` (Done)
- [x] \`docker compose exec front yarn test\` (260 examples 0 failures)
- [ ] back PR #222 マージ後、実際の API レスポンスで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)