### PR TITLE
Add: 打席記録v2 の基盤レイヤー（型 / 定数 / API通信 / ユーティリティ）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - stg
+      - "release/**"
   pull_request:
     branches:
       - main
       - stg
+      - "release/**"
 
 jobs:
   lint-and-test:

--- a/app/constants/groundCanvas.ts
+++ b/app/constants/groundCanvas.ts
@@ -16,19 +16,19 @@ export const GROUND_OUTFIELD_RY = 295;
 
 // HOME を通る ±45° のファウルライン上で外野楕円と交わる点までの距離。
 // (x-cx)² / rx² + (y-cy)² / ry² = 1 を傾き1の直線で解いて求める。
-const FAUL_LINE_DIST = Math.sqrt(
+const FOUL_LINE_DIST = Math.sqrt(
   (GROUND_OUTFIELD_RX ** 2 * GROUND_OUTFIELD_RY ** 2) /
     (GROUND_OUTFIELD_RX ** 2 + GROUND_OUTFIELD_RY ** 2),
 );
 
 // ファウルライン端点（外野楕円とファウルラインの交点）。
 export const GROUND_LEFT_END = {
-  x: GROUND_HOME.x - FAUL_LINE_DIST,
-  y: GROUND_HOME.y - FAUL_LINE_DIST,
+  x: GROUND_HOME.x - FOUL_LINE_DIST,
+  y: GROUND_HOME.y - FOUL_LINE_DIST,
 } as const;
 export const GROUND_RIGHT_END = {
-  x: GROUND_HOME.x + FAUL_LINE_DIST,
-  y: GROUND_HOME.y - FAUL_LINE_DIST,
+  x: GROUND_HOME.x + FOUL_LINE_DIST,
+  y: GROUND_HOME.y - FOUL_LINE_DIST,
 } as const;
 
 // 正規化座標の DB 保存精度。back の hit_location_x/y は decimal(4,3) のため

--- a/app/constants/groundCanvas.ts
+++ b/app/constants/groundCanvas.ts
@@ -1,0 +1,74 @@
+// グラウンドイラスト（打席記録の打球方向選択用）のキャンバスサイズ。
+// クリック座標は pixel / canvas で 0.0〜1.0 の正規化座標に変換し、
+// plate_appearances.hit_location_x / hit_location_y で保存する。
+// 同じ座標系を打席記録 UI と stats の打球分布図（SprayChart）で共有する。
+
+export const GROUND_CANVAS_WIDTH = 420;
+export const GROUND_CANVAS_HEIGHT = 340;
+
+// 球場形状の pixel 座標（GROUND_CANVAS_WIDTH/HEIGHT 基準）。
+export const GROUND_HOME = { x: 210, y: 315 } as const;
+export const GROUND_FIRST = { x: 285, y: 240 } as const;
+export const GROUND_SECOND = { x: 210, y: 165 } as const;
+export const GROUND_THIRD = { x: 135, y: 240 } as const;
+export const GROUND_OUTFIELD_RX = 235;
+export const GROUND_OUTFIELD_RY = 295;
+
+// HOME を通る ±45° のファウルライン上で外野楕円と交わる点までの距離。
+// (x-cx)² / rx² + (y-cy)² / ry² = 1 を傾き1の直線で解いて求める。
+const FAUL_LINE_DIST = Math.sqrt(
+  (GROUND_OUTFIELD_RX ** 2 * GROUND_OUTFIELD_RY ** 2) /
+    (GROUND_OUTFIELD_RX ** 2 + GROUND_OUTFIELD_RY ** 2),
+);
+
+// ファウルライン端点（外野楕円とファウルラインの交点）。
+export const GROUND_LEFT_END = {
+  x: GROUND_HOME.x - FAUL_LINE_DIST,
+  y: GROUND_HOME.y - FAUL_LINE_DIST,
+} as const;
+export const GROUND_RIGHT_END = {
+  x: GROUND_HOME.x + FAUL_LINE_DIST,
+  y: GROUND_HOME.y - FAUL_LINE_DIST,
+} as const;
+
+// 正規化座標の DB 保存精度。back の hit_location_x/y は decimal(4,3) のため
+// 小数 3 桁。送信前に Number(value.toFixed(HIT_LOCATION_PRECISION)) で丸める。
+export const HIT_LOCATION_PRECISION = 3;
+
+// グラウンド上の打球方向ラベル表示位置（pixel 座標）。
+// key (1〜13) は plate_appearances.hit_direction_id と一致させる（1=投 〜 13=右線）。
+export const DIRECTION_LABEL_POSITIONS: Record<
+  number,
+  { x: number; y: number }
+> = {
+  1: { x: 210, y: 258 },
+  2: { x: 210, y: 332 },
+  3: { x: 285, y: 240 },
+  4: { x: 255, y: 180 },
+  5: { x: 135, y: 240 },
+  6: { x: 165, y: 180 },
+  7: { x: 50, y: 160 },
+  8: { x: 100, y: 120 },
+  9: { x: 132, y: 65 },
+  10: { x: 210, y: 75 },
+  11: { x: 280, y: 65 },
+  12: { x: 315, y: 115 },
+  13: { x: 360, y: 160 },
+};
+
+// hit_direction_id (1〜13) → 日本語短縮ラベル。
+export const DIRECTION_LABELS: Record<number, string> = {
+  1: "投",
+  2: "捕",
+  3: "一",
+  4: "二",
+  5: "三",
+  6: "遊",
+  7: "左線",
+  8: "左",
+  9: "左中",
+  10: "中",
+  11: "右中",
+  12: "右",
+  13: "右線",
+};

--- a/app/constants/plateResults.ts
+++ b/app/constants/plateResults.ts
@@ -1,0 +1,142 @@
+// v2 打席記録で使う plate_result マスタの分類。
+// back の db/data/master_seeds/plate_results.yml (id 1-19) と完全一致させる。
+// id を変えると既存 plate_appearances の意味が壊れるため固定する。
+//
+// - hit_direction_required=false の結果は「打球方向なし」グループ（三振 / 四球 / 死球 / 打撃妨害 / 振り逃げ）
+// - hit_direction_required=true の結果はタップ必要グループ（アウト系 / ヒット系 / 失策 / 野選 / 犠打 / 犠飛）
+// アウト・ヒットはサブ選択で plate_result_id を確定し、out_type / hit_type を併送する。
+// 走塁妨害 (id=18) は新仕様 UI では非表示（既存データのみ残す）。
+
+import type {
+  HitType,
+  OutType,
+  SwingType,
+} from "@app/interface/plateAppearanceV2";
+
+export const PLATE_RESULT_IDS = {
+  GROUND_OUT: 1,
+  FLY_OUT: 2,
+  FOUL_FLY: 3,
+  LINE_OUT: 4,
+  ERROR: 5,
+  FIELDERS_CHOICE: 6,
+  SINGLE: 7,
+  DOUBLE: 8,
+  TRIPLE: 9,
+  HOME_RUN: 10,
+  SACRIFICE_HIT: 11,
+  SACRIFICE_FLY: 12,
+  STRIKEOUT: 13,
+  STRIKEOUT_REACHED: 14,
+  WALK: 15,
+  HIT_BY_PITCH: 16,
+  INTERFERENCE: 17,
+  OBSTRUCTION: 18,
+  DOUBLE_PLAY: 19,
+} as const;
+
+export type PlateResultId =
+  (typeof PLATE_RESULT_IDS)[keyof typeof PLATE_RESULT_IDS];
+
+// 打球方向を伴わない結果のボタン。
+// 空振り / 見逃し三振は plate_result_id=13 共通で swing_type のみ異なる。
+export interface NoDirectionOption {
+  label: string;
+  plate_result_id: PlateResultId;
+  swing_type?: SwingType;
+}
+
+export const NO_DIRECTION_RESULT_OPTIONS: readonly NoDirectionOption[] = [
+  {
+    label: "空振り三振",
+    plate_result_id: PLATE_RESULT_IDS.STRIKEOUT,
+    swing_type: "swinging",
+  },
+  {
+    label: "見逃し三振",
+    plate_result_id: PLATE_RESULT_IDS.STRIKEOUT,
+    swing_type: "looking",
+  },
+  { label: "振り逃げ", plate_result_id: PLATE_RESULT_IDS.STRIKEOUT_REACHED },
+  { label: "四球", plate_result_id: PLATE_RESULT_IDS.WALK },
+  { label: "死球", plate_result_id: PLATE_RESULT_IDS.HIT_BY_PITCH },
+  { label: "打撃妨害", plate_result_id: PLATE_RESULT_IDS.INTERFERENCE },
+] as const;
+
+// アウト種別サブ選択。plate_result_id と out_type を併送する。
+export interface OutTypeOption {
+  label: string;
+  plate_result_id: PlateResultId;
+  out_type: OutType;
+}
+
+export const OUT_TYPE_OPTIONS: readonly OutTypeOption[] = [
+  {
+    label: "ゴロ",
+    plate_result_id: PLATE_RESULT_IDS.GROUND_OUT,
+    out_type: "ground_ball",
+  },
+  {
+    label: "フライ",
+    plate_result_id: PLATE_RESULT_IDS.FLY_OUT,
+    out_type: "fly_ball",
+  },
+  {
+    label: "ライナー",
+    plate_result_id: PLATE_RESULT_IDS.LINE_OUT,
+    out_type: "line_drive",
+  },
+  {
+    label: "併殺打",
+    plate_result_id: PLATE_RESULT_IDS.DOUBLE_PLAY,
+    out_type: "double_play",
+  },
+  {
+    label: "ファールフライ",
+    plate_result_id: PLATE_RESULT_IDS.FOUL_FLY,
+    out_type: "foul_fly",
+  },
+] as const;
+
+// ヒット種別サブ選択。plate_result_id と hit_type を併送する。
+export interface HitTypeOption {
+  label: string;
+  plate_result_id: PlateResultId;
+  hit_type: HitType;
+}
+
+export const HIT_TYPE_OPTIONS: readonly HitTypeOption[] = [
+  {
+    label: "単打",
+    plate_result_id: PLATE_RESULT_IDS.SINGLE,
+    hit_type: "single",
+  },
+  {
+    label: "二塁打",
+    plate_result_id: PLATE_RESULT_IDS.DOUBLE,
+    hit_type: "double",
+  },
+  {
+    label: "三塁打",
+    plate_result_id: PLATE_RESULT_IDS.TRIPLE,
+    hit_type: "triple",
+  },
+  {
+    label: "本塁打",
+    plate_result_id: PLATE_RESULT_IDS.HOME_RUN,
+    hit_type: "home_run",
+  },
+] as const;
+
+// タップ必要グループのうち、サブ選択モーダルを経由せず直接送る単発ボタン。
+export interface DirectionOnlyOption {
+  label: string;
+  plate_result_id: PlateResultId;
+}
+
+export const DIRECTION_ONLY_RESULT_OPTIONS: readonly DirectionOnlyOption[] = [
+  { label: "失策", plate_result_id: PLATE_RESULT_IDS.ERROR },
+  { label: "野選", plate_result_id: PLATE_RESULT_IDS.FIELDERS_CHOICE },
+  { label: "犠打", plate_result_id: PLATE_RESULT_IDS.SACRIFICE_HIT },
+  { label: "犠飛", plate_result_id: PLATE_RESULT_IDS.SACRIFICE_FLY },
+] as const;

--- a/app/constants/runnersState.ts
+++ b/app/constants/runnersState.ts
@@ -1,0 +1,17 @@
+import type { RunnersState } from "@app/interface/plateAppearanceV2";
+
+// ランナー状況の選択肢。key は back の PlateAppearance#runners_state enum
+// （no_runner=0 起点）と一致させる。
+export const RUNNERS_STATE_OPTIONS: ReadonlyArray<{
+  key: RunnersState;
+  label: string;
+}> = [
+  { key: "no_runner", label: "無走者" },
+  { key: "first", label: "一塁" },
+  { key: "second", label: "二塁" },
+  { key: "third", label: "三塁" },
+  { key: "first_second", label: "一・二塁" },
+  { key: "first_third", label: "一・三塁" },
+  { key: "second_third", label: "二・三塁" },
+  { key: "bases_loaded", label: "満塁" },
+];

--- a/app/constants/throwHand.ts
+++ b/app/constants/throwHand.ts
@@ -1,0 +1,13 @@
+import type { ThrowHand } from "@app/interface/pitcher";
+
+// 投手リスト向けのフルラベル。
+export const THROW_HAND_FULL_LABELS: Readonly<Record<ThrowHand, string>> = {
+  right: "右投げ",
+  left: "左投げ",
+};
+
+// チップ等の省スペース表示向けの短縮ラベル。
+export const THROW_HAND_SHORT_LABELS: Readonly<Record<ThrowHand, string>> = {
+  right: "右",
+  left: "左",
+};

--- a/app/interface/pitcher.ts
+++ b/app/interface/pitcher.ts
@@ -1,0 +1,38 @@
+import type {
+  ArmAngleMaster,
+  Pagination,
+  PitcherStyleMaster,
+  VelocityZoneMaster,
+} from "@app/interface/plateAppearanceMasters";
+
+// 投手の利き手（back の Pitcher#throw_hand enum: right=0 / left=1）。
+export type ThrowHand = "right" | "left";
+
+// 投手はユーザー固有マスタ（created_by_user_id でスコープ）。
+// GET /api/v2/pitchers の各要素 / PlateAppearanceV2.pitcher のネスト形。
+export interface Pitcher {
+  id: number;
+  name: string;
+  throw_hand: ThrowHand | null;
+  team_id: number | null;
+  memo: string | null;
+  arm_angle: ArmAngleMaster | null;
+  velocity_zone: VelocityZoneMaster | null;
+  pitcher_style: PitcherStyleMaster | null;
+}
+
+// POST/PATCH /api/v2/pitchers の body（{ pitcher: PitcherInput }）。
+export interface PitcherInput {
+  name: string;
+  throw_hand?: ThrowHand | null;
+  team_id?: number | null;
+  arm_angle_id?: number | null;
+  velocity_zone_id?: number | null;
+  pitcher_style_id?: number | null;
+  memo?: string | null;
+}
+
+export interface PitcherListResponse {
+  data: Pitcher[];
+  pagination: Pagination;
+}

--- a/app/interface/plateAppearanceMasters.ts
+++ b/app/interface/plateAppearanceMasters.ts
@@ -1,0 +1,25 @@
+// v2 打席記録の詳細データで使うマスタ系の型。
+// back の各マスタ API（GET /api/v2/{contact_qualities,timings,...}）が返す
+// `{ id, name, display_order }` 形と一致させる。display_order 昇順で返る。
+
+export interface MasterItem {
+  id: number;
+  name: string;
+  display_order: number;
+}
+
+export type ContactQualityMaster = MasterItem;
+export type TimingMaster = MasterItem;
+export type PitchTypeMaster = MasterItem;
+export type ArmAngleMaster = MasterItem;
+export type VelocityZoneMaster = MasterItem;
+export type PitcherStyleMaster = MasterItem;
+export type AppearanceSituationMaster = MasterItem;
+
+// stadiums / pitchers の index が返すページネーション情報。
+export interface Pagination {
+  current_page: number;
+  per_page: number;
+  total_count: number;
+  total_pages: number;
+}

--- a/app/interface/plateAppearanceV2.ts
+++ b/app/interface/plateAppearanceV2.ts
@@ -66,6 +66,9 @@ export interface PlateAppearanceV2 {
 
 // POST/PATCH /api/v2/plate_appearances で送る属性。
 // 送信時の hit_location_x/y は数値（送信前に小数3桁へ丸める）。
+// opponent_memo は意図的に含めない。対戦相手メモは打席単位ではなく投手単位
+// （pitcher.memo）へ移行したため、打席記録からは送信しない。レスポンス型
+// PlateAppearanceV2.opponent_memo は既存データ読み出しのため残している。
 export interface PlateAppearanceV2Input {
   game_result_id: number;
   batter_box_number: number;

--- a/app/interface/plateAppearanceV2.ts
+++ b/app/interface/plateAppearanceV2.ts
@@ -1,0 +1,104 @@
+import type { Pitcher } from "@app/interface/pitcher";
+import type {
+  AppearanceSituationMaster,
+  ContactQualityMaster,
+  PitchTypeMaster,
+  TimingMaster,
+} from "@app/interface/plateAppearanceMasters";
+
+// back の PlateAppearance enum 群（v2 で露出するカラム）。
+export type OutType =
+  | "ground_ball"
+  | "fly_ball"
+  | "line_drive"
+  | "double_play"
+  | "foul_fly";
+export type HitType = "single" | "double" | "triple" | "home_run";
+export type SwingType = "swinging" | "looking";
+export type RunnersState =
+  | "no_runner"
+  | "first"
+  | "second"
+  | "third"
+  | "first_second"
+  | "first_third"
+  | "second_third"
+  | "bases_loaded";
+
+// GET /api/v2/plate_appearances/by_game の各要素（V2::PlateAppearanceSerializer）。
+// hit_location_x/y は DB decimal(4,3) のため文字列で返る（例 "0.500"）。
+export interface PlateAppearanceV2 {
+  id: number;
+  game_result_id: number;
+  user_id: number;
+  batter_box_number: number;
+  batting_result: string;
+  plate_result_id: number;
+  hit_direction_id: number | null;
+  batting_position_id: number | null;
+  out_type: OutType | null;
+  hit_type: HitType | null;
+  swing_type: SwingType | null;
+  hit_location_x: string | null;
+  hit_location_y: string | null;
+  rbi: number | null;
+  run_scored: number | null;
+  stolen_bases: number | null;
+  caught_stealing: number | null;
+  final_balls: number | null;
+  final_strikes: number | null;
+  final_outs: number | null;
+  first_pitch_swing: boolean | null;
+  runners_state: RunnersState | null;
+  inning: number | null;
+  self_analysis_memo: string | null;
+  opponent_memo: string | null;
+  is_new_format: boolean;
+  has_detail_data: boolean;
+  created_at: string;
+  updated_at: string;
+  contact_quality: ContactQualityMaster | null;
+  timing: TimingMaster | null;
+  pitch_type: PitchTypeMaster | null;
+  pitcher: Pitcher | null;
+  appearance_situation: AppearanceSituationMaster | null;
+}
+
+// POST/PATCH /api/v2/plate_appearances で送る属性。
+// 送信時の hit_location_x/y は数値（送信前に小数3桁へ丸める）。
+export interface PlateAppearanceV2Input {
+  game_result_id: number;
+  batter_box_number: number;
+  plate_result_id: number;
+  hit_direction_id?: number | null;
+  batting_position_id?: number | null;
+  out_type?: OutType | null;
+  hit_type?: HitType | null;
+  swing_type?: SwingType | null;
+  hit_location_x?: number | null;
+  hit_location_y?: number | null;
+  rbi?: number | null;
+  run_scored?: number | null;
+  stolen_bases?: number | null;
+  caught_stealing?: number | null;
+  final_balls?: number | null;
+  final_strikes?: number | null;
+  final_outs?: number | null;
+  first_pitch_swing?: boolean | null;
+  runners_state?: RunnersState | null;
+  inning?: number | null;
+  contact_quality_id?: number | null;
+  timing_id?: number | null;
+  pitch_type_id?: number | null;
+  self_analysis_memo?: string | null;
+  pitcher_id?: number | null;
+  appearance_situation_id?: number | null;
+}
+
+export interface PlateAppearanceV2Payload {
+  plate_appearance: PlateAppearanceV2Input;
+}
+
+export interface PlateAppearanceListResponse {
+  plate_appearances: PlateAppearanceV2[];
+}

--- a/app/interface/stadium.ts
+++ b/app/interface/stadium.ts
@@ -1,0 +1,24 @@
+import type { Pagination } from "@app/interface/plateAppearanceMasters";
+
+export interface StadiumPrefecture {
+  id: number;
+  name: string;
+}
+
+// 球場はグローバルマスタ（全ユーザー共有、create で created_by_user_id を自動セット）。
+export interface Stadium {
+  id: number;
+  name: string;
+  prefecture: StadiumPrefecture | null;
+}
+
+export interface StadiumSearchResponse {
+  data: Stadium[];
+  pagination: Pagination;
+}
+
+// POST /api/v2/stadiums の body（{ stadium: CreateStadiumPayload }）。
+export interface CreateStadiumPayload {
+  name: string;
+  prefecture_id?: number;
+}

--- a/app/services/v2/authHeaders.ts
+++ b/app/services/v2/authHeaders.ts
@@ -23,8 +23,8 @@ export type ActionResult<T> =
   | { ok: true; data: T }
   | { ok: false; errors: string[] };
 
-// 認証欠落時の共通エラー。
-export const UNAUTHENTICATED_RESULT: { ok: false; errors: string[] } = {
-  ok: false,
-  errors: ["ログインが必要です"],
-};
+// 認証欠落時の共通エラー。呼び出しごとに新規オブジェクトを返し、
+// errors 配列の共有参照（呼び出し元の破壊的操作の波及）を避ける。
+export function unauthenticatedResult(): { ok: false; errors: string[] } {
+  return { ok: false, errors: ["ログインが必要です"] };
+}

--- a/app/services/v2/authHeaders.ts
+++ b/app/services/v2/authHeaders.ts
@@ -1,0 +1,30 @@
+import { cookies } from "next/headers";
+
+// v2 API 呼び出しで共通利用する認証ヘッダー取得（DeviseTokenAuth の3トークン）。
+// stats/actions.ts と同じ実装を v2 サービス層で共通化する。
+// next/headers の cookies() を使うためサーバー実行専用。
+export async function getAuthHeaders(): Promise<Record<string, string> | null> {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("access-token")?.value;
+  const client = cookieStore.get("client")?.value;
+  const uid = cookieStore.get("uid")?.value;
+  if (!accessToken || !client || !uid) return null;
+  return {
+    "Content-Type": "application/json",
+    "access-token": accessToken,
+    client,
+    uid,
+  };
+}
+
+// ミューテーション系 Server Action の戻り値。UI 側でバリデーションエラー
+// （back の 422 `{ errors: [...] }`）を扱えるよう成否を明示する。
+export type ActionResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; errors: string[] };
+
+// 認証欠落時の共通エラー。
+export const UNAUTHENTICATED_RESULT: { ok: false; errors: string[] } = {
+  ok: false,
+  errors: ["ログインが必要です"],
+};

--- a/app/services/v2/masterService.ts
+++ b/app/services/v2/masterService.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import type {
+  AppearanceSituationMaster,
+  ArmAngleMaster,
+  ContactQualityMaster,
+  PitcherStyleMaster,
+  PitchTypeMaster,
+  TimingMaster,
+  VelocityZoneMaster,
+} from "@app/interface/plateAppearanceMasters";
+import { RAILS_API_URL } from "@app/constants/api";
+import { captureServerActionError } from "../../../lib/sentry-helpers";
+import { getAuthHeaders } from "./authHeaders";
+
+// 各マスタ API は { "<resourceKey>": MasterItem[] } を返す。
+// 取得失敗時は空配列を返す（UI 側で fallback）。
+async function fetchMaster<T>(
+  path: string,
+  responseKey: string,
+  action: string,
+): Promise<T[]> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return [];
+
+    const response = await fetch(`${RAILS_API_URL}/api/v2/${path}`, {
+      headers,
+      cache: "no-store",
+    });
+    if (!response.ok) return [];
+
+    const body = await response.json();
+    return body[responseKey] ?? [];
+  } catch (error) {
+    captureServerActionError(error, { action });
+    return [];
+  }
+}
+
+export async function getContactQualities(): Promise<ContactQualityMaster[]> {
+  return fetchMaster(
+    "contact_qualities",
+    "contact_qualities",
+    "getContactQualities",
+  );
+}
+
+export async function getTimings(): Promise<TimingMaster[]> {
+  return fetchMaster("timings", "timings", "getTimings");
+}
+
+export async function getPitchTypes(): Promise<PitchTypeMaster[]> {
+  return fetchMaster("pitch_types", "pitch_types", "getPitchTypes");
+}
+
+export async function getArmAngles(): Promise<ArmAngleMaster[]> {
+  return fetchMaster("arm_angles", "arm_angles", "getArmAngles");
+}
+
+export async function getVelocityZones(): Promise<VelocityZoneMaster[]> {
+  return fetchMaster("velocity_zones", "velocity_zones", "getVelocityZones");
+}
+
+export async function getPitcherStyles(): Promise<PitcherStyleMaster[]> {
+  return fetchMaster("pitcher_styles", "pitcher_styles", "getPitcherStyles");
+}
+
+export async function getAppearanceSituations(): Promise<
+  AppearanceSituationMaster[]
+> {
+  return fetchMaster(
+    "appearance_situations",
+    "appearance_situations",
+    "getAppearanceSituations",
+  );
+}

