### PR TITLE
Fix: /tools/ops の OG 画像が SNS シェア時に表示されない問題を修正

### DIFF
--- a/app/(app)/tools/ops/_components/OpsResultCard.tsx
+++ b/app/(app)/tools/ops/_components/OpsResultCard.tsx
@@ -75,7 +75,10 @@ export default function OpsResultCard({ ops, obp, slg }: Props) {
   const obpText = formatRate(obp);
   const slgText = formatRate(slg);
 
-  const toolUrl = `${SITE_URL}/tools/ops`;
+  // SNS シェア時に Twitter / LINE が取得する URL。
+  // /tools/ops の generateMetadata がこのクエリから動的に og:image を組み立てるので、
+  // share URL 側に必ずクエリを含める。
+  const toolUrl = `${SITE_URL}/tools/ops?ops=${ops.toFixed(3)}&obp=${obp.toFixed(3)}&slg=${slg.toFixed(3)}`;
   const ogUrl = `${SITE_URL}/api/og/ops-card?ops=${ops.toFixed(3)}&obp=${obp.toFixed(3)}&slg=${slg.toFixed(3)}`;
   const shareText = buildShareText(opsText, obpText, slgText);
   const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(toolUrl)}`;

--- a/app/(app)/tools/ops/page.tsx
+++ b/app/(app)/tools/ops/page.tsx
@@ -13,11 +13,20 @@ type OpsSearchParams = {
   slg?: string;
 };
 
-function isValidShareParam(value: string | undefined): value is string {
-  if (!value) return false;
+// 数値だけを許容する厳密な正規表現。Number.parseFloat は "0.5<script>" のような
+// 末尾ゴミ付き文字列も部分的にパースしてしまうため、metadata 注入を防ぐ目的で
+// 文字列全体が数値表現であることをチェックする。
+const NUMERIC_PARAM_RE = /^\d+(?:\.\d{1,3})?$/;
+
+/**
+ * シェア URL のクエリパラメータを安全な数値に正規化する。
+ * 形式不正・範囲外なら null。0..5 の範囲は OPS の理論最大値 5.000 に合わせている。
+ */
+function parseShareParam(value: string | undefined): number | null {
+  if (!value || !NUMERIC_PARAM_RE.test(value)) return null;
   const parsed = Number.parseFloat(value);
-  if (Number.isNaN(parsed)) return false;
-  return parsed >= 0 && parsed <= 5;
+  if (Number.isNaN(parsed) || parsed < 0 || parsed > 5) return null;
+  return parsed;
 }
 
 export async function generateMetadata({
@@ -26,10 +35,9 @@ export async function generateMetadata({
   searchParams: Promise<OpsSearchParams>;
 }): Promise<Metadata> {
   const sp = await searchParams;
-  const hasShareParams =
-    isValidShareParam(sp.ops) &&
-    isValidShareParam(sp.obp) &&
-    isValidShareParam(sp.slg);
+  const opsValue = parseShareParam(sp.ops);
+  const obpValue = parseShareParam(sp.obp);
+  const slgValue = parseShareParam(sp.slg);
 
   const baseMetadata: Metadata = {
     title: definition.metaTitle,
@@ -39,32 +47,35 @@ export async function generateMetadata({
     },
   };
 
-  if (!hasShareParams) {
+  if (opsValue === null || obpValue === null || slgValue === null) {
     return baseMetadata;
   }
 
-  const ogImageUrl = `${SITE_URL}/api/og/ops-card?ops=${encodeURIComponent(
-    sp.ops!,
-  )}&obp=${encodeURIComponent(sp.obp!)}&slg=${encodeURIComponent(sp.slg!)}`;
+  // 以降は必ず正規化済みの数値文字列のみを使い、生クエリは description / alt に
+  // 一切流入させない。これにより metadata 注入の余地を構造的に消す。
+  const opsText = opsValue.toFixed(3);
+  const obpText = obpValue.toFixed(3);
+  const slgText = slgValue.toFixed(3);
+  const ogImageUrl = `${SITE_URL}/api/og/ops-card?ops=${opsText}&obp=${obpText}&slg=${slgText}`;
 
   return {
     ...baseMetadata,
     openGraph: {
       title: definition.metaTitle,
-      description: `OPS ${sp.ops} の計算結果。出塁率 ${sp.obp} / 長打率 ${sp.slg}。あなたも BUZZ BASE で OPS を計算してシェアしよう。`,
+      description: `OPS ${opsText} の計算結果。出塁率 ${obpText} / 長打率 ${slgText}。あなたも BUZZ BASE で OPS を計算してシェアしよう。`,
       images: [
         {
           url: ogImageUrl,
           width: 1200,
           height: 630,
-          alt: `OPS ${sp.ops} の計算結果カード`,
+          alt: `OPS ${opsText} の計算結果カード`,
         },
       ],
     },
     twitter: {
       card: "summary_large_image",
       title: definition.metaTitle,
-      description: `OPS ${sp.ops}（出塁率 ${sp.obp} / 長打率 ${sp.slg}）`,
+      description: `OPS ${opsText}（出塁率 ${obpText} / 長打率 ${slgText}）`,
       images: [ogImageUrl],
     },
   };

--- a/app/(app)/tools/ops/page.tsx
+++ b/app/(app)/tools/ops/page.tsx
@@ -1,18 +1,74 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { SITE_URL } from "@app/constants/app";
 import { getCalculatorDefinition } from "@app/data/baseball-stats/calculator-definitions";
 import CalculatorPageContent from "../_components/CalculatorPageContent";
 import OpsCalculator from "./_components/OpsCalculator";
 
 const definition = getCalculatorDefinition("ops")!;
 
-export const metadata: Metadata = {
-  title: definition.metaTitle,
-  description: definition.metaDescription,
-  alternates: {
-    canonical: `https://buzzbase.jp/tools/${definition.slug}`,
-  },
+type OpsSearchParams = {
+  ops?: string;
+  obp?: string;
+  slg?: string;
 };
