### PR TITLE
Add: 打席記録ステップ式ウィザード（打球方向 + 打席結果 + 得点入力）

### DIFF
--- a/app/(app)/game-result/plate-appearances/_components/GroundTapField.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/GroundTapField.tsx
@@ -1,0 +1,233 @@
+"use client";
+import {
+  DIRECTION_LABEL_POSITIONS,
+  DIRECTION_LABELS,
+  GROUND_CANVAS_HEIGHT,
+  GROUND_CANVAS_WIDTH,
+  GROUND_FIRST,
+  GROUND_HOME,
+  GROUND_LEFT_END,
+  GROUND_OUTFIELD_RX,
+  GROUND_OUTFIELD_RY,
+  GROUND_RIGHT_END,
+  GROUND_SECOND,
+  GROUND_THIRD,
+} from "@app/constants/groundCanvas";
+import {
+  detectClosestDirection,
+  type Point,
+} from "@app/utils/groundZoneDetector";
+
+interface GroundTapFieldProps {
+  hitLocation: Point | null;
+  onSelect: (args: {
+    x: number;
+    y: number;
+    directionId: number | null;
+  }) => void;
+}
+
+// 球場形状の派生座標（mobile の GroundTapField と同一の計算）。
+const HOME = GROUND_HOME;
+const FIRST = GROUND_FIRST;
+const SECOND = GROUND_SECOND;
+const THIRD = GROUND_THIRD;
+const LEFT_END = GROUND_LEFT_END;
+const RIGHT_END = GROUND_RIGHT_END;
+const MOUND = { x: HOME.x, y: (HOME.y + SECOND.y) / 2 + 5 };
+const DIRT_CENTER = { x: HOME.x, y: (HOME.y + SECOND.y) / 2 };
+const DIRT_R = 95;
+const DIRT_DY = HOME.y - DIRT_CENTER.y;
+const DIRT_LINE_CHORD = Math.sqrt(DIRT_R ** 2 - DIRT_DY ** 2 / 2);
+const DIRT_FOUL_LEFT = {
+  x: HOME.x - DIRT_DY / 2 - DIRT_LINE_CHORD / Math.SQRT2,
+  y: HOME.y - DIRT_DY / 2 - DIRT_LINE_CHORD / Math.SQRT2,
+};
+const DIRT_FOUL_RIGHT = {
+  x: HOME.x + DIRT_DY / 2 + DIRT_LINE_CHORD / Math.SQRT2,
+  y: HOME.y - DIRT_DY / 2 - DIRT_LINE_CHORD / Math.SQRT2,
+};
+
+const CHIP_HEIGHT = 18;
+const CHIP_PADDING_X = 6;
+const estimateChipWidth = (label: string): number =>
+  CHIP_PADDING_X * 2 + label.length * 12;
+
+const clampNormalized = (value: number): number =>
+  Math.max(0, Math.min(1, value));
+
+/**
+ * グラウンドイラスト。クリック位置を 0〜1 の正規化座標に変換し、
+ * detectClosestDirection で最寄りの打球方向 id を導出して親へ通知する。
+ */
+export function GroundTapField({ hitLocation, onSelect }: GroundTapFieldProps) {
+  const handleClick = (event: React.MouseEvent<SVGSVGElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const x = clampNormalized((event.clientX - rect.left) / rect.width);
+    const y = clampNormalized((event.clientY - rect.top) / rect.height);
+    onSelect({ x, y, directionId: detectClosestDirection({ x, y }) });
+  };
+
+  const markerX = hitLocation ? hitLocation.x * GROUND_CANVAS_WIDTH : null;
+  const markerY = hitLocation ? hitLocation.y * GROUND_CANVAS_HEIGHT : null;
+  const selectedDirectionId = hitLocation
+    ? detectClosestDirection(hitLocation)
+    : null;
+
+  return (
+    <div className="flex justify-center">
+      <svg
+        role="button"
+        aria-label="グラウンド（クリックで打球方向を選択）"
+        width={GROUND_CANVAS_WIDTH}
+        height={GROUND_CANVAS_HEIGHT}
+        viewBox={`0 0 ${GROUND_CANVAS_WIDTH} ${GROUND_CANVAS_HEIGHT}`}
+        className="max-w-full h-auto cursor-pointer touch-none select-none"
+        onClick={handleClick}
+      >
+        <path
+          d={`M ${HOME.x},${HOME.y} L ${LEFT_END.x},${LEFT_END.y} A ${GROUND_OUTFIELD_RX},${GROUND_OUTFIELD_RY} 0 0,1 ${RIGHT_END.x},${RIGHT_END.y} Z`}
+          fill="#4a8e32"
+          stroke="#3a7a28"
+          strokeWidth={2}
+        />
+        <path
+          d={`M ${HOME.x},${HOME.y} L ${DIRT_FOUL_LEFT.x},${DIRT_FOUL_LEFT.y} A ${DIRT_R},${DIRT_R} 0 0,1 ${DIRT_FOUL_RIGHT.x},${DIRT_FOUL_RIGHT.y} Z`}
+          fill="#b07840"
+        />
+        <path
+          d={`M ${HOME.x},${HOME.y} L ${FIRST.x},${FIRST.y} L ${SECOND.x},${SECOND.y} L ${THIRD.x},${THIRD.y} Z`}
+          fill="#5fa341"
+        />
+        <line
+          x1={HOME.x}
+          y1={HOME.y}
+          x2={LEFT_END.x}
+          y2={LEFT_END.y}
+          stroke="rgba(255,255,255,0.6)"
+          strokeWidth={1.5}
+        />
+        <line
+          x1={HOME.x}
+          y1={HOME.y}
+          x2={RIGHT_END.x}
+          y2={RIGHT_END.y}
+          stroke="rgba(255,255,255,0.6)"
+          strokeWidth={1.5}
+        />
+        <line
+          x1={HOME.x}
+          y1={HOME.y - 3}
+          x2={FIRST.x}
+          y2={FIRST.y}
+          stroke="rgba(255,255,255,0.7)"
+          strokeWidth={1.5}
+        />
+        <line
+          x1={FIRST.x}
+          y1={FIRST.y}
+          x2={SECOND.x}
+          y2={SECOND.y}
+          stroke="rgba(255,255,255,0.7)"
+          strokeWidth={1.5}
+        />
+        <line
+          x1={SECOND.x}
+          y1={SECOND.y}
+          x2={THIRD.x}
+          y2={THIRD.y}
+          stroke="rgba(255,255,255,0.7)"
+          strokeWidth={1.5}
+        />
+        <line
+          x1={THIRD.x}
+          y1={THIRD.y}
+          x2={HOME.x}
+          y2={HOME.y - 3}
+          stroke="rgba(255,255,255,0.7)"
+          strokeWidth={1.5}
+        />
+        <circle cx={MOUND.x} cy={MOUND.y} r={9} fill="#9a6d3a" />
+        <polygon
+          points={`${HOME.x},${HOME.y - 8} ${HOME.x - 6},${HOME.y - 3} ${HOME.x - 4},${HOME.y + 2} ${HOME.x + 4},${HOME.y + 2} ${HOME.x + 6},${HOME.y - 3}`}
+          fill="white"
+        />
+        {[FIRST, SECOND, THIRD].map((base, index) => (
+          <rect
+            key={`base-${index}`}
+            x={base.x - 4}
+            y={base.y - 4}
+            width={8}
+            height={8}
+            fill="white"
+            transform={`rotate(45, ${base.x}, ${base.y})`}
+          />
+        ))}
+        {selectedDirectionId !== null &&
+          DIRECTION_LABEL_POSITIONS[selectedDirectionId] && (
+            <circle
+              cx={DIRECTION_LABEL_POSITIONS[selectedDirectionId].x}
+              cy={DIRECTION_LABEL_POSITIONS[selectedDirectionId].y}
+              fill="none"
+              stroke="#d08000"
+              strokeWidth={2}
+            >
+              <animate
+                attributeName="r"
+                values="10;42"
+                dur="2s"
+                repeatCount="indefinite"
+              />
+              <animate
+                attributeName="opacity"
+                values="0.7;0"
+                dur="2s"
+                repeatCount="indefinite"
+              />
+            </circle>
+          )}
+        {Object.entries(DIRECTION_LABELS).map(([idKey, label]) => {
+          const id = Number(idKey);
+          const position = DIRECTION_LABEL_POSITIONS[id];
+          if (!position) return null;
+          const chipWidth = estimateChipWidth(label);
+          const isSelected = selectedDirectionId === id;
+          return (
+            <g key={`dir-${id}`}>
+              <rect
+                x={position.x - chipWidth / 2}
+                y={position.y - CHIP_HEIGHT / 2}
+                width={chipWidth}
+                height={CHIP_HEIGHT}
+                rx={4}
+                fill={isSelected ? "#d08000" : "rgba(0,0,0,0.65)"}
+              />
+              <text
+                x={position.x}
+                y={position.y + 4}
+                fill="#F4F4F4"
+                fontSize={11}
+                fontWeight={700}
+                textAnchor="middle"
+              >
+                {label}
+              </text>
+            </g>
+          );
+        })}
+        {markerX !== null && markerY !== null && (
+          <>
+            <circle
+              cx={markerX}
+              cy={markerY}
+              r={10}
+              fill="#d08000"
+              opacity={0.35}
+            />
+            <circle cx={markerX} cy={markerY} r={6} fill="#d08000" />
+          </>
+        )}
+      </svg>
+    </div>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/HitTypeModal.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/HitTypeModal.tsx
@@ -29,10 +29,9 @@ export function HitTypeModal({ isOpen, onSelect, onClose }: HitTypeModalProps) {
               <Button
                 key={option.hit_type}
                 variant="bordered"
-                color="primary"
                 radius="sm"
                 size="sm"
-                className="font-bold min-w-0 px-0"
+                className="font-bold min-w-0 px-0 border-2 border-[#d08000] bg-transparent text-[#d08000]"
                 onPress={() => onSelect(option)}
               >
                 {option.label}

--- a/app/(app)/game-result/plate-appearances/_components/HitTypeModal.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/HitTypeModal.tsx
@@ -31,7 +31,7 @@ export function HitTypeModal({ isOpen, onSelect, onClose }: HitTypeModalProps) {
                 variant="bordered"
                 radius="sm"
                 size="sm"
-                className="font-bold min-w-0 px-0 border-2 border-[#d08000] bg-transparent text-[#d08000]"
+                className="font-bold min-w-0 px-0 h-11 border-2 border-[#d08000] bg-transparent text-[#d08000]"
                 onPress={() => onSelect(option)}
               >
                 {option.label}

--- a/app/(app)/game-result/plate-appearances/_components/HitTypeModal.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/HitTypeModal.tsx
@@ -1,0 +1,46 @@
+"use client";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+} from "@heroui/react";
+import {
+  HIT_TYPE_OPTIONS,
+  type HitTypeOption,
+} from "@app/constants/plateResults";
+
+interface HitTypeModalProps {
+  isOpen: boolean;
+  onSelect: (option: HitTypeOption) => void;
+  onClose: () => void;
+}
+
+/** 「ヒット」押下時のサブ選択モーダル。plate_result_id と hit_type を親へ返す。 */
+export function HitTypeModal({ isOpen, onSelect, onClose }: HitTypeModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} placement="center" size="sm">
+      <ModalContent>
+        <ModalHeader className="justify-center">ヒット種別</ModalHeader>
+        <ModalBody className="pb-6">
+          <div className="grid grid-cols-4 gap-2">
+            {HIT_TYPE_OPTIONS.map((option) => (
+              <Button
+                key={option.hit_type}
+                variant="bordered"
+                color="primary"
+                radius="sm"
+                size="sm"
+                className="font-bold min-w-0 px-0"
+                onPress={() => onSelect(option)}
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/OutTypeModal.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/OutTypeModal.tsx
@@ -1,0 +1,45 @@
+"use client";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+} from "@heroui/react";
+import {
+  OUT_TYPE_OPTIONS,
+  type OutTypeOption,
+} from "@app/constants/plateResults";
+
+interface OutTypeModalProps {
+  isOpen: boolean;
+  onSelect: (option: OutTypeOption) => void;
+  onClose: () => void;
+}
+
+/** 「アウト」押下時のサブ選択モーダル。plate_result_id と out_type を親へ返す。 */
+export function OutTypeModal({ isOpen, onSelect, onClose }: OutTypeModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} placement="center" size="sm">
+      <ModalContent>
+        <ModalHeader className="justify-center">アウト種別</ModalHeader>
+        <ModalBody className="pb-6">
+          <div className="flex flex-col gap-y-2">
+            {OUT_TYPE_OPTIONS.map((option) => (
+              <Button
+                key={option.out_type}
+                variant="bordered"
+                color="danger"
+                radius="sm"
+                className="font-bold"
+                onPress={() => onSelect(option)}
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/OutTypeModal.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/OutTypeModal.tsx
@@ -29,9 +29,8 @@ export function OutTypeModal({ isOpen, onSelect, onClose }: OutTypeModalProps) {
               <Button
                 key={option.out_type}
                 variant="bordered"
-                color="danger"
                 radius="sm"
-                className="font-bold"
+                className="font-bold border-2 border-[#d08000] bg-transparent text-[#d08000]"
                 onPress={() => onSelect(option)}
               >
                 {option.label}

--- a/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
@@ -136,6 +136,8 @@ export function PlateAppearanceWizard({
       caught_stealing: scores.caughtStealing,
     });
     if (result.ok) {
+      // onCompleted が遷移しなかった場合でもボタンが永続 disabled にならないよう先に解除する。
+      setIsSubmitting(false);
       onCompleted();
     } else {
       setErrors(result.errors);

--- a/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
@@ -1,0 +1,232 @@
+"use client";
+import type {
+  HitTypeOption,
+  OutTypeOption,
+  PlateResultId,
+} from "@app/constants/plateResults";
+import type {
+  HitType,
+  OutType,
+  SwingType,
+} from "@app/interface/plateAppearanceV2";
+import { Button } from "@heroui/react";
+import { useState } from "react";
+import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
+import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
+import { createPlateAppearanceV2 } from "@app/services/v2/plateAppearanceService";
+import { roundHitLocation, type Point } from "@app/utils/groundZoneDetector";
+import { GroundTapField } from "./GroundTapField";
+import { HitTypeModal } from "./HitTypeModal";
+import { OutTypeModal } from "./OutTypeModal";
+import { PlateResultButtons } from "./PlateResultButtons";
+import { ScoreCounterInput, type ScoreCounterKey } from "./ScoreCounterInput";
+
+interface PlateAppearanceWizardProps {
+  gameResultId: number;
+  batterBoxNumber: number;
+  onCompleted: () => void;
+  onCancel?: () => void;
+}
+
+type WizardStep = "result" | "score";
+
+/**
+ * 1 打席分の記録ウィザード。
+ * Step1: グラウンドで打球方向を選び、打席結果を確定する。
+ * Step2: 打点・得点・盗塁・盗塁死を入力して保存する（POST /api/v2/plate_appearances）。
+ */
+export function PlateAppearanceWizard({
+  gameResultId,
+  batterBoxNumber,
+  onCompleted,
+  onCancel,
+}: PlateAppearanceWizardProps) {
+  const [step, setStep] = useState<WizardStep>("result");
+  const [hitLocation, setHitLocation] = useState<Point | null>(null);
+  const [directionId, setDirectionId] = useState<number | null>(null);
+  const [plateResultId, setPlateResultId] = useState<PlateResultId | null>(
+    null,
+  );
+  const [outType, setOutType] = useState<OutType | null>(null);
+  const [hitType, setHitType] = useState<HitType | null>(null);
+  const [swingType, setSwingType] = useState<SwingType | null>(null);
+  const [scores, setScores] = useState({
+    rbi: 0,
+    runScored: 0,
+    stolenBases: 0,
+    caughtStealing: 0,
+  });
+  const [isOutModalOpen, setIsOutModalOpen] = useState(false);
+  const [isHitModalOpen, setIsHitModalOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const goToScore = () => setStep("score");
+
+  const handleGroundSelect = (args: {
+    x: number;
+    y: number;
+    directionId: number | null;
+  }) => {
+    setHitLocation({ x: args.x, y: args.y });
+    setDirectionId(args.directionId);
+  };
+
+  const handleSelectOutOption = (option: OutTypeOption) => {
+    setPlateResultId(option.plate_result_id);
+    setOutType(option.out_type);
+    setHitType(null);
+    setSwingType(null);
+    setIsOutModalOpen(false);
+    goToScore();
+  };
+
+  const handleSelectHitOption = (option: HitTypeOption) => {
+    setPlateResultId(option.plate_result_id);
+    setHitType(option.hit_type);
+    setOutType(null);
+    setSwingType(null);
+    setIsHitModalOpen(false);
+    goToScore();
+  };
+
+  const handleSelectDirectionOnly = (id: PlateResultId) => {
+    setPlateResultId(id);
+    setOutType(null);
+    setHitType(null);
+    setSwingType(null);
+    goToScore();
+  };
+
+  const handleSelectNoDirection = (
+    id: PlateResultId,
+    selectedSwingType?: SwingType,
+  ) => {
+    // 打球方向なしの結果は座標・方向を持たない。
+    setHitLocation(null);
+    setDirectionId(null);
+    setPlateResultId(id);
+    setOutType(null);
+    setHitType(null);
+    setSwingType(selectedSwingType ?? null);
+    goToScore();
+  };
+
+  const handleScoreChange = (key: ScoreCounterKey, value: number) => {
+    setScores((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = async () => {
+    if (plateResultId === null || isSubmitting) return;
+    setIsSubmitting(true);
+    setErrors([]);
+    const result = await createPlateAppearanceV2({
+      game_result_id: gameResultId,
+      batter_box_number: batterBoxNumber,
+      plate_result_id: plateResultId,
+      hit_direction_id: directionId,
+      out_type: outType,
+      hit_type: hitType,
+      swing_type: swingType,
+      hit_location_x: hitLocation ? roundHitLocation(hitLocation.x) : null,
+      hit_location_y: hitLocation ? roundHitLocation(hitLocation.y) : null,
+      rbi: scores.rbi,
+      run_scored: scores.runScored,
+      stolen_bases: scores.stolenBases,
+      caught_stealing: scores.caughtStealing,
+    });
+    if (result.ok) {
+      onCompleted();
+    } else {
+      setErrors(result.errors);
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-y-6">
+      {isSubmitting && <LoadingSpinner />}
+      {errors.length > 0 && (
+        <ul className="text-red-500 text-sm list-disc pl-5">
+          {errors.map((error) => (
+            <li key={error}>{error}</li>
+          ))}
+        </ul>
+      )}
+
+      {step === "result" ? (
+        <>
+          <p className="text-center text-base font-medium">
+            第{batterBoxNumber}打席の結果を入力
+          </p>
+          <GroundTapField
+            hitLocation={hitLocation}
+            onSelect={handleGroundSelect}
+          />
+          <PlateResultButtons
+            hasHitLocation={hitLocation !== null}
+            selectedPlateResultId={plateResultId}
+            selectedSwingType={swingType}
+            onSelectOut={() => setIsOutModalOpen(true)}
+            onSelectHit={() => setIsHitModalOpen(true)}
+            onSelectDirectionOnly={handleSelectDirectionOnly}
+            onSelectNoDirection={handleSelectNoDirection}
+          />
+          {onCancel && (
+            <Button
+              variant="light"
+              radius="sm"
+              className="self-center text-zinc-400"
+              onPress={onCancel}
+            >
+              記録を中断する
+            </Button>
+          )}
+        </>
+      ) : (
+        <>
+          <p className="text-center text-base font-medium">打点・得点を入力</p>
+          <ScoreCounterInput
+            rbi={scores.rbi}
+            runScored={scores.runScored}
+            stolenBases={scores.stolenBases}
+            caughtStealing={scores.caughtStealing}
+            onChange={handleScoreChange}
+          />
+          <div className="flex items-center justify-between">
+            <Button
+              variant="light"
+              radius="sm"
+              className="text-zinc-400"
+              onPress={() => setStep("result")}
+              isDisabled={isSubmitting}
+            >
+              打席結果に戻る
+            </Button>
+            <Button
+              color="primary"
+              radius="sm"
+              className="px-6 font-bold"
+              onPress={handleSubmit}
+              endContent={<NextArrowIcon stroke="#F4F4F4" />}
+              isDisabled={isSubmitting}
+            >
+              この打席を保存
+            </Button>
+          </div>
+        </>
+      )}
+
+      <OutTypeModal
+        isOpen={isOutModalOpen}
+        onSelect={handleSelectOutOption}
+        onClose={() => setIsOutModalOpen(false)}
+      />
+      <HitTypeModal
+        isOpen={isHitModalOpen}
+        onSelect={handleSelectHitOption}
+        onClose={() => setIsHitModalOpen(false)}
+      />
+    </div>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
@@ -193,20 +193,19 @@ export function PlateAppearanceWizard({
             caughtStealing={scores.caughtStealing}
             onChange={handleScoreChange}
           />
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-y-3">
             <Button
-              variant="light"
+              variant="bordered"
               radius="sm"
-              className="text-zinc-400"
+              className="w-full font-bold border-2 border-[#d08000] bg-transparent text-[#d08000]"
               onPress={() => setStep("result")}
               isDisabled={isSubmitting}
             >
               打席結果に戻る
             </Button>
             <Button
-              color="primary"
               radius="sm"
-              className="px-6 font-bold"
+              className="w-full font-bold bg-[#d08000] text-white"
               onPress={handleSubmit}
               endContent={<NextArrowIcon stroke="#F4F4F4" />}
               isDisabled={isSubmitting}

--- a/app/(app)/game-result/plate-appearances/_components/PlateResultButtons.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateResultButtons.tsx
@@ -92,6 +92,8 @@ export function PlateResultButtons({
           >
             ヒット
           </Button>
+        </div>
+        <div className="grid grid-cols-4 gap-2">
           {DIRECTION_ONLY_RESULT_OPTIONS.map((option) => {
             const isSelected = selectedPlateResultId === option.plate_result_id;
             return (
@@ -99,7 +101,11 @@ export function PlateResultButtons({
                 key={option.plate_result_id}
                 variant="bordered"
                 radius="sm"
-                className={`font-bold ${toneClass("orange", isSelected)}`}
+                size="sm"
+                className={`font-bold min-w-0 px-0 ${toneClass(
+                  "orange",
+                  isSelected,
+                )}`}
                 isDisabled={!hasHitLocation}
                 onPress={() => onSelectDirectionOnly(option.plate_result_id)}
               >

--- a/app/(app)/game-result/plate-appearances/_components/PlateResultButtons.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateResultButtons.tsx
@@ -102,7 +102,7 @@ export function PlateResultButtons({
                 variant="bordered"
                 radius="sm"
                 size="sm"
-                className={`font-bold min-w-0 px-0 ${toneClass(
+                className={`font-bold min-w-0 px-0 h-12 ${toneClass(
                   "orange",
                   isSelected,
                 )}`}

--- a/app/(app)/game-result/plate-appearances/_components/PlateResultButtons.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateResultButtons.tsx
@@ -101,8 +101,7 @@ export function PlateResultButtons({
                 key={option.plate_result_id}
                 variant="bordered"
                 radius="sm"
-                size="sm"
-                className={`font-bold min-w-0 px-0 h-12 ${toneClass(
+                className={`font-bold min-w-0 px-0 ${toneClass(
                   "orange",
                   isSelected,
                 )}`}

--- a/app/(app)/game-result/plate-appearances/_components/PlateResultButtons.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateResultButtons.tsx
@@ -22,7 +22,18 @@ interface PlateResultButtonsProps {
   onSelectDirectionOnly: (plateResultId: PlateResultId) => void;
 }
 
-// out 系（赤）で表示する plate_result_id（アウト/三振/振り逃げ）。それ以外は primary。
+// mobile に合わせた 2 階調配色。HeroUI のテーマ依存（primary が環境で青に解決される）を
+// 避けるため、リテラルの Tailwind クラスで色を固定する。
+// オレンジ #d08000: ヒット / 失策 / 野選 / 犠打 / 犠飛 / 四球 / 死球 / 打撃妨害
+// 赤 #f31260: アウト / 空振り三振 / 見逃し三振 / 振り逃げ
+const ORANGE = "#d08000";
+const RED = "#f31260";
+const ORANGE_BORDER = "border-2 border-[#d08000] bg-transparent text-[#d08000]";
+const ORANGE_SOLID = "border-2 border-[#d08000] bg-[#d08000] text-white";
+const RED_BORDER = "border-2 border-[#f31260] bg-transparent text-[#f31260]";
+const RED_SOLID = "border-2 border-[#f31260] bg-[#f31260] text-white";
+
+// out 系（赤）で表示する plate_result_id（アウト/三振/振り逃げ）。それ以外はオレンジ。
 const OUT_COLORED_IDS: readonly number[] = [
   PLATE_RESULT_IDS.GROUND_OUT,
   PLATE_RESULT_IDS.FLY_OUT,
@@ -33,8 +44,13 @@ const OUT_COLORED_IDS: readonly number[] = [
   PLATE_RESULT_IDS.STRIKEOUT_REACHED,
 ];
 
-const colorFor = (plateResultId: number): "danger" | "primary" =>
-  OUT_COLORED_IDS.includes(plateResultId) ? "danger" : "primary";
+const toneFor = (plateResultId: number): "orange" | "red" =>
+  OUT_COLORED_IDS.includes(plateResultId) ? "red" : "orange";
+
+const toneClass = (tone: "orange" | "red", selected: boolean): string => {
+  if (tone === "red") return selected ? RED_SOLID : RED_BORDER;
+  return selected ? ORANGE_SOLID : ORANGE_BORDER;
+};
 
 /**
  * 打席結果ボタン群。打球方向あり系（アウト/ヒット/失策/野選/犠打/犠飛）はグラウンド
@@ -57,24 +73,22 @@ export function PlateResultButtons({
         </p>
         <div className="grid grid-cols-2 gap-2">
           <Button
-            color="danger"
             variant="bordered"
             radius="sm"
-            className="font-bold justify-between"
+            className={`font-bold justify-between ${RED_BORDER}`}
             isDisabled={!hasHitLocation}
             onPress={onSelectOut}
-            endContent={<NextArrowIcon stroke="#f31260" />}
+            endContent={<NextArrowIcon stroke={RED} />}
           >
             アウト
           </Button>
           <Button
-            color="primary"
             variant="bordered"
             radius="sm"
-            className="font-bold justify-between"
+            className={`font-bold justify-between ${ORANGE_BORDER}`}
             isDisabled={!hasHitLocation}
             onPress={onSelectHit}
-            endContent={<NextArrowIcon stroke="#d08000" />}
+            endContent={<NextArrowIcon stroke={ORANGE} />}
           >
             ヒット
           </Button>
@@ -83,10 +97,9 @@ export function PlateResultButtons({
             return (
               <Button
                 key={option.plate_result_id}
-                color="primary"
-                variant={isSelected ? "solid" : "bordered"}
+                variant="bordered"
                 radius="sm"
-                className="font-bold"
+                className={`font-bold ${toneClass("orange", isSelected)}`}
                 isDisabled={!hasHitLocation}
                 onPress={() => onSelectDirectionOnly(option.plate_result_id)}
               >
@@ -108,10 +121,12 @@ export function PlateResultButtons({
             return (
               <Button
                 key={`${option.plate_result_id}-${option.label}`}
-                color={colorFor(option.plate_result_id)}
-                variant={isSelected ? "solid" : "bordered"}
+                variant="bordered"
                 radius="sm"
-                className="font-bold"
+                className={`font-bold ${toneClass(
+                  toneFor(option.plate_result_id),
+                  isSelected,
+                )}`}
                 isDisabled={hasHitLocation}
                 onPress={() =>
                   onSelectNoDirection(option.plate_result_id, option.swing_type)

--- a/app/(app)/game-result/plate-appearances/_components/PlateResultButtons.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateResultButtons.tsx
@@ -1,0 +1,128 @@
+"use client";
+import type { SwingType } from "@app/interface/plateAppearanceV2";
+import { Button } from "@heroui/react";
+import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
+import {
+  DIRECTION_ONLY_RESULT_OPTIONS,
+  NO_DIRECTION_RESULT_OPTIONS,
+  PLATE_RESULT_IDS,
+  type PlateResultId,
+} from "@app/constants/plateResults";
+
+interface PlateResultButtonsProps {
+  hasHitLocation: boolean;
+  selectedPlateResultId?: PlateResultId | null;
+  selectedSwingType?: SwingType | null;
+  onSelectNoDirection: (
+    plateResultId: PlateResultId,
+    swingType?: SwingType,
+  ) => void;
+  onSelectOut: () => void;
+  onSelectHit: () => void;
+  onSelectDirectionOnly: (plateResultId: PlateResultId) => void;
+}
+
+// out 系（赤）で表示する plate_result_id（アウト/三振/振り逃げ）。それ以外は primary。
+const OUT_COLORED_IDS: readonly number[] = [
+  PLATE_RESULT_IDS.GROUND_OUT,
+  PLATE_RESULT_IDS.FLY_OUT,
+  PLATE_RESULT_IDS.FOUL_FLY,
+  PLATE_RESULT_IDS.LINE_OUT,
+  PLATE_RESULT_IDS.DOUBLE_PLAY,
+  PLATE_RESULT_IDS.STRIKEOUT,
+  PLATE_RESULT_IDS.STRIKEOUT_REACHED,
+];
+
+const colorFor = (plateResultId: number): "danger" | "primary" =>
+  OUT_COLORED_IDS.includes(plateResultId) ? "danger" : "primary";
+
+/**
+ * 打席結果ボタン群。打球方向あり系（アウト/ヒット/失策/野選/犠打/犠飛）はグラウンド
+ * クリック後のみ活性。打球方向なし系（三振/四球/死球/打撃妨害/振り逃げ）は未クリック時のみ活性。
+ */
+export function PlateResultButtons({
+  hasHitLocation,
+  selectedPlateResultId,
+  selectedSwingType,
+  onSelectNoDirection,
+  onSelectOut,
+  onSelectHit,
+  onSelectDirectionOnly,
+}: PlateResultButtonsProps) {
+  return (
+    <div className="flex flex-col gap-y-5">
+      <section className="flex flex-col gap-y-2">
+        <p className="text-sm text-zinc-400">
+          打球方向あり（グラウンドをクリック）
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          <Button
+            color="danger"
+            variant="bordered"
+            radius="sm"
+            className="font-bold justify-between"
+            isDisabled={!hasHitLocation}
+            onPress={onSelectOut}
+            endContent={<NextArrowIcon stroke="#f31260" />}
+          >
+            アウト
+          </Button>
+          <Button
+            color="primary"
+            variant="bordered"
+            radius="sm"
+            className="font-bold justify-between"
+            isDisabled={!hasHitLocation}
+            onPress={onSelectHit}
+            endContent={<NextArrowIcon stroke="#d08000" />}
+          >
+            ヒット
+          </Button>
+          {DIRECTION_ONLY_RESULT_OPTIONS.map((option) => {
+            const isSelected = selectedPlateResultId === option.plate_result_id;
+            return (
+              <Button
+                key={option.plate_result_id}
+                color="primary"
+                variant={isSelected ? "solid" : "bordered"}
+                radius="sm"
+                className="font-bold"
+                isDisabled={!hasHitLocation}
+                onPress={() => onSelectDirectionOnly(option.plate_result_id)}
+              >
+                {option.label}
+              </Button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-y-2">
+        <p className="text-sm text-zinc-400">打球方向なし</p>
+        <div className="grid grid-cols-2 gap-2">
+          {NO_DIRECTION_RESULT_OPTIONS.map((option) => {
+            const isSelected =
+              selectedPlateResultId === option.plate_result_id &&
+              (option.swing_type == null ||
+                option.swing_type === selectedSwingType);
+            return (
+              <Button
+                key={`${option.plate_result_id}-${option.label}`}
+                color={colorFor(option.plate_result_id)}
+                variant={isSelected ? "solid" : "bordered"}
+                radius="sm"
+                className="font-bold"
+                isDisabled={hasHitLocation}
+                onPress={() =>
+                  onSelectNoDirection(option.plate_result_id, option.swing_type)
+                }
+              >
+                {option.label}
+              </Button>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/PlateResultButtons.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateResultButtons.tsx
@@ -44,6 +44,21 @@ const OUT_COLORED_IDS: readonly number[] = [
   PLATE_RESULT_IDS.STRIKEOUT_REACHED,
 ];
 
+// 「アウト」「ヒット」ボタンの選択済み判定用（サブモーダルで確定する種別 id）。
+const OUT_MODAL_IDS: readonly number[] = [
+  PLATE_RESULT_IDS.GROUND_OUT,
+  PLATE_RESULT_IDS.FLY_OUT,
+  PLATE_RESULT_IDS.FOUL_FLY,
+  PLATE_RESULT_IDS.LINE_OUT,
+  PLATE_RESULT_IDS.DOUBLE_PLAY,
+];
+const HIT_IDS: readonly number[] = [
+  PLATE_RESULT_IDS.SINGLE,
+  PLATE_RESULT_IDS.DOUBLE,
+  PLATE_RESULT_IDS.TRIPLE,
+  PLATE_RESULT_IDS.HOME_RUN,
+];
+
 const toneFor = (plateResultId: number): "orange" | "red" =>
   OUT_COLORED_IDS.includes(plateResultId) ? "red" : "orange";
 
@@ -65,6 +80,11 @@ export function PlateResultButtons({
   onSelectHit,
   onSelectDirectionOnly,
 }: PlateResultButtonsProps) {
+  const isOutSelected =
+    selectedPlateResultId != null &&
+    OUT_MODAL_IDS.includes(selectedPlateResultId);
+  const isHitSelected =
+    selectedPlateResultId != null && HIT_IDS.includes(selectedPlateResultId);
   return (
     <div className="flex flex-col gap-y-5">
       <section className="flex flex-col gap-y-2">
@@ -75,20 +95,24 @@ export function PlateResultButtons({
           <Button
             variant="bordered"
             radius="sm"
-            className={`font-bold justify-between ${RED_BORDER}`}
+            className={`font-bold justify-between ${toneClass("red", isOutSelected)}`}
             isDisabled={!hasHitLocation}
             onPress={onSelectOut}
-            endContent={<NextArrowIcon stroke={RED} />}
+            endContent={
+              <NextArrowIcon stroke={isOutSelected ? "#F4F4F4" : RED} />
+            }
           >
             アウト
           </Button>
           <Button
             variant="bordered"
             radius="sm"
-            className={`font-bold justify-between ${ORANGE_BORDER}`}
+            className={`font-bold justify-between ${toneClass("orange", isHitSelected)}`}
             isDisabled={!hasHitLocation}
             onPress={onSelectHit}
-            endContent={<NextArrowIcon stroke={ORANGE} />}
+            endContent={
+              <NextArrowIcon stroke={isHitSelected ? "#F4F4F4" : ORANGE} />
+            }
           >
             ヒット
           </Button>

--- a/app/(app)/game-result/plate-appearances/_components/ScoreCounterInput.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/ScoreCounterInput.tsx
@@ -1,0 +1,99 @@
+"use client";
+import { Button, Input } from "@heroui/react";
+
+export type ScoreCounterKey =
+  | "rbi"
+  | "runScored"
+  | "stolenBases"
+  | "caughtStealing";
+
+interface ScoreCounterInputProps {
+  rbi: number;
+  runScored: number;
+  stolenBases: number;
+  caughtStealing: number;
+  onChange: (key: ScoreCounterKey, value: number) => void;
+}
+
+const ROWS: { key: ScoreCounterKey; label: string }[] = [
+  { key: "rbi", label: "打点" },
+  { key: "runScored", label: "得点" },
+  { key: "stolenBases", label: "盗塁" },
+  { key: "caughtStealing", label: "盗塁死" },
+];
+
+/**
+ * 打点・得点・盗塁・盗塁死を +/- ボタン + 手入力で増減する 4 行ブロック。
+ * 値は 0 以上に制限する（0 のとき減少ボタンを disabled）。
+ */
+export function ScoreCounterInput({
+  rbi,
+  runScored,
+  stolenBases,
+  caughtStealing,
+  onChange,
+}: ScoreCounterInputProps) {
+  const values: Record<ScoreCounterKey, number> = {
+    rbi,
+    runScored,
+    stolenBases,
+    caughtStealing,
+  };
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      {ROWS.map((row) => {
+        const value = values[row.key];
+        const decrementDisabled = value <= 0;
+        return (
+          <div key={row.key} className="flex items-center justify-between">
+            <span className="text-sm">{row.label}</span>
+            <div className="flex items-center gap-x-1">
+              <Button
+                isIconOnly
+                size="sm"
+                radius="full"
+                variant="solid"
+                color="primary"
+                className="h-7 w-7 min-w-7 text-base"
+                aria-label={`${row.label}を減らす`}
+                isDisabled={decrementDisabled}
+                onPress={() => onChange(row.key, Math.max(0, value - 1))}
+              >
+                −
+              </Button>
+              <Input
+                type="number"
+                size="md"
+                variant="bordered"
+                min={0}
+                aria-label={row.label}
+                className="w-16"
+                value={String(value)}
+                onChange={(event) => {
+                  const parsed = Number(event.target.value);
+                  onChange(
+                    row.key,
+                    Number.isNaN(parsed) ? 0 : Math.max(0, parsed),
+                  );
+                }}
+              />
+              <Button
+                isIconOnly
+                size="sm"
+                radius="full"
+                variant="solid"
+                color="primary"
+                className="h-7 w-7 min-w-7 text-base"
+                aria-label={`${row.label}を増やす`}
+                onPress={() => onChange(row.key, value + 1)}
+              >
+                +
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/ScoreCounterInput.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/ScoreCounterInput.tsx
@@ -75,9 +75,10 @@ export function ScoreCounterInput({
                 value={String(value)}
                 onChange={(event) => {
                   const parsed = Number(event.target.value);
+                  // 整数のみ。小数入力は切り捨てる。
                   onChange(
                     row.key,
-                    Number.isNaN(parsed) ? 0 : Math.max(0, parsed),
+                    Number.isNaN(parsed) ? 0 : Math.max(0, Math.floor(parsed)),
                   );
                 }}
               />

--- a/app/(app)/game-result/plate-appearances/_components/ScoreCounterInput.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/ScoreCounterInput.tsx
@@ -47,15 +47,17 @@ export function ScoreCounterInput({
         const decrementDisabled = value <= 0;
         return (
           <div key={row.key} className="flex items-center justify-between">
-            <span className="text-sm">{row.label}</span>
-            <div className="flex items-center gap-x-1">
+            <span className="text-base">{row.label}</span>
+            <div className="flex items-center gap-x-2">
               <Button
                 isIconOnly
-                size="sm"
                 radius="full"
                 variant="solid"
-                color="primary"
-                className="h-7 w-7 min-w-7 text-base"
+                className={`h-8 w-8 min-w-8 text-lg ${
+                  decrementDisabled
+                    ? "bg-zinc-600 text-zinc-400"
+                    : "bg-[#d08000] text-white"
+                }`}
                 aria-label={`${row.label}を減らす`}
                 isDisabled={decrementDisabled}
                 onPress={() => onChange(row.key, Math.max(0, value - 1))}
@@ -68,7 +70,8 @@ export function ScoreCounterInput({
                 variant="bordered"
                 min={0}
                 aria-label={row.label}
-                className="w-16"
+                className="w-20"
+                classNames={{ input: "text-center" }}
                 value={String(value)}
                 onChange={(event) => {
                   const parsed = Number(event.target.value);
@@ -80,11 +83,9 @@ export function ScoreCounterInput({
               />
               <Button
                 isIconOnly
-                size="sm"
                 radius="full"
                 variant="solid"
-                color="primary"
-                className="h-7 w-7 min-w-7 text-base"
+                className="h-8 w-8 min-w-8 text-lg bg-[#d08000] text-white"
                 aria-label={`${row.label}を増やす`}
                 onPress={() => onChange(row.key, value + 1)}
               >

--- a/app/(app)/game-result/plate-appearances/page.tsx
+++ b/app/(app)/game-result/plate-appearances/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import HeaderResult from "@app/components/header/HeaderResult";
+import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
+import { RECORD_PATTERN_STORAGE_KEY } from "@app/constants/gameRecord";
+import useRequireAuth from "@app/hooks/auth/useRequireAuth";
+import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
+import { PlateAppearanceWizard } from "./_components/PlateAppearanceWizard";
+
+export default function PlateAppearanceRecordPage() {
+  const router = useRouter();
+  useRequireAuth();
+  const [gameResultId, setGameResultId] = useState<number | null>(null);
+  const [batterBoxNumber, setBatterBoxNumber] = useState<number | null>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem("gameResultId");
+    if (!saved) {
+      router.push("/game-result/record");
+      return;
+    }
+    const id = JSON.parse(saved) as number;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setGameResultId(id);
+    // 既存打席数 +1 を打席番号として採番する。
+    getPlateAppearancesByGame(id).then((plateAppearances) => {
+      setBatterBoxNumber(plateAppearances.length + 1);
+    });
+  }, [router]);
+
+  const handleCompleted = () => {
+    const raw = localStorage.getItem(RECORD_PATTERN_STORAGE_KEY);
+    const pattern = raw ? JSON.parse(raw) : "both";
+    router.push(
+      pattern === "both" ? "/game-result/pitching/" : "/game-result/summary/",
+    );
+  };
+
+  return (
+    <>
+      <HeaderResult />
+      <main className="h-full">
+        <div className="pb-40 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+          <div className="pt-12 px-4 lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:px-6 lg:pb-6">
+            {gameResultId !== null && batterBoxNumber !== null ? (
+              <PlateAppearanceWizard
+                gameResultId={gameResultId}
+                batterBoxNumber={batterBoxNumber}
+                onCompleted={handleCompleted}
+                onCancel={() => router.push("/game-result/record")}
+              />
+            ) : (
+              <LoadingSpinner />
+            )}
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/page.tsx
+++ b/app/(app)/game-result/plate-appearances/page.tsx
@@ -31,7 +31,14 @@ export default function PlateAppearanceRecordPage() {
 
   const handleCompleted = () => {
     const raw = localStorage.getItem(RECORD_PATTERN_STORAGE_KEY);
-    const pattern = raw ? JSON.parse(raw) : "both";
+    // 壊れた値が入っていても遷移が止まらないよう既定 both にフォールバックする。
+    const pattern = (() => {
+      try {
+        return raw ? JSON.parse(raw) : "both";
+      } catch {
+        return "both";
+      }
+    })();
     router.push(
       pattern === "both" ? "/game-result/pitching/" : "/game-result/summary/",
     );

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -658,13 +658,16 @@ export default function GameRecord() {
         RECORD_PATTERN_STORAGE_KEY,
         JSON.stringify(effectivePattern),
       );
-      // 未出場はまとめへ、投手のみは投手入力へ、それ以外は打撃入力へ。
+      // 未出場はまとめへ、投手のみは投手入力へ、新規の打撃/両方は v2 打席ウィザードへ。
+      // 編集モード（pattern 未指定）は v2 打席編集が未実装のため当面 v1 打撃入力へ。
       const nextPath =
         appearanceType === "no_play"
           ? `/game-result/summary/`
-          : effectivePattern === "pitching"
+          : pattern === "pitching"
             ? `/game-result/pitching/`
-            : `/game-result/batting/`;
+            : pattern
+              ? `/game-result/plate-appearances/`
+              : `/game-result/batting/`;
       router.push(nextPath);
     } catch (error) {
       throw error;


### PR DESCRIPTION
## 概要

mobile [buzzbase_mobile#101](https://github.com/ippei-shimizu/buzzbase_mobile/pull/101) 追従シリーズ ([ippei-shimizu/buzzbase#395](https://github.com/ippei-shimizu/buzzbase/issues/395))。新仕様の打席記録ステップ式ウィザード（打球方向 + 打席結果 + 得点入力）を Web に実装する。#393 の v2 基盤・#394 のパターン分岐の上に積む **stacked PR**（base = `feature/394-game-info-stadium-pattern`）。

Closes ippei-shimizu/buzzbase#395

## 変更内容
- 新ルート `app/(app)/game-result/plate-appearances/`。
- `GroundTapField`: web SVG。クリック位置を 0〜1 正規化座標に変換し `detectClosestDirection` で打球方向を判定、マーカー/方向ラベルをハイライト。
- `PlateResultButtons`: 打球方向あり（アウト/ヒットはサブモーダル、失策/野選/犠打/犠飛）と打球方向なし（三振/四球/死球/打撃妨害/振り逃げ）を2グループ表示。タップ有無で活性切替、2階調配色。
- `OutTypeModal` / `HitTypeModal`: HeroUI モーダルで種別選択。
- `ScoreCounterInput`: 打点/得点/盗塁/盗塁死の +/- ステッパー。
- `PlateAppearanceWizard`: Step1(打球方向+結果) → Step2(得点) で1打席を `POST /api/v2/plate_appearances`。既存打席数 +1 を打席番号に採番。
- 記録ページ: 新規の batting/both パターンをこの新ルートへ遷移（編集モードは v2 編集未実装のため当面 v1 のまま）。

## スコープ / 制約
- 本 PR は **1打席ずつの記録**まで。打席リスト・複数打席の連続記録・編集・削除は #397 で対応（完了後はパターンに応じ投手入力/まとめへ遷移）。
- 詳細データ（カウント/球質/球種/投手等）入力は #396。
- グラウンドはRNのジェスチャ/reanimated を移植せず、Web の click + SVG SMIL アニメで再現。
- UIコンポーネントの結合テストは未追加（draft。後続でカバー予定）。

## 確認
- `yarn typecheck`（追加/変更ファイルにエラーなし）、`yarn lint` / `yarn format:check` パス、`yarn test` 全252件パス。
- 手動確認推奨: グラウンドクリック→方向判定、アウト/ヒットのサブモーダル、打球方向なし系の活性制御、保存後の遷移。