--- a/app/services/v2/pitcherService.ts
+++ b/app/services/v2/pitcherService.ts
@@ -10,7 +10,7 @@ import { captureServerActionError } from "../../../lib/sentry-helpers";
 import {
   type ActionResult,
   getAuthHeaders,
-  UNAUTHENTICATED_RESULT,
+  unauthenticatedResult,
 } from "./authHeaders";
 
 interface GetPitchersParams {
@@ -65,7 +65,7 @@ export async function createPitcher(
 ): Promise<ActionResult<Pitcher>> {
   try {
     const headers = await getAuthHeaders();
-    if (!headers) return UNAUTHENTICATED_RESULT;
+    if (!headers) return unauthenticatedResult();
 
     const response = await fetch(`${RAILS_API_URL}/api/v2/pitchers`, {
       method: "POST",
@@ -93,7 +93,7 @@ export async function updatePitcher(
 ): Promise<ActionResult<Pitcher>> {
   try {
     const headers = await getAuthHeaders();
-    if (!headers) return UNAUTHENTICATED_RESULT;
+    if (!headers) return unauthenticatedResult();
 
     const response = await fetch(`${RAILS_API_URL}/api/v2/pitchers/${id}`, {
       method: "PATCH",

--- a/app/services/v2/pitcherService.ts
+++ b/app/services/v2/pitcherService.ts
@@ -1,0 +1,113 @@
+"use server";
+
+import type {
+  Pitcher,
+  PitcherInput,
+  PitcherListResponse,
+} from "@app/interface/pitcher";
+import { RAILS_API_URL } from "@app/constants/api";
+import { captureServerActionError } from "../../../lib/sentry-helpers";
+import {
+  type ActionResult,
+  getAuthHeaders,
+  UNAUTHENTICATED_RESULT,
+} from "./authHeaders";
+
+interface GetPitchersParams {
+  q?: string;
+  team_id?: number | null;
+  per_page?: number;
+}
+
+/**
+ * 投手マスタ（current_user 固有）を取得する（GET /api/v2/pitchers）。
+ * 失敗時は空の一覧を返す。
+ */
+export async function getPitchers(
+  params: GetPitchersParams = {},
+): Promise<PitcherListResponse> {
+  const empty: PitcherListResponse = {
+    data: [],
+    pagination: {
+      current_page: 1,
+      per_page: 0,
+      total_count: 0,
+      total_pages: 0,
+    },
+  };
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return empty;
+
+    const query = new URLSearchParams();
+    if (params.q) query.append("q", params.q);
+    if (params.team_id != null) query.append("team_id", String(params.team_id));
+    if (params.per_page != null)
+      query.append("per_page", String(params.per_page));
+
+    const response = await fetch(`${RAILS_API_URL}/api/v2/pitchers?${query}`, {
+      headers,
+      cache: "no-store",
+    });
+    if (!response.ok) return empty;
+    return await response.json();
+  } catch (error) {
+    captureServerActionError(error, { action: "getPitchers" });
+    return empty;
+  }
+}
+
+/**
+ * 投手マスタを新規作成する（POST /api/v2/pitchers）。
+ */
+export async function createPitcher(
+  input: PitcherInput,
+): Promise<ActionResult<Pitcher>> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return UNAUTHENTICATED_RESULT;
+
+    const response = await fetch(`${RAILS_API_URL}/api/v2/pitchers`, {
+      method: "POST",
+      headers,
+      cache: "no-store",
+      body: JSON.stringify({ pitcher: input }),
+    });
+    const body = await response.json();
+    if (!response.ok) {
+      return { ok: false, errors: body.errors ?? ["投手の作成に失敗しました"] };
+    }
+    return { ok: true, data: body };
+  } catch (error) {
+    captureServerActionError(error, { action: "createPitcher" });
+    return { ok: false, errors: ["投手の作成に失敗しました"] };
+  }
+}
+
+/**
+ * 投手マスタを更新する（PATCH /api/v2/pitchers/:id）。自分の投手のみ更新可。
+ */
+export async function updatePitcher(
+  id: number,
+  input: PitcherInput,
+): Promise<ActionResult<Pitcher>> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return UNAUTHENTICATED_RESULT;
+
+    const response = await fetch(`${RAILS_API_URL}/api/v2/pitchers/${id}`, {
+      method: "PATCH",
+      headers,
+      cache: "no-store",
+      body: JSON.stringify({ pitcher: input }),
+    });
+    const body = await response.json();
+    if (!response.ok) {
+      return { ok: false, errors: body.errors ?? ["投手の更新に失敗しました"] };
+    }
+    return { ok: true, data: body };
+  } catch (error) {
+    captureServerActionError(error, { action: "updatePitcher" });
+    return { ok: false, errors: ["投手の更新に失敗しました"] };
+  }
+}

--- a/app/services/v2/pitcherService.ts
+++ b/app/services/v2/pitcherService.ts
@@ -73,9 +73,12 @@ export async function createPitcher(
       cache: "no-store",
       body: JSON.stringify({ pitcher: input }),
     });
-    const body = await response.json();
+    const body = await response.json().catch(() => null);
     if (!response.ok) {
-      return { ok: false, errors: body.errors ?? ["投手の作成に失敗しました"] };
+      return {
+        ok: false,
+        errors: body?.errors ?? ["投手の作成に失敗しました"],
+      };
     }
     return { ok: true, data: body };
   } catch (error) {
@@ -101,9 +104,12 @@ export async function updatePitcher(
       cache: "no-store",
       body: JSON.stringify({ pitcher: input }),
     });
-    const body = await response.json();
+    const body = await response.json().catch(() => null);
     if (!response.ok) {
-      return { ok: false, errors: body.errors ?? ["投手の更新に失敗しました"] };
+      return {
+        ok: false,
+        errors: body?.errors ?? ["投手の更新に失敗しました"],
+      };
     }
     return { ok: true, data: body };
   } catch (error) {

--- a/app/services/v2/plateAppearanceService.ts
+++ b/app/services/v2/plateAppearanceService.ts
@@ -55,11 +55,11 @@ export async function createPlateAppearanceV2(
       cache: "no-store",
       body: JSON.stringify({ plate_appearance: input }),
     });
-    const body = await response.json();
+    const body = await response.json().catch(() => null);
     if (!response.ok) {
       return {
         ok: false,
-        errors: body.errors ?? ["打席結果の保存に失敗しました"],
+        errors: body?.errors ?? ["打席結果の保存に失敗しました"],
       };
     }
     return { ok: true, data: body };
@@ -89,11 +89,11 @@ export async function updatePlateAppearanceV2(
         body: JSON.stringify({ plate_appearance: input }),
       },
     );
-    const body = await response.json();
+    const body = await response.json().catch(() => null);
     if (!response.ok) {
       return {
         ok: false,
-        errors: body.errors ?? ["打席結果の更新に失敗しました"],
+        errors: body?.errors ?? ["打席結果の更新に失敗しました"],
       };
     }
     return { ok: true, data: body };
@@ -121,7 +121,7 @@ export async function deletePlateAppearanceV2(
       const body = await response.json().catch(() => ({}));
       return {
         ok: false,
-        errors: body.errors ?? ["打席結果の削除に失敗しました"],
+        errors: body?.errors ?? ["打席結果の削除に失敗しました"],
       };
     }
     return { ok: true, data: null };

--- a/app/services/v2/plateAppearanceService.ts
+++ b/app/services/v2/plateAppearanceService.ts
@@ -1,0 +1,132 @@
+"use server";
+
+import type {
+  PlateAppearanceListResponse,
+  PlateAppearanceV2,
+  PlateAppearanceV2Input,
+} from "@app/interface/plateAppearanceV2";
+import { RAILS_API_URL } from "@app/constants/api";
+import { captureServerActionError } from "../../../lib/sentry-helpers";
+import {
+  type ActionResult,
+  getAuthHeaders,
+  UNAUTHENTICATED_RESULT,
+} from "./authHeaders";
+
+/**
+ * 試合単位の打席一覧を取得する（GET /api/v2/plate_appearances/by_game/:id）。
+ * batter_box_number 昇順・マスタ include 済み。失敗時は空配列。
+ */
+export async function getPlateAppearancesByGame(
+  gameResultId: number,
+): Promise<PlateAppearanceV2[]> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return [];
+
+    const response = await fetch(
+      `${RAILS_API_URL}/api/v2/plate_appearances/by_game/${gameResultId}`,
+      { headers, cache: "no-store" },
+    );
+    if (!response.ok) return [];
+
+    const body: PlateAppearanceListResponse = await response.json();
+    return body.plate_appearances ?? [];
+  } catch (error) {
+    captureServerActionError(error, { action: "getPlateAppearancesByGame" });
+    return [];
+  }
+}
+
+/**
+ * 打席を1件作成する（POST /api/v2/plate_appearances）。
+ * batting_result / is_new_format はサーバー側で付与される。
+ */
+export async function createPlateAppearanceV2(
+  input: PlateAppearanceV2Input,
+): Promise<ActionResult<PlateAppearanceV2>> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return UNAUTHENTICATED_RESULT;
+
+    const response = await fetch(`${RAILS_API_URL}/api/v2/plate_appearances`, {
+      method: "POST",
+      headers,
+      cache: "no-store",
+      body: JSON.stringify({ plate_appearance: input }),
+    });
+    const body = await response.json();
+    if (!response.ok) {
+      return {
+        ok: false,
+        errors: body.errors ?? ["打席結果の保存に失敗しました"],
+      };
+    }
+    return { ok: true, data: body };
+  } catch (error) {
+    captureServerActionError(error, { action: "createPlateAppearanceV2" });
+    return { ok: false, errors: ["打席結果の保存に失敗しました"] };
+  }
+}
+
+/**
+ * 打席を更新する（PATCH /api/v2/plate_appearances/:id）。
+ */
+export async function updatePlateAppearanceV2(
+  id: number,
+  input: PlateAppearanceV2Input,
+): Promise<ActionResult<PlateAppearanceV2>> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return UNAUTHENTICATED_RESULT;
+
+    const response = await fetch(
+      `${RAILS_API_URL}/api/v2/plate_appearances/${id}`,
+      {
+        method: "PATCH",
+        headers,
+        cache: "no-store",
+        body: JSON.stringify({ plate_appearance: input }),
+      },
+    );
+    const body = await response.json();
+    if (!response.ok) {
+      return {
+        ok: false,
+        errors: body.errors ?? ["打席結果の更新に失敗しました"],
+      };
+    }
+    return { ok: true, data: body };
+  } catch (error) {
+    captureServerActionError(error, { action: "updatePlateAppearanceV2" });
+    return { ok: false, errors: ["打席結果の更新に失敗しました"] };
+  }
+}
+
+/**
+ * 打席を削除する（DELETE /api/v2/plate_appearances/:id）。
+ */
+export async function deletePlateAppearanceV2(
+  id: number,
+): Promise<ActionResult<null>> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return UNAUTHENTICATED_RESULT;
+
+    const response = await fetch(
+      `${RAILS_API_URL}/api/v2/plate_appearances/${id}`,
+      { method: "DELETE", headers, cache: "no-store" },
+    );
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      return {
+        ok: false,
+        errors: body.errors ?? ["打席結果の削除に失敗しました"],
+      };
+    }
+    return { ok: true, data: null };
+  } catch (error) {
+    captureServerActionError(error, { action: "deletePlateAppearanceV2" });
+    return { ok: false, errors: ["打席結果の削除に失敗しました"] };
+  }
+}

