### PR TITLE
Chore: CI workflow の対象ブランチに release/* を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - stg
+      - "release/*"
   pull_request:
     branches:
       - main
       - stg
+      - "release/*"
 
 jobs:
   lint-and-test:


### PR DESCRIPTION
## Summary

CI workflow の pull_request / push トリガーに \`release/*\` を追加し、リリースブランチ上での PR・push でも CI が走るようにする。

## 変更

- \`.github/workflows/ci.yml\` の \`on.pull_request.branches\` と \`on.push.branches\` に \`'release/*'\` を追加

## Test plan

- [x] YAML 構文に問題なし
- [ ] マージ後の release ブランチへの push で CI が起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)