### PR TITLE
Add: 打席詳細データ入力 + 相手投手マスタ

### DIFF
--- a/app/(app)/game-result/plate-appearances/_components/HitTypeModal.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/HitTypeModal.tsx
@@ -20,7 +20,13 @@ interface HitTypeModalProps {
 /** 「ヒット」押下時のサブ選択モーダル。plate_result_id と hit_type を親へ返す。 */
 export function HitTypeModal({ isOpen, onSelect, onClose }: HitTypeModalProps) {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} placement="center" size="sm">
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      placement="center"
+      size="sm"
+      classNames={{ base: "buzz-dark" }}
+    >
       <ModalContent>
         <ModalHeader className="justify-center">ヒット種別</ModalHeader>
         <ModalBody className="pb-6">

--- a/app/(app)/game-result/plate-appearances/_components/OutTypeModal.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/OutTypeModal.tsx
@@ -20,7 +20,13 @@ interface OutTypeModalProps {
 /** 「アウト」押下時のサブ選択モーダル。plate_result_id と out_type を親へ返す。 */
 export function OutTypeModal({ isOpen, onSelect, onClose }: OutTypeModalProps) {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} placement="center" size="sm">
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      placement="center"
+      size="sm"
+      classNames={{ base: "buzz-dark" }}
+    >
       <ModalContent>
         <ModalHeader className="justify-center">アウト種別</ModalHeader>
         <ModalBody className="pb-6">

--- a/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
@@ -207,7 +207,9 @@ export function PlateAppearanceWizard({
         </>
       ) : step === "score" ? (
         <>
-          <p className="text-center text-base font-medium">打点・得点を入力</p>
+          <p className="text-center text-base font-medium">
+            第{batterBoxNumber}打席 打点・得点を入力
+          </p>
           <ScoreCounterInput
             rbi={scores.rbi}
             runScored={scores.runScored}
@@ -247,7 +249,9 @@ export function PlateAppearanceWizard({
         </>
       ) : (
         <>
-          <p className="text-center text-base font-medium">詳細データを入力</p>
+          <p className="text-center text-base font-medium">
+            第{batterBoxNumber}打席 詳細を入力
+          </p>
           <DetailDataForm
             detail={detail}
             setDetail={setDetail}

--- a/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
@@ -256,7 +256,7 @@ export function PlateAppearanceWizard({
             <Button
               variant="light"
               radius="sm"
-              className="text-[#d08000] underline"
+              className="text-zinc-400 underline"
               onPress={handleSubmit}
               isDisabled={isSubmitting}
             >

--- a/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
@@ -15,6 +15,8 @@ import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import { createPlateAppearanceV2 } from "@app/services/v2/plateAppearanceService";
 import { roundHitLocation, type Point } from "@app/utils/groundZoneDetector";
+import { DetailDataForm } from "./detail/DetailDataForm";
+import { EMPTY_DETAIL, type DetailState } from "./detail/detailState";
 import { GroundTapField } from "./GroundTapField";
 import { HitTypeModal } from "./HitTypeModal";
 import { OutTypeModal } from "./OutTypeModal";
@@ -26,9 +28,10 @@ interface PlateAppearanceWizardProps {
   batterBoxNumber: number;
   onCompleted: () => void;
   onCancel?: () => void;
+  defaultTeamId?: number | null;
 }
 
-type WizardStep = "result" | "score";
+type WizardStep = "result" | "score" | "detail";
 
 /**
  * 1 打席分の記録ウィザード。
@@ -40,6 +43,7 @@ export function PlateAppearanceWizard({
   batterBoxNumber,
   onCompleted,
   onCancel,
+  defaultTeamId,
 }: PlateAppearanceWizardProps) {
   const [step, setStep] = useState<WizardStep>("result");
   const [hitLocation, setHitLocation] = useState<Point | null>(null);
@@ -56,10 +60,14 @@ export function PlateAppearanceWizard({
     stolenBases: 0,
     caughtStealing: 0,
   });
+  const [detail, setDetailState] = useState<DetailState>(EMPTY_DETAIL);
   const [isOutModalOpen, setIsOutModalOpen] = useState(false);
   const [isHitModalOpen, setIsHitModalOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
+
+  const setDetail = (patch: Partial<DetailState>) =>
+    setDetailState((prev) => ({ ...prev, ...patch }));
 
   const goToScore = () => setStep("score");
 
@@ -134,6 +142,18 @@ export function PlateAppearanceWizard({
       run_scored: scores.runScored,
       stolen_bases: scores.stolenBases,
       caught_stealing: scores.caughtStealing,
+      final_balls: detail.finalBalls,
+      final_strikes: detail.finalStrikes,
+      final_outs: detail.finalOuts,
+      first_pitch_swing: detail.firstPitchSwing,
+      runners_state: detail.runnersState,
+      inning: detail.inning,
+      contact_quality_id: detail.contactQualityId,
+      timing_id: detail.timingId,
+      pitch_type_id: detail.pitchTypeId,
+      self_analysis_memo: detail.selfAnalysisMemo,
+      pitcher_id: detail.pitcherId,
+      appearance_situation_id: detail.appearanceSituationId,
     });
     if (result.ok) {
       onCompleted();
@@ -183,7 +203,7 @@ export function PlateAppearanceWizard({
             </Button>
           )}
         </>
-      ) : (
+      ) : step === "score" ? (
         <>
           <p className="text-center text-base font-medium">打点・得点を入力</p>
           <ScoreCounterInput
@@ -193,27 +213,65 @@ export function PlateAppearanceWizard({
             caughtStealing={scores.caughtStealing}
             onChange={handleScoreChange}
           />
-          <div className="flex items-center justify-between">
+          <Button
+            variant="light"
+            radius="sm"
+            className="self-start text-zinc-400"
+            onPress={() => setStep("result")}
+            isDisabled={isSubmitting}
+          >
+            打席結果に戻る
+          </Button>
+          <div className="flex flex-col gap-y-2">
             <Button
-              variant="light"
+              color="primary"
+              variant="bordered"
               radius="sm"
-              className="text-zinc-400"
-              onPress={() => setStep("result")}
+              className="font-bold"
+              onPress={() => setStep("detail")}
               isDisabled={isSubmitting}
             >
-              打席結果に戻る
+              詳細を入力する
             </Button>
             <Button
               color="primary"
               radius="sm"
-              className="px-6 font-bold"
+              className="font-bold"
               onPress={handleSubmit}
               endContent={<NextArrowIcon stroke="#F4F4F4" />}
               isDisabled={isSubmitting}
             >
-              この打席を保存
+              スキップして保存
             </Button>
           </div>
+        </>
+      ) : (
+        <>
+          <p className="text-center text-base font-medium">詳細データを入力</p>
+          <DetailDataForm
+            detail={detail}
+            setDetail={setDetail}
+            defaultTeamId={defaultTeamId}
+          />
+          <Button
+            variant="light"
+            radius="sm"
+            className="self-start text-zinc-400"
+            onPress={() => setStep("score")}
+            isDisabled={isSubmitting}
+          >
+            打点・得点に戻る
+          </Button>
+          <Button
+            color="primary"
+            radius="sm"
+            className="font-bold"
+            onPress={handleSubmit}
+            endContent={<NextArrowIcon stroke="#F4F4F4" />}
+            isDisabled={isSubmitting}
+          >
+            この打席を保存
+          </Button>
         </>
       )}
 

--- a/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
@@ -249,9 +249,20 @@ export function PlateAppearanceWizard({
         </>
       ) : (
         <>
-          <p className="text-center text-base font-medium">
-            第{batterBoxNumber}打席 詳細を入力
-          </p>
+          <div className="flex items-center justify-between">
+            <p className="text-base font-bold">
+              第{batterBoxNumber}打席の詳細（すべて任意）
+            </p>
+            <Button
+              variant="light"
+              radius="sm"
+              className="text-[#d08000] underline"
+              onPress={handleSubmit}
+              isDisabled={isSubmitting}
+            >
+              スキップして完了
+            </Button>
+          </div>
           <DetailDataForm
             detail={detail}
             setDetail={setDetail}

--- a/app/(app)/game-result/plate-appearances/_components/detail/CountBSOSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/CountBSOSelector.tsx
@@ -44,8 +44,9 @@ export function CountBSOSelector({
           const current = values[row.key] ?? 0;
           return (
             <div key={row.key} className="flex items-center justify-between">
-              <span className="text-xs text-zinc-300 w-20">{row.label}</span>
-              <div className="flex gap-x-2">
+              <span className="text-xs text-zinc-300 w-24">{row.label}</span>
+              {/* ドット枠を固定幅にして左揃え。本数が違っても各行の先頭ドットが縦に揃う。 */}
+              <div className="flex gap-x-2 w-24 justify-start">
                 {Array.from({ length: row.max }).map((_, index) => {
                   const lit = index < current;
                   const isLastLit = index === current - 1;

--- a/app/(app)/game-result/plate-appearances/_components/detail/CountBSOSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/CountBSOSelector.tsx
@@ -7,6 +7,7 @@ interface CountBSOSelectorProps {
   strikes: number | null;
   outs: number | null;
   onChange: (key: DetailCountKey, value: number | null) => void;
+  description?: string;
 }
 
 const ROWS: {
@@ -29,6 +30,7 @@ export function CountBSOSelector({
   strikes,
   outs,
   onChange,
+  description,
 }: CountBSOSelectorProps) {
   const values: Record<DetailCountKey, number | null> = {
     finalBalls: balls,
@@ -38,7 +40,12 @@ export function CountBSOSelector({
 
   return (
     <div className="flex flex-col gap-y-2 rounded-lg bg-[#1f1f1f] p-3">
-      <p className="text-sm font-medium">最終カウント</p>
+      <div>
+        <p className="text-sm font-medium">最終カウント</p>
+        {description ? (
+          <p className="text-xs text-zinc-400">{description}</p>
+        ) : null}
+      </div>
       <div className="flex flex-col gap-y-2">
         {ROWS.map((row) => {
           const current = values[row.key] ?? 0;

--- a/app/(app)/game-result/plate-appearances/_components/detail/CountBSOSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/CountBSOSelector.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+export type DetailCountKey = "finalBalls" | "finalStrikes" | "finalOuts";
+
+interface CountBSOSelectorProps {
+  balls: number | null;
+  strikes: number | null;
+  outs: number | null;
+  onChange: (key: DetailCountKey, value: number | null) => void;
+}
+
+const ROWS: {
+  key: DetailCountKey;
+  label: string;
+  max: number;
+  color: string;
+}[] = [
+  { key: "finalBalls", label: "ボール", max: 3, color: "#22c55e" },
+  { key: "finalStrikes", label: "ストライク", max: 2, color: "#eab308" },
+  { key: "finalOuts", label: "アウト", max: 2, color: "#ef4444" },
+];
+
+/**
+ * 最終カウントを球場カウントボード風のドット UI で入力する。
+ * ドット i をタップで値を i+1 に、点灯済みの最後のドット再タップで 1 段下げる。
+ */
+export function CountBSOSelector({
+  balls,
+  strikes,
+  outs,
+  onChange,
+}: CountBSOSelectorProps) {
+  const values: Record<DetailCountKey, number | null> = {
+    finalBalls: balls,
+    finalStrikes: strikes,
+    finalOuts: outs,
+  };
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <p className="text-sm font-medium">最終カウント</p>
+      <div className="flex flex-col gap-y-2">
+        {ROWS.map((row) => {
+          const current = values[row.key] ?? 0;
+          return (
+            <div key={row.key} className="flex items-center justify-between">
+              <span className="text-xs text-zinc-300 w-20">{row.label}</span>
+              <div className="flex gap-x-2">
+                {Array.from({ length: row.max }).map((_, index) => {
+                  const lit = index < current;
+                  const isLastLit = index === current - 1;
+                  return (
+                    <button
+                      key={index}
+                      type="button"
+                      aria-label={`${row.label} ${index + 1}`}
+                      className="h-6 w-6 rounded-full border-2"
+                      style={{
+                        borderColor: row.color,
+                        backgroundColor: lit ? row.color : "transparent",
+                      }}
+                      onClick={() =>
+                        onChange(row.key, isLastLit ? index : index + 1)
+                      }
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/detail/CountBSOSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/CountBSOSelector.tsx
@@ -37,15 +37,15 @@ export function CountBSOSelector({
   };
 
   return (
-    <div className="flex flex-col gap-y-2">
+    <div className="flex flex-col gap-y-2 rounded-lg bg-[#1f1f1f] p-3">
       <p className="text-sm font-medium">最終カウント</p>
       <div className="flex flex-col gap-y-2">
         {ROWS.map((row) => {
           const current = values[row.key] ?? 0;
           return (
-            <div key={row.key} className="flex items-center justify-between">
+            <div key={row.key} className="flex items-center gap-x-4">
               <span className="text-xs text-zinc-300 w-24">{row.label}</span>
-              {/* ドット枠を固定幅にして左揃え。本数が違っても各行の先頭ドットが縦に揃う。 */}
+              {/* ラベルの直後にドットを左揃え。本数が違っても各行の先頭ドットが縦に揃う。 */}
               <div className="flex gap-x-2 w-24 justify-start">
                 {Array.from({ length: row.max }).map((_, index) => {
                   const lit = index < current;

--- a/app/(app)/game-result/plate-appearances/_components/detail/DetailDataForm.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/DetailDataForm.tsx
@@ -6,7 +6,13 @@ import type {
   PitchTypeMaster,
   TimingMaster,
 } from "@app/interface/plateAppearanceMasters";
+import {
+  FlagIcon,
+  PencilSquareIcon,
+  UserIcon,
+} from "@heroicons/react/24/outline";
 import { useEffect, useState } from "react";
+import { BallIcon } from "@app/components/icon/BallIcon";
 import {
   getAppearanceSituations,
   getContactQualities,
@@ -32,16 +38,21 @@ interface DetailDataFormProps {
 function Card({
   title,
   subtitle,
+  icon,
   children,
 }: {
   title: string;
   subtitle: string;
+  icon: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (
     <section className="rounded-xl bg-bg_sub p-4 flex flex-col gap-y-4">
       <div>
-        <h3 className="text-base font-bold">{title}</h3>
+        <div className="flex items-center gap-x-2">
+          <span className="text-[#d08000]">{icon}</span>
+          <h3 className="text-base font-bold">{title}</h3>
+        </div>
         <p className="text-xs text-zinc-400">{subtitle}</p>
       </div>
       {children}
@@ -76,7 +87,11 @@ export function DetailDataForm({
 
   return (
     <div className="flex flex-col gap-y-4">
-      <Card title="打席の状況" subtitle="打席時の状況を記録します">
+      <Card
+        title="打席の状況"
+        subtitle="打席時の状況を記録します"
+        icon={<FlagIcon className="h-5 w-5" />}
+      >
         <CountBSOSelector
           balls={detail.finalBalls}
           strikes={detail.finalStrikes}
@@ -97,7 +112,11 @@ export function DetailDataForm({
         />
       </Card>
 
-      <Card title="打球" subtitle="打球の質感や対応した球種を記録します">
+      <Card
+        title="打球"
+        subtitle="打球の質感や対応した球種を記録します"
+        icon={<BallIcon width="20" height="20" fill="#d08000" />}
+      >
         <MasterChipSelector
           label="打球の質"
           options={contactQualities}
@@ -118,7 +137,11 @@ export function DetailDataForm({
         />
       </Card>
 
-      <Card title="相手投手" subtitle="自分が記録した投手のみ表示されます">
+      <Card
+        title="相手投手"
+        subtitle="自分が記録した投手のみ表示されます"
+        icon={<UserIcon className="h-5 w-5" />}
+      >
         <PitcherSelector
           value={detail.pitcherId}
           onChange={(id) => setDetail({ pitcherId: id })}
@@ -132,7 +155,11 @@ export function DetailDataForm({
         />
       </Card>
 
-      <Card title="メモ" subtitle="次の打席に活かしたい振り返り">
+      <Card
+        title="メモ"
+        subtitle="次の打席に活かしたい振り返り"
+        icon={<PencilSquareIcon className="h-5 w-5" />}
+      >
         <MemoTextArea
           value={detail.selfAnalysisMemo}
           onChange={(text) => setDetail({ selfAnalysisMemo: text || null })}

--- a/app/(app)/game-result/plate-appearances/_components/detail/DetailDataForm.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/DetailDataForm.tsx
@@ -26,6 +26,7 @@ import {
   MemoTextArea,
   RunnersStateSelector,
 } from "./DetailFields";
+import { DetailValueBanner } from "./DetailValueBanner";
 import { MasterChipSelector } from "./MasterChipSelector";
 import { PitcherSelector } from "./PitcherSelector";
 
@@ -100,6 +101,7 @@ export function DetailDataForm({
 
   return (
     <div className="flex flex-col gap-y-4">
+      <DetailValueBanner />
       <Card
         title="打席の状況"
         subtitle="打席時の状況を記録します"

--- a/app/(app)/game-result/plate-appearances/_components/detail/DetailDataForm.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/DetailDataForm.tsx
@@ -1,0 +1,143 @@
+"use client";
+import type { DetailState } from "./detailState";
+import type {
+  AppearanceSituationMaster,
+  ContactQualityMaster,
+  PitchTypeMaster,
+  TimingMaster,
+} from "@app/interface/plateAppearanceMasters";
+import { useEffect, useState } from "react";
+import {
+  getAppearanceSituations,
+  getContactQualities,
+  getPitchTypes,
+  getTimings,
+} from "@app/services/v2/masterService";
+import { CountBSOSelector } from "./CountBSOSelector";
+import {
+  FirstPitchSwingToggle,
+  InningStepper,
+  MemoTextArea,
+  RunnersStateSelector,
+} from "./DetailFields";
+import { MasterChipSelector } from "./MasterChipSelector";
+import { PitcherSelector } from "./PitcherSelector";
+
+interface DetailDataFormProps {
+  detail: DetailState;
+  setDetail: (patch: Partial<DetailState>) => void;
+  defaultTeamId?: number | null;
+}
+
+function Card({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-xl bg-bg_sub p-4 flex flex-col gap-y-4">
+      <div>
+        <h3 className="text-base font-bold">{title}</h3>
+        <p className="text-xs text-zinc-400">{subtitle}</p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * 打席詳細入力（Step3）の本体。打席の状況 / 打球 / 相手投手 / メモ の4カードに分け、
+ * すべて任意入力。マスタはサーバーアクションで取得する。
+ */
+export function DetailDataForm({
+  detail,
+  setDetail,
+  defaultTeamId,
+}: DetailDataFormProps) {
+  const [contactQualities, setContactQualities] = useState<
+    ContactQualityMaster[]
+  >([]);
+  const [timings, setTimings] = useState<TimingMaster[]>([]);
+  const [pitchTypes, setPitchTypes] = useState<PitchTypeMaster[]>([]);
+  const [appearanceSituations, setAppearanceSituations] = useState<
+    AppearanceSituationMaster[]
+  >([]);
+
+  useEffect(() => {
+    getContactQualities().then(setContactQualities);
+    getTimings().then(setTimings);
+    getPitchTypes().then(setPitchTypes);
+    getAppearanceSituations().then(setAppearanceSituations);
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <Card title="打席の状況" subtitle="打席時の状況を記録します">
+        <CountBSOSelector
+          balls={detail.finalBalls}
+          strikes={detail.finalStrikes}
+          outs={detail.finalOuts}
+          onChange={(key, value) => setDetail({ [key]: value })}
+        />
+        <FirstPitchSwingToggle
+          value={detail.firstPitchSwing}
+          onChange={(value) => setDetail({ firstPitchSwing: value })}
+        />
+        <RunnersStateSelector
+          value={detail.runnersState}
+          onChange={(value) => setDetail({ runnersState: value })}
+        />
+        <InningStepper
+          value={detail.inning}
+          onChange={(value) => setDetail({ inning: value })}
+        />
+      </Card>
+
+      <Card title="打球" subtitle="打球の質感や対応した球種を記録します">
+        <MasterChipSelector
+          label="打球の質"
+          options={contactQualities}
+          value={detail.contactQualityId}
+          onChange={(id) => setDetail({ contactQualityId: id })}
+        />
+        <MasterChipSelector
+          label="タイミング"
+          options={timings}
+          value={detail.timingId}
+          onChange={(id) => setDetail({ timingId: id })}
+        />
+        <MasterChipSelector
+          label="球種"
+          options={pitchTypes}
+          value={detail.pitchTypeId}
+          onChange={(id) => setDetail({ pitchTypeId: id })}
+        />
+      </Card>
+
+      <Card title="相手投手" subtitle="自分が記録した投手のみ表示されます">
+        <PitcherSelector
+          value={detail.pitcherId}
+          onChange={(id) => setDetail({ pitcherId: id })}
+          defaultTeamId={defaultTeamId}
+        />
+        <MasterChipSelector
+          label="登板状況"
+          options={appearanceSituations}
+          value={detail.appearanceSituationId}
+          onChange={(id) => setDetail({ appearanceSituationId: id })}
+        />
+      </Card>
+
+      <Card title="メモ" subtitle="次の打席に活かしたい振り返り">
+        <MemoTextArea
+          value={detail.selfAnalysisMemo}
+          onChange={(text) => setDetail({ selfAnalysisMemo: text || null })}
+        />
+      </Card>
+    </div>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/detail/DetailDataForm.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/DetailDataForm.tsx
@@ -35,6 +35,19 @@ interface DetailDataFormProps {
   defaultTeamId?: number | null;
 }
 
+// mobile と同様、各項目に1文の説明を出す。文言は1箇所に集約する。
+const SECTION_DESCRIPTIONS = {
+  finalCount: "打席が終わった時点のボール・ストライク・アウトのカウント",
+  firstPitchSwing: "1球目を打って打席結果が決まったかどうか",
+  runnersState: "打席結果が出たタイミングのランナー位置",
+  inning: "この打席が何回（イニング）目に発生したか",
+  contactQuality: "ボールがバットのどこに当たった感触か",
+  timing: "ピッチャーの球に対するスイングのタイミング",
+  pitchType: "打席結果が決まった最後の1球の球種",
+  selfAnalysisMemo: "打席を振り返って、自分の良かった点・課題を書き残す",
+  appearanceSituation: "投手の登板タイミング（試合終盤の対戦成績の分析に使う）",
+} as const;
+
 function Card({
   title,
   subtitle,
@@ -97,18 +110,22 @@ export function DetailDataForm({
           strikes={detail.finalStrikes}
           outs={detail.finalOuts}
           onChange={(key, value) => setDetail({ [key]: value })}
+          description={SECTION_DESCRIPTIONS.finalCount}
         />
         <FirstPitchSwingToggle
           value={detail.firstPitchSwing}
           onChange={(value) => setDetail({ firstPitchSwing: value })}
+          description={SECTION_DESCRIPTIONS.firstPitchSwing}
         />
         <RunnersStateSelector
           value={detail.runnersState}
           onChange={(value) => setDetail({ runnersState: value })}
+          description={SECTION_DESCRIPTIONS.runnersState}
         />
         <InningStepper
           value={detail.inning}
           onChange={(value) => setDetail({ inning: value })}
+          description={SECTION_DESCRIPTIONS.inning}
         />
       </Card>
 
@@ -122,24 +139,27 @@ export function DetailDataForm({
           options={contactQualities}
           value={detail.contactQualityId}
           onChange={(id) => setDetail({ contactQualityId: id })}
+          description={SECTION_DESCRIPTIONS.contactQuality}
         />
         <MasterChipSelector
           label="タイミング"
           options={timings}
           value={detail.timingId}
           onChange={(id) => setDetail({ timingId: id })}
+          description={SECTION_DESCRIPTIONS.timing}
         />
         <MasterChipSelector
           label="球種"
           options={pitchTypes}
           value={detail.pitchTypeId}
           onChange={(id) => setDetail({ pitchTypeId: id })}
+          description={SECTION_DESCRIPTIONS.pitchType}
         />
       </Card>
 
       <Card
         title="相手投手"
-        subtitle="自分が記録した投手のみ表示されます"
+        subtitle="対戦した投手を選択 / 新規追加すると、投手別の成績が見られる"
         icon={<UserIcon className="h-5 w-5" />}
       >
         <PitcherSelector
@@ -152,6 +172,7 @@ export function DetailDataForm({
           options={appearanceSituations}
           value={detail.appearanceSituationId}
           onChange={(id) => setDetail({ appearanceSituationId: id })}
+          description={SECTION_DESCRIPTIONS.appearanceSituation}
         />
       </Card>
 
@@ -163,6 +184,7 @@ export function DetailDataForm({
         <MemoTextArea
           value={detail.selfAnalysisMemo}
           onChange={(text) => setDetail({ selfAnalysisMemo: text || null })}
+          description={SECTION_DESCRIPTIONS.selfAnalysisMemo}
         />
       </Card>
     </div>

--- a/app/(app)/game-result/plate-appearances/_components/detail/DetailFields.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/DetailFields.tsx
@@ -28,8 +28,12 @@ export function FirstPitchSwingToggle({
               key={option.label}
               size="sm"
               radius="sm"
-              color="primary"
               variant={isSelected ? "solid" : "bordered"}
+              className={
+                isSelected
+                  ? "border-2 border-[#d08000] bg-[#d08000] text-white"
+                  : "border-2 border-[#d08000] bg-transparent text-[#d08000]"
+              }
               onPress={() => onChange(isSelected ? null : option.value)}
             >
               {option.label}
@@ -64,7 +68,7 @@ export function RunnersStateSelector({
               aria-pressed={isSelected}
               className={`rounded-full border px-3 py-1 text-sm transition-colors ${
                 isSelected
-                  ? "border-primary bg-primary text-white"
+                  ? "border-[#d08000] bg-[#d08000] text-white"
                   : "border-zinc-600 text-zinc-200"
               }`}
               onClick={() => onChange(isSelected ? null : option.key)}
@@ -92,11 +96,13 @@ export function InningStepper({ value, onChange }: InningStepperProps) {
       <div className="flex items-center gap-x-1">
         <Button
           isIconOnly
-          size="sm"
           radius="full"
           variant="solid"
-          color="primary"
-          className="h-7 w-7 min-w-7 text-base"
+          className={`h-8 w-8 min-w-8 text-lg ${
+            decrementDisabled
+              ? "bg-zinc-600 text-zinc-400"
+              : "bg-[#d08000] text-white"
+          }`}
           aria-label="イニングを減らす"
           isDisabled={decrementDisabled}
           onPress={() => onChange(Math.max(1, (value ?? 1) - 1))}
@@ -123,11 +129,9 @@ export function InningStepper({ value, onChange }: InningStepperProps) {
         />
         <Button
           isIconOnly
-          size="sm"
           radius="full"
           variant="solid"
-          color="primary"
-          className="h-7 w-7 min-w-7 text-base"
+          className="h-8 w-8 min-w-8 text-lg bg-[#d08000] text-white"
           aria-label="イニングを増やす"
           onPress={() => onChange((value ?? 0) + 1)}
         >

--- a/app/(app)/game-result/plate-appearances/_components/detail/DetailFields.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/DetailFields.tsx
@@ -91,7 +91,7 @@ export function RunnersStateSelector({
               className={`rounded-full border px-3 py-1 text-sm transition-colors ${
                 isSelected
                   ? "border-[#d08000] bg-[#d08000] text-white"
-                  : "border-zinc-600 text-zinc-200"
+                  : "border-zinc-500 text-zinc-200"
               }`}
               onClick={() => onChange(isSelected ? null : option.key)}
             >

--- a/app/(app)/game-result/plate-appearances/_components/detail/DetailFields.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/DetailFields.tsx
@@ -1,0 +1,159 @@
+"use client";
+import type { RunnersState } from "@app/interface/plateAppearanceV2";
+import { Button, Input, Textarea } from "@heroui/react";
+import { RUNNERS_STATE_OPTIONS } from "@app/constants/runnersState";
+
+interface FirstPitchSwingToggleProps {
+  value: boolean | null;
+  onChange: (value: boolean | null) => void;
+}
+
+/** 初球打ち（1球目で打席結果が決まったか）を はい/いいえ で選ぶ。再選択で解除。 */
+export function FirstPitchSwingToggle({
+  value,
+  onChange,
+}: FirstPitchSwingToggleProps) {
+  const OPTIONS: { label: string; value: boolean }[] = [
+    { label: "はい", value: true },
+    { label: "いいえ", value: false },
+  ];
+  return (
+    <div className="flex flex-col gap-y-2">
+      <p className="text-sm font-medium">初球打ち</p>
+      <div className="flex gap-x-2">
+        {OPTIONS.map((option) => {
+          const isSelected = value === option.value;
+          return (
+            <Button
+              key={option.label}
+              size="sm"
+              radius="sm"
+              color="primary"
+              variant={isSelected ? "solid" : "bordered"}
+              onPress={() => onChange(isSelected ? null : option.value)}
+            >
+              {option.label}
+            </Button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface RunnersStateSelectorProps {
+  value: RunnersState | null;
+  onChange: (value: RunnersState | null) => void;
+}
+
+/** ランナー状況をチップで選ぶ。再選択で解除。 */
+export function RunnersStateSelector({
+  value,
+  onChange,
+}: RunnersStateSelectorProps) {
+  return (
+    <div className="flex flex-col gap-y-2">
+      <p className="text-sm font-medium">ランナー状況</p>
+      <div className="flex flex-wrap gap-2">
+        {RUNNERS_STATE_OPTIONS.map((option) => {
+          const isSelected = value === option.key;
+          return (
+            <button
+              key={option.key}
+              type="button"
+              aria-pressed={isSelected}
+              className={`rounded-full border px-3 py-1 text-sm transition-colors ${
+                isSelected
+                  ? "border-primary bg-primary text-white"
+                  : "border-zinc-600 text-zinc-200"
+              }`}
+              onClick={() => onChange(isSelected ? null : option.key)}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface InningStepperProps {
+  value: number | null;
+  onChange: (value: number | null) => void;
+}
+
+/** イニングを +/- と手入力で設定する（1 以上、空欄は未入力）。 */
+export function InningStepper({ value, onChange }: InningStepperProps) {
+  const decrementDisabled = value === null || value <= 1;
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-sm font-medium">イニング</span>
+      <div className="flex items-center gap-x-1">
+        <Button
+          isIconOnly
+          size="sm"
+          radius="full"
+          variant="solid"
+          color="primary"
+          className="h-7 w-7 min-w-7 text-base"
+          aria-label="イニングを減らす"
+          isDisabled={decrementDisabled}
+          onPress={() => onChange(Math.max(1, (value ?? 1) - 1))}
+        >
+          −
+        </Button>
+        <Input
+          type="number"
+          size="md"
+          variant="bordered"
+          min={1}
+          aria-label="イニング"
+          className="w-16"
+          value={value !== null ? String(value) : ""}
+          onChange={(event) => {
+            const raw = event.target.value;
+            if (raw === "") {
+              onChange(null);
+              return;
+            }
+            const parsed = Number(raw);
+            if (!Number.isNaN(parsed)) onChange(Math.max(1, parsed));
+          }}
+        />
+        <Button
+          isIconOnly
+          size="sm"
+          radius="full"
+          variant="solid"
+          color="primary"
+          className="h-7 w-7 min-w-7 text-base"
+          aria-label="イニングを増やす"
+          onPress={() => onChange((value ?? 0) + 1)}
+        >
+          +
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+interface MemoTextAreaProps {
+  value: string | null;
+  onChange: (value: string) => void;
+}
+
+/** 自己分析メモ。 */
+export function MemoTextArea({ value, onChange }: MemoTextAreaProps) {
+  return (
+    <Textarea
+      variant="bordered"
+      label="自己分析メモ"
+      labelPlacement="outside"
+      placeholder="例: 高めの球に手が出てしまった"
+      maxLength={1000}
+      value={value ?? ""}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/detail/DetailFields.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/DetailFields.tsx
@@ -3,15 +3,35 @@ import type { RunnersState } from "@app/interface/plateAppearanceV2";
 import { Button, Input, Textarea } from "@heroui/react";
 import { RUNNERS_STATE_OPTIONS } from "@app/constants/runnersState";
 
+/** 詳細項目のラベル + 説明文（mobile 同様、各項目に1文の説明を出す）。 */
+export function FieldLabel({
+  label,
+  description,
+}: {
+  label: string;
+  description?: string;
+}) {
+  return (
+    <div>
+      <p className="text-sm font-medium">{label}</p>
+      {description ? (
+        <p className="text-xs text-zinc-400">{description}</p>
+      ) : null}
+    </div>
+  );
+}
+
 interface FirstPitchSwingToggleProps {
   value: boolean | null;
   onChange: (value: boolean | null) => void;
+  description?: string;
 }
 
 /** 初球打ち（1球目で打席結果が決まったか）を はい/いいえ で選ぶ。再選択で解除。 */
 export function FirstPitchSwingToggle({
   value,
   onChange,
+  description,
 }: FirstPitchSwingToggleProps) {
   const OPTIONS: { label: string; value: boolean }[] = [
     { label: "はい", value: true },
@@ -19,7 +39,7 @@ export function FirstPitchSwingToggle({
   ];
   return (
     <div className="flex flex-col gap-y-2">
-      <p className="text-sm font-medium">初球打ち</p>
+      <FieldLabel label="初球打ち" description={description} />
       <div className="flex gap-x-2">
         {OPTIONS.map((option) => {
           const isSelected = value === option.value;
@@ -48,16 +68,18 @@ export function FirstPitchSwingToggle({
 interface RunnersStateSelectorProps {
   value: RunnersState | null;
   onChange: (value: RunnersState | null) => void;
+  description?: string;
 }
 
 /** ランナー状況をチップで選ぶ。再選択で解除。 */
 export function RunnersStateSelector({
   value,
   onChange,
+  description,
 }: RunnersStateSelectorProps) {
   return (
     <div className="flex flex-col gap-y-2">
-      <p className="text-sm font-medium">ランナー状況</p>
+      <FieldLabel label="ランナー状況" description={description} />
       <div className="flex flex-wrap gap-2">
         {RUNNERS_STATE_OPTIONS.map((option) => {
           const isSelected = value === option.key;
@@ -85,14 +107,19 @@ export function RunnersStateSelector({
 interface InningStepperProps {
   value: number | null;
   onChange: (value: number | null) => void;
+  description?: string;
 }
 
 /** イニングを +/- と手入力で設定する（1 以上、空欄は未入力）。 */
-export function InningStepper({ value, onChange }: InningStepperProps) {
+export function InningStepper({
+  value,
+  onChange,
+  description,
+}: InningStepperProps) {
   const decrementDisabled = value === null || value <= 1;
   return (
-    <div className="flex items-center justify-between">
-      <span className="text-sm font-medium">イニング</span>
+    <div className="flex flex-col gap-y-2">
+      <FieldLabel label="イニング" description={description} />
       <div className="flex items-center gap-x-1">
         <Button
           isIconOnly
@@ -145,15 +172,21 @@ export function InningStepper({ value, onChange }: InningStepperProps) {
 interface MemoTextAreaProps {
   value: string | null;
   onChange: (value: string) => void;
+  description?: string;
 }
 
 /** 自己分析メモ。 */
-export function MemoTextArea({ value, onChange }: MemoTextAreaProps) {
+export function MemoTextArea({
+  value,
+  onChange,
+  description,
+}: MemoTextAreaProps) {
   return (
     <Textarea
       variant="bordered"
       label="自己分析メモ"
       labelPlacement="outside"
+      description={description}
       placeholder="例: 高めの球に手が出てしまった"
       maxLength={1000}
       value={value ?? ""}

--- a/app/(app)/game-result/plate-appearances/_components/detail/DetailValueBanner.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/DetailValueBanner.tsx
@@ -4,7 +4,7 @@ import { LightBulbIcon } from "@heroicons/react/24/solid";
 /** 詳細入力の価値訴求バナー（mobile 同様、記録するメリットを伝える）。 */
 export function DetailValueBanner() {
   return (
-    <div className="flex items-start gap-x-3 rounded-xl border-2 border-[#d08000] bg-bg_sub p-4">
+    <div className="flex items-start gap-x-3 rounded-xl border-2 border-[#d08000] bg-[#3a3024] p-4">
       <LightBulbIcon className="h-6 w-6 text-[#d08000] shrink-0" />
       <div>
         <p className="text-sm">

--- a/app/(app)/game-result/plate-appearances/_components/detail/DetailValueBanner.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/DetailValueBanner.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { LightBulbIcon } from "@heroicons/react/24/solid";
+
+/** 詳細入力の価値訴求バナー（mobile 同様、記録するメリットを伝える）。 */
+export function DetailValueBanner() {
+  return (
+    <div className="flex items-start gap-x-3 rounded-xl border-2 border-[#d08000] bg-bg_sub p-4">
+      <LightBulbIcon className="h-6 w-6 text-[#d08000] shrink-0" />
+      <div>
+        <p className="text-sm">
+          詳細を記録すると、球質別の打率や状況別の分析が見られます
+        </p>
+        <p className="text-xs text-zinc-400 mt-1">あとから追記もできます</p>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/detail/MasterChipSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/MasterChipSelector.tsx
@@ -44,7 +44,7 @@ export function MasterChipSelector({
                 className={`rounded-full border px-3 py-1 text-sm transition-colors ${
                   isSelected
                     ? "border-[#d08000] bg-[#d08000] text-white"
-                    : "border-zinc-600 text-zinc-200"
+                    : "border-zinc-500 text-zinc-200"
                 }`}
                 onClick={() => onChange(isSelected ? null : option.id)}
               >

--- a/app/(app)/game-result/plate-appearances/_components/detail/MasterChipSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/MasterChipSelector.tsx
@@ -43,7 +43,7 @@ export function MasterChipSelector({
                 aria-pressed={isSelected}
                 className={`rounded-full border px-3 py-1 text-sm transition-colors ${
                   isSelected
-                    ? "border-primary bg-primary text-white"
+                    ? "border-[#d08000] bg-[#d08000] text-white"
                     : "border-zinc-600 text-zinc-200"
                 }`}
                 onClick={() => onChange(isSelected ? null : option.id)}

--- a/app/(app)/game-result/plate-appearances/_components/detail/MasterChipSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/MasterChipSelector.tsx
@@ -1,0 +1,59 @@
+"use client";
+import type { MasterItem } from "@app/interface/plateAppearanceMasters";
+
+interface MasterChipSelectorProps {
+  label: string;
+  description?: string;
+  options: MasterItem[];
+  value: number | null;
+  onChange: (id: number | null) => void;
+  isError?: boolean;
+}
+
+/**
+ * マスタ（球質 / タイミング / 球種 / 登板状況など）を1つだけ選ぶチップ群。
+ * 選択済みのチップを再度押すと未選択(null)に戻す。
+ */
+export function MasterChipSelector({
+  label,
+  description,
+  options,
+  value,
+  onChange,
+  isError,
+}: MasterChipSelectorProps) {
+  return (
+    <div className="flex flex-col gap-y-2">
+      <div>
+        <p className="text-sm font-medium">{label}</p>
+        {description ? (
+          <p className="text-xs text-zinc-400">{description}</p>
+        ) : null}
+      </div>
+      {isError ? (
+        <p className="text-xs text-red-500">{label}の取得に失敗しました</p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {options.map((option) => {
+            const isSelected = value === option.id;
+            return (
+              <button
+                key={option.id}
+                type="button"
+                aria-pressed={isSelected}
+                className={`rounded-full border px-3 py-1 text-sm transition-colors ${
+                  isSelected
+                    ? "border-primary bg-primary text-white"
+                    : "border-zinc-600 text-zinc-200"
+                }`}
+                onClick={() => onChange(isSelected ? null : option.id)}
+              >
+                {option.name}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherFormModal.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherFormModal.tsx
@@ -128,7 +128,7 @@ export function PitcherFormModal({
             labelPlacement="outside"
             variant="bordered"
             placeholder="例: 田中投手"
-            classNames={{ inputWrapper: "border-zinc-600" }}
+            classNames={{ inputWrapper: "border-zinc-500" }}
             value={name}
             onChange={(event) => setName(event.target.value)}
           />
@@ -179,7 +179,7 @@ export function PitcherFormModal({
             labelPlacement="outside"
             variant="bordered"
             placeholder="例: 初球はストレート / 決め球は外角スライダー"
-            classNames={{ inputWrapper: "border-zinc-600" }}
+            classNames={{ inputWrapper: "border-zinc-500" }}
             maxLength={1000}
             value={memo}
             onChange={(event) => setMemo(event.target.value)}

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherFormModal.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherFormModal.tsx
@@ -125,8 +125,12 @@ export function PitcherFormModal({
                     key={hand}
                     size="sm"
                     radius="sm"
-                    color="primary"
                     variant={isSelected ? "solid" : "bordered"}
+                    className={
+                      isSelected
+                        ? "border-2 border-[#d08000] bg-[#d08000] text-white"
+                        : "border-2 border-[#d08000] bg-transparent text-[#d08000]"
+                    }
                     onPress={() => setThrowHand(isSelected ? null : hand)}
                   >
                     {THROW_HAND_FULL_LABELS[hand]}
@@ -168,8 +172,7 @@ export function PitcherFormModal({
             キャンセル
           </Button>
           <Button
-            color="primary"
-            className="font-bold"
+            className="font-bold bg-[#d08000] text-white"
             onPress={handleSave}
             isDisabled={isSubmitting || !name.trim()}
           >

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherFormModal.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherFormModal.tsx
@@ -1,0 +1,182 @@
+"use client";
+import type { Pitcher, ThrowHand } from "@app/interface/pitcher";
+import type {
+  ArmAngleMaster,
+  PitcherStyleMaster,
+  VelocityZoneMaster,
+} from "@app/interface/plateAppearanceMasters";
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Textarea,
+} from "@heroui/react";
+import { useState } from "react";
+import { THROW_HAND_FULL_LABELS } from "@app/constants/throwHand";
+import { createPitcher, updatePitcher } from "@app/services/v2/pitcherService";
+import { MasterChipSelector } from "./MasterChipSelector";
+
+interface PitcherFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSaved: (pitcher: Pitcher) => void;
+  editingPitcher?: Pitcher | null;
+  defaultTeamId?: number | null;
+  armAngles: ArmAngleMaster[];
+  velocityZones: VelocityZoneMaster[];
+  pitcherStyles: PitcherStyleMaster[];
+}
+
+const THROW_HANDS: ThrowHand[] = ["right", "left"];
+
+/** 相手投手の新規登録 / 編集モーダル。保存後に作成/更新された投手を親へ返す。 */
+export function PitcherFormModal({
+  isOpen,
+  onClose,
+  onSaved,
+  editingPitcher,
+  defaultTeamId,
+  armAngles,
+  velocityZones,
+  pitcherStyles,
+}: PitcherFormModalProps) {
+  const isEdit = !!editingPitcher;
+  const [name, setName] = useState(editingPitcher?.name ?? "");
+  const [throwHand, setThrowHand] = useState<ThrowHand | null>(
+    editingPitcher?.throw_hand ?? null,
+  );
+  const [armAngleId, setArmAngleId] = useState<number | null>(
+    editingPitcher?.arm_angle?.id ?? null,
+  );
+  const [velocityZoneId, setVelocityZoneId] = useState<number | null>(
+    editingPitcher?.velocity_zone?.id ?? null,
+  );
+  const [pitcherStyleId, setPitcherStyleId] = useState<number | null>(
+    editingPitcher?.pitcher_style?.id ?? null,
+  );
+  const [memo, setMemo] = useState(editingPitcher?.memo ?? "");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const handleSave = async () => {
+    if (!name.trim() || isSubmitting) return;
+    setIsSubmitting(true);
+    setErrors([]);
+    const input = {
+      name: name.trim(),
+      throw_hand: throwHand,
+      arm_angle_id: armAngleId,
+      velocity_zone_id: velocityZoneId,
+      pitcher_style_id: pitcherStyleId,
+      memo: memo.trim() || null,
+      // 編集時は既存 team_id を尊重し、新規時のみ相手チームを自動セットする。
+      team_id: isEdit ? editingPitcher?.team_id : defaultTeamId,
+    };
+    const result =
+      isEdit && editingPitcher
+        ? await updatePitcher(editingPitcher.id, input)
+        : await createPitcher(input);
+    if (result.ok) {
+      onSaved(result.data);
+    } else {
+      setErrors(result.errors);
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      placement="center"
+      size="md"
+      scrollBehavior="inside"
+    >
+      <ModalContent>
+        <ModalHeader>{isEdit ? "投手を編集" : "投手を新規登録"}</ModalHeader>
+        <ModalBody>
+          {errors.length > 0 && (
+            <ul className="text-red-500 text-sm list-disc pl-5">
+              {errors.map((error) => (
+                <li key={error}>{error}</li>
+              ))}
+            </ul>
+          )}
+          <Input
+            isRequired
+            label="名前"
+            labelPlacement="outside"
+            variant="bordered"
+            placeholder="投手名を入力"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+          <div className="flex flex-col gap-y-2">
+            <p className="text-sm font-medium">利き手</p>
+            <div className="flex gap-x-2">
+              {THROW_HANDS.map((hand) => {
+                const isSelected = throwHand === hand;
+                return (
+                  <Button
+                    key={hand}
+                    size="sm"
+                    radius="sm"
+                    color="primary"
+                    variant={isSelected ? "solid" : "bordered"}
+                    onPress={() => setThrowHand(isSelected ? null : hand)}
+                  >
+                    {THROW_HAND_FULL_LABELS[hand]}
+                  </Button>
+                );
+              })}
+            </div>
+          </div>
+          <MasterChipSelector
+            label="腕の角度"
+            options={armAngles}
+            value={armAngleId}
+            onChange={setArmAngleId}
+          />
+          <MasterChipSelector
+            label="球速帯"
+            options={velocityZones}
+            value={velocityZoneId}
+            onChange={setVelocityZoneId}
+          />
+          <MasterChipSelector
+            label="投手タイプ"
+            options={pitcherStyles}
+            value={pitcherStyleId}
+            onChange={setPitcherStyleId}
+          />
+          <Textarea
+            label="メモ"
+            labelPlacement="outside"
+            variant="bordered"
+            placeholder="配球の傾向や特徴など"
+            maxLength={1000}
+            value={memo}
+            onChange={(event) => setMemo(event.target.value)}
+          />
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="light" onPress={onClose} isDisabled={isSubmitting}>
+            キャンセル
+          </Button>
+          <Button
+            color="primary"
+            className="font-bold"
+            onPress={handleSave}
+            isDisabled={isSubmitting || !name.trim()}
+          >
+            保存
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherFormModal.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherFormModal.tsx
@@ -128,6 +128,7 @@ export function PitcherFormModal({
             labelPlacement="outside"
             variant="bordered"
             placeholder="例: 田中投手"
+            classNames={{ inputWrapper: "border-zinc-600" }}
             value={name}
             onChange={(event) => setName(event.target.value)}
           />
@@ -178,6 +179,7 @@ export function PitcherFormModal({
             labelPlacement="outside"
             variant="bordered"
             placeholder="例: 初球はストレート / 決め球は外角スライダー"
+            classNames={{ inputWrapper: "border-zinc-600" }}
             maxLength={1000}
             value={memo}
             onChange={(event) => setMemo(event.target.value)}

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherFormModal.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherFormModal.tsx
@@ -15,8 +15,13 @@ import {
   ModalHeader,
   Textarea,
 } from "@heroui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { THROW_HAND_FULL_LABELS } from "@app/constants/throwHand";
+import {
+  getArmAngles,
+  getPitcherStyles,
+  getVelocityZones,
+} from "@app/services/v2/masterService";
 import { createPitcher, updatePitcher } from "@app/services/v2/pitcherService";
 import { MasterChipSelector } from "./MasterChipSelector";
 
@@ -27,9 +32,6 @@ interface PitcherFormModalProps {
   editingPitcher?: Pitcher | null;
   defaultTeamId?: number | null;
   teams?: { id: string; name: string }[];
-  armAngles: ArmAngleMaster[];
-  velocityZones: VelocityZoneMaster[];
-  pitcherStyles: PitcherStyleMaster[];
 }
 
 const THROW_HANDS: ThrowHand[] = ["right", "left"];
@@ -42,11 +44,17 @@ export function PitcherFormModal({
   editingPitcher,
   defaultTeamId,
   teams,
-  armAngles,
-  velocityZones,
-  pitcherStyles,
 }: PitcherFormModalProps) {
   const isEdit = !!editingPitcher;
+  // フォームでしか使わないマスタはモーダルを開いたとき（マウント時）に取得する。
+  const [armAngles, setArmAngles] = useState<ArmAngleMaster[]>([]);
+  const [velocityZones, setVelocityZones] = useState<VelocityZoneMaster[]>([]);
+  const [pitcherStyles, setPitcherStyles] = useState<PitcherStyleMaster[]>([]);
+  useEffect(() => {
+    getArmAngles().then(setArmAngles);
+    getVelocityZones().then(setVelocityZones);
+    getPitcherStyles().then(setPitcherStyles);
+  }, []);
   // 編集時のみ、紐づく所属チーム名を読み取り専用で表示する。
   const editingTeamName =
     isEdit && editingPitcher?.team_id != null
@@ -90,6 +98,8 @@ export function PitcherFormModal({
         ? await updatePitcher(editingPitcher.id, input)
         : await createPitcher(input);
     if (result.ok) {
+      // onSaved が閉じないケースでもボタンが永続 disabled にならないよう先に解除する。
+      setIsSubmitting(false);
       onSaved(result.data);
     } else {
       setErrors(result.errors);

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherFormModal.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherFormModal.tsx
@@ -95,6 +95,7 @@ export function PitcherFormModal({
       placement="center"
       size="md"
       scrollBehavior="inside"
+      classNames={{ base: "buzz-dark" }}
     >
       <ModalContent>
         <ModalHeader>{isEdit ? "投手を編集" : "投手を新規登録"}</ModalHeader>

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherFormModal.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherFormModal.tsx
@@ -26,6 +26,7 @@ interface PitcherFormModalProps {
   onSaved: (pitcher: Pitcher) => void;
   editingPitcher?: Pitcher | null;
   defaultTeamId?: number | null;
+  teams?: { id: string; name: string }[];
   armAngles: ArmAngleMaster[];
   velocityZones: VelocityZoneMaster[];
   pitcherStyles: PitcherStyleMaster[];
@@ -40,11 +41,19 @@ export function PitcherFormModal({
   onSaved,
   editingPitcher,
   defaultTeamId,
+  teams,
   armAngles,
   velocityZones,
   pitcherStyles,
 }: PitcherFormModalProps) {
   const isEdit = !!editingPitcher;
+  // 編集時のみ、紐づく所属チーム名を読み取り専用で表示する。
+  const editingTeamName =
+    isEdit && editingPitcher?.team_id != null
+      ? teams?.find(
+          (team) => String(team.id) === String(editingPitcher.team_id),
+        )?.name
+      : undefined;
   const [name, setName] = useState(editingPitcher?.name ?? "");
   const [throwHand, setThrowHand] = useState<ThrowHand | null>(
     editingPitcher?.throw_hand ?? null,
@@ -98,7 +107,7 @@ export function PitcherFormModal({
       classNames={{ base: "buzz-dark" }}
     >
       <ModalContent>
-        <ModalHeader>{isEdit ? "投手を編集" : "投手を新規登録"}</ModalHeader>
+        <ModalHeader>{isEdit ? "投手を編集" : "相手投手を追加"}</ModalHeader>
         <ModalBody>
           {errors.length > 0 && (
             <ul className="text-red-500 text-sm list-disc pl-5">
@@ -107,12 +116,18 @@ export function PitcherFormModal({
               ))}
             </ul>
           )}
+          {editingTeamName ? (
+            <div className="flex flex-col gap-y-1">
+              <p className="text-sm font-medium">所属チーム</p>
+              <p className="text-sm text-zinc-300">{editingTeamName}</p>
+            </div>
+          ) : null}
           <Input
             isRequired
-            label="名前"
+            label="投手名（必須）"
             labelPlacement="outside"
             variant="bordered"
-            placeholder="投手名を入力"
+            placeholder="例: 田中投手"
             value={name}
             onChange={(event) => setName(event.target.value)}
           />
@@ -159,10 +174,10 @@ export function PitcherFormModal({
             onChange={setPitcherStyleId}
           />
           <Textarea
-            label="メモ"
+            label="メモ（配球傾向・特徴など）"
             labelPlacement="outside"
             variant="bordered"
-            placeholder="配球の傾向や特徴など"
+            placeholder="例: 初球はストレート / 決め球は外角スライダー"
             maxLength={1000}
             value={memo}
             onChange={(event) => setMemo(event.target.value)}
@@ -177,7 +192,7 @@ export function PitcherFormModal({
             onPress={handleSave}
             isDisabled={isSubmitting || !name.trim()}
           >
-            保存
+            {isEdit ? "更新" : "登録"}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
@@ -156,6 +156,7 @@ export function PitcherSelector({
               variant="bordered"
               size="sm"
               placeholder="投手名で検索"
+              classNames={{ inputWrapper: "border-zinc-600" }}
               value={query}
               onChange={(event) => setQuery(event.target.value)}
             />

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
@@ -154,11 +154,17 @@ export function PitcherSelector({
           <ModalBody>
             <Input
               variant="bordered"
-              size="sm"
+              size="md"
+              radius="full"
               placeholder="投手名で検索"
-              classNames={{ inputWrapper: "border-zinc-500" }}
+              classNames={{ inputWrapper: "border-zinc-500 bg-zinc-800" }}
+              startContent={
+                <MagnifyingGlassIcon className="h-4 w-4 text-zinc-400" />
+              }
+              isClearable
               value={query}
               onChange={(event) => setQuery(event.target.value)}
+              onClear={() => setQuery("")}
             />
             <div className="flex flex-col gap-y-2">
               {filtered.map((pitcher) => (

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
@@ -81,15 +81,26 @@ export function PitcherSelector({
 
   return (
     <div className="flex flex-col gap-y-2">
-      <p className="text-sm font-medium">相手投手</p>
-      <Button
-        variant="bordered"
-        radius="sm"
-        className="justify-between"
-        onPress={() => setIsPickerOpen(true)}
-      >
-        {selected ? selected.name : "投手を選択 / 新規登録"}
-      </Button>
+      <div className="flex items-center gap-x-2">
+        <div className="flex-1 rounded-lg border border-zinc-600 px-3 py-2 text-sm">
+          {selected ? (
+            <span>{selected.name}</span>
+          ) : (
+            <span className="text-zinc-500">投手未選択</span>
+          )}
+        </div>
+        <Button
+          variant="bordered"
+          radius="sm"
+          className="font-bold border-2 border-[#d08000] bg-transparent text-[#d08000]"
+          onPress={() => setIsPickerOpen(true)}
+        >
+          選択
+        </Button>
+      </div>
+      <p className="text-xs text-zinc-500">
+        自分が追加した投手だけ表示されます
+      </p>
 
       <Modal
         isOpen={isPickerOpen}

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
@@ -108,6 +108,7 @@ export function PitcherSelector({
         placement="center"
         size="md"
         scrollBehavior="inside"
+        classNames={{ base: "buzz-dark" }}
       >
         <ModalContent>
           <ModalHeader>投手を選択</ModalHeader>

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
@@ -1,10 +1,5 @@
 "use client";
 import type { Pitcher } from "@app/interface/pitcher";
-import type {
-  ArmAngleMaster,
-  PitcherStyleMaster,
-  VelocityZoneMaster,
-} from "@app/interface/plateAppearanceMasters";
 import {
   MagnifyingGlassIcon,
   PencilSquareIcon,
@@ -22,11 +17,6 @@ import {
 import { useEffect, useState } from "react";
 import { THROW_HAND_FULL_LABELS } from "@app/constants/throwHand";
 import { getTeams } from "@app/services/teamsService";
-import {
-  getArmAngles,
-  getPitcherStyles,
-  getVelocityZones,
-} from "@app/services/v2/masterService";
 import { getPitchers } from "@app/services/v2/pitcherService";
 import { PitcherFormModal } from "./PitcherFormModal";
 
@@ -60,9 +50,6 @@ export function PitcherSelector({
 }: PitcherSelectorProps) {
   const [pitchers, setPitchers] = useState<Pitcher[]>([]);
   const [teams, setTeams] = useState<Team[]>([]);
-  const [armAngles, setArmAngles] = useState<ArmAngleMaster[]>([]);
-  const [velocityZones, setVelocityZones] = useState<VelocityZoneMaster[]>([]);
-  const [pitcherStyles, setPitcherStyles] = useState<PitcherStyleMaster[]>([]);
   const [query, setQuery] = useState("");
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -71,9 +58,6 @@ export function PitcherSelector({
   useEffect(() => {
     getPitchers({}).then((response) => setPitchers(response.data));
     getTeams().then(setTeams);
-    getArmAngles().then(setArmAngles);
-    getVelocityZones().then(setVelocityZones);
-    getPitcherStyles().then(setPitcherStyles);
   }, []);
 
   const teamNameById = new Map(
@@ -244,9 +228,6 @@ export function PitcherSelector({
           editingPitcher={editingPitcher}
           defaultTeamId={defaultTeamId}
           teams={teams}
-          armAngles={armAngles}
-          velocityZones={velocityZones}
-          pitcherStyles={pitcherStyles}
         />
       )}
     </div>

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
@@ -109,10 +109,9 @@ export function PitcherSelector({
               onChange={(event) => setQuery(event.target.value)}
             />
             <Button
-              color="primary"
               variant="bordered"
               radius="sm"
-              className="font-bold"
+              className="font-bold border-2 border-[#d08000] bg-transparent text-[#d08000]"
               onPress={() => {
                 setEditingPitcher(null);
                 setIsFormOpen(true);
@@ -125,7 +124,9 @@ export function PitcherSelector({
                 <div
                   key={pitcher.id}
                   className={`flex items-center justify-between rounded-lg border px-3 py-2 ${
-                    value === pitcher.id ? "border-primary" : "border-zinc-700"
+                    value === pitcher.id
+                      ? "border-[#d08000]"
+                      : "border-zinc-700"
                   }`}
                 >
                   <button

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
@@ -1,0 +1,185 @@
+"use client";
+import type { Pitcher } from "@app/interface/pitcher";
+import type {
+  ArmAngleMaster,
+  PitcherStyleMaster,
+  VelocityZoneMaster,
+} from "@app/interface/plateAppearanceMasters";
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+} from "@heroui/react";
+import { useEffect, useState } from "react";
+import { THROW_HAND_SHORT_LABELS } from "@app/constants/throwHand";
+import {
+  getArmAngles,
+  getPitcherStyles,
+  getVelocityZones,
+} from "@app/services/v2/masterService";
+import { getPitchers } from "@app/services/v2/pitcherService";
+import { PitcherFormModal } from "./PitcherFormModal";
+
+interface PitcherSelectorProps {
+  value: number | null;
+  onChange: (id: number | null) => void;
+  defaultTeamId?: number | null;
+}
+
+const summarize = (pitcher: Pitcher): string => {
+  const parts = [
+    pitcher.throw_hand ? THROW_HAND_SHORT_LABELS[pitcher.throw_hand] : null,
+    pitcher.arm_angle?.name,
+    pitcher.velocity_zone?.name,
+    pitcher.pitcher_style?.name,
+  ].filter(Boolean);
+  return parts.join(" / ");
+};
+
+/** 相手投手の選択。一覧 + 検索 + 新規登録 / 編集に対応する。 */
+export function PitcherSelector({
+  value,
+  onChange,
+  defaultTeamId,
+}: PitcherSelectorProps) {
+  const [pitchers, setPitchers] = useState<Pitcher[]>([]);
+  const [armAngles, setArmAngles] = useState<ArmAngleMaster[]>([]);
+  const [velocityZones, setVelocityZones] = useState<VelocityZoneMaster[]>([]);
+  const [pitcherStyles, setPitcherStyles] = useState<PitcherStyleMaster[]>([]);
+  const [query, setQuery] = useState("");
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingPitcher, setEditingPitcher] = useState<Pitcher | null>(null);
+
+  useEffect(() => {
+    getPitchers({}).then((response) => setPitchers(response.data));
+    getArmAngles().then(setArmAngles);
+    getVelocityZones().then(setVelocityZones);
+    getPitcherStyles().then(setPitcherStyles);
+  }, []);
+
+  const selected = pitchers.find((pitcher) => pitcher.id === value) ?? null;
+  const filtered = query
+    ? pitchers.filter((pitcher) => pitcher.name.includes(query))
+    : pitchers;
+
+  const handleSaved = (pitcher: Pitcher) => {
+    setPitchers((prev) => {
+      const exists = prev.some((item) => item.id === pitcher.id);
+      return exists
+        ? prev.map((item) => (item.id === pitcher.id ? pitcher : item))
+        : [...prev, pitcher];
+    });
+    onChange(pitcher.id);
+    setIsFormOpen(false);
+    setEditingPitcher(null);
+    setIsPickerOpen(false);
+  };
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <p className="text-sm font-medium">相手投手</p>
+      <Button
+        variant="bordered"
+        radius="sm"
+        className="justify-between"
+        onPress={() => setIsPickerOpen(true)}
+      >
+        {selected ? selected.name : "投手を選択 / 新規登録"}
+      </Button>
+
+      <Modal
+        isOpen={isPickerOpen}
+        onClose={() => setIsPickerOpen(false)}
+        placement="center"
+        size="md"
+        scrollBehavior="inside"
+      >
+        <ModalContent>
+          <ModalHeader>投手を選択</ModalHeader>
+          <ModalBody className="pb-6">
+            <Input
+              variant="bordered"
+              size="sm"
+              placeholder="投手名で検索"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+            <Button
+              color="primary"
+              variant="bordered"
+              radius="sm"
+              className="font-bold"
+              onPress={() => {
+                setEditingPitcher(null);
+                setIsFormOpen(true);
+              }}
+            >
+              + 投手を新規登録
+            </Button>
+            <div className="flex flex-col gap-y-2">
+              {filtered.map((pitcher) => (
+                <div
+                  key={pitcher.id}
+                  className={`flex items-center justify-between rounded-lg border px-3 py-2 ${
+                    value === pitcher.id ? "border-primary" : "border-zinc-700"
+                  }`}
+                >
+                  <button
+                    type="button"
+                    className="flex-1 text-left"
+                    onClick={() => {
+                      onChange(pitcher.id);
+                      setIsPickerOpen(false);
+                    }}
+                  >
+                    <p className="text-sm font-medium">{pitcher.name}</p>
+                    {summarize(pitcher) ? (
+                      <p className="text-xs text-zinc-400">
+                        {summarize(pitcher)}
+                      </p>
+                    ) : null}
+                  </button>
+                  <Button
+                    size="sm"
+                    variant="light"
+                    onPress={() => {
+                      setEditingPitcher(pitcher);
+                      setIsFormOpen(true);
+                    }}
+                  >
+                    編集
+                  </Button>
+                </div>
+              ))}
+              {filtered.length === 0 ? (
+                <p className="text-sm text-zinc-400 text-center py-4">
+                  投手がいません。新規登録してください。
+                </p>
+              ) : null}
+            </div>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+
+      {isFormOpen && (
+        <PitcherFormModal
+          isOpen={isFormOpen}
+          onClose={() => {
+            setIsFormOpen(false);
+            setEditingPitcher(null);
+          }}
+          onSaved={handleSaved}
+          editingPitcher={editingPitcher}
+          defaultTeamId={defaultTeamId}
+          armAngles={armAngles}
+          velocityZones={velocityZones}
+          pitcherStyles={pitcherStyles}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
@@ -5,7 +5,11 @@ import type {
   PitcherStyleMaster,
   VelocityZoneMaster,
 } from "@app/interface/plateAppearanceMasters";
-import { PencilSquareIcon, XCircleIcon } from "@heroicons/react/24/outline";
+import {
+  MagnifyingGlassIcon,
+  PencilSquareIcon,
+  XCircleIcon,
+} from "@heroicons/react/24/outline";
 import {
   Button,
   Input,

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
@@ -108,7 +108,7 @@ export function PitcherSelector({
   return (
     <div className="flex flex-col gap-y-2">
       <div className="flex items-center gap-x-2">
-        <div className="flex-1 rounded-lg border border-zinc-600 bg-bg_sub px-3 py-2 text-sm">
+        <div className="flex-1 rounded-lg border border-zinc-500 bg-bg_sub px-3 py-2 text-sm">
           {selected ? (
             <div>
               <p className="font-medium">{selected.name}</p>
@@ -156,7 +156,7 @@ export function PitcherSelector({
               variant="bordered"
               size="sm"
               placeholder="投手名で検索"
-              classNames={{ inputWrapper: "border-zinc-600" }}
+              classNames={{ inputWrapper: "border-zinc-500" }}
               value={query}
               onChange={(event) => setQuery(event.target.value)}
             />
@@ -164,10 +164,10 @@ export function PitcherSelector({
               {filtered.map((pitcher) => (
                 <div
                   key={pitcher.id}
-                  className={`flex items-center justify-between rounded-lg border px-3 py-2 ${
+                  className={`flex items-center justify-between rounded-lg border-2 px-3 py-2 ${
                     value === pitcher.id
                       ? "border-[#d08000]"
-                      : "border-zinc-700"
+                      : "border-zinc-500"
                   }`}
                 >
                   <button

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
@@ -5,16 +5,19 @@ import type {
   PitcherStyleMaster,
   VelocityZoneMaster,
 } from "@app/interface/plateAppearanceMasters";
+import { PencilSquareIcon, XCircleIcon } from "@heroicons/react/24/outline";
 import {
   Button,
   Input,
   Modal,
   ModalBody,
   ModalContent,
+  ModalFooter,
   ModalHeader,
 } from "@heroui/react";
 import { useEffect, useState } from "react";
-import { THROW_HAND_SHORT_LABELS } from "@app/constants/throwHand";
+import { THROW_HAND_FULL_LABELS } from "@app/constants/throwHand";
+import { getTeams } from "@app/services/teamsService";
 import {
   getArmAngles,
   getPitcherStyles,
@@ -29,14 +32,20 @@ interface PitcherSelectorProps {
   defaultTeamId?: number | null;
 }
 
-const summarize = (pitcher: Pitcher): string => {
-  const parts = [
-    pitcher.throw_hand ? THROW_HAND_SHORT_LABELS[pitcher.throw_hand] : null,
-    pitcher.arm_angle?.name,
-    pitcher.velocity_zone?.name,
-    pitcher.pitcher_style?.name,
-  ].filter(Boolean);
-  return parts.join(" / ");
+interface Team {
+  id: string;
+  name: string;
+}
+
+const formatSummary = (pitcher: Pitcher, teamName?: string): string => {
+  const parts: string[] = [];
+  if (teamName) parts.push(teamName);
+  if (pitcher.throw_hand)
+    parts.push(THROW_HAND_FULL_LABELS[pitcher.throw_hand]);
+  if (pitcher.arm_angle?.name) parts.push(pitcher.arm_angle.name);
+  if (pitcher.velocity_zone?.name) parts.push(pitcher.velocity_zone.name);
+  if (pitcher.pitcher_style?.name) parts.push(pitcher.pitcher_style.name);
+  return parts.length === 0 ? "未設定" : parts.join(" / ");
 };
 
 /** 相手投手の選択。一覧 + 検索 + 新規登録 / 編集に対応する。 */
@@ -46,6 +55,7 @@ export function PitcherSelector({
   defaultTeamId,
 }: PitcherSelectorProps) {
   const [pitchers, setPitchers] = useState<Pitcher[]>([]);
+  const [teams, setTeams] = useState<Team[]>([]);
   const [armAngles, setArmAngles] = useState<ArmAngleMaster[]>([]);
   const [velocityZones, setVelocityZones] = useState<VelocityZoneMaster[]>([]);
   const [pitcherStyles, setPitcherStyles] = useState<PitcherStyleMaster[]>([]);
@@ -56,15 +66,30 @@ export function PitcherSelector({
 
   useEffect(() => {
     getPitchers({}).then((response) => setPitchers(response.data));
+    getTeams().then(setTeams);
     getArmAngles().then(setArmAngles);
     getVelocityZones().then(setVelocityZones);
     getPitcherStyles().then(setPitcherStyles);
   }, []);
 
+  const teamNameById = new Map(
+    teams.map((team) => [String(team.id), team.name]),
+  );
+  const teamNameFor = (pitcher: Pitcher): string | undefined =>
+    pitcher.team_id != null
+      ? teamNameById.get(String(pitcher.team_id))
+      : undefined;
+
   const selected = pitchers.find((pitcher) => pitcher.id === value) ?? null;
   const filtered = query
     ? pitchers.filter((pitcher) => pitcher.name.includes(query))
     : pitchers;
+
+  // 閉じる時は検索クエリをリセットして、次回開いた時に全件表示にする。
+  const closePicker = () => {
+    setQuery("");
+    setIsPickerOpen(false);
+  };
 
   const handleSaved = (pitcher: Pitcher) => {
     setPitchers((prev) => {
@@ -73,18 +98,22 @@ export function PitcherSelector({
         ? prev.map((item) => (item.id === pitcher.id ? pitcher : item))
         : [...prev, pitcher];
     });
-    onChange(pitcher.id);
+    // 新規作成時のみ自動選択。編集時は元の選択を維持する。
+    if (!editingPitcher) onChange(pitcher.id);
     setIsFormOpen(false);
     setEditingPitcher(null);
-    setIsPickerOpen(false);
+    closePicker();
   };
 
   return (
     <div className="flex flex-col gap-y-2">
       <div className="flex items-center gap-x-2">
-        <div className="flex-1 rounded-lg border border-zinc-600 px-3 py-2 text-sm">
+        <div className="flex-1 rounded-lg border border-zinc-600 bg-bg_sub px-3 py-2 text-sm">
           {selected ? (
-            <span>{selected.name}</span>
+            <div>
+              <p className="font-medium">{selected.name}</p>
+              <p className="text-xs text-zinc-400">{formatSummary(selected)}</p>
+            </div>
           ) : (
             <span className="text-zinc-500">投手未選択</span>
           )}
@@ -97,6 +126,16 @@ export function PitcherSelector({
         >
           選択
         </Button>
+        {value !== null && (
+          <button
+            type="button"
+            aria-label="投手の選択を解除"
+            className="text-zinc-400"
+            onClick={() => onChange(null)}
+          >
+            <XCircleIcon className="h-6 w-6" />
+          </button>
+        )}
       </div>
       <p className="text-xs text-zinc-500">
         自分が追加した投手だけ表示されます
@@ -104,15 +143,15 @@ export function PitcherSelector({
 
       <Modal
         isOpen={isPickerOpen}
-        onClose={() => setIsPickerOpen(false)}
+        onClose={closePicker}
         placement="center"
         size="md"
         scrollBehavior="inside"
         classNames={{ base: "buzz-dark" }}
       >
         <ModalContent>
-          <ModalHeader>投手を選択</ModalHeader>
-          <ModalBody className="pb-6">
+          <ModalHeader>相手投手を選択</ModalHeader>
+          <ModalBody>
             <Input
               variant="bordered"
               size="sm"
@@ -120,17 +159,6 @@ export function PitcherSelector({
               value={query}
               onChange={(event) => setQuery(event.target.value)}
             />
-            <Button
-              variant="bordered"
-              radius="sm"
-              className="font-bold border-2 border-[#d08000] bg-transparent text-[#d08000]"
-              onPress={() => {
-                setEditingPitcher(null);
-                setIsFormOpen(true);
-              }}
-            >
-              + 投手を新規登録
-            </Button>
             <div className="flex flex-col gap-y-2">
               {filtered.map((pitcher) => (
                 <div
@@ -146,35 +174,51 @@ export function PitcherSelector({
                     className="flex-1 text-left"
                     onClick={() => {
                       onChange(pitcher.id);
-                      setIsPickerOpen(false);
+                      closePicker();
                     }}
                   >
                     <p className="text-sm font-medium">{pitcher.name}</p>
-                    {summarize(pitcher) ? (
-                      <p className="text-xs text-zinc-400">
-                        {summarize(pitcher)}
-                      </p>
-                    ) : null}
+                    <p className="text-xs text-zinc-400">
+                      {formatSummary(pitcher, teamNameFor(pitcher))}
+                    </p>
                   </button>
-                  <Button
-                    size="sm"
-                    variant="light"
-                    onPress={() => {
+                  <button
+                    type="button"
+                    aria-label={`投手 ${pitcher.name} を編集`}
+                    className="text-[#d08000] px-1"
+                    onClick={() => {
                       setEditingPitcher(pitcher);
                       setIsFormOpen(true);
                     }}
                   >
-                    編集
-                  </Button>
+                    <PencilSquareIcon className="h-5 w-5" />
+                  </button>
                 </div>
               ))}
               {filtered.length === 0 ? (
                 <p className="text-sm text-zinc-400 text-center py-4">
-                  投手がいません。新規登録してください。
+                  {query
+                    ? "該当する投手が見つかりません"
+                    : "投手がまだ登録されていません"}
                 </p>
               ) : null}
             </div>
           </ModalBody>
+          <ModalFooter>
+            <Button variant="light" onPress={closePicker}>
+              閉じる
+            </Button>
+            <Button
+              radius="sm"
+              className="font-bold bg-[#d08000] text-white"
+              onPress={() => {
+                setEditingPitcher(null);
+                setIsFormOpen(true);
+              }}
+            >
+              + 新規追加
+            </Button>
+          </ModalFooter>
         </ModalContent>
       </Modal>
 
@@ -188,6 +232,7 @@ export function PitcherSelector({
           onSaved={handleSaved}
           editingPitcher={editingPitcher}
           defaultTeamId={defaultTeamId}
+          teams={teams}
           armAngles={armAngles}
           velocityZones={velocityZones}
           pitcherStyles={pitcherStyles}

--- a/app/(app)/game-result/plate-appearances/_components/detail/detailState.ts
+++ b/app/(app)/game-result/plate-appearances/_components/detail/detailState.ts
@@ -1,0 +1,32 @@
+import type { RunnersState } from "@app/interface/plateAppearanceV2";
+
+// 打席詳細データ（すべて任意入力）。ウィザードが保持し PA ペイロードへ流す。
+export interface DetailState {
+  finalBalls: number | null;
+  finalStrikes: number | null;
+  finalOuts: number | null;
+  firstPitchSwing: boolean | null;
+  runnersState: RunnersState | null;
+  inning: number | null;
+  contactQualityId: number | null;
+  timingId: number | null;
+  pitchTypeId: number | null;
+  selfAnalysisMemo: string | null;
+  pitcherId: number | null;
+  appearanceSituationId: number | null;
+}
+
+export const EMPTY_DETAIL: DetailState = {
+  finalBalls: null,
+  finalStrikes: null,
+  finalOuts: null,
+  firstPitchSwing: null,
+  runnersState: null,
+  inning: null,
+  contactQualityId: null,
+  timingId: null,
+  pitchTypeId: null,
+  selfAnalysisMemo: null,
+  pitcherId: null,
+  appearanceSituationId: null,
+};

--- a/app/(app)/game-result/plate-appearances/page.tsx
+++ b/app/(app)/game-result/plate-appearances/page.tsx
@@ -58,7 +58,7 @@ export default function PlateAppearanceRecordPage() {
   return (
     <>
       <HeaderResult />
-      <main className="h-full">
+      <main className="buzz-dark h-full">
         <div className="pb-52 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
           <div className="pt-12 px-4 lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:px-6 lg:pb-6">
             {gameResultId !== null && batterBoxNumber !== null ? (

--- a/app/(app)/game-result/plate-appearances/page.tsx
+++ b/app/(app)/game-result/plate-appearances/page.tsx
@@ -58,7 +58,7 @@ export default function PlateAppearanceRecordPage() {
   return (
     <>
       <HeaderResult />
-      <main className="buzz-dark h-full">
+      <main className="buzz-dark min-h-full">
         <div className="pb-52 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
           <div className="pt-12 px-4 lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:px-6 lg:pb-6">
             {gameResultId !== null && batterBoxNumber !== null ? (

--- a/app/(app)/game-result/plate-appearances/page.tsx
+++ b/app/(app)/game-result/plate-appearances/page.tsx
@@ -59,7 +59,7 @@ export default function PlateAppearanceRecordPage() {
     <>
       <HeaderResult />
       <main className="h-full">
-        <div className="pb-40 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-52 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
           <div className="pt-12 px-4 lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:px-6 lg:pb-6">
             {gameResultId !== null && batterBoxNumber !== null ? (
               <PlateAppearanceWizard

--- a/app/(app)/game-result/plate-appearances/page.tsx
+++ b/app/(app)/game-result/plate-appearances/page.tsx
@@ -5,6 +5,8 @@ import HeaderResult from "@app/components/header/HeaderResult";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import { RECORD_PATTERN_STORAGE_KEY } from "@app/constants/gameRecord";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
+import { checkExistingMatchResults } from "@app/services/matchResultsService";
+import { getCurrentUserId } from "@app/services/userService";
 import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
 import { PlateAppearanceWizard } from "./_components/PlateAppearanceWizard";
 
@@ -13,6 +15,7 @@ export default function PlateAppearanceRecordPage() {
   useRequireAuth();
   const [gameResultId, setGameResultId] = useState<number | null>(null);
   const [batterBoxNumber, setBatterBoxNumber] = useState<number | null>(null);
+  const [opponentTeamId, setOpponentTeamId] = useState<number | null>(null);
 
   useEffect(() => {
     const saved = localStorage.getItem("gameResultId");
@@ -26,6 +29,14 @@ export default function PlateAppearanceRecordPage() {
     // 既存打席数 +1 を打席番号として採番する。
     getPlateAppearancesByGame(id).then((plateAppearances) => {
       setBatterBoxNumber(plateAppearances.length + 1);
+    });
+    // 投手の新規登録で相手チームを自動セットするため、相手チーム id を取得する。
+    getCurrentUserId().then((userId) => {
+      checkExistingMatchResults(id, userId).then((matchResult) => {
+        if (matchResult?.opponent_team_id) {
+          setOpponentTeamId(matchResult.opponent_team_id);
+        }
+      });
     });
   }, [router]);
 
@@ -49,6 +60,7 @@ export default function PlateAppearanceRecordPage() {
                 batterBoxNumber={batterBoxNumber}
                 onCompleted={handleCompleted}
                 onCancel={() => router.push("/game-result/record")}
+                defaultTeamId={opponentTeamId}
               />
             ) : (
               <LoadingSpinner />


### PR DESCRIPTION
## 概要

mobile [buzzbase_mobile#101](https://github.com/ippei-shimizu/buzzbase_mobile/pull/101) 追従シリーズ ([ippei-shimizu/buzzbase#396](https://github.com/ippei-shimizu/buzzbase/issues/396))。打席記録ウィザードに詳細データ入力ステップと相手投手マスタを追加する。**stacked PR**（base = `feature/395-plate-appearance-wizard`）。

Closes ippei-shimizu/buzzbase#396

## 変更内容
- ウィザードに Step3（詳細データ）を追加。Step2 の保存ボタンを「詳細を入力する / スキップして保存」に分割。
- 詳細セクション（すべて任意）: 最終カウント(BSOドット)/初球打ち/ランナー状況/イニング/球質/タイミング/球種/自己分析メモ。
- 相手投手マスタ: `PitcherSelector`(一覧+検索+選択) と `PitcherFormModal`(名前/利き手/腕の角度/球速帯/投手タイプ/メモ)。新規登録時は試合の相手チームを自動セット、編集時は既存 team_id を尊重。
- マスタ取得は #393 のサーバーアクション（contact_qualities / timings / pitch_types / appearance_situations / arm_angles / velocity_zones / pitcher_styles / pitchers）。
- 詳細フィールドは `PlateAppearanceV2Input` に snake_case で反映して保存。

## スコープ / 制約
- front は zustand を使わず、詳細状態はウィザードの React state で保持。
- 打席リスト・編集・削除・サマリー表示は #397。
- 結合テストは未追加（draft）。

## 確認
- `yarn typecheck`（追加/変更ファイルにエラーなし）、`yarn lint` / `yarn format:check` パス、`yarn test` 全252件パス。