--- a/app/services/v2/plateAppearanceService.ts
+++ b/app/services/v2/plateAppearanceService.ts
@@ -10,7 +10,7 @@ import { captureServerActionError } from "../../../lib/sentry-helpers";
 import {
   type ActionResult,
   getAuthHeaders,
-  UNAUTHENTICATED_RESULT,
+  unauthenticatedResult,
 } from "./authHeaders";
 
 /**
@@ -47,7 +47,7 @@ export async function createPlateAppearanceV2(
 ): Promise<ActionResult<PlateAppearanceV2>> {
   try {
     const headers = await getAuthHeaders();
-    if (!headers) return UNAUTHENTICATED_RESULT;
+    if (!headers) return unauthenticatedResult();
 
     const response = await fetch(`${RAILS_API_URL}/api/v2/plate_appearances`, {
       method: "POST",
@@ -78,7 +78,7 @@ export async function updatePlateAppearanceV2(
 ): Promise<ActionResult<PlateAppearanceV2>> {
   try {
     const headers = await getAuthHeaders();
-    if (!headers) return UNAUTHENTICATED_RESULT;
+    if (!headers) return unauthenticatedResult();
 
     const response = await fetch(
       `${RAILS_API_URL}/api/v2/plate_appearances/${id}`,
@@ -111,7 +111,7 @@ export async function deletePlateAppearanceV2(
 ): Promise<ActionResult<null>> {
   try {
     const headers = await getAuthHeaders();
-    if (!headers) return UNAUTHENTICATED_RESULT;
+    if (!headers) return unauthenticatedResult();
 
     const response = await fetch(
       `${RAILS_API_URL}/api/v2/plate_appearances/${id}`,

--- a/app/services/v2/stadiumService.ts
+++ b/app/services/v2/stadiumService.ts
@@ -75,9 +75,12 @@ export async function createStadium(
       cache: "no-store",
       body: JSON.stringify({ stadium: payload }),
     });
-    const body = await response.json();
+    const body = await response.json().catch(() => null);
     if (!response.ok) {
-      return { ok: false, errors: body.errors ?? ["球場の作成に失敗しました"] };
+      return {
+        ok: false,
+        errors: body?.errors ?? ["球場の作成に失敗しました"],
+      };
     }
     return { ok: true, data: body };
   } catch (error) {

--- a/app/services/v2/stadiumService.ts
+++ b/app/services/v2/stadiumService.ts
@@ -10,7 +10,7 @@ import { captureServerActionError } from "../../../lib/sentry-helpers";
 import {
   type ActionResult,
   getAuthHeaders,
-  UNAUTHENTICATED_RESULT,
+  unauthenticatedResult,
 } from "./authHeaders";
 
 interface SearchStadiumsParams {
@@ -67,7 +67,7 @@ export async function createStadium(
 ): Promise<ActionResult<Stadium>> {
   try {
     const headers = await getAuthHeaders();
-    if (!headers) return UNAUTHENTICATED_RESULT;
+    if (!headers) return unauthenticatedResult();
 
     const response = await fetch(`${RAILS_API_URL}/api/v2/stadiums`, {
       method: "POST",

--- a/app/services/v2/stadiumService.ts
+++ b/app/services/v2/stadiumService.ts
@@ -1,0 +1,87 @@
+"use server";
+
+import type {
+  CreateStadiumPayload,
+  Stadium,
+  StadiumSearchResponse,
+} from "@app/interface/stadium";
+import { RAILS_API_URL } from "@app/constants/api";
+import { captureServerActionError } from "../../../lib/sentry-helpers";
+import {
+  type ActionResult,
+  getAuthHeaders,
+  UNAUTHENTICATED_RESULT,
+} from "./authHeaders";
+
+interface SearchStadiumsParams {
+  q?: string;
+  prefecture_id?: number;
+  per_page?: number;
+}
+
+/**
+ * 球場マスタを部分一致検索する（GET /api/v2/stadiums）。
+ * 失敗時は空の検索結果を返す。
+ */
+export async function searchStadiums(
+  params: SearchStadiumsParams = {},
+): Promise<StadiumSearchResponse> {
+  const empty: StadiumSearchResponse = {
+    data: [],
+    pagination: {
+      current_page: 1,
+      per_page: 0,
+      total_count: 0,
+      total_pages: 0,
+    },
+  };
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return empty;
+
+    const query = new URLSearchParams();
+    if (params.q) query.append("q", params.q);
+    if (params.prefecture_id != null)
+      query.append("prefecture_id", String(params.prefecture_id));
+    if (params.per_page != null)
+      query.append("per_page", String(params.per_page));
+
+    const response = await fetch(`${RAILS_API_URL}/api/v2/stadiums?${query}`, {
+      headers,
+      cache: "no-store",
+    });
+    if (!response.ok) return empty;
+    return await response.json();
+  } catch (error) {
+    captureServerActionError(error, { action: "searchStadiums" });
+    return empty;
+  }
+}
+
+/**
+ * 球場マスタを新規作成する（POST /api/v2/stadiums）。
+ * 成否を ActionResult で返す。
+ */
+export async function createStadium(
+  payload: CreateStadiumPayload,
+): Promise<ActionResult<Stadium>> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return UNAUTHENTICATED_RESULT;
+
+    const response = await fetch(`${RAILS_API_URL}/api/v2/stadiums`, {
+      method: "POST",
+      headers,
+      cache: "no-store",
+      body: JSON.stringify({ stadium: payload }),
+    });
+    const body = await response.json();
+    if (!response.ok) {
+      return { ok: false, errors: body.errors ?? ["球場の作成に失敗しました"] };
+    }
+    return { ok: true, data: body };
+  } catch (error) {
+    captureServerActionError(error, { action: "createStadium" });
+    return { ok: false, errors: ["球場の作成に失敗しました"] };
+  }
+}

