### PR TITLE
Update: 運営者Xアカウントリンクを @ippei_buzzbase に差し替え

### DIFF
--- a/app/components/footer/Footer.tsx
+++ b/app/components/footer/Footer.tsx
@@ -64,14 +64,14 @@ export default function Footer() {
               </li>
               <li>
                 <Link
-                  href="https://twitter.com/ippei_111"
+                  href="https://x.com/ippei_buzzbase"
                   target="_blank"
                   className="flex items-baseline text-sm"
                 >
                   運営者
                   <span className="flex items-center gap-x-1 pl-2">
                     <XIcon fill="#f4f4f4" width="14" height="14" />
-                    @ippei_111
+                    @ippei_buzzbase
                   </span>
                 </Link>
               </li>


### PR DESCRIPTION
## 概要

Web フッターの「運営者」リンクを開発者個人の新Xアカウント [@ippei_buzzbase](https://x.com/ippei_buzzbase) に差し替えました。

Closes #319

## 変更内容

`app/components/footer/Footer.tsx`

- `href`: `https://twitter.com/ippei_111` → `https://x.com/ippei_buzzbase`
- 表示テキスト: `@ippei_111` → `@ippei_buzzbase`
- ドメインを `twitter.com` から `x.com`（ブランド変更後の正式ドメイン）に統一

## スコープ外

- `StatsShareComponent.tsx` / `ResultShareComponent.tsx` の `twitter.com/intent/tweet` URL は本Issueのスコープ外（必要なら別Issueで対応）

## 動作確認

- [x] `yarn lint` 通過
- [x] `yarn typecheck` 通過
- [ ] フッターから新アカウントのプロフィールに遷移できることを目視確認（PC/スマホブラウザ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)