### PR TITLE
Update: DH 制の投手で打順「なし」を許容し、総投球数を表示 (#360)

### DIFF
--- a/app/(app)/dashboard/_components/StatsOverview.tsx
+++ b/app/(app)/dashboard/_components/StatsOverview.tsx
@@ -455,8 +455,12 @@ function PitchingTable({ pitchingStats }: { pitchingStats: PitchingStats }) {
           </div>
           <div className={styleTableBox}>
             <p className={styleTableTitle}>K/BB</p>
+            <span className={styleTableData}>{displayValue(calc?.k_bb)}</span>
+          </div>
+          <div className={styleTableBox}>
+            <p className={`${styleTableTitle} rounded-bl-md`}>総投球数</p>
             <span className={`${styleTableData} rounded-br-md`}>
-              {displayValue(calc?.k_bb)}
+              {displayValue(agg?.number_of_pitches)}
             </span>
           </div>
         </div>

--- a/app/(app)/dashboard/actions.ts
+++ b/app/(app)/dashboard/actions.ts
@@ -74,6 +74,7 @@ export interface PitchingStats {
     hit_by_pitch: number;
     run_allowed: number;
     earned_run: number;
+    number_of_pitches: number;
   } | null;
   calculated: {
     era: number;

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -125,7 +125,6 @@ export default function GameRecord() {
   const [isMyTeamScoreValid, setIsMyTeamScoreValid] = useState(true);
   const [isOpponentTeamScoreValid, setIsOpponentTeamScoreValid] =
     useState(true);
-  const [isBattingOrderValid, setIsBattingOrderValid] = useState(true);
   const [isDefensivePositionValid, setIsDefensivePositionValid] =
     useState(true);
   const [errors, setErrors] = useState<string[]>([]);
@@ -405,18 +404,11 @@ export default function GameRecord() {
       setIsOpponentTeamScoreValid(true);
     }
 
-    // 先発／途中出場の場合のみ打順／守備位置を必須とする。
+    // 先発／途中出場の場合のみ守備位置を必須とする。
+    // 打順は DH 制で投手として出場する場合「なし」を許容するため任意。
     // 代打／代走／未出場は入力任意（出場区分切替時に自動で空文字がセットされる）。
     const lineupRequired =
       appearanceType === "starter" || appearanceType === "substitute";
-
-    if (lineupRequired && !matchBattingOrder && !existingMatchBattingOrder) {
-      setIsBattingOrderValid(false);
-      isValid = false;
-      newErrors.push("打順が未入力です。");
-    } else {
-      setIsBattingOrderValid(true);
-    }
 
     if (
       lineupRequired &&
@@ -820,16 +812,11 @@ export default function GameRecord() {
                 </div>
                 <Divider className="my-4" />
                 <Select
-                  isRequired={
-                    appearanceType === "starter" ||
-                    appearanceType === "substitute"
-                  }
                   variant="faded"
                   label="打順"
                   labelPlacement="outside-left"
                   size="md"
                   fullWidth={false}
-                  color={isBattingOrderValid ? "default" : "danger"}
                   className="grid justify-between items-center grid-cols-[auto_96px]"
                   onChange={handleBattingOrderChange}
                   selectedKeys={

--- a/app/(app)/stats/_components/PitchingStatsTable.tsx
+++ b/app/(app)/stats/_components/PitchingStatsTable.tsx
@@ -18,6 +18,7 @@ const PITCHING_COLUMNS: Column<PitchingStatsRow>[] = [
   { key: "complete_games", label: "完投", format: fmtInt },
   { key: "shutouts", label: "完封", format: fmtInt },
   { key: "innings_pitched", label: "投球回", format: fmt2 },
+  { key: "number_of_pitches", label: "総投球数", format: fmtInt },
   { key: "hits_allowed", label: "被安打", format: fmtInt },
   { key: "home_runs_hit", label: "被本塁打", format: fmtInt },
   { key: "strikeouts", label: "三振", format: fmtInt },

--- a/app/(app)/stats/actions.ts
+++ b/app/(app)/stats/actions.ts
@@ -51,6 +51,7 @@ export interface PitchingStatsRow {
   hit_by_pitch: number;
   run_allowed: number;
   earned_run: number;
+  number_of_pitches: number;
   era: number;
   whip: number;
   k_per_nine: number;

--- a/app/components/table/PitchingRecordTable.tsx
+++ b/app/components/table/PitchingRecordTable.tsx
@@ -16,6 +16,7 @@ type PersonalPitchingResults = {
   hit_by_pitch: number;
   run_allowed: number;
   earned_run: number;
+  number_of_pitches: number;
 };
 
 type PersonalPitchingStatus = {
@@ -205,8 +206,10 @@ export default function PitchingRecordTable(props: Props) {
               </span>
             </div>
             <div className={styleTableBox}>
-              <p className={styleTableTitle}>---</p>
-              <span className={`${styleTableData} rounded-br-md`}>---</span>
+              <p className={styleTableTitle}>総投球数</p>
+              <span className={`${styleTableData} rounded-br-md`}>
+                {displayValue(pitchingResult?.number_of_pitches)}
+              </span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#360

## 概要

DH 制の試合で先発投手として出場した場合に打順「なし」で保存できるようにし、あわせて投手成績テーブルとダッシュボードに総投球数を表示する。バックエンド側は ippei-shimizu/buzzbase_back#251、モバイル側は ippei-shimizu/buzzbase_mobile#110 で対応。

## 変更内容

- `app/(app)/game-result/record/page.tsx` の打順必須バリデーションを削除（守備位置の必須は維持）
  - 不要になった `isBattingOrderValid` state と Select の `isRequired` プロップも合わせて削除
- `app/(app)/stats/actions.ts` の `PitchingStatsRow` に `number_of_pitches` を追加
- `app/(app)/stats/_components/PitchingStatsTable.tsx` の `PITCHING_COLUMNS` に「総投球数」列を追加（投球回の隣）
- `app/(app)/dashboard/actions.ts` の `PitchingStats.aggregate` に `number_of_pitches` を追加
- `app/(app)/dashboard/_components/StatsOverview.tsx` の投手成績テーブルに「総投球数」を追加

## スクリーンショット

| Before | After |
| ------ | ----- |
|        |       |

## 確認手順

1. `yarn typecheck` パス
2. `yarn lint` パス
3. `yarn test --testPathPatterns="dashboard|stats|game-result/record"` パス
4. ブラウザで:
   - `/game-result/record` で出場区分「先発」+ 打順「なし」+ 守備位置「投手」で保存できる
   - `/stats` の投手成績テーブルに「総投球数」列が表示される
   - `/dashboard` の投手成績テーブルに「総投球数」が表示される

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る
- [x] 関連テストが通る
- [ ] 動作確認済み（レビュー時にブラウザで確認）

## 関連 PR

- back: ippei-shimizu/buzzbase_back#251
- mobile: ippei-shimizu/buzzbase_mobile#110