--- a/app/utils/__tests__/groundZoneDetector.test.ts
+++ b/app/utils/__tests__/groundZoneDetector.test.ts
@@ -1,0 +1,43 @@
+import {
+  DIRECTION_LABEL_POSITIONS,
+  GROUND_CANVAS_HEIGHT,
+  GROUND_CANVAS_WIDTH,
+} from "@app/constants/groundCanvas";
+import {
+  detectClosestDirection,
+  roundHitLocation,
+} from "@app/utils/groundZoneDetector";
+
+// pixel 座標を正規化座標 (0..1) に変換するヘルパー。
+const toNormalized = (pixelX: number, pixelY: number) => ({
+  x: pixelX / GROUND_CANVAS_WIDTH,
+  y: pixelY / GROUND_CANVAS_HEIGHT,
+});
+
+describe("detectClosestDirection", () => {
+  it("各方向ラベルの中心位置は、その方向 id を返す", () => {
+    for (const [idKey, pos] of Object.entries(DIRECTION_LABEL_POSITIONS)) {
+      const point = toNormalized(pos.x, pos.y);
+      expect(detectClosestDirection(point)).toBe(Number(idKey));
+    }
+  });
+
+  it("ラベル中心から少しずれた近傍点も、その方向 id を返す", () => {
+    const centerField = DIRECTION_LABEL_POSITIONS[10]; // 中
+    const point = toNormalized(centerField.x + 8, centerField.y + 8);
+    expect(detectClosestDirection(point)).toBe(10);
+  });
+
+  it("捕手側（左下隅付近）は捕(2)を返す", () => {
+    const point = toNormalized(210, 339);
+    expect(detectClosestDirection(point)).toBe(2);
+  });
+});
+
+describe("roundHitLocation", () => {
+  it("小数3桁に丸める（DB decimal(4,3) に合わせる）", () => {
+    expect(roundHitLocation(0.123456)).toBe(0.123);
+    expect(roundHitLocation(0.5)).toBe(0.5);
+    expect(roundHitLocation(0.9999)).toBe(1);
+  });
+});

