### PR TITLE
Update: 試合情報入力に球場選択と記録パターン分岐を追加

### DIFF
--- a/app/(app)/dashboard/_components/RecordGameButton.tsx
+++ b/app/(app)/dashboard/_components/RecordGameButton.tsx
@@ -5,6 +5,10 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { PlusIcon } from "@app/components/icon/PlusIcon";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
+import {
+  GAME_RECORD_EDIT_MODE_STORAGE_KEY,
+  RECORD_PATTERN_STORAGE_KEY,
+} from "@app/constants/gameRecord";
 import { createGameResult } from "@app/services/gameResultsService";
 
 export default function RecordGameButton() {
@@ -16,6 +20,9 @@ export default function RecordGameButton() {
     try {
       const newGameResult = await createGameResult();
       localStorage.setItem("gameResultId", JSON.stringify(newGameResult.id));
+      // 新規記録フローなので編集フラグと前回のパターンをクリアする。
+      localStorage.removeItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY);
+      localStorage.removeItem(RECORD_PATTERN_STORAGE_KEY);
       router.push("/game-result/record");
     } catch (error) {
       console.error("試合記録の作成に失敗しました", error);

--- a/app/(app)/game-result/batting/page.tsx
+++ b/app/(app)/game-result/batting/page.tsx
@@ -9,6 +9,7 @@ import HeaderResult from "@app/components/header/HeaderResult";
 import { DeleteIcon } from "@app/components/icon/DeleteIcon";
 import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
+import { RECORD_PATTERN_STORAGE_KEY } from "@app/constants/gameRecord";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import {
   checkExistingBattingAverage,
@@ -24,6 +25,16 @@ import {
   updatePlateAppearance,
 } from "@app/services/plateAppearanceService";
 import { getCurrentUserId } from "@app/services/userService";
+
+// 記録パターンに応じた打撃入力後の遷移先。打撃のみ(batting)は投手入力を
+// スキップしてまとめへ、それ以外（both / pitching / 既定）は投手入力へ進む。
+const resolveBattingNextPath = (): string => {
+  const raw = localStorage.getItem(RECORD_PATTERN_STORAGE_KEY);
+  const pattern = raw ? JSON.parse(raw) : "both";
+  return pattern === "batting"
+    ? "/game-result/summary/"
+    : "/game-result/pitching/";
+};
 
 const battingResultsPositions = [
   { id: 0, direction: "-" },
@@ -458,7 +469,7 @@ export default function BattingRecord() {
       cs === 0;
 
     if (isBattingEmpty) {
-      router.push(`/game-result/pitching/`);
+      router.push(resolveBattingNextPath());
       return;
     }
 
@@ -553,7 +564,7 @@ export default function BattingRecord() {
           );
         }
       }
-      router.push(`/game-result/pitching/`);
+      router.push(resolveBattingNextPath());
     } catch {}
   };
   return (

--- a/app/(app)/game-result/batting/page.tsx
+++ b/app/(app)/game-result/batting/page.tsx
@@ -155,6 +155,7 @@ const useBattingStatistics = (battingBoxes: BattingBox[]) => {
 
 export default function BattingRecord() {
   const [currentUserId, setCurrentUserId] = useState<number | null>(null);
+  const [isBattingOnly, setIsBattingOnly] = useState(false);
   const [runsBattedIn, setRunsBattedIn] = useState(0);
   const [existingRunsBattedIn, setExistingRunsBattedIn] = useState(0);
   const [run, setRun] = useState(0);
@@ -290,6 +291,12 @@ export default function BattingRecord() {
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchData();
+    // 記録パターンが「打撃のみ」かどうか（投手入力をスキップしてまとめへ進む）。
+    const recordPatternRaw = localStorage.getItem(RECORD_PATTERN_STORAGE_KEY);
+
+    setIsBattingOnly(
+      (recordPatternRaw ? JSON.parse(recordPatternRaw) : "both") === "batting",
+    );
     // ローカルストレージからid取得
     const savedGameResultId = localStorage.getItem("gameResultId");
     if (savedGameResultId) {
@@ -773,7 +780,7 @@ export default function BattingRecord() {
                   endContent={<NextArrowIcon stroke="#F4F4F4" />}
                   isDisabled={isSubmitting}
                 >
-                  投手結果
+                  {isBattingOnly ? "試合結果まとめ" : "投手結果"}
                 </Button>
               </div>
             </form>

--- a/app/(app)/game-result/lists/page.tsx
+++ b/app/(app)/game-result/lists/page.tsx
@@ -9,6 +9,10 @@ import Header from "@app/components/header/Header";
 import { PlusIcon } from "@app/components/icon/PlusIcon";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import MatchResultList from "@app/components/user/MatchResultList";
+import {
+  GAME_RECORD_EDIT_MODE_STORAGE_KEY,
+  RECORD_PATTERN_STORAGE_KEY,
+} from "@app/constants/gameRecord";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import { createGameResult } from "@app/services/gameResultsService";
 import { getCurrentUserId } from "@app/services/userService";
@@ -36,6 +40,9 @@ export default function GameResultList() {
     try {
       const newGameResult = await createGameResult();
       localStorage.setItem("gameResultId", JSON.stringify(newGameResult.id));
+      // 新規記録フローなので編集フラグと前回のパターンをクリアする。
+      localStorage.removeItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY);
+      localStorage.removeItem(RECORD_PATTERN_STORAGE_KEY);
       router.push(`/game-result/record`);
     } catch {}
   };

--- a/app/(app)/game-result/record/_components/PatternSelector.tsx
+++ b/app/(app)/game-result/record/_components/PatternSelector.tsx
@@ -1,0 +1,45 @@
+"use client";
+import type { RecordPattern } from "@app/interface/gameRecord";
+import { Button } from "@heroui/react";
+import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
+import { RECORD_PATTERN_OPTIONS } from "@app/constants/gameRecord";
+
+interface PatternSelectorProps {
+  onSelect: (pattern: RecordPattern) => void;
+  disabled?: boolean;
+}
+
+/**
+ * 記録パターン（打撃のみ / 投手のみ / 両方）を選ぶ3ボタン。
+ * 押下したパターンを onSelect で親に渡し、親が送信と遷移を行う。
+ */
+export default function PatternSelector({
+  onSelect,
+  disabled,
+}: PatternSelectorProps) {
+  return (
+    <div className="flex flex-col gap-y-3">
+      {RECORD_PATTERN_OPTIONS.map((option) => {
+        const isPrimary = option.emphasis === "primary";
+        return (
+          <Button
+            key={option.pattern}
+            color="primary"
+            variant={isPrimary ? "solid" : "bordered"}
+            size="lg"
+            radius="sm"
+            type="button"
+            className="w-full justify-between font-bold text-base"
+            isDisabled={disabled}
+            onPress={() => onSelect(option.pattern)}
+            endContent={
+              <NextArrowIcon stroke={isPrimary ? "#F4F4F4" : "#d08000"} />
+            }
+          >
+            {option.label}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(app)/game-result/record/_components/ScoreStepper.tsx
+++ b/app/(app)/game-result/record/_components/ScoreStepper.tsx
@@ -30,6 +30,7 @@ export default function ScoreStepper({
         radius="full"
         variant="solid"
         color="primary"
+        className="h-7 w-7 min-w-7 text-base"
         aria-label={`${ariaLabel}を減らす`}
         isDisabled={decrementDisabled}
         onPress={() => onChange(Math.max(0, (value ?? 0) - 1))}
@@ -62,10 +63,11 @@ export default function ScoreStepper({
         radius="full"
         variant="solid"
         color="primary"
+        className="h-7 w-7 min-w-7 text-base"
         aria-label={`${ariaLabel}を増やす`}
         onPress={() => onChange((value ?? 0) + 1)}
       >
-        ＋
+        +
       </Button>
     </div>
   );

--- a/app/(app)/game-result/record/_components/ScoreStepper.tsx
+++ b/app/(app)/game-result/record/_components/ScoreStepper.tsx
@@ -1,0 +1,72 @@
+"use client";
+import { Button, Input } from "@heroui/react";
+
+interface ScoreStepperProps {
+  value: number | null;
+  onChange: (next: number | null) => void;
+  ariaLabel: string;
+  placeholder?: string;
+  isValid?: boolean;
+}
+
+/**
+ * 点数入力欄。+/- ボタンで増減でき、キーボード手入力も併用する。
+ * 空欄は null（未入力）として扱い、0（完封）と区別する。
+ */
+export default function ScoreStepper({
+  value,
+  onChange,
+  ariaLabel,
+  placeholder,
+  isValid = true,
+}: ScoreStepperProps) {
+  const decrementDisabled = value === null || value <= 0;
+
+  return (
+    <div className="flex items-center gap-x-1">
+      <Button
+        isIconOnly
+        size="sm"
+        radius="full"
+        variant="light"
+        color="primary"
+        aria-label={`${ariaLabel}を減らす`}
+        isDisabled={decrementDisabled}
+        onPress={() => onChange(Math.max(0, (value ?? 0) - 1))}
+      >
+        −
+      </Button>
+      <Input
+        type="number"
+        size="md"
+        variant="bordered"
+        min={0}
+        aria-label={ariaLabel}
+        placeholder={placeholder}
+        className="w-16"
+        color={isValid ? "default" : "danger"}
+        value={value !== null ? String(value) : ""}
+        onChange={(event) => {
+          const raw = event.target.value;
+          if (raw === "") {
+            onChange(null);
+            return;
+          }
+          const parsed = Number(raw);
+          if (!Number.isNaN(parsed)) onChange(Math.max(0, parsed));
+        }}
+      />
+      <Button
+        isIconOnly
+        size="sm"
+        radius="full"
+        variant="light"
+        color="primary"
+        aria-label={`${ariaLabel}を増やす`}
+        onPress={() => onChange((value ?? 0) + 1)}
+      >
+        ＋
+      </Button>
+    </div>
+  );
+}

--- a/app/(app)/game-result/record/_components/ScoreStepper.tsx
+++ b/app/(app)/game-result/record/_components/ScoreStepper.tsx
@@ -54,7 +54,8 @@ export default function ScoreStepper({
             return;
           }
           const parsed = Number(raw);
-          if (!Number.isNaN(parsed)) onChange(Math.max(0, parsed));
+          // 点数は整数のみ。小数入力は切り捨てる。
+          if (!Number.isNaN(parsed)) onChange(Math.max(0, Math.floor(parsed)));
         }}
       />
       <Button

--- a/app/(app)/game-result/record/_components/ScoreStepper.tsx
+++ b/app/(app)/game-result/record/_components/ScoreStepper.tsx
@@ -28,7 +28,7 @@ export default function ScoreStepper({
         isIconOnly
         size="sm"
         radius="full"
-        variant="light"
+        variant="solid"
         color="primary"
         aria-label={`${ariaLabel}を減らす`}
         isDisabled={decrementDisabled}
@@ -60,7 +60,7 @@ export default function ScoreStepper({
         isIconOnly
         size="sm"
         radius="full"
-        variant="light"
+        variant="solid"
         color="primary"
         aria-label={`${ariaLabel}を増やす`}
         onPress={() => onChange((value ?? 0) + 1)}

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -5,6 +5,8 @@ import type {
   SeasonData,
   TournamentData,
 } from "@app/interface";
+import type { RecordPattern } from "@app/interface/gameRecord";
+import type { Stadium } from "@app/interface/stadium";
 import {
   Autocomplete,
   AutocompleteItem,
@@ -24,6 +26,7 @@ import HeaderResult from "@app/components/header/HeaderResult";
 import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import { APPEARANCE_TYPE_OPTIONS } from "@app/constants/appearanceType";
+import { RECORD_PATTERN_STORAGE_KEY } from "@app/constants/gameRecord";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import {
   createGameResult,
@@ -44,6 +47,9 @@ import {
   updateTournament,
 } from "@app/services/tournamentsService";
 import { getCurrentUserId, getUserData } from "@app/services/userService";
+import { createStadium, searchStadiums } from "@app/services/v2/stadiumService";
+import PatternSelector from "./_components/PatternSelector";
+import ScoreStepper from "./_components/ScoreStepper";
 
 // 打順の選択肢。代打・代走・途中出場・未出場のケースで「なし」を選べるよう先頭に追加。
 // 「なし」は id=""（空文字）として、state（matchBattingOrder）と Select の selectedKeys を一致させる。
@@ -98,10 +104,14 @@ export default function GameRecord() {
   const [existingOpponentTeam, setExistingOpponentTeam] = useState<
     number | undefined
   >(undefined);
-  const [myTeamScore, setMyTeamScore] = useState<number | null>(null);
-  const [opponentTeamScore, setOpponentTeamScore] = useState<number | null>(
-    null,
-  );
+  // 点数は完封 0-0 を許容するため初期値 0。手入力で空にしたときは null（未入力）。
+  const [myTeamScore, setMyTeamScore] = useState<number | null>(0);
+  const [opponentTeamScore, setOpponentTeamScore] = useState<number | null>(0);
+  const [stadiumName, setStadiumName] = useState("");
+  const [stadiumId, setStadiumId] = useState<number | null>(null);
+  const [stadiumData, setStadiumData] = useState<Stadium[]>([]);
+  // 既存試合の編集中かどうか（編集時はパターン選択を出さず単一ボタンにする）。
+  const [isEditMode, setIsEditMode] = useState(false);
   const [matchBattingOrder, setMatchBattingOrder] = useState("");
   const [existingMatchBattingOrder, setExistingMatchBattingOrder] =
     useState("");
@@ -156,6 +166,8 @@ export default function GameRecord() {
       const positionDataList = await getPositions();
       setPositionData(positionDataList);
       setTournamentData(getTournamentList);
+      const stadiumsResponse = await searchStadiums({});
+      setStadiumData(stadiumsResponse.data);
     } catch (error) {
       throw error;
     }
@@ -170,6 +182,18 @@ export default function GameRecord() {
         currentUserId,
       );
       if (existingMatchResult) {
+        setIsEditMode(true);
+        // 編集時は stadium_id を復元する。v1 レスポンスは球場名を含まないため、
+        // 表示名は候補リストから id で best-effort に引き当てる（見つからなくても
+        // stadium_id は保持され、保存時に球場が維持される）。
+        if (existingMatchResult.stadium_id) {
+          setStadiumId(existingMatchResult.stadium_id);
+          const stadiumList = await searchStadiums({ per_page: 100 });
+          const foundStadium = stadiumList.data.find(
+            (stadium) => stadium.id === existingMatchResult.stadium_id,
+          );
+          if (foundStadium) setStadiumName(foundStadium.name);
+        }
         const date = new Date(existingMatchResult.date_and_time);
         const formattedDate = `${date.getFullYear()}-${(date.getMonth() + 1)
           .toString()
@@ -321,16 +345,26 @@ export default function GameRecord() {
     setSelectedSeason(value as number | null);
   };
 
-  // 自分チーム得点
-  const handleMyScoreChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setMyTeamScore(Number(event.target.value));
+  // 球場の入力。入力名が候補と完全一致すれば id を確定、そうでなければ未確定(null)に
+  // 戻す。あわせてサーバー検索で候補を更新する。
+  const handleStadiumInputChange = (value: string) => {
+    setStadiumName(value);
+    const matched = stadiumData.find((stadium) => stadium.name === value);
+    setStadiumId(matched ? matched.id : null);
+    void (async () => {
+      const response = await searchStadiums(value ? { q: value } : {});
+      setStadiumData(response.data);
+    })();
   };
-
-  // 相手チーム得点
-  const handleOpponentScoreChange = (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    setOpponentTeamScore(Number(event.target.value));
+  const handleStadiumSelectionChange = (key: React.Key | null) => {
+    if (key == null) return;
+    const found = stadiumData.find(
+      (stadium) => String(stadium.id) === String(key),
+    );
+    if (found) {
+      setStadiumId(found.id);
+      setStadiumName(found.name);
+    }
   };
 
   // 打順。「なし」は id=""（空文字）なのでそのまま state に保存する。
@@ -438,8 +472,9 @@ export default function GameRecord() {
     return isValid;
   };
 
-  // フォームデータ送信
-  const handleSubmit = async () => {
+  // フォームデータ送信。pattern は新規記録時のパターン選択で渡される
+  // （編集 / 未出場の単一ボタン経由では undefined）。
+  const handleSubmit = async (pattern?: RecordPattern) => {
     if (!validateForm() || isSubmitting) {
       return;
     }
@@ -447,6 +482,23 @@ export default function GameRecord() {
     setErrors([]);
     try {
       const userId = userData?.id;
+
+      // 球場の解決: 入力名があり id 未確定なら新規作成して id を確定させる。
+      // 作成に失敗しても保存はブロックせず、球場なし（null）で続行する。
+      let resolvedStadiumId = stadiumId;
+      const trimmedStadiumName = stadiumName.trim();
+      if (trimmedStadiumName && !resolvedStadiumId) {
+        const createdStadium = await createStadium({
+          name: trimmedStadiumName,
+        });
+        if (createdStadium.ok) {
+          resolvedStadiumId = createdStadium.data.id;
+        } else {
+          setErrorsWithTimeout([
+            "球場の登録に失敗しました。球場なしで保存します。",
+          ]);
+        }
+      }
       let myTeamId = teamsData.find((team) => team.name === myTeam)?.id;
       if (!myTeamId) {
         const newTeam = await createOrUpdateTeam({
@@ -536,6 +588,7 @@ export default function GameRecord() {
             ? existingDefensivePosition
             : myPosition,
           tournament_id: tournamentId,
+          stadium_id: resolvedStadiumId,
           memo: matchMemo,
           inning_format: inningFormat,
           appearance_type: appearanceType,
@@ -574,11 +627,19 @@ export default function GameRecord() {
           );
         }
       }
-      // 未出場の場合は打撃・投手成績の入力をスキップして試合結果まとめへ。
+      // 記録パターンを次画面へ引き継ぐ（編集 / 未出場の単一ボタンは both 相当）。
+      const effectivePattern: RecordPattern = pattern ?? "both";
+      localStorage.setItem(
+        RECORD_PATTERN_STORAGE_KEY,
+        JSON.stringify(effectivePattern),
+      );
+      // 未出場はまとめへ、投手のみは投手入力へ、それ以外は打撃入力へ。
       const nextPath =
         appearanceType === "no_play"
           ? `/game-result/summary/`
-          : `/game-result/batting/`;
+          : effectivePattern === "pitching"
+            ? `/game-result/pitching/`
+            : `/game-result/batting/`;
       router.push(nextPath);
     } catch (error) {
       throw error;
@@ -695,6 +756,26 @@ export default function GameRecord() {
                 <Divider className="my-4" />
                 <Autocomplete
                   allowsCustomValue
+                  label="球場"
+                  variant="bordered"
+                  placeholder="球場名を入力"
+                  labelPlacement="outside-left"
+                  className="[&>div]:justify-between [&>div&>label]:whitespace-nowrap"
+                  size="md"
+                  inputValue={stadiumName}
+                  onInputChange={handleStadiumInputChange}
+                  onSelectionChange={handleStadiumSelectionChange}
+                  selectedKey={stadiumId ? stadiumId.toString() : null}
+                >
+                  {stadiumData.map((stadium) => (
+                    <AutocompleteItem key={stadium.id} textValue={stadium.name}>
+                      {stadium.name}
+                    </AutocompleteItem>
+                  ))}
+                </Autocomplete>
+                <Divider className="my-4" />
+                <Autocomplete
+                  allowsCustomValue
                   label="大会名"
                   variant="bordered"
                   placeholder="大会名を入力"
@@ -787,34 +868,20 @@ export default function GameRecord() {
                     点数<span className="text-red-500 pl-1">*</span>
                   </p>
                   <div className="flex gap-x-2 items-center">
-                    <Input
-                      isRequired
-                      type="number"
-                      size="md"
-                      variant="bordered"
-                      labelPlacement="outside"
+                    <ScoreStepper
+                      value={myTeamScore}
+                      onChange={setMyTeamScore}
+                      ariaLabel="自チームの点数"
                       placeholder="自分"
-                      className="flex justify-between items-center w-20"
-                      defaultValue={myTeamScore?.toString()}
-                      value={myTeamScore?.toString()}
-                      color={isMyTeamScoreValid ? "default" : "danger"}
-                      min={0}
-                      onChange={handleMyScoreChange}
+                      isValid={isMyTeamScoreValid}
                     />
                     <span>対</span>
-                    <Input
-                      isRequired
-                      type="number"
-                      size="md"
-                      variant="bordered"
+                    <ScoreStepper
+                      value={opponentTeamScore}
+                      onChange={setOpponentTeamScore}
+                      ariaLabel="相手チームの点数"
                       placeholder="相手"
-                      labelPlacement="outside"
-                      className="flex justify-between items-center w-20"
-                      defaultValue={opponentTeamScore?.toString()}
-                      value={opponentTeamScore?.toString()}
-                      color={isOpponentTeamScoreValid ? "default" : "danger"}
-                      min={0}
-                      onChange={handleOpponentScoreChange}
+                      isValid={isOpponentTeamScoreValid}
                     />
                   </div>
                 </div>
@@ -892,18 +959,27 @@ export default function GameRecord() {
                 />
               </div>
               <div className="mt-8">
-                <Button
-                  color="primary"
-                  size="md"
-                  type="button"
-                  radius="sm"
-                  className="ml-auto mr-0 px-6 font-bold text-base flex items-center"
-                  onPress={() => handleSubmit()}
-                  endContent={<NextArrowIcon stroke="#F4F4F4" />}
-                  isDisabled={isSubmitting}
-                >
-                  {appearanceType === "no_play" ? "試合結果まとめ" : "打撃結果"}
-                </Button>
+                {appearanceType === "no_play" || isEditMode ? (
+                  <Button
+                    color="primary"
+                    size="md"
+                    type="button"
+                    radius="sm"
+                    className="ml-auto mr-0 px-6 font-bold text-base flex items-center"
+                    onPress={() => handleSubmit()}
+                    endContent={<NextArrowIcon stroke="#F4F4F4" />}
+                    isDisabled={isSubmitting}
+                  >
+                    {appearanceType === "no_play"
+                      ? "試合結果まとめ"
+                      : "打撃結果"}
+                  </Button>
+                ) : (
+                  <PatternSelector
+                    onSelect={(pattern) => handleSubmit(pattern)}
+                    disabled={isSubmitting}
+                  />
+                )}
               </div>
             </form>
           </div>

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -250,15 +250,12 @@ export default function GameRecord() {
   };
 
   useEffect(() => {
-     
     fetchData();
     // 既存試合の編集として入ったときだけ編集モード。新規記録フロー（保存して
     // 戻った場合を含む）はパターン選択を出すため false のままにする。
-    setIsEditMode(
-      localStorage.getItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY) === "true",
-    );
     const isEdit =
       localStorage.getItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY) === "true";
+    setIsEditMode(isEdit);
     // ローカルストレージからid取得
     const savedGameResultId = localStorage.getItem("gameResultId");
     if (savedGameResultId) {
@@ -304,7 +301,6 @@ export default function GameRecord() {
         (position) => position.id === userPositionFirstId,
       );
       if (userPosition) {
-         
         setMyPosition(userPosition.id.toString());
       }
     }
@@ -315,7 +311,6 @@ export default function GameRecord() {
     if (existingMyTeam) {
       const foundTeam = teamsData.find((team) => team.id === existingMyTeam);
       if (foundTeam) {
-         
         setMyTeam(foundTeam.name);
       }
     }
@@ -815,7 +810,7 @@ export default function GameRecord() {
                   onInputChange={handleTournamentInputChange}
                   onSelectionChange={handleTournamentSelectionChange}
                   selectedKey={
-                    tournament !== undefined ? tournament?.toString() : null
+                    tournament !== null ? tournament.toString() : null
                   }
                 >
                   {tournamentData.map((data) => (
@@ -836,9 +831,7 @@ export default function GameRecord() {
                   onInputChange={handleSeasonInputChange}
                   onSelectionChange={handleSeasonSelectionChange}
                   selectedKey={
-                    selectedSeason !== undefined
-                      ? selectedSeason?.toString()
-                      : null
+                    selectedSeason !== null ? selectedSeason.toString() : null
                   }
                 >
                   {seasonsData.map((data) => (

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -151,25 +151,34 @@ export default function GameRecord() {
 
   const fetchData = async () => {
     try {
-      const currentUserData = await getUserData();
+      // 互いに独立した取得なので並列化して初期表示を速くする。
+      const [
+        currentUserData,
+        getTeamsList,
+        getTournamentList,
+        getSeasonsList,
+        positionDataList,
+        stadiumsResponse,
+      ] = await Promise.all([
+        getUserData(),
+        getTeams(),
+        getTournaments(),
+        getSeasons(),
+        getPositions(),
+        searchStadiums({}),
+      ]);
       setUserData(currentUserData);
-      const userTeamId = currentUserData.team_id;
-      const getTeamsList = await getTeams();
-      const getTournamentList = await getTournaments();
-      const getSeasonsList = await getSeasons();
       setTeamsData(getTeamsList);
       setSeasonsData(getSeasonsList);
       // マイチーム名取得
       const userTeam = getTeamsList.find(
-        (team: { id: string }) => team.id === userTeamId,
+        (team: { id: string }) => team.id === currentUserData.team_id,
       );
       if (userTeam) {
         setMyTeam(userTeam.name);
       }
-      const positionDataList = await getPositions();
       setPositionData(positionDataList);
       setTournamentData(getTournamentList);
-      const stadiumsResponse = await searchStadiums({});
       setStadiumData(stadiumsResponse.data);
     } catch (error) {
       throw error;

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -176,8 +176,11 @@ export default function GameRecord() {
     }
   };
 
-  // 既に同じgame_result_idが存在する場合
-  const fetchExistingMatchResult = async (gameResultId: number) => {
+  // 既に同じ game_result_id の試合記録が存在すれば各フィールドへ反映し、
+  // 見つかったかどうかを boolean で返す（新規記録時のデフォルト適用判定に使う）。
+  const fetchExistingMatchResult = async (
+    gameResultId: number,
+  ): Promise<boolean> => {
     try {
       const currentUserId = await getCurrentUserId();
       const existingMatchResult = await checkExistingMatchResults(
@@ -223,8 +226,26 @@ export default function GameRecord() {
         // ランタイムガードは不要。inning_format と同様にそのまま反映する。
         setAppearanceType(existingMatchResult.appearance_type);
       }
+      return Boolean(existingMatchResult);
     } catch (error) {
       console.error("Error fetching existing match result:", error);
+      return false;
+    }
+  };
+
+  // 新規記録時のフォーム初期値（直近試合の inning_format / 打順）を適用する。
+  const applyFormDefaults = async () => {
+    try {
+      const defaults = await getMatchResultFormDefaults();
+      if (defaults?.inning_format === 7 || defaults?.inning_format === 9) {
+        setInningFormat(defaults.inning_format);
+      }
+      if (defaults?.batting_order) {
+        setMatchBattingOrder(defaults.batting_order);
+        setExistingMatchBattingOrder(defaults.batting_order);
+      }
+    } catch (error) {
+      console.error("フォーム初期値の取得に失敗しました", error);
     }
   };
 
@@ -236,11 +257,16 @@ export default function GameRecord() {
     setIsEditMode(
       localStorage.getItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY) === "true",
     );
+    const isEdit =
+      localStorage.getItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY) === "true";
     // ローカルストレージからid取得
     const savedGameResultId = localStorage.getItem("gameResultId");
     if (savedGameResultId) {
       setLocalStorageGameResultId(JSON.parse(savedGameResultId));
-      fetchExistingMatchResult(JSON.parse(savedGameResultId));
+      // 既存試合がなければ（＝新規記録フロー）直近試合のデフォルトを適用する。
+      fetchExistingMatchResult(JSON.parse(savedGameResultId)).then((found) => {
+        if (!found && !isEdit) applyFormDefaults();
+      });
     } else if (pathname === "/game-result/record") {
       // gameResultId がない＝新規記録なので、編集フラグは確実に解除しておく。
       localStorage.removeItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY);
@@ -259,18 +285,7 @@ export default function GameRecord() {
         }
       };
       createNew();
-      // 新規作成時は直近試合のイニング制を初期値として読み込む（履歴なしは 9）
-      const loadInningFormatDefault = async () => {
-        try {
-          const defaults = await getMatchResultFormDefaults();
-          if (defaults?.inning_format === 7 || defaults?.inning_format === 9) {
-            setInningFormat(defaults.inning_format);
-          }
-        } catch (error) {
-          console.error("フォーム初期値の取得に失敗しました", error);
-        }
-      };
-      loadInningFormatDefault();
+      applyFormDefaults();
     }
     if (
       !(pathname === "/game-result/battings") &&

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -250,7 +250,7 @@ export default function GameRecord() {
   };
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+     
     fetchData();
     // 既存試合の編集として入ったときだけ編集モード。新規記録フロー（保存して
     // 戻った場合を含む）はパターン選択を出すため false のままにする。
@@ -304,7 +304,7 @@ export default function GameRecord() {
         (position) => position.id === userPositionFirstId,
       );
       if (userPosition) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
+         
         setMyPosition(userPosition.id.toString());
       }
     }
@@ -315,7 +315,7 @@ export default function GameRecord() {
     if (existingMyTeam) {
       const foundTeam = teamsData.find((team) => team.id === existingMyTeam);
       if (foundTeam) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
+         
         setMyTeam(foundTeam.name);
       }
     }
@@ -667,7 +667,12 @@ export default function GameRecord() {
             : `/game-result/batting/`;
       router.push(nextPath);
     } catch (error) {
-      throw error;
+      console.error("試合結果の保存に失敗しました", error);
+      setErrorsWithTimeout([
+        "保存に失敗しました。時間をおいて再度お試しください。",
+      ]);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -20,7 +20,7 @@ import {
   Textarea,
 } from "@heroui/react";
 import { usePathname, useRouter } from "next/navigation";
-import { type SetStateAction, useEffect, useState } from "react";
+import { type SetStateAction, useEffect, useRef, useState } from "react";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import HeaderResult from "@app/components/header/HeaderResult";
 import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
@@ -148,6 +148,9 @@ export default function GameRecord() {
   const pathname = usePathname();
   const router = useRouter();
   useRequireAuth();
+  // 球場サジェスト検索のデバウンスタイマーと、最新リクエスト判定用のシーケンス番号。
+  const stadiumSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stadiumRequestId = useRef(0);
 
   const fetchData = async () => {
     try {
@@ -380,10 +383,17 @@ export default function GameRecord() {
     setStadiumName(value);
     const matched = stadiumData.find((stadium) => stadium.name === value);
     setStadiumId(matched ? matched.id : null);
-    void (async () => {
-      const response = await searchStadiums(value ? { q: value } : {});
-      setStadiumData(response.data);
-    })();
+    // デバウンス + 最新リクエスト勝ちで、高速入力時の過剰リクエストとレースを防ぐ。
+    if (stadiumSearchTimer.current) clearTimeout(stadiumSearchTimer.current);
+    stadiumSearchTimer.current = setTimeout(() => {
+      const requestId = stadiumRequestId.current + 1;
+      stadiumRequestId.current = requestId;
+      searchStadiums(value ? { q: value } : {}).then((response) => {
+        if (requestId === stadiumRequestId.current) {
+          setStadiumData(response.data);
+        }
+      });
+    }, 250);
   };
   const handleStadiumSelectionChange = (key: React.Key | null) => {
     if (key == null) return;

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -26,7 +26,10 @@ import HeaderResult from "@app/components/header/HeaderResult";
 import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import { APPEARANCE_TYPE_OPTIONS } from "@app/constants/appearanceType";
-import { RECORD_PATTERN_STORAGE_KEY } from "@app/constants/gameRecord";
+import {
+  GAME_RECORD_EDIT_MODE_STORAGE_KEY,
+  RECORD_PATTERN_STORAGE_KEY,
+} from "@app/constants/gameRecord";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import {
   createGameResult,
@@ -182,8 +185,7 @@ export default function GameRecord() {
         currentUserId,
       );
       if (existingMatchResult) {
-        setIsEditMode(true);
-        // 編集時は stadium_id を復元する。v1 レスポンスは球場名を含まないため、
+        // stadium_id を復元する。v1 レスポンスは球場名を含まないため、
         // 表示名は候補リストから id で best-effort に引き当てる（見つからなくても
         // stadium_id は保持され、保存時に球場が維持される）。
         if (existingMatchResult.stadium_id) {
@@ -229,12 +231,20 @@ export default function GameRecord() {
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchData();
+    // 既存試合の編集として入ったときだけ編集モード。新規記録フロー（保存して
+    // 戻った場合を含む）はパターン選択を出すため false のままにする。
+    setIsEditMode(
+      localStorage.getItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY) === "true",
+    );
     // ローカルストレージからid取得
     const savedGameResultId = localStorage.getItem("gameResultId");
     if (savedGameResultId) {
       setLocalStorageGameResultId(JSON.parse(savedGameResultId));
       fetchExistingMatchResult(JSON.parse(savedGameResultId));
     } else if (pathname === "/game-result/record") {
+      // gameResultId がない＝新規記録なので、編集フラグは確実に解除しておく。
+      localStorage.removeItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY);
+      setIsEditMode(false);
       // gameResultId がない場合は自動作成
       const createNew = async () => {
         try {

--- a/app/(app)/game-result/summary/[slug]/page.tsx
+++ b/app/(app)/game-result/summary/[slug]/page.tsx
@@ -27,6 +27,7 @@ import HeaderGameDetail from "@app/components/header/HeaderGameDetail";
 import SummaryResultHeader from "@app/components/header/SummaryHeader";
 import ResultShareComponent from "@app/components/share/ResultShareComponent";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
+import { GAME_RECORD_EDIT_MODE_STORAGE_KEY } from "@app/constants/gameRecord";
 import { useAuthContext } from "@app/contexts/useAuthContext";
 import { getUserBattingAverage } from "@app/services/battingAveragesService";
 import { deleteGameResult } from "@app/services/gameResultsService";
@@ -277,6 +278,8 @@ export default function ResultsSummary() {
   };
 
   const handleResultComplete = () => {
+    // 既存試合の編集として試合情報入力画面へ入ることを記録する。
+    localStorage.setItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY, "true");
     router.push("/game-result/record");
   };
 

--- a/app/constants/gameRecord.ts
+++ b/app/constants/gameRecord.ts
@@ -3,6 +3,10 @@ import type { RecordPattern } from "@app/interface/gameRecord";
 // 記録パターンを試合情報入力 → 打撃ページ間で受け渡すための localStorage キー。
 export const RECORD_PATTERN_STORAGE_KEY = "recordPattern";
 
+// 既存試合の編集として試合情報入力画面へ入ったことを示す localStorage キー。
+// 新規記録フロー（保存して戻った場合を含む）と区別するために使う。
+export const GAME_RECORD_EDIT_MODE_STORAGE_KEY = "gameRecordEditMode";
+
 // 記録パターン選択ボタンの定義。「打撃・投手記録を入力(both)」を推奨として
 // primary(塗りつぶし)、片方のみは outlined(枠線)で視覚的に階層化する。
 export const RECORD_PATTERN_OPTIONS: ReadonlyArray<{

--- a/app/constants/gameRecord.ts
+++ b/app/constants/gameRecord.ts
@@ -1,0 +1,16 @@
+import type { RecordPattern } from "@app/interface/gameRecord";
+
+// 記録パターンを試合情報入力 → 打撃ページ間で受け渡すための localStorage キー。
+export const RECORD_PATTERN_STORAGE_KEY = "recordPattern";
+
+// 記録パターン選択ボタンの定義。「打撃・投手記録を入力(both)」を推奨として
+// primary(塗りつぶし)、片方のみは outlined(枠線)で視覚的に階層化する。
+export const RECORD_PATTERN_OPTIONS: ReadonlyArray<{
+  pattern: RecordPattern;
+  label: string;
+  emphasis: "primary" | "outlined";
+}> = [
+  { pattern: "batting", label: "打撃結果のみ入力", emphasis: "outlined" },
+  { pattern: "pitching", label: "投手結果のみ入力", emphasis: "outlined" },
+  { pattern: "both", label: "打撃・投手記録を入力", emphasis: "primary" },
+];

--- a/app/interface/gameRecord.ts
+++ b/app/interface/gameRecord.ts
@@ -1,0 +1,3 @@
+// 試合記録のパターン分岐。クライアント状態のみで DB には保存せず、
+// 試合情報入力 → 打撃 / 投手 への遷移分岐に使う。
+export type RecordPattern = "batting" | "pitching" | "both";

--- a/app/services/matchResultsService.tsx
+++ b/app/services/matchResultsService.tsx
@@ -105,12 +105,15 @@ export const getUserMatchResult = async (gameResultId: number | null) => {
 };
 
 /**
- * 試合作成・編集フォームの初期値を取得する。
- * 直近試合の inning_format（試合のイニング制: 7 or 9）が返る。
- * 履歴がない場合は 9。
+ * 試合作成フォームの初期値を取得する。直近試合をもとに
+ * inning_format（イニング制: 7 or 9。履歴なしは 9）、
+ * batting_order（直近試合の打順。履歴なしは null）、
+ * defensive_position（プロフィール最優先 → 直近試合 → null）が返る。
  */
 export const getMatchResultFormDefaults = async (): Promise<{
   inning_format: number;
+  batting_order: string | null;
+  defensive_position: string | null;
 }> => {
   try {
     const response = await axiosInstance.get(


### PR DESCRIPTION
## 概要

mobile [buzzbase_mobile#101](https://github.com/ippei-shimizu/buzzbase_mobile/pull/101) 追従シリーズ ([ippei-shimizu/buzzbase#394](https://github.com/ippei-shimizu/buzzbase/issues/394))。試合情報入力画面に「球場選択」「記録パターン分岐」「点数の +/- ステッパー」を追加する。基盤 #393 の v2 stadium API を利用する。

Closes ippei-shimizu/buzzbase#394

## 変更内容

### 球場選択（`record/page.tsx`）
- 大会名の上に球場サジェスト入力欄を追加（チーム/大会と同じ Autocomplete UI）。
- v2 `searchStadiums` で検索し、入力名が既存に一致すれば `stadium_id` を確定、未存在なら送信時に `createStadium` で作成して確定。
- `match_result` ペイロードに `stadium_id` を追加（back v1 は既に `stadium_id` を許可済み）。
- 編集時は `stadium_id` を復元し、表示名は候補リストから best-effort で引き当て（v1 レスポンスは球場名を含まないため）。

### 記録パターン分岐
- 送信ボタンを3択 `PatternSelector`（打撃結果のみ / 投手結果のみ / 打撃・投手記録を入力）に置換。「両方」を primary 強調、片方は outlined。
- 遷移: `pitching` → 投手入力 / `batting`・`both` → 打撃入力 / 未出場 → まとめ。選択したパターンは `localStorage` で次画面へ引き継ぐ。
- 打撃入力後（`batting/page.tsx`）は、`batting` パターンなら投手入力をスキップしてまとめへ遷移。
- 編集モード・未出場は従来どおり単一ボタン（パターン選択を出さない）。

### 点数ステッパー
- 自/相手チーム点数を `ScoreStepper`（+/- ボタン + 手入力）に置換。初期値 0、空欄は null（未入力）、完封 0-0 を許容、既存バリデーションは維持。

## 新規ファイル
- `app/interface/gameRecord.ts`（`RecordPattern` 型）
- `app/constants/gameRecord.ts`（localStorage キー / パターン選択肢）
- `app/(app)/game-result/record/_components/PatternSelector.tsx`
- `app/(app)/game-result/record/_components/ScoreStepper.tsx`

## スコープ外
- 打席記録ウィザード本体（#395。本 PR では batting/both は既存 v1 打撃入力へ遷移する暫定接続）
- 投手マスタ登録 UI（#396）

## 確認
- `yarn typecheck`（追加/変更ファイルにエラーなし。残りはローカル `.next/dev/types` の stale エラーのみ）、`yarn lint` / `yarn format:check` パス、`yarn test` 全252件パス。
- 手動確認推奨: 球場サジェストの検索/新規作成、3パターンそれぞれの遷移、点数ステッパーの 0/空欄挙動、編集モードでの球場復元。
