### PR TITLE
Add: K/BB と WHIP 計算ツールに結果カードと登録CTAを追加

### DIFF
--- a/app/(app)/tools/k-bb/_components/KBBCalculator.tsx
+++ b/app/(app)/tools/k-bb/_components/KBBCalculator.tsx
@@ -2,6 +2,7 @@
 
 import { getCalculatorDefinition } from "@app/data/baseball-stats/calculator-definitions";
 import CalculatorForm from "../../_components/CalculatorForm";
+import KBBResultCard from "./KBBResultCard";
 
 const definition = getCalculatorDefinition("k-bb")!;
 
@@ -22,6 +23,10 @@ export default function KBBCalculator() {
       calculate={definition.calculate}
       nextActions={nextActions}
       analyticsSourceTool={definition.slug}
+      renderExtraResult={(raw) => {
+        if (typeof raw !== "number" || Number.isNaN(raw)) return null;
+        return <KBBResultCard kbb={raw} />;
+      }}
     />
   );
 }

--- a/app/(app)/tools/k-bb/_components/KBBResultCard.tsx
+++ b/app/(app)/tools/k-bb/_components/KBBResultCard.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import Link from "next/link";
+import { SITE_URL } from "@app/constants/app";
+import { classifyKbb } from "@app/data/baseball-stats/kbbLevel";
+import { trackEvent } from "@app/lib/analytics";
+
+type Props = {
+  kbb: number;
+};
+
+function formatKbb(value: number): string {
+  if (Number.isNaN(value)) return "-";
+  return value.toFixed(2);
+}
+
+function buildShareText(kbbText: string) {
+  return `K/BB ${kbbText}
+あなたも BUZZ BASE で K/BB を計算してシェアしよう。`;
+}
+
+export default function KBBResultCard({ kbb }: Props) {
+  const level = classifyKbb(kbb);
+  const kbbText = formatKbb(kbb);
+
+  const kbbQuery = kbb.toFixed(2);
+  const toolUrl = `${SITE_URL}/tools/k-bb?kbb=${kbbQuery}`;
+  const shareText = buildShareText(kbbText);
+  const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(toolUrl)}`;
+  const lineUrl = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(toolUrl)}&text=${encodeURIComponent(shareText)}`;
+
+  const handleTwitterShare = () => {
+    trackEvent("share", { method: "twitter", content_type: "kbb_result" });
+  };
+  const handleLineShare = () => {
+    trackEvent("share", { method: "line", content_type: "kbb_result" });
+  };
+  const handleSignupClick = () => {
+    trackEvent("generate_lead", { source_tool: "k-bb" });
+  };
+
+  const badgeClass: Record<typeof level.key, string> = {
+    S: "bg-amber-400 text-zinc-900",
+    A: "bg-yellow-500 text-zinc-900",
+    B: "bg-yellow-600 text-white",
+    C: "bg-zinc-500 text-white",
+    D: "bg-zinc-700 text-zinc-200",
+  };
+
+  return (
+    <div className="space-y-5 rounded-xl border border-yellow-700/40 bg-gradient-to-br from-zinc-900 via-zinc-900 to-yellow-950/30 p-5">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm text-zinc-400">あなたの K/BB 評価</p>
+        <span
+          className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-bold ${badgeClass[level.key]}`}
+        >
+          {level.key} ／ {level.label}
+        </span>
+      </div>
+
+      <p className="text-sm text-zinc-300 leading-6">{level.comment}</p>
+
+      <div className="rounded-lg border border-zinc-700/70 bg-zinc-950/50 px-4 py-3">
+        <p className="mb-1 text-xs text-zinc-500">シェアプレビュー</p>
+        <p className="text-sm whitespace-pre-line text-zinc-200 leading-6">
+          {shareText}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <a
+          href={twitterUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={handleTwitterShare}
+          className="inline-flex items-center justify-center gap-2 rounded-lg bg-black px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-zinc-800"
+        >
+          X でシェア
+        </a>
+        <a
+          href={lineUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={handleLineShare}
+          className="inline-flex items-center justify-center gap-2 rounded-lg bg-[#06C755] px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-[#04a346]"
+        >
+          LINEでシェア
+        </a>
+      </div>
+
+      <div className="rounded-lg border border-yellow-600/40 bg-yellow-900/20 px-4 py-4">
+        <p className="text-sm text-zinc-200 leading-6">
+          BUZZ BASE に無料登録すると、試合ごとに K/BB・防御率・WHIP・K/9
+          をまとめて記録できます。グラフで成績推移を確認したり、チーム内ランキングで比較したりも可能です。
+        </p>
+        <Link
+          href="/signup"
+          onClick={handleSignupClick}
+          className="mt-3 inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2.5 text-sm font-bold text-zinc-900 transition-colors hover:bg-yellow-400"
+        >
+          無料登録して成績を記録する &rarr;
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/tools/k-bb/_components/KBBResultCard.tsx
+++ b/app/(app)/tools/k-bb/_components/KBBResultCard.tsx
@@ -22,9 +22,7 @@ function buildShareText(kbbText: string) {
 export default function KBBResultCard({ kbb }: Props) {
   const level = classifyKbb(kbb);
   const kbbText = formatKbb(kbb);
-
-  const kbbQuery = kbb.toFixed(2);
-  const toolUrl = `${SITE_URL}/tools/k-bb?kbb=${kbbQuery}`;
+  const toolUrl = `${SITE_URL}/tools/k-bb?kbb=${kbbText}`;
   const shareText = buildShareText(kbbText);
   const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(toolUrl)}`;
   const lineUrl = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(toolUrl)}&text=${encodeURIComponent(shareText)}`;

--- a/app/(app)/tools/whip/_components/WhipCalculator.tsx
+++ b/app/(app)/tools/whip/_components/WhipCalculator.tsx
@@ -2,6 +2,7 @@
 
 import { getCalculatorDefinition } from "@app/data/baseball-stats/calculator-definitions";
 import CalculatorForm from "../../_components/CalculatorForm";
+import WhipResultCard from "./WhipResultCard";
 
 const definition = getCalculatorDefinition("whip")!;
 
@@ -22,6 +23,10 @@ export default function WhipCalculator() {
       calculate={definition.calculate}
       nextActions={nextActions}
       analyticsSourceTool={definition.slug}
+      renderExtraResult={(raw) => {
+        if (typeof raw !== "number" || Number.isNaN(raw)) return null;
+        return <WhipResultCard whip={raw} />;
+      }}
     />
   );
 }

--- a/app/(app)/tools/whip/_components/WhipResultCard.tsx
+++ b/app/(app)/tools/whip/_components/WhipResultCard.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import Link from "next/link";
+import { SITE_URL } from "@app/constants/app";
+import { classifyWhip } from "@app/data/baseball-stats/whipLevel";
+import { trackEvent } from "@app/lib/analytics";
+
+type Props = {
+  whip: number;
+};
+
+function formatWhip(value: number): string {
+  if (Number.isNaN(value)) return "-";
+  return value.toFixed(2);
+}
+
+function buildShareText(whipText: string) {
+  return `WHIP ${whipText}
+あなたも BUZZ BASE で WHIP を計算してシェアしよう。`;
+}
+
+export default function WhipResultCard({ whip }: Props) {
+  const level = classifyWhip(whip);
+  const whipText = formatWhip(whip);
+
+  const whipQuery = whip.toFixed(2);
+  const toolUrl = `${SITE_URL}/tools/whip?whip=${whipQuery}`;
+  const shareText = buildShareText(whipText);
+  const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(toolUrl)}`;
+  const lineUrl = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(toolUrl)}&text=${encodeURIComponent(shareText)}`;
+
+  const handleTwitterShare = () => {
+    trackEvent("share", { method: "twitter", content_type: "whip_result" });
+  };
+  const handleLineShare = () => {
+    trackEvent("share", { method: "line", content_type: "whip_result" });
+  };
+  const handleSignupClick = () => {
+    trackEvent("generate_lead", { source_tool: "whip" });
+  };
+
+  const badgeClass: Record<typeof level.key, string> = {
+    S: "bg-amber-400 text-zinc-900",
+    A: "bg-yellow-500 text-zinc-900",
+    B: "bg-yellow-600 text-white",
+    C: "bg-zinc-500 text-white",
+    D: "bg-zinc-700 text-zinc-200",
+  };
+
+  return (
+    <div className="space-y-5 rounded-xl border border-yellow-700/40 bg-gradient-to-br from-zinc-900 via-zinc-900 to-yellow-950/30 p-5">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm text-zinc-400">あなたの WHIP 評価</p>
+        <span
+          className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-bold ${badgeClass[level.key]}`}
+        >
+          {level.key} ／ {level.label}
+        </span>
+      </div>
+
+      <p className="text-sm text-zinc-300 leading-6">{level.comment}</p>
+
+      <div className="rounded-lg border border-zinc-700/70 bg-zinc-950/50 px-4 py-3">
+        <p className="mb-1 text-xs text-zinc-500">シェアプレビュー</p>
+        <p className="text-sm whitespace-pre-line text-zinc-200 leading-6">
+          {shareText}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <a
+          href={twitterUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={handleTwitterShare}
+          className="inline-flex items-center justify-center gap-2 rounded-lg bg-black px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-zinc-800"
+        >
+          X でシェア
+        </a>
+        <a
+          href={lineUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={handleLineShare}
+          className="inline-flex items-center justify-center gap-2 rounded-lg bg-[#06C755] px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-[#04a346]"
+        >
+          LINEでシェア
+        </a>
+      </div>
+
+      <div className="rounded-lg border border-yellow-600/40 bg-yellow-900/20 px-4 py-4">
+        <p className="text-sm text-zinc-200 leading-6">
+          BUZZ BASE に無料登録すると、試合ごとに WHIP・防御率・K/BB・K/9
+          をまとめて記録できます。グラフで成績推移を確認したり、チーム内ランキングで比較したりも可能です。
+        </p>
+        <Link
+          href="/signup"
+          onClick={handleSignupClick}
+          className="mt-3 inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2.5 text-sm font-bold text-zinc-900 transition-colors hover:bg-yellow-400"
+        >
+          無料登録して成績を記録する &rarr;
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/tools/whip/_components/WhipResultCard.tsx
+++ b/app/(app)/tools/whip/_components/WhipResultCard.tsx
@@ -22,9 +22,7 @@ function buildShareText(whipText: string) {
 export default function WhipResultCard({ whip }: Props) {
   const level = classifyWhip(whip);
   const whipText = formatWhip(whip);
-
-  const whipQuery = whip.toFixed(2);
-  const toolUrl = `${SITE_URL}/tools/whip?whip=${whipQuery}`;
+  const toolUrl = `${SITE_URL}/tools/whip?whip=${whipText}`;
   const shareText = buildShareText(whipText);
   const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(toolUrl)}`;
   const lineUrl = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(toolUrl)}&text=${encodeURIComponent(shareText)}`;

--- a/app/data/baseball-stats/kbbLevel.ts
+++ b/app/data/baseball-stats/kbbLevel.ts
@@ -1,0 +1,71 @@
+/**
+ * K/BB（奪三振 ÷ 与四球）のレベル評価ヘルパー。
+ * `/tools/k-bb` の結果カード (KBBResultCard) と OG 画像生成の閾値を一元管理する。
+ */
+
+export type KbbLevelKey = "S" | "A" | "B" | "C" | "D";
+
+export type KbbLevel = {
+  key: KbbLevelKey;
+  /** バッジ表示用の短いラベル */
+  label: string;
+  /** 結果カードに表示する説明文 */
+  comment: string;
+  /** OG 画像で塗るバッジ色 (16進カラー) */
+  ogColor: string;
+};
+
+/**
+ * NPB 基準のレベル区分。
+ * NPB 平均はおおむね 2.50 前後。
+ * - S: 5.00〜 (リーグトップクラス)
+ * - A: 4.00〜4.99 (一流)
+ * - B: 3.00〜3.99 (優秀)
+ * - C: 2.00〜2.99 (リーグ平均前後)
+ * - D: 〜1.99 (要改善)
+ */
+export function classifyKbb(kbb: number): KbbLevel {
+  if (kbb >= 5.0) {
+    return {
+      key: "S",
+      label: "リーグトップ",
+      comment:
+        "K/BB 5.00 以上。NPB でも数えるほどの制球力と奪三振能力。最多奪三振・最優秀防御率の主役級。",
+      ogColor: "#f59e0b",
+    };
+  }
+  if (kbb >= 4.0) {
+    return {
+      key: "A",
+      label: "一流",
+      comment:
+        "K/BB 4.00 以上。三振を量産しながら四球が極めて少ない。リーグを代表するエース格の制球力。",
+      ogColor: "#fbbf24",
+    };
+  }
+  if (kbb >= 3.0) {
+    return {
+      key: "B",
+      label: "優秀",
+      comment:
+        "K/BB 3.00 以上。ローテーションの柱として安定して投げられる制球力。タイトル争いに絡む水準。",
+      ogColor: "#facc15",
+    };
+  }
+  if (kbb >= 2.0) {
+    return {
+      key: "C",
+      label: "平均",
+      comment:
+        "K/BB 2.00 以上。NPB のリーグ平均前後。先発ローテーション維持のライン。",
+      ogColor: "#a3a3a3",
+    };
+  }
+  return {
+    key: "D",
+    label: "要改善",
+    comment:
+      "K/BB 2.00 未満。四球が多く制球力に課題あり。コントロール改善でランナー数を減らしたい。",
+    ogColor: "#737373",
+  };
+}

--- a/app/data/baseball-stats/whipLevel.ts
+++ b/app/data/baseball-stats/whipLevel.ts
@@ -1,0 +1,69 @@
+/**
+ * WHIP（1イニングあたりの被安打＋与四球）のレベル評価ヘルパー。
+ * `/tools/whip` の結果カード (WhipResultCard) と OG 画像生成の閾値を一元管理する。
+ */
+
+export type WhipLevelKey = "S" | "A" | "B" | "C" | "D";
+
+export type WhipLevel = {
+  key: WhipLevelKey;
+  /** バッジ表示用の短いラベル */
+  label: string;
+  /** 結果カードに表示する説明文 */
+  comment: string;
+  /** OG 画像で塗るバッジ色 (16進カラー) */
+  ogColor: string;
+};
+
+/**
+ * NPB 基準のレベル区分。値が低いほど優秀（走者を許さない）。
+ * - S: 〜0.99 (歴代級)
+ * - A: 1.00〜1.09 (エース)
+ * - B: 1.10〜1.24 (好投手)
+ * - C: 1.25〜1.39 (リーグ平均前後)
+ * - D: 1.40〜 (要改善)
+ */
+export function classifyWhip(whip: number): WhipLevel {
+  if (whip < 1.0) {
+    return {
+      key: "S",
+      label: "歴代級",
+      comment:
+        "WHIP 1.00 未満。1イニングあたりの走者数が1人を切る歴代級。沢村賞・MVP 候補水準。",
+      ogColor: "#f59e0b",
+    };
+  }
+  if (whip < 1.1) {
+    return {
+      key: "A",
+      label: "エース",
+      comment:
+        "WHIP 1.00 台前半。安定して走者を出さない。リーグを代表するエースの数値。",
+      ogColor: "#fbbf24",
+    };
+  }
+  if (whip < 1.25) {
+    return {
+      key: "B",
+      label: "好投手",
+      comment: "WHIP 1.10〜1.24。ローテーションの柱として計算できる安定感。",
+      ogColor: "#facc15",
+    };
+  }
+  if (whip < 1.4) {
+    return {
+      key: "C",
+      label: "平均",
+      comment:
+        "WHIP 1.25〜1.39。NPB のリーグ平均前後。先発ローテーション維持のライン。",
+      ogColor: "#a3a3a3",
+    };
+  }
+  return {
+    key: "D",
+    label: "要改善",
+    comment:
+      "WHIP 1.40 以上。被安打または与四球が多くランナーを背負いやすい。失点リスクが高い。",
+    ogColor: "#737373",
+  };
+}


### PR DESCRIPTION
## issue

close ippei-shimizu/buzzbase#373

## 実装概要

これまで OPS / ERA / OBP / Slugging / Batting Average のみに実装されていた「計算結果直下の評価バッジ + シェア + 無料登録 CTA」のパターンを、K/BB と WHIP の 2 ツールにも展開する。

## 背景

戦略分析（`docs/strategy/user-acquisition-plan-202606.md`）で、計算ツール経由の登録動線が一部ツールで完全に欠落していることが判明した。/tools/k-bb は月 324 セッション・/tools/whip も流入があるにもかかわらず、計算後の評価カードと登録 CTA が表示されないままユーザーが離脱していた。実装の穴を塞ぎ、計算ツール経由の登録経路を計測可能にする。

## やらなかったこと

- OG 画像生成 API（`/api/og/kbb-card`・`/api/og/whip-card`）の実装は別 issue に切り出し
- `/column/k-bb-criteria` / `/column/whip-criteria` の解説コラム新規作成も別 issue
- ResultCard コンポーネントのテスト追加は既存 ResultCard（OBP/SLG 等）にもテストがないため、既存方針に合わせて見送り

## 受入基準

- [ ] `/tools/k-bb` で計算成功時に K/BB の評価バッジ（S/A/B/C/D）・コメント・シェアプレビュー・X/LINE シェアボタン・無料登録 CTA が表示される
- [ ] `/tools/whip` で同様に WHIP の結果カードが表示される
- [ ] 「無料登録して成績を記録する」リンクから `/signup` に遷移する
- [ ] GA4 で `generate_lead` イベント（`source_tool: "k-bb"` または `"whip"`）が発火する
- [ ] `yarn typecheck` / `yarn lint` ともにパスする

## 実装詳細

### 新規ファイル

- `app/data/baseball-stats/kbbLevel.ts` — K/BB の NPB 基準レベル分類（S: 5.00〜 / A: 4.00〜4.99 / B: 3.00〜3.99 / C: 2.00〜2.99 / D: 〜1.99）
- `app/data/baseball-stats/whipLevel.ts` — WHIP の NPB 基準レベル分類（S: 〜0.99 / A: 1.00〜1.09 / B: 1.10〜1.24 / C: 1.25〜1.39 / D: 1.40〜）
- `app/(app)/tools/k-bb/_components/KBBResultCard.tsx` — 評価バッジ・シェア・登録 CTA を含む結果カード
- `app/(app)/tools/whip/_components/WhipResultCard.tsx` — 同上

### 変更ファイル

- `app/(app)/tools/k-bb/_components/KBBCalculator.tsx` — `renderExtraResult` で KBBResultCard を計算結果直下に描画
- `app/(app)/tools/whip/_components/WhipCalculator.tsx` — 同上で WhipResultCard

既存 ObpResultCard / SlgResultCard のパターンをそのまま踏襲。閾値や評価コメントは `calculator-definitions.ts` の guide テーブルおよび一般的な NPB 基準と一致させた。

## スクリーンショット

実機で `/tools/k-bb` および `/tools/whip` を開いて計算実行することで確認可能。デザインは既存の OPS / ERA / OBP / SLG / Batting Average の結果カードと統一。

## 確認手順

1. `yarn dev` で開発サーバー起動
2. `http://localhost:8100/tools/k-bb` で奪三振 80 / 与四球 20 を入力して「計算する」
   - K/BB 4.00 が表示され、結果カードに「A ／ 一流」バッジ・コメント・シェアボタン・登録 CTA が表示される
3. `http://localhost:8100/tools/whip` で与四球 15 / 被安打 50 / 投球回 60 を入力
   - WHIP 1.08 が表示され、「A ／ エース」バッジ・登録 CTA が表示される
4. 「無料登録して成績を記録する」をクリックして `/signup` に遷移するか確認
5. ブラウザの DevTools で `generate_lead` イベントが発火しているか確認（`source_tool: k-bb` / `whip`）

## 影響範囲

- `/tools/k-bb` および `/tools/whip` の 2 ページのみ
- 既存ツール（OPS / ERA / OBP / SLG / Batting Average）への影響なし
- `CalculatorForm.tsx` の `renderExtraResult` は optional prop で、未指定のままの他ツールにも影響なし

## コード上の懸念点

- K/BB と WHIP のレベル分類閾値はプロ野球（NPB）基準で設定したため、ターゲットの中高生野球部員には厳しめに評価される可能性がある。利用データを見て必要に応じて閾値を調整する
- `/column/k-bb-criteria` `/column/whip-criteria` のコラムページが未作成のため、既存 `obpLevel.ts` のような「コラムテーブルと一致させる」コメントは付けず、ツール側のみで閾値を管理している。コラム新設時は同期が必要

## その他

特になし