--- a/app/utils/__tests__/groundZoneDetector.test.ts
+++ b/app/utils/__tests__/groundZoneDetector.test.ts
@@ -32,6 +32,19 @@ describe("detectClosestDirection", () => {
     const point = toNormalized(210, 339);
     expect(detectClosestDirection(point)).toBe(2);
   });
+
+  it("2ラベルの中点はより近い方（同距離なら先に走査した小さい id）を返す", () => {
+    // 左中(9){132,65} と 中(10){210,75} の中点。距離はほぼ同じだが
+    // Object.entries の走査順で先に評価される 9 が選ばれる。
+    const mid = toNormalized((132 + 210) / 2, (65 + 75) / 2);
+    expect(detectClosestDirection(mid)).toBe(9);
+  });
+
+  it("正規化範囲外(x>1)でも最寄りの外縁ラベル id を返す（null にしない）", () => {
+    const result = detectClosestDirection({ x: 1.5, y: 0.5 });
+    expect(result).not.toBeNull();
+    expect(Object.keys(DIRECTION_LABEL_POSITIONS)).toContain(String(result));
+  });
 });
 
 describe("roundHitLocation", () => {
@@ -39,5 +52,10 @@ describe("roundHitLocation", () => {
     expect(roundHitLocation(0.123456)).toBe(0.123);
     expect(roundHitLocation(0.5)).toBe(0.5);
     expect(roundHitLocation(0.9999)).toBe(1);
+  });
+
+  it("0 と境界値を保持する", () => {
+    expect(roundHitLocation(0)).toBe(0);
+    expect(roundHitLocation(1)).toBe(1);
   });
 });