+
+function isValidShareParam(value: string | undefined): value is string {
+  if (!value) return false;
+  const parsed = Number.parseFloat(value);
+  if (Number.isNaN(parsed)) return false;
+  return parsed >= 0 && parsed <= 5;
+}
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<OpsSearchParams>;
+}): Promise<Metadata> {
+  const sp = await searchParams;
+  const hasShareParams =
+    isValidShareParam(sp.ops) &&
+    isValidShareParam(sp.obp) &&
+    isValidShareParam(sp.slg);
+
+  const baseMetadata: Metadata = {
+    title: definition.metaTitle,
+    description: definition.metaDescription,
+    alternates: {
+      canonical: `${SITE_URL}/tools/${definition.slug}`,
+    },
+  };
+
+  if (!hasShareParams) {
+    return baseMetadata;
+  }
+
+  const ogImageUrl = `${SITE_URL}/api/og/ops-card?ops=${encodeURIComponent(
+    sp.ops!,
+  )}&obp=${encodeURIComponent(sp.obp!)}&slg=${encodeURIComponent(sp.slg!)}`;
+
+  return {
+    ...baseMetadata,
+    openGraph: {
+      title: definition.metaTitle,
+      description: `OPS ${sp.ops} の計算結果。出塁率 ${sp.obp} / 長打率 ${sp.slg}。あなたも BUZZ BASE で OPS を計算してシェアしよう。`,
+      images: [
+        {
+          url: ogImageUrl,
+          width: 1200,
+          height: 630,
+          alt: `OPS ${sp.ops} の計算結果カード`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: definition.metaTitle,
+      description: `OPS ${sp.ops}（出塁率 ${sp.obp} / 長打率 ${sp.slg}）`,
+      images: [ogImageUrl],
+    },
+  };
+}
 
 export default function OpsPage() {
   return (


### PR DESCRIPTION
## 概要

OPS 計算結果を SNS にシェアしても **画像プレビューが表示されない** バグの修正。

OGP 検証ツールで確認すると `/tools/ops` の HTML に `<meta property="og:image">` が一切無いことが判明。`/api/og/ops-card` の動的画像エンドポイントは PR #331 で実装済みだったが、どのページからも `og:image` として参照されていない孤立状態だった。

## 原因

`/tools/ops/page.tsx` の metadata は `title` / `description` / `canonical` のみで `openGraph` 未設定。さらにルート `app/layout.tsx` の openGraph にも `images` 指定が無かったため、Twitter / LINE が `/tools/ops` を取得しても画像 URL が見つからずプレビューが出ない状態だった。

## 修正内容

### 1. `/tools/ops/page.tsx`

- `export const metadata` を `export async function generateMetadata({ searchParams })` に変更
- `?ops=...&obp=...&slg=...` クエリが付いている場合のみ、`/api/og/ops-card?...` を `og:image` および `twitter:image` に設定
- searchParams が不正・不在の場合は従来の静的 metadata にフォールバック
- パラメータの妥当性検証 (`isValidShareParam`) を追加し、`0 <= 値 <= 5` の範囲外や数値でない入力は無視

### 2. `OpsResultCard.tsx`

- Twitter / LINE シェア URL を `/tools/ops` → `/tools/ops?ops=...&obp=...&slg=...` 形式に変更
- これにより Twitter が URL を取得した際、`generateMetadata` が `searchParams` から動的に OG 画像を組み立てる

### 動作フロー (修正後)

1. ユーザーが OPS 計算 → 結果カードの「X でシェア」をクリック
2. Twitter intent URL に `url=https://buzzbase.jp/tools/ops?ops=0.291&obp=0.178&slg=0.113` が含まれる
3. Twitter がそのページを取得 → `generateMetadata` が動的に og:image / twitter:image を `/api/og/ops-card?ops=...` に設定
4. Twitter が OG 画像を取得して 1200x630 のカード画像をプレビューに表示

## 影響範囲

- 通常訪問 (`/tools/ops`): 従来どおり (og:image 無し、ルート metadata に fallback)
- シェア経由訪問 (`/tools/ops?ops=...&obp=...&slg=...`): 動的に生成された OPS カード画像が表示
- canonical は常に `https://buzzbase.jp/tools/ops` で SEO への悪影響なし
- searchParams を使うため page が dynamic rendering になるが、計算ツール本体は元々 Client Component なのでパフォーマンス影響は最小限

## 検証

- `yarn typecheck` ✅
- `yarn lint` ✅
- `yarn test` 245/245 PASS ✅

### マージ後の動作確認手順

1. OPS 計算 → 結果カードの X シェアクリック → ツイート文に `https://buzzbase.jp/tools/ops?ops=...&obp=...&slg=...` 形式の URL が含まれることを確認
2. ラッコツールズなどの OGP 検証ツールに **シェア URL (クエリ付き)** を入れると、`og:image` が `/api/og/ops-card?...` を指していることを確認
3. 実際に X 投稿してプレビューに 1200×630 のカード画像が表示されることを確認
4. クエリなしの `https://buzzbase.jp/tools/ops` を OGP 検証ツールにかけても `og:image` が無いまま (canonical のみ) であることを確認

## 関連

- OG 画像エンドポイント実装: ippei-shimizu/buzzbase_front#331
- 計装基盤実装: ippei-shimizu/buzzbase_front#333