--- a/app/utils/groundZoneDetector.ts
+++ b/app/utils/groundZoneDetector.ts
@@ -1,0 +1,43 @@
+import {
+  DIRECTION_LABEL_POSITIONS,
+  GROUND_CANVAS_HEIGHT,
+  GROUND_CANVAS_WIDTH,
+  HIT_LOCATION_PRECISION,
+} from "@app/constants/groundCanvas";
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * クリック位置（正規化座標）に最も近い DIRECTION_LABEL_POSITIONS のラベル ID を返す。
+ * 画面上のラベル位置と pixel 距離で比較するだけなので、表示ラベルと完全に連動する。
+ *
+ * @param point クリック位置の正規化座標 (x: 0..1, y: 0..1)
+ * @returns 最寄りラベルの id。DIRECTION_LABEL_POSITIONS が空のときのみ null
+ */
+export function detectClosestDirection(point: Point): number | null {
+  const pixelX = point.x * GROUND_CANVAS_WIDTH;
+  const pixelY = point.y * GROUND_CANVAS_HEIGHT;
+  let closestId: number | null = null;
+  let closestDistSq = Infinity;
+  for (const [idKey, pos] of Object.entries(DIRECTION_LABEL_POSITIONS)) {
+    const dx = pos.x - pixelX;
+    const dy = pos.y - pixelY;
+    const distSq = dx * dx + dy * dy;
+    if (distSq < closestDistSq) {
+      closestDistSq = distSq;
+      closestId = Number(idKey);
+    }
+  }
+  return closestId;
+}
+
+/**
+ * 正規化座標を DB の hit_location_x/y の精度（小数3桁）に丸める。
+ * 送信ペイロード生成時に使用する。
+ */
+export function roundHitLocation(value: number): number {
+  return Number(value.toFixed(HIT_LOCATION_PRECISION));
+}


### PR DESCRIPTION
## 概要

mobile [buzzbase_mobile#101](https://github.com/ippei-shimizu/buzzbase_mobile/pull/101) の新仕様（打撃成績記録・分析）に front を追従させるシリーズ ([ippei-shimizu/buzzbase#393](https://github.com/ippei-shimizu/buzzbase/issues/393)) の最初の **基盤レイヤー**。型定義 / 定数 / ユーティリティ / API 通信層（Server Actions）のみを追加し、UI・画面・ルーティングは変更しない（後続 #394〜で利用）。

Closes ippei-shimizu/buzzbase#393

## 変更内容

### 型定義（`app/interface/`）
- `plateAppearanceV2.ts` / `pitcher.ts` / `stadium.ts` / `plateAppearanceMasters.ts`
- back の v2 API レスポンス/リクエスト形と一致。`hit_location_x/y` は DB `decimal(4,3)` に合わせ「レスポンスは文字列・送信は数値」。

### 定数（`app/constants/`）
- `plateResults.ts`（plate_results 1-19・out_type・hit_type のサブ選択定義）
- `runnersState.ts` / `throwHand.ts`
- `groundCanvas.ts`（キャンバス420x340・13方向ラベル座標・`HIT_LOCATION_PRECISION=3`）

### ユーティリティ（`app/utils/`）
- `groundZoneDetector.ts`: `detectClosestDirection`（正規化座標→最寄り方向 id）/ `roundHitLocation`（小数3桁丸め）
- 単体テスト `app/utils/__tests__/groundZoneDetector.test.ts`

### API 通信（`app/services/v2/`・Server Actions）
- `stadiumService` / `pitcherService` / `masterService` / `plateAppearanceService`
- `authHeaders.ts` に共通の `getAuthHeaders` と `ActionResult<T>`。
- 読み取り系は失敗時 fallback、ミューテーション系は `ActionResult` で 422 の `{ errors }` を UI に渡す。

## 設計メモ
- front の v2 慣習（Server Actions + `fetch` + `cookies()`）に合わせ、mobile の axios / TanStack / zustand は移植していない。
- 定数・enum・ID は back / mobile と一致（DB 整合のため）。
- issue 本文の「decimal(5,4)」は mobile 定数由来の表記で、実体は back schema の `decimal(4,3)`（小数3桁）。本 PR は 3 桁で統一。

## スコープ外
- UI コンポーネント・画面・store（#394〜#399）。v1 サービス/型の改修。打球深さ(hit_depth)関連（back/mobile とも撤廃済み）。

## 確認
- `yarn lint` パス、`yarn test app/utils/__tests__/groundZoneDetector.test.ts` パス（4件）。
- `yarn typecheck` は追加ファイルにエラーなし（ローカルの `.next/dev/types` 由来の stale エラーのみ。クリーンチェックアウトの CI では発生しない）。
