### PR TITLE
Add: 打席リスト・タブ式編集・削除と試合結果サマリー v2 対応

### DIFF
--- a/app/(app)/game-result/plate-appearances/[id]/edit/page.tsx
+++ b/app/(app)/game-result/plate-appearances/[id]/edit/page.tsx
@@ -52,8 +52,8 @@ export default function EditPlateAppearancePage() {
   return (
     <>
       <HeaderResult />
-      <main className="h-full">
-        <div className="pb-40 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+      <main className="buzz-dark min-h-full">
+        <div className="pb-52 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
           <div className="pt-12 px-4 lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:px-6 lg:pb-6">
             {gameResultId !== null && editing !== null ? (
               <PlateAppearanceWizard

--- a/app/(app)/game-result/plate-appearances/[id]/edit/page.tsx
+++ b/app/(app)/game-result/plate-appearances/[id]/edit/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+import type { PlateAppearanceV2 } from "@app/interface/plateAppearanceV2";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import HeaderResult from "@app/components/header/HeaderResult";
+import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
+import useRequireAuth from "@app/hooks/auth/useRequireAuth";
+import { checkExistingMatchResults } from "@app/services/matchResultsService";
+import { getCurrentUserId } from "@app/services/userService";
+import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
+import { PlateAppearanceWizard } from "../../_components/PlateAppearanceWizard";
+
+const LIST_PATH = "/game-result/plate-appearances";
+
+export default function EditPlateAppearancePage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  useRequireAuth();
+  const plateAppearanceId = Number(params.id);
+  const [gameResultId, setGameResultId] = useState<number | null>(null);
+  const [editing, setEditing] = useState<PlateAppearanceV2 | null>(null);
+  const [opponentTeamId, setOpponentTeamId] = useState<number | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    const saved = localStorage.getItem("gameResultId");
+    if (!saved) {
+      router.push("/game-result/record");
+      return;
+    }
+    const id = JSON.parse(saved) as number;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setGameResultId(id);
+    getPlateAppearancesByGame(id).then((list) => {
+      const target = list.find((item) => item.id === plateAppearanceId);
+      if (target) setEditing(target);
+      else setNotFound(true);
+    });
+    getCurrentUserId().then((userId) => {
+      checkExistingMatchResults(id, userId).then((matchResult) => {
+        if (matchResult?.opponent_team_id) {
+          setOpponentTeamId(matchResult.opponent_team_id);
+        }
+      });
+    });
+  }, [router, plateAppearanceId]);
+
+  useEffect(() => {
+    if (notFound) router.push(LIST_PATH);
+  }, [notFound, router]);
+
+  return (
+    <>
+      <HeaderResult />
+      <main className="h-full">
+        <div className="pb-40 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+          <div className="pt-12 px-4 lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:px-6 lg:pb-6">
+            {gameResultId !== null && editing !== null ? (
+              <PlateAppearanceWizard
+                gameResultId={gameResultId}
+                batterBoxNumber={editing.batter_box_number}
+                editingPlateAppearance={editing}
+                onCompleted={() => router.push(LIST_PATH)}
+                onCancel={() => router.push(LIST_PATH)}
+                defaultTeamId={opponentTeamId}
+              />
+            ) : (
+              <LoadingSpinner />
+            )}
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/[id]/edit/page.tsx
+++ b/app/(app)/game-result/plate-appearances/[id]/edit/page.tsx
@@ -34,15 +34,20 @@ export default function EditPlateAppearancePage() {
   const [notFound, setNotFound] = useState(false);
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const handleDelete = async () => {
     setIsDeleting(true);
+    setDeleteError(null);
     const result = await deletePlateAppearanceV2(plateAppearanceId);
     if (result.ok) {
       router.push(LIST_PATH);
     } else {
       setIsDeleting(false);
-      setIsConfirmOpen(false);
+      setDeleteError(
+        result.errors[0] ??
+          "削除に失敗しました。時間をおいて再度お試しください。",
+      );
     }
   };
 
@@ -107,7 +112,10 @@ export default function EditPlateAppearancePage() {
 
       <Modal
         isOpen={isConfirmOpen}
-        onClose={() => setIsConfirmOpen(false)}
+        onClose={() => {
+          setIsConfirmOpen(false);
+          setDeleteError(null);
+        }}
         placement="center"
         size="sm"
         classNames={{ base: "buzz-dark" }}
@@ -116,6 +124,9 @@ export default function EditPlateAppearancePage() {
           <ModalHeader>打席を削除しますか？</ModalHeader>
           <ModalBody>
             <p className="text-sm text-zinc-300">この操作は取り消せません。</p>
+            {deleteError !== null ? (
+              <p className="text-sm text-danger">{deleteError}</p>
+            ) : null}
           </ModalBody>
           <ModalFooter>
             <Button

--- a/app/(app)/game-result/plate-appearances/[id]/edit/page.tsx
+++ b/app/(app)/game-result/plate-appearances/[id]/edit/page.tsx
@@ -1,5 +1,13 @@
 "use client";
 import type { PlateAppearanceV2 } from "@app/interface/plateAppearanceV2";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import HeaderResult from "@app/components/header/HeaderResult";
@@ -7,7 +15,10 @@ import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import { checkExistingMatchResults } from "@app/services/matchResultsService";
 import { getCurrentUserId } from "@app/services/userService";
-import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
+import {
+  deletePlateAppearanceV2,
+  getPlateAppearancesByGame,
+} from "@app/services/v2/plateAppearanceService";
 import { PlateAppearanceWizard } from "../../_components/PlateAppearanceWizard";
 
 const LIST_PATH = "/game-result/plate-appearances";
@@ -21,6 +32,19 @@ export default function EditPlateAppearancePage() {
   const [editing, setEditing] = useState<PlateAppearanceV2 | null>(null);
   const [opponentTeamId, setOpponentTeamId] = useState<number | null>(null);
   const [notFound, setNotFound] = useState(false);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    const result = await deletePlateAppearanceV2(plateAppearanceId);
+    if (result.ok) {
+      router.push(LIST_PATH);
+    } else {
+      setIsDeleting(false);
+      setIsConfirmOpen(false);
+    }
+  };
 
   useEffect(() => {
     const saved = localStorage.getItem("gameResultId");
@@ -56,20 +80,62 @@ export default function EditPlateAppearancePage() {
         <div className="pb-52 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
           <div className="pt-12 px-4 lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:px-6 lg:pb-6">
             {gameResultId !== null && editing !== null ? (
-              <PlateAppearanceWizard
-                gameResultId={gameResultId}
-                batterBoxNumber={editing.batter_box_number}
-                editingPlateAppearance={editing}
-                onCompleted={() => router.push(LIST_PATH)}
-                onCancel={() => router.push(LIST_PATH)}
-                defaultTeamId={opponentTeamId}
-              />
+              <>
+                <PlateAppearanceWizard
+                  gameResultId={gameResultId}
+                  batterBoxNumber={editing.batter_box_number}
+                  editingPlateAppearance={editing}
+                  onCompleted={() => router.push(LIST_PATH)}
+                  onCancel={() => router.push(LIST_PATH)}
+                  defaultTeamId={opponentTeamId}
+                />
+                <Button
+                  variant="light"
+                  radius="sm"
+                  className="mt-6 w-full text-danger"
+                  onPress={() => setIsConfirmOpen(true)}
+                >
+                  この打席を削除
+                </Button>
+              </>
             ) : (
               <LoadingSpinner />
             )}
           </div>
         </div>
       </main>
+
+      <Modal
+        isOpen={isConfirmOpen}
+        onClose={() => setIsConfirmOpen(false)}
+        placement="center"
+        size="sm"
+        classNames={{ base: "buzz-dark" }}
+      >
+        <ModalContent>
+          <ModalHeader>打席を削除しますか？</ModalHeader>
+          <ModalBody>
+            <p className="text-sm text-zinc-300">この操作は取り消せません。</p>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="light"
+              onPress={() => setIsConfirmOpen(false)}
+              isDisabled={isDeleting}
+            >
+              キャンセル
+            </Button>
+            <Button
+              color="danger"
+              className="font-bold"
+              onPress={handleDelete}
+              isDisabled={isDeleting}
+            >
+              削除する
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </>
   );
 }

--- a/app/(app)/game-result/plate-appearances/_components/AddPlateAppearanceCard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/AddPlateAppearanceCard.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { Button } from "@heroui/react";
+
+interface AddPlateAppearanceCardProps {
+  batterBoxNumber: number;
+  onAdd: () => void;
+}
+
+/** 打席リスト末尾の「結果を入力」プレースホルダ。次の打席番号を表示する。 */
+export function AddPlateAppearanceCard({
+  batterBoxNumber,
+  onAdd,
+}: AddPlateAppearanceCardProps) {
+  return (
+    <div className="flex items-center justify-between rounded-xl border border-dashed border-zinc-600 px-4 py-3">
+      <span className="text-xs text-zinc-400">第{batterBoxNumber}打席</span>
+      <Button
+        color="primary"
+        radius="full"
+        size="sm"
+        className="font-bold"
+        onPress={onAdd}
+      >
+        結果を入力
+      </Button>
+    </div>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/AddPlateAppearanceCard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/AddPlateAppearanceCard.tsx
@@ -1,5 +1,7 @@
 "use client";
+import { PlusIcon } from "@heroicons/react/24/solid";
 import { Button } from "@heroui/react";
+import { useState } from "react";
 
 interface AddPlateAppearanceCardProps {
   batterBoxNumber: number;
@@ -11,15 +13,25 @@ export function AddPlateAppearanceCard({
   batterBoxNumber,
   onAdd,
 }: AddPlateAppearanceCardProps) {
+  // クリック後、遷移するまでの間ボタンを無効化して多重クリックを防ぐ。
+  const [isNavigating, setIsNavigating] = useState(false);
+
   return (
     <div className="flex items-center justify-between rounded-xl border border-dashed border-zinc-600 px-4 py-3">
-      <span className="text-xs text-zinc-400">第{batterBoxNumber}打席</span>
+      <span className="text-base font-medium text-zinc-300">
+        第{batterBoxNumber}打席
+      </span>
       <Button
         color="primary"
         radius="full"
         size="sm"
         className="font-bold"
-        onPress={onAdd}
+        startContent={<PlusIcon className="h-4 w-4" />}
+        isDisabled={isNavigating}
+        onPress={() => {
+          setIsNavigating(true);
+          onAdd();
+        }}
       >
         結果を入力
       </Button>

--- a/app/(app)/game-result/plate-appearances/_components/PlateAppearanceCard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateAppearanceCard.tsx
@@ -1,0 +1,68 @@
+"use client";
+import type { PlateAppearanceV2 } from "@app/interface/plateAppearanceV2";
+import { Button } from "@heroui/react";
+import { DeleteIcon } from "@app/components/icon/DeleteIcon";
+
+interface PlateAppearanceCardProps {
+  plateAppearance: PlateAppearanceV2;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+const scoreChips = (pa: PlateAppearanceV2): string[] => {
+  const chips: string[] = [];
+  if (pa.rbi && pa.rbi > 0) chips.push(`打点${pa.rbi}`);
+  if (pa.run_scored && pa.run_scored > 0) chips.push(`得点${pa.run_scored}`);
+  if (pa.stolen_bases && pa.stolen_bases > 0)
+    chips.push(`盗塁${pa.stolen_bases}`);
+  if (pa.caught_stealing && pa.caught_stealing > 0)
+    chips.push(`盗塁死${pa.caught_stealing}`);
+  return chips;
+};
+
+/** 打席リストの1件カード。タップで編集、ゴミ箱で削除する。 */
+export function PlateAppearanceCard({
+  plateAppearance,
+  onEdit,
+  onDelete,
+}: PlateAppearanceCardProps) {
+  const chips = scoreChips(plateAppearance);
+  return (
+    <div className="flex items-center justify-between rounded-xl bg-bg_sub px-4 py-3">
+      <button
+        type="button"
+        className="flex-1 text-left flex items-center gap-x-3"
+        onClick={onEdit}
+      >
+        <span className="text-xs text-zinc-400 shrink-0">
+          第{plateAppearance.batter_box_number}打席
+        </span>
+        <span className="font-bold">{plateAppearance.batting_result}</span>
+        <span className="flex flex-wrap gap-1">
+          {chips.map((chip) => (
+            <span
+              key={chip}
+              className="rounded-full bg-zinc-700 px-2 py-0.5 text-xs text-zinc-200"
+            >
+              {chip}
+            </span>
+          ))}
+          {!plateAppearance.has_detail_data ? (
+            <span className="rounded-full border border-zinc-600 px-2 py-0.5 text-xs text-zinc-500">
+              詳細未入力
+            </span>
+          ) : null}
+        </span>
+      </button>
+      <Button
+        isIconOnly
+        size="sm"
+        variant="light"
+        aria-label="この打席を削除"
+        onPress={onDelete}
+      >
+        <DeleteIcon />
+      </Button>
+    </div>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/_components/PlateAppearanceCard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateAppearanceCard.tsx
@@ -1,7 +1,5 @@
 "use client";
 import type { PlateAppearanceV2 } from "@app/interface/plateAppearanceV2";
-import { Button } from "@heroui/react";
-import { DeleteIcon } from "@app/components/icon/DeleteIcon";
 import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
 import { getBattingResultColor } from "@app/utils/battingResultColor";
 import {
@@ -12,7 +10,6 @@ import {
 interface PlateAppearanceCardProps {
   plateAppearance: PlateAppearanceV2;
   onEdit: () => void;
-  onDelete: () => void;
 }
 
 interface MetaItem {
@@ -41,7 +38,6 @@ const buildMetaItems = (pa: PlateAppearanceV2): MetaItem[] => {
 export function PlateAppearanceCard({
   plateAppearance,
   onEdit,
-  onDelete,
 }: PlateAppearanceCardProps) {
   const resultText = plateAppearance.batting_result || "未入力";
   const resultColor = getBattingResultColor(resultText);
@@ -109,15 +105,6 @@ export function PlateAppearanceCard({
         )}
       </button>
       <NextArrowIcon stroke="#A1A1AA" />
-      <Button
-        isIconOnly
-        size="sm"
-        variant="light"
-        aria-label="この打席を削除"
-        onPress={onDelete}
-      >
-        <DeleteIcon />
-      </Button>
     </div>
   );
 }

--- a/app/(app)/game-result/plate-appearances/_components/PlateAppearanceCard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateAppearanceCard.tsx
@@ -48,12 +48,12 @@ export function PlateAppearanceCard({
   const showMetaRow = metaItems.length > 0 || !hasDetail;
 
   return (
-    <div className="flex items-center gap-x-2 rounded-xl bg-bg_sub px-4 py-3">
-      <button
-        type="button"
-        className="flex-1 text-left flex flex-col gap-y-1.5"
-        onClick={onEdit}
-      >
+    <button
+      type="button"
+      className="flex w-full items-center gap-x-2 rounded-xl bg-bg_sub px-4 py-3 text-left"
+      onClick={onEdit}
+    >
+      <div className="flex-1 flex flex-col gap-y-1.5">
         <div className="flex items-center gap-x-2.5">
           <span className="text-xs text-zinc-400 shrink-0">
             第{plateAppearance.batter_box_number}打席
@@ -103,8 +103,8 @@ export function PlateAppearanceCard({
             ))}
           </div>
         )}
-      </button>
+      </div>
       <NextArrowIcon stroke="#A1A1AA" />
-    </div>
+    </button>
   );
 }

--- a/app/(app)/game-result/plate-appearances/_components/PlateAppearanceCard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateAppearanceCard.tsx
@@ -2,6 +2,12 @@
 import type { PlateAppearanceV2 } from "@app/interface/plateAppearanceV2";
 import { Button } from "@heroui/react";
 import { DeleteIcon } from "@app/components/icon/DeleteIcon";
+import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
+import { getBattingResultColor } from "@app/utils/battingResultColor";
+import {
+  buildPitchAndPitcherChips,
+  buildSituationChips,
+} from "@app/utils/plateAppearanceChips";
 
 interface PlateAppearanceCardProps {
   plateAppearance: PlateAppearanceV2;
@@ -9,51 +15,100 @@ interface PlateAppearanceCardProps {
   onDelete: () => void;
 }
 
-const scoreChips = (pa: PlateAppearanceV2): string[] => {
-  const chips: string[] = [];
-  if (pa.rbi && pa.rbi > 0) chips.push(`打点${pa.rbi}`);
-  if (pa.run_scored && pa.run_scored > 0) chips.push(`得点${pa.run_scored}`);
-  if (pa.stolen_bases && pa.stolen_bases > 0)
-    chips.push(`盗塁${pa.stolen_bases}`);
-  if (pa.caught_stealing && pa.caught_stealing > 0)
-    chips.push(`盗塁死${pa.caught_stealing}`);
-  return chips;
+interface MetaItem {
+  label: string;
+  value: number;
+}
+
+const buildMetaItems = (pa: PlateAppearanceV2): MetaItem[] => {
+  const items: MetaItem[] = [];
+  if ((pa.rbi ?? 0) > 0) items.push({ label: "打点", value: pa.rbi as number });
+  if ((pa.run_scored ?? 0) > 0)
+    items.push({ label: "得点", value: pa.run_scored as number });
+  if ((pa.stolen_bases ?? 0) > 0)
+    items.push({ label: "盗塁", value: pa.stolen_bases as number });
+  if ((pa.caught_stealing ?? 0) > 0)
+    items.push({ label: "盗塁死", value: pa.caught_stealing as number });
+  return items;
 };
 
-/** 打席リストの1件カード。タップで編集、ゴミ箱で削除する。 */
+/**
+ * 打席リストの1件カード。タップで編集、ゴミ箱で削除する。
+ * 上段: 第N打席 + 結果（安打=赤/犠打犠飛=青）。
+ * 中段: 打点・得点・盗塁・盗塁死（1以上）+ 詳細未入力バッジ。
+ * 下段: 状況チップ / 打球・投手チップ（入力済みのみ）。
+ */
 export function PlateAppearanceCard({
   plateAppearance,
   onEdit,
   onDelete,
 }: PlateAppearanceCardProps) {
-  const chips = scoreChips(plateAppearance);
+  const resultText = plateAppearance.batting_result || "未入力";
+  const resultColor = getBattingResultColor(resultText);
+  const metaItems = buildMetaItems(plateAppearance);
+  const situationChips = buildSituationChips(plateAppearance);
+  const pitchChips = buildPitchAndPitcherChips(plateAppearance);
+  const hasDetail = plateAppearance.has_detail_data;
+  const showMetaRow = metaItems.length > 0 || !hasDetail;
+
   return (
-    <div className="flex items-center justify-between rounded-xl bg-bg_sub px-4 py-3">
+    <div className="flex items-center gap-x-2 rounded-xl bg-bg_sub px-4 py-3">
       <button
         type="button"
-        className="flex-1 text-left flex items-center gap-x-3"
+        className="flex-1 text-left flex flex-col gap-y-1.5"
         onClick={onEdit}
       >
-        <span className="text-xs text-zinc-400 shrink-0">
-          第{plateAppearance.batter_box_number}打席
-        </span>
-        <span className="font-bold">{plateAppearance.batting_result}</span>
-        <span className="flex flex-wrap gap-1">
-          {chips.map((chip) => (
-            <span
-              key={chip}
-              className="rounded-full bg-zinc-700 px-2 py-0.5 text-xs text-zinc-200"
-            >
-              {chip}
-            </span>
-          ))}
-          {!plateAppearance.has_detail_data ? (
-            <span className="rounded-full border border-zinc-600 px-2 py-0.5 text-xs text-zinc-500">
-              詳細未入力
-            </span>
-          ) : null}
-        </span>
+        <div className="flex items-center gap-x-2.5">
+          <span className="text-xs text-zinc-400 shrink-0">
+            第{plateAppearance.batter_box_number}打席
+          </span>
+          <span className="text-base font-bold" style={{ color: resultColor }}>
+            {resultText}
+          </span>
+        </div>
+
+        {showMetaRow && (
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            {metaItems.map((item) => (
+              <span key={item.label} className="text-[13px] text-zinc-300">
+                {item.label} {item.value}
+              </span>
+            ))}
+            {!hasDetail && (
+              <span className="rounded bg-zinc-600 px-1.5 py-0.5 text-[11px] text-zinc-100">
+                詳細未入力
+              </span>
+            )}
+          </div>
+        )}
+
+        {situationChips.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {situationChips.map((chip) => (
+              <span
+                key={`s-${chip}`}
+                className="rounded-md bg-[#424242] px-2 py-0.5 text-[11px] text-zinc-300"
+              >
+                {chip}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {pitchChips.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {pitchChips.map((chip) => (
+              <span
+                key={`p-${chip}`}
+                className="rounded-md border border-[#d08000] bg-[#3a3024] px-2 py-0.5 text-[11px] text-zinc-100"
+              >
+                {chip}
+              </span>
+            ))}
+          </div>
+        )}
       </button>
+      <NextArrowIcon stroke="#A1A1AA" />
       <Button
         isIconOnly
         size="sm"

--- a/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
@@ -7,13 +7,17 @@ import type {
 import type {
   HitType,
   OutType,
+  PlateAppearanceV2,
   SwingType,
 } from "@app/interface/plateAppearanceV2";
 import { Button } from "@heroui/react";
 import { useState } from "react";
 import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
-import { createPlateAppearanceV2 } from "@app/services/v2/plateAppearanceService";
+import {
+  createPlateAppearanceV2,
+  updatePlateAppearanceV2,
+} from "@app/services/v2/plateAppearanceService";
 import { roundHitLocation, type Point } from "@app/utils/groundZoneDetector";
 import { DetailDataForm } from "./detail/DetailDataForm";
 import { EMPTY_DETAIL, type DetailState } from "./detail/detailState";
@@ -29,9 +33,26 @@ interface PlateAppearanceWizardProps {
   onCompleted: () => void;
   onCancel?: () => void;
   defaultTeamId?: number | null;
+  // 指定時は編集モード（PATCH /api/v2/plate_appearances/:id）。
+  editingPlateAppearance?: PlateAppearanceV2 | null;
 }
 
 type WizardStep = "result" | "score" | "detail";
+
+const detailFromPlateAppearance = (pa: PlateAppearanceV2): DetailState => ({
+  finalBalls: pa.final_balls,
+  finalStrikes: pa.final_strikes,
+  finalOuts: pa.final_outs,
+  firstPitchSwing: pa.first_pitch_swing,
+  runnersState: pa.runners_state,
+  inning: pa.inning,
+  contactQualityId: pa.contact_quality?.id ?? null,
+  timingId: pa.timing?.id ?? null,
+  pitchTypeId: pa.pitch_type?.id ?? null,
+  selfAnalysisMemo: pa.self_analysis_memo,
+  pitcherId: pa.pitcher?.id ?? null,
+  appearanceSituationId: pa.appearance_situation?.id ?? null,
+});
 
 /**
  * 1 打席分の記録ウィザード。
@@ -44,23 +65,47 @@ export function PlateAppearanceWizard({
   onCompleted,
   onCancel,
   defaultTeamId,
+  editingPlateAppearance,
 }: PlateAppearanceWizardProps) {
+  const isEdit = !!editingPlateAppearance;
+  const initialHitLocation: Point | null =
+    editingPlateAppearance?.hit_location_x != null &&
+    editingPlateAppearance?.hit_location_y != null
+      ? {
+          x: Number(editingPlateAppearance.hit_location_x),
+          y: Number(editingPlateAppearance.hit_location_y),
+        }
+      : null;
   const [step, setStep] = useState<WizardStep>("result");
-  const [hitLocation, setHitLocation] = useState<Point | null>(null);
-  const [directionId, setDirectionId] = useState<number | null>(null);
-  const [plateResultId, setPlateResultId] = useState<PlateResultId | null>(
-    null,
+  const [hitLocation, setHitLocation] = useState<Point | null>(
+    initialHitLocation,
   );
-  const [outType, setOutType] = useState<OutType | null>(null);
-  const [hitType, setHitType] = useState<HitType | null>(null);
-  const [swingType, setSwingType] = useState<SwingType | null>(null);
+  const [directionId, setDirectionId] = useState<number | null>(
+    editingPlateAppearance?.hit_direction_id ?? null,
+  );
+  const [plateResultId, setPlateResultId] = useState<PlateResultId | null>(
+    (editingPlateAppearance?.plate_result_id as PlateResultId) ?? null,
+  );
+  const [outType, setOutType] = useState<OutType | null>(
+    editingPlateAppearance?.out_type ?? null,
+  );
+  const [hitType, setHitType] = useState<HitType | null>(
+    editingPlateAppearance?.hit_type ?? null,
+  );
+  const [swingType, setSwingType] = useState<SwingType | null>(
+    editingPlateAppearance?.swing_type ?? null,
+  );
   const [scores, setScores] = useState({
-    rbi: 0,
-    runScored: 0,
-    stolenBases: 0,
-    caughtStealing: 0,
+    rbi: editingPlateAppearance?.rbi ?? 0,
+    runScored: editingPlateAppearance?.run_scored ?? 0,
+    stolenBases: editingPlateAppearance?.stolen_bases ?? 0,
+    caughtStealing: editingPlateAppearance?.caught_stealing ?? 0,
   });
-  const [detail, setDetailState] = useState<DetailState>(EMPTY_DETAIL);
+  const [detail, setDetailState] = useState<DetailState>(
+    editingPlateAppearance
+      ? detailFromPlateAppearance(editingPlateAppearance)
+      : EMPTY_DETAIL,
+  );
   const [isOutModalOpen, setIsOutModalOpen] = useState(false);
   const [isHitModalOpen, setIsHitModalOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -69,7 +114,16 @@ export function PlateAppearanceWizard({
   const setDetail = (patch: Partial<DetailState>) =>
     setDetailState((prev) => ({ ...prev, ...patch }));
 
-  const goToScore = () => setStep("score");
+  // 編集モードはタブで自由に切り替えるため、結果選択での自動遷移はしない。
+  const goToScore = () => {
+    if (!isEdit) setStep("score");
+  };
+
+  const EDIT_TABS: { step: WizardStep; label: string }[] = [
+    { step: "result", label: "打席結果" },
+    { step: "score", label: "打点・得点" },
+    { step: "detail", label: "詳細" },
+  ];
 
   const handleGroundSelect = (args: {
     x: number;
@@ -128,7 +182,7 @@ export function PlateAppearanceWizard({
     if (plateResultId === null || isSubmitting) return;
     setIsSubmitting(true);
     setErrors([]);
-    const result = await createPlateAppearanceV2({
+    const input = {
       game_result_id: gameResultId,
       batter_box_number: batterBoxNumber,
       plate_result_id: plateResultId,
@@ -154,7 +208,11 @@ export function PlateAppearanceWizard({
       self_analysis_memo: detail.selfAnalysisMemo,
       pitcher_id: detail.pitcherId,
       appearance_situation_id: detail.appearanceSituationId,
-    });
+    };
+    const result =
+      isEdit && editingPlateAppearance
+        ? await updatePlateAppearanceV2(editingPlateAppearance.id, input)
+        : await createPlateAppearanceV2(input);
     if (result.ok) {
       onCompleted();
     } else {
@@ -172,6 +230,25 @@ export function PlateAppearanceWizard({
             <li key={error}>{error}</li>
           ))}
         </ul>
+      )}
+
+      {isEdit && (
+        <div className="flex border-b border-zinc-700">
+          {EDIT_TABS.map((tab) => (
+            <button
+              key={tab.step}
+              type="button"
+              className={`flex-1 pb-2 text-sm font-medium border-b-2 transition-colors ${
+                step === tab.step
+                  ? "border-primary text-primary"
+                  : "border-transparent text-zinc-400"
+              }`}
+              onClick={() => setStep(tab.step)}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
       )}
 
       {step === "result" ? (
@@ -213,37 +290,41 @@ export function PlateAppearanceWizard({
             caughtStealing={scores.caughtStealing}
             onChange={handleScoreChange}
           />
-          <Button
-            variant="light"
-            radius="sm"
-            className="self-start text-zinc-400"
-            onPress={() => setStep("result")}
-            isDisabled={isSubmitting}
-          >
-            打席結果に戻る
-          </Button>
-          <div className="flex flex-col gap-y-2">
-            <Button
-              color="primary"
-              variant="bordered"
-              radius="sm"
-              className="font-bold"
-              onPress={() => setStep("detail")}
-              isDisabled={isSubmitting}
-            >
-              詳細を入力する
-            </Button>
-            <Button
-              color="primary"
-              radius="sm"
-              className="font-bold"
-              onPress={handleSubmit}
-              endContent={<NextArrowIcon stroke="#F4F4F4" />}
-              isDisabled={isSubmitting}
-            >
-              スキップして保存
-            </Button>
-          </div>
+          {!isEdit && (
+            <>
+              <Button
+                variant="light"
+                radius="sm"
+                className="self-start text-zinc-400"
+                onPress={() => setStep("result")}
+                isDisabled={isSubmitting}
+              >
+                打席結果に戻る
+              </Button>
+              <div className="flex flex-col gap-y-2">
+                <Button
+                  color="primary"
+                  variant="bordered"
+                  radius="sm"
+                  className="font-bold"
+                  onPress={() => setStep("detail")}
+                  isDisabled={isSubmitting}
+                >
+                  詳細を入力する
+                </Button>
+                <Button
+                  color="primary"
+                  radius="sm"
+                  className="font-bold"
+                  onPress={handleSubmit}
+                  endContent={<NextArrowIcon stroke="#F4F4F4" />}
+                  isDisabled={isSubmitting}
+                >
+                  スキップして保存
+                </Button>
+              </div>
+            </>
+          )}
         </>
       ) : (
         <>
@@ -253,26 +334,42 @@ export function PlateAppearanceWizard({
             setDetail={setDetail}
             defaultTeamId={defaultTeamId}
           />
-          <Button
-            variant="light"
-            radius="sm"
-            className="self-start text-zinc-400"
-            onPress={() => setStep("score")}
-            isDisabled={isSubmitting}
-          >
-            打点・得点に戻る
-          </Button>
-          <Button
-            color="primary"
-            radius="sm"
-            className="font-bold"
-            onPress={handleSubmit}
-            endContent={<NextArrowIcon stroke="#F4F4F4" />}
-            isDisabled={isSubmitting}
-          >
-            この打席を保存
-          </Button>
+          {!isEdit && (
+            <>
+              <Button
+                variant="light"
+                radius="sm"
+                className="self-start text-zinc-400"
+                onPress={() => setStep("score")}
+                isDisabled={isSubmitting}
+              >
+                打点・得点に戻る
+              </Button>
+              <Button
+                color="primary"
+                radius="sm"
+                className="font-bold"
+                onPress={handleSubmit}
+                endContent={<NextArrowIcon stroke="#F4F4F4" />}
+                isDisabled={isSubmitting}
+              >
+                この打席を保存
+              </Button>
+            </>
+          )}
         </>
+      )}
+
+      {isEdit && (
+        <Button
+          color="primary"
+          radius="sm"
+          className="font-bold"
+          onPress={handleSubmit}
+          isDisabled={isSubmitting}
+        >
+          この打席を更新
+        </Button>
       )}
 
       <OutTypeModal

--- a/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
@@ -380,7 +380,7 @@ export function PlateAppearanceWizard({
           radius="sm"
           className="font-bold"
           onPress={handleSubmit}
-          isDisabled={isSubmitting}
+          isDisabled={isSubmitting || plateResultId === null}
         >
           この打席を更新
         </Button>

--- a/app/(app)/game-result/plate-appearances/new/page.tsx
+++ b/app/(app)/game-result/plate-appearances/new/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import HeaderResult from "@app/components/header/HeaderResult";
+import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
+import useRequireAuth from "@app/hooks/auth/useRequireAuth";
+import { checkExistingMatchResults } from "@app/services/matchResultsService";
+import { getCurrentUserId } from "@app/services/userService";
+import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
+import { PlateAppearanceWizard } from "../_components/PlateAppearanceWizard";
+
+const LIST_PATH = "/game-result/plate-appearances";
+
+export default function NewPlateAppearancePage() {
+  const router = useRouter();
+  useRequireAuth();
+  const [gameResultId, setGameResultId] = useState<number | null>(null);
+  const [batterBoxNumber, setBatterBoxNumber] = useState<number | null>(null);
+  const [opponentTeamId, setOpponentTeamId] = useState<number | null>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem("gameResultId");
+    if (!saved) {
+      router.push("/game-result/record");
+      return;
+    }
+    const id = JSON.parse(saved) as number;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setGameResultId(id);
+    getPlateAppearancesByGame(id).then((plateAppearances) => {
+      setBatterBoxNumber(plateAppearances.length + 1);
+    });
+    getCurrentUserId().then((userId) => {
+      checkExistingMatchResults(id, userId).then((matchResult) => {
+        if (matchResult?.opponent_team_id) {
+          setOpponentTeamId(matchResult.opponent_team_id);
+        }
+      });
+    });
+  }, [router]);
+
+  return (
+    <>
+      <HeaderResult />
+      <main className="h-full">
+        <div className="pb-40 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+          <div className="pt-12 px-4 lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:px-6 lg:pb-6">
+            {gameResultId !== null && batterBoxNumber !== null ? (
+              <PlateAppearanceWizard
+                gameResultId={gameResultId}
+                batterBoxNumber={batterBoxNumber}
+                onCompleted={() => router.push(LIST_PATH)}
+                onCancel={() => router.push(LIST_PATH)}
+                defaultTeamId={opponentTeamId}
+              />
+            ) : (
+              <LoadingSpinner />
+            )}
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/app/(app)/game-result/plate-appearances/new/page.tsx
+++ b/app/(app)/game-result/plate-appearances/new/page.tsx
@@ -42,8 +42,8 @@ export default function NewPlateAppearancePage() {
   return (
     <>
       <HeaderResult />
-      <main className="h-full">
-        <div className="pb-40 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+      <main className="buzz-dark min-h-full">
+        <div className="pb-52 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
           <div className="pt-12 px-4 lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:px-6 lg:pb-6">
             {gameResultId !== null && batterBoxNumber !== null ? (
               <PlateAppearanceWizard

--- a/app/(app)/game-result/plate-appearances/page.tsx
+++ b/app/(app)/game-result/plate-appearances/page.tsx
@@ -50,7 +50,7 @@ export default function PlateAppearanceListPage() {
       localStorage.getItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY) === "true";
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsEditMode(editMode);
-     
+
     void (async () => {
       const list = await getPlateAppearancesByGame(id);
       setPlateAppearances(list);

--- a/app/(app)/game-result/plate-appearances/page.tsx
+++ b/app/(app)/game-result/plate-appearances/page.tsx
@@ -6,11 +6,28 @@ import { useEffect, useState } from "react";
 import HeaderResult from "@app/components/header/HeaderResult";
 import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
-import { RECORD_PATTERN_STORAGE_KEY } from "@app/constants/gameRecord";
+import {
+  GAME_RECORD_EDIT_MODE_STORAGE_KEY,
+  RECORD_PATTERN_STORAGE_KEY,
+} from "@app/constants/gameRecord";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
+import { getCurrentPitchingResult } from "@app/services/pitchingResultsService";
 import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
 import { AddPlateAppearanceCard } from "./_components/AddPlateAppearanceCard";
 import { PlateAppearanceCard } from "./_components/PlateAppearanceCard";
+
+const PITCHING_PATH = "/game-result/pitching/";
+const SUMMARY_PATH = "/game-result/summary/";
+
+const readRecordPattern = (): string => {
+  const raw = localStorage.getItem(RECORD_PATTERN_STORAGE_KEY);
+  // 壊れた値が入っていても遷移が止まらないよう既定 both にフォールバックする。
+  try {
+    return raw ? JSON.parse(raw) : "both";
+  } catch {
+    return "both";
+  }
+};
 
 export default function PlateAppearanceListPage() {
   const router = useRouter();
@@ -18,13 +35,9 @@ export default function PlateAppearanceListPage() {
   const [plateAppearances, setPlateAppearances] = useState<PlateAppearanceV2[]>(
     [],
   );
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [hasPitching, setHasPitching] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-
-  const reload = async (id: number) => {
-    const list = await getPlateAppearancesByGame(id);
-    setPlateAppearances(list);
-    setIsLoading(false);
-  };
 
   useEffect(() => {
     const saved = localStorage.getItem("gameResultId");
@@ -33,23 +46,25 @@ export default function PlateAppearanceListPage() {
       return;
     }
     const id = JSON.parse(saved) as number;
+    const editMode =
+      localStorage.getItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY) === "true";
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    reload(id);
+    setIsEditMode(editMode);
+     
+    void (async () => {
+      const list = await getPlateAppearancesByGame(id);
+      setPlateAppearances(list);
+      if (editMode) {
+        const pitching = await getCurrentPitchingResult(id);
+        setHasPitching(Array.isArray(pitching) && pitching.length > 0);
+      }
+      setIsLoading(false);
+    })();
   }, [router]);
 
-  const handleComplete = () => {
-    const raw = localStorage.getItem(RECORD_PATTERN_STORAGE_KEY);
-    // 壊れた値が入っていても遷移が止まらないよう既定 both にフォールバックする。
-    const pattern = (() => {
-      try {
-        return raw ? JSON.parse(raw) : "both";
-      } catch {
-        return "both";
-      }
-    })();
-    router.push(
-      pattern === "both" ? "/game-result/pitching/" : "/game-result/summary/",
-    );
+  // 新規記録時は「両方」パターンのときだけ投手成績入力へ進む。
+  const goNewComplete = () => {
+    router.push(readRecordPattern() === "both" ? PITCHING_PATH : SUMMARY_PATH);
   };
 
   return (
@@ -89,16 +104,40 @@ export default function PlateAppearanceListPage() {
                     router.push("/game-result/plate-appearances/new")
                   }
                 />
-                <Button
-                  color="primary"
-                  radius="sm"
-                  className="mt-6 font-bold"
-                  onPress={handleComplete}
-                  endContent={<NextArrowIcon stroke="#F4F4F4" />}
-                  isDisabled={plateAppearances.length === 0}
-                >
-                  入力を完了する
-                </Button>
+
+                {isEditMode ? (
+                  <div className="mt-6 flex flex-col gap-y-3">
+                    {/* 編集時は投手成績の有無に関わらず投手記録へ進める。 */}
+                    <Button
+                      color="primary"
+                      radius="sm"
+                      className="font-bold"
+                      onPress={() => router.push(PITCHING_PATH)}
+                      endContent={<NextArrowIcon stroke="#F4F4F4" />}
+                    >
+                      {hasPitching ? "投手成績編集へ" : "投手成績を追加"}
+                    </Button>
+                    <Button
+                      variant="bordered"
+                      radius="sm"
+                      className="font-bold border-2 border-[#d08000] bg-transparent text-[#d08000]"
+                      onPress={() => router.push(SUMMARY_PATH)}
+                    >
+                      試合結果まとめへ
+                    </Button>
+                  </div>
+                ) : (
+                  <Button
+                    color="primary"
+                    radius="sm"
+                    className="mt-6 font-bold"
+                    onPress={goNewComplete}
+                    endContent={<NextArrowIcon stroke="#F4F4F4" />}
+                    isDisabled={plateAppearances.length === 0}
+                  >
+                    入力を完了する
+                  </Button>
+                )}
               </div>
             )}
           </div>

--- a/app/(app)/game-result/plate-appearances/page.tsx
+++ b/app/(app)/game-result/plate-appearances/page.tsx
@@ -8,17 +8,13 @@ import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import { RECORD_PATTERN_STORAGE_KEY } from "@app/constants/gameRecord";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
-import {
-  deletePlateAppearanceV2,
-  getPlateAppearancesByGame,
-} from "@app/services/v2/plateAppearanceService";
+import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
 import { AddPlateAppearanceCard } from "./_components/AddPlateAppearanceCard";
 import { PlateAppearanceCard } from "./_components/PlateAppearanceCard";
 
 export default function PlateAppearanceListPage() {
   const router = useRouter();
   useRequireAuth();
-  const [gameResultId, setGameResultId] = useState<number | null>(null);
   const [plateAppearances, setPlateAppearances] = useState<PlateAppearanceV2[]>(
     [],
   );
@@ -38,14 +34,8 @@ export default function PlateAppearanceListPage() {
     }
     const id = JSON.parse(saved) as number;
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setGameResultId(id);
     reload(id);
   }, [router]);
-
-  const handleDelete = async (id: number) => {
-    const result = await deletePlateAppearanceV2(id);
-    if (result.ok && gameResultId !== null) reload(gameResultId);
-  };
 
   const handleComplete = () => {
     const raw = localStorage.getItem(RECORD_PATTERN_STORAGE_KEY);
@@ -84,7 +74,6 @@ export default function PlateAppearanceListPage() {
                         `/game-result/plate-appearances/${plateAppearance.id}/edit`,
                       )
                     }
-                    onDelete={() => handleDelete(plateAppearance.id)}
                   />
                 ))}
                 {plateAppearances.length === 0 ? (

--- a/app/(app)/game-result/plate-appearances/page.tsx
+++ b/app/(app)/game-result/plate-appearances/page.tsx
@@ -1,21 +1,34 @@
 "use client";
+import type { PlateAppearanceV2 } from "@app/interface/plateAppearanceV2";
+import { Button } from "@heroui/react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import HeaderResult from "@app/components/header/HeaderResult";
+import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import { RECORD_PATTERN_STORAGE_KEY } from "@app/constants/gameRecord";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
-import { checkExistingMatchResults } from "@app/services/matchResultsService";
-import { getCurrentUserId } from "@app/services/userService";
-import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
-import { PlateAppearanceWizard } from "./_components/PlateAppearanceWizard";
+import {
+  deletePlateAppearanceV2,
+  getPlateAppearancesByGame,
+} from "@app/services/v2/plateAppearanceService";
+import { AddPlateAppearanceCard } from "./_components/AddPlateAppearanceCard";
+import { PlateAppearanceCard } from "./_components/PlateAppearanceCard";
 
-export default function PlateAppearanceRecordPage() {
+export default function PlateAppearanceListPage() {
   const router = useRouter();
   useRequireAuth();
   const [gameResultId, setGameResultId] = useState<number | null>(null);
-  const [batterBoxNumber, setBatterBoxNumber] = useState<number | null>(null);
-  const [opponentTeamId, setOpponentTeamId] = useState<number | null>(null);
+  const [plateAppearances, setPlateAppearances] = useState<PlateAppearanceV2[]>(
+    [],
+  );
+  const [isLoading, setIsLoading] = useState(true);
+
+  const reload = async (id: number) => {
+    const list = await getPlateAppearancesByGame(id);
+    setPlateAppearances(list);
+    setIsLoading(false);
+  };
 
   useEffect(() => {
     const saved = localStorage.getItem("gameResultId");
@@ -26,21 +39,15 @@ export default function PlateAppearanceRecordPage() {
     const id = JSON.parse(saved) as number;
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setGameResultId(id);
-    // 既存打席数 +1 を打席番号として採番する。
-    getPlateAppearancesByGame(id).then((plateAppearances) => {
-      setBatterBoxNumber(plateAppearances.length + 1);
-    });
-    // 投手の新規登録で相手チームを自動セットするため、相手チーム id を取得する。
-    getCurrentUserId().then((userId) => {
-      checkExistingMatchResults(id, userId).then((matchResult) => {
-        if (matchResult?.opponent_team_id) {
-          setOpponentTeamId(matchResult.opponent_team_id);
-        }
-      });
-    });
+    reload(id);
   }, [router]);
 
-  const handleCompleted = () => {
+  const handleDelete = async (id: number) => {
+    const result = await deletePlateAppearanceV2(id);
+    if (result.ok && gameResultId !== null) reload(gameResultId);
+  };
+
+  const handleComplete = () => {
     const raw = localStorage.getItem(RECORD_PATTERN_STORAGE_KEY);
     const pattern = raw ? JSON.parse(raw) : "both";
     router.push(
@@ -54,16 +61,49 @@ export default function PlateAppearanceRecordPage() {
       <main className="h-full">
         <div className="pb-40 relative w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
           <div className="pt-12 px-4 lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:px-6 lg:pb-6">
-            {gameResultId !== null && batterBoxNumber !== null ? (
-              <PlateAppearanceWizard
-                gameResultId={gameResultId}
-                batterBoxNumber={batterBoxNumber}
-                onCompleted={handleCompleted}
-                onCancel={() => router.push("/game-result/record")}
-                defaultTeamId={opponentTeamId}
-              />
-            ) : (
+            <h2 className="text-base text-center mb-6">
+              打席結果を記録しよう！
+            </h2>
+            {isLoading ? (
               <LoadingSpinner />
+            ) : (
+              <div className="flex flex-col gap-y-3">
+                {plateAppearances.map((plateAppearance) => (
+                  <PlateAppearanceCard
+                    key={plateAppearance.id}
+                    plateAppearance={plateAppearance}
+                    onEdit={() =>
+                      router.push(
+                        `/game-result/plate-appearances/${plateAppearance.id}/edit`,
+                      )
+                    }
+                    onDelete={() => handleDelete(plateAppearance.id)}
+                  />
+                ))}
+                {plateAppearances.length === 0 ? (
+                  <p className="text-center text-sm text-zinc-400">
+                    「結果を入力」ボタンをタップして
+                    <br />
+                    最初の打席を記録しよう
+                  </p>
+                ) : null}
+                <AddPlateAppearanceCard
+                  batterBoxNumber={plateAppearances.length + 1}
+                  onAdd={() =>
+                    router.push("/game-result/plate-appearances/new")
+                  }
+                />
+                <Button
+                  color="primary"
+                  radius="sm"
+                  className="mt-6 font-bold"
+                  onPress={handleComplete}
+                  endContent={<NextArrowIcon stroke="#F4F4F4" />}
+                  isDisabled={plateAppearances.length === 0}
+                >
+                  入力を完了する
+                </Button>
+              </div>
             )}
           </div>
         </div>

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -672,16 +672,14 @@ export default function GameRecord() {
         RECORD_PATTERN_STORAGE_KEY,
         JSON.stringify(effectivePattern),
       );
-      // 未出場はまとめへ、投手のみは投手入力へ、新規の打撃/両方は v2 打席ウィザードへ。
-      // 編集モード（pattern 未指定）は v2 打席編集が未実装のため当面 v1 打撃入力へ。
+      // 未出場はまとめへ、投手のみは投手入力へ、新規の打撃/両方と編集モードは
+      // 新仕様の v2 打席リストへ（旧仕様試合も保存時に新仕様カラムが埋まる）。
       const nextPath =
         appearanceType === "no_play"
           ? `/game-result/summary/`
           : pattern === "pitching"
             ? `/game-result/pitching/`
-            : pattern
-              ? `/game-result/plate-appearances/`
-              : `/game-result/batting/`;
+            : `/game-result/plate-appearances/`;
       router.push(nextPath);
     } catch (error) {
       console.error("試合結果の保存に失敗しました", error);

--- a/app/(app)/game-result/summary/[slug]/page.tsx
+++ b/app/(app)/game-result/summary/[slug]/page.tsx
@@ -147,23 +147,22 @@ export default function ResultsSummary() {
   // 試合データ取得
   const fetchCurrentResultData = async (localStorageGameResultId: number) => {
     try {
-      const matchResultData = await getUserMatchResult(
-        localStorageGameResultId,
-      );
-      const battingAverageData = await getUserBattingAverage(
-        localStorageGameResultId,
-      );
-      const pitchingResultData = await getUserPitchingResult(
-        localStorageGameResultId,
-      );
-      const plateAppearanceData = await getUserPlateAppearance(
-        localStorageGameResultId,
-      );
-      const plateAppearancesV2Data = await getPlateAppearancesByGame(
-        localStorageGameResultId,
-      );
+      const [
+        matchResultData,
+        battingAverageData,
+        pitchingResultData,
+        plateAppearanceData,
+        plateAppearancesV2Data,
+        currentUserIdData,
+      ] = await Promise.all([
+        getUserMatchResult(localStorageGameResultId),
+        getUserBattingAverage(localStorageGameResultId),
+        getUserPitchingResult(localStorageGameResultId),
+        getUserPlateAppearance(localStorageGameResultId),
+        getPlateAppearancesByGame(localStorageGameResultId),
+        getCurrentUserId(),
+      ]);
       setPlateAppearancesV2(plateAppearancesV2Data);
-      const currentUserIdData = await getCurrentUserId();
       if (matchResultData && matchResultData.length > 0) {
         setMemo(matchResultData[0].memo);
       }

--- a/app/(app)/game-result/summary/[slug]/page.tsx
+++ b/app/(app)/game-result/summary/[slug]/page.tsx
@@ -5,6 +5,7 @@ import type {
   PitchingResult,
   PlateAppearanceSummary,
 } from "@app/interface";
+import type { PlateAppearanceV2 } from "@app/interface/plateAppearanceV2";
 import {
   Button,
   Chip,
@@ -41,6 +42,8 @@ import {
   getCurrentUserId,
   getCurrentUsersUserId,
 } from "@app/services/userService";
+import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
+import { PlateAppearanceSummaryCard } from "../_components/PlateAppearanceSummaryCard";
 
 type MatchResultDisplay = MatchResult & {
   id: number;
@@ -72,6 +75,9 @@ export default function ResultsSummary() {
   const [matchResult, setMatchResult] = useState<MatchResultDisplay[]>([]);
   const [plateAppearance, setPlateAppearance] = useState<
     PlateAppearanceSummary[]
+  >([]);
+  const [plateAppearancesV2, setPlateAppearancesV2] = useState<
+    PlateAppearanceV2[]
   >([]);
   const [battingAverage, setBattingAverage] = useState<BattingAverage[]>([]);
   const [pitchingResult, setPitchingResult] = useState<PitchingResult[]>([]);
@@ -149,6 +155,10 @@ export default function ResultsSummary() {
       const plateAppearanceData = await getUserPlateAppearance(
         localStorageGameResultId,
       );
+      const plateAppearancesV2Data = await getPlateAppearancesByGame(
+        localStorageGameResultId,
+      );
+      setPlateAppearancesV2(plateAppearancesV2Data);
       const currentUserIdData = await getCurrentUserId();
       if (matchResultData && matchResultData.length > 0) {
         setMemo(matchResultData[0].memo);
@@ -479,6 +489,22 @@ export default function ResultsSummary() {
                   </>
                 )}
               </div>
+              {plateAppearancesV2.length > 0 && (
+                <>
+                  <Divider className="my-4" />
+                  <div>
+                    <p className="text-xs text-zinc-400 mb-2">打席詳細</p>
+                    <div className="flex flex-col gap-y-2">
+                      {plateAppearancesV2.map((plate) => (
+                        <PlateAppearanceSummaryCard
+                          key={plate.id}
+                          plateAppearance={plate}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                </>
+              )}
               <Divider className="my-4" />
               {/* 投手成績 */}
               <div>

--- a/app/(app)/game-result/summary/[slug]/page.tsx
+++ b/app/(app)/game-result/summary/[slug]/page.tsx
@@ -43,6 +43,10 @@ import {
   getCurrentUsersUserId,
 } from "@app/services/userService";
 import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
+import {
+  getBattingResultColor,
+  HIT_RESULT_COLOR,
+} from "@app/utils/battingResultColor";
 import { PlateAppearanceSummaryCard } from "../_components/PlateAppearanceSummaryCard";
 
 type MatchResultDisplay = MatchResult & {
@@ -213,44 +217,10 @@ export default function ResultsSummary() {
 
   // 打席
   const getBattingResultClassName = (battingResult: string) => {
-    const hits = [
-      "投安",
-      "捕安",
-      "一安",
-      "二安",
-      "三安",
-      "遊安",
-      "左安",
-      "中安",
-      "右安",
-      "投二",
-      "捕二",
-      "一二",
-      "二二",
-      "三二",
-      "遊二",
-      "左二",
-      "中二",
-      "右二",
-      "投三",
-      "捕三",
-      "一三",
-      "二三",
-      "三三",
-      "遊三",
-      "左三",
-      "中三",
-      "右三",
-      "投本",
-      "捕本",
-      "一本",
-      "二本",
-      "三本",
-      "遊本",
-      "左本",
-      "中本",
-      "右本",
-    ];
+    // 安打系(右中/左中/線など全方向)は共通判定で赤に。四球/死球/犠打/犠飛/打妨は青。
+    if (getBattingResultColor(battingResult) === HIT_RESULT_COLOR) {
+      return "text-red-500";
+    }
     const walks = [
       "四球",
       "死球",
@@ -262,14 +232,10 @@ export default function ResultsSummary() {
       "遊犠",
       "打妨",
     ];
-
-    if (hits.includes(battingResult)) {
-      return "text-red-500";
-    } else if (walks.includes(battingResult)) {
+    if (walks.includes(battingResult)) {
       return "text-blue-400";
-    } else {
-      return "";
     }
+    return "";
   };
 
   // 投球数

--- a/app/(app)/game-result/summary/_components/PlateAppearanceSummaryCard.tsx
+++ b/app/(app)/game-result/summary/_components/PlateAppearanceSummaryCard.tsx
@@ -1,0 +1,68 @@
+"use client";
+import type { PlateAppearanceV2 } from "@app/interface/plateAppearanceV2";
+import { getBattingResultColor } from "@app/utils/battingResultColor";
+import {
+  buildPitchAndPitcherChips,
+  buildSituationChips,
+} from "@app/utils/plateAppearanceChips";
+
+interface PlateAppearanceSummaryCardProps {
+  plateAppearance: PlateAppearanceV2;
+}
+
+/**
+ * 試合サマリー画面で1打席分の詳細を表示する表示専用カード。
+ * 打席リストの編集用カードとは異なりタップ不可・コンパクト。
+ */
+export function PlateAppearanceSummaryCard({
+  plateAppearance,
+}: PlateAppearanceSummaryCardProps) {
+  const resultText = plateAppearance.batting_result || "未入力";
+  const resultColor = getBattingResultColor(resultText);
+  const situationChips = buildSituationChips(plateAppearance);
+  const pitchChips = buildPitchAndPitcherChips(plateAppearance);
+  const hasAnyDetail = situationChips.length > 0 || pitchChips.length > 0;
+
+  return (
+    <div className="flex flex-col gap-y-1.5 rounded-lg border border-zinc-600 bg-[#2E2E2E] px-2.5 py-2">
+      <div className="flex items-center gap-x-2.5">
+        <span className="text-xs text-zinc-400">
+          第{plateAppearance.batter_box_number}打席
+        </span>
+        <span className="text-sm font-bold" style={{ color: resultColor }}>
+          {resultText}
+        </span>
+      </div>
+      {hasAnyDetail ? (
+        <>
+          {situationChips.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {situationChips.map((chip) => (
+                <span
+                  key={`s-${chip}`}
+                  className="rounded-md bg-[#424242] px-2 py-0.5 text-[11px] text-zinc-300"
+                >
+                  {chip}
+                </span>
+              ))}
+            </div>
+          )}
+          {pitchChips.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {pitchChips.map((chip) => (
+                <span
+                  key={`p-${chip}`}
+                  className="rounded-md border border-[#d08000] bg-[#3a3024] px-2 py-0.5 text-[11px] text-zinc-100"
+                >
+                  {chip}
+                </span>
+              ))}
+            </div>
+          )}
+        </>
+      ) : (
+        <span className="text-[11px] text-zinc-500">詳細未入力</span>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/game-result/summary/page.tsx
+++ b/app/(app)/game-result/summary/page.tsx
@@ -27,6 +27,7 @@ import {
   getCurrentUsersUserId,
 } from "@app/services/userService";
 import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
+import { PlateAppearanceSummaryCard } from "./_components/PlateAppearanceSummaryCard";
 
 type MatchResultDisplay = MatchResult & {
   id: number;
@@ -417,6 +418,22 @@ export default function ResultsSummary() {
                   </>
                 )}
               </div>
+              {plateAppearancesV2.length > 0 && (
+                <>
+                  <Divider className="my-4" />
+                  <div>
+                    <p className="text-xs text-zinc-400 mb-2">打席詳細</p>
+                    <div className="flex flex-col gap-y-2">
+                      {plateAppearancesV2.map((plate) => (
+                        <PlateAppearanceSummaryCard
+                          key={plate.id}
+                          plateAppearance={plate}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                </>
+              )}
               <Divider className="my-4" />
               {/* 投手成績 */}
               <div>

--- a/app/(app)/game-result/summary/page.tsx
+++ b/app/(app)/game-result/summary/page.tsx
@@ -27,6 +27,10 @@ import {
   getCurrentUsersUserId,
 } from "@app/services/userService";
 import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
+import {
+  getBattingResultColor,
+  HIT_RESULT_COLOR,
+} from "@app/utils/battingResultColor";
 import { PlateAppearanceSummaryCard } from "./_components/PlateAppearanceSummaryCard";
 
 type MatchResultDisplay = MatchResult & {
@@ -176,44 +180,10 @@ export default function ResultsSummary() {
 
   // 打席
   const getBattingResultClassName = (battingResult: string) => {
-    const hits = [
-      "投安",
-      "捕安",
-      "一安",
-      "二安",
-      "三安",
-      "遊安",
-      "左安",
-      "中安",
-      "右安",
-      "投二",
-      "捕二",
-      "一二",
-      "二二",
-      "三二",
-      "遊二",
-      "左二",
-      "中二",
-      "右二",
-      "投三",
-      "捕三",
-      "一三",
-      "二三",
-      "三三",
-      "遊三",
-      "左三",
-      "中三",
-      "右三",
-      "投本",
-      "捕本",
-      "一本",
-      "二本",
-      "三本",
-      "遊本",
-      "左本",
-      "中本",
-      "右本",
-    ];
+    // 安打系(右中/左中/線など全方向)は共通判定で赤に。四球/死球/犠打/犠飛/打妨は青。
+    if (getBattingResultColor(battingResult) === HIT_RESULT_COLOR) {
+      return "text-red-500";
+    }
     const walks = [
       "四球",
       "死球",
@@ -234,14 +204,10 @@ export default function ResultsSummary() {
       "右犠飛",
       "打妨",
     ];
-
-    if (hits.includes(battingResult)) {
-      return "text-red-500";
-    } else if (walks.includes(battingResult)) {
+    if (walks.includes(battingResult)) {
       return "text-blue-400";
-    } else {
-      return "";
     }
+    return "";
   };
 
   // 投球数

--- a/app/(app)/game-result/summary/page.tsx
+++ b/app/(app)/game-result/summary/page.tsx
@@ -5,6 +5,7 @@ import type {
   PitchingResult,
   PlateAppearanceSummary,
 } from "@app/interface";
+import type { PlateAppearanceV2 } from "@app/interface/plateAppearanceV2";
 import { Chip, Divider } from "@heroui/react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -25,6 +26,7 @@ import {
   getCurrentUserId,
   getCurrentUsersUserId,
 } from "@app/services/userService";
+import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
 
 type MatchResultDisplay = MatchResult & {
   id: number;
@@ -55,6 +57,9 @@ export default function ResultsSummary() {
   const [matchResult, setMatchResult] = useState<MatchResultDisplay[]>([]);
   const [plateAppearance, setPlateAppearance] = useState<
     PlateAppearanceSummary[]
+  >([]);
+  const [plateAppearancesV2, setPlateAppearancesV2] = useState<
+    PlateAppearanceV2[]
   >([]);
   const [battingAverage, setBattingAverage] = useState<BattingAverage[]>([]);
   const [pitchingResult, setPitchingResult] = useState<PitchingResult[]>([]);
@@ -117,13 +122,16 @@ export default function ResultsSummary() {
         pitchingResultData,
         plateAppearanceData,
         currentUserIdData,
+        plateAppearancesV2Data,
       ] = await Promise.all([
         getCurrentMatchResult(localStorageGameResultId),
         getCurrentBattingAverage(localStorageGameResultId),
         getCurrentPitchingResult(localStorageGameResultId),
         getCurrentPlateAppearance(localStorageGameResultId),
         getCurrentUserId(),
+        getPlateAppearancesByGame(localStorageGameResultId),
       ]);
+      setPlateAppearancesV2(plateAppearancesV2Data);
       if (matchResultData && matchResultData.length > 0) {
         setMemo(matchResultData[0].memo);
       }
@@ -352,21 +360,20 @@ export default function ResultsSummary() {
                     <div key={batting.id}>
                       <p className="text-xs text-zinc-400">打撃</p>
                       <ul className="flex flex-wrap gap-2 mt-2">
-                        {plateAppearance ? (
-                          plateAppearance.map((plate) => (
-                            <li key={plate.batter_box_number}>
-                              <p
-                                className={`font-bold ${getBattingResultClassName(
-                                  plate.batting_result,
-                                )}`}
-                              >
-                                {plate.batting_result}
-                              </p>
-                            </li>
-                          ))
-                        ) : (
-                          <></>
-                        )}
+                        {(plateAppearancesV2.length > 0
+                          ? plateAppearancesV2
+                          : (plateAppearance ?? [])
+                        ).map((plate) => (
+                          <li key={plate.batter_box_number}>
+                            <p
+                              className={`font-bold ${getBattingResultClassName(
+                                plate.batting_result,
+                              )}`}
+                            >
+                              {plate.batting_result}
+                            </p>
+                          </li>
+                        ))}
                       </ul>
                       <div className="mt-1.5 grid grid-cols-3 gap-x-3 gap-y-1">
                         <div className="flex items-center">

--- a/app/(app)/game-result/summary/page.tsx
+++ b/app/(app)/game-result/summary/page.tsx
@@ -330,8 +330,10 @@ export default function ResultsSummary() {
                         {(plateAppearancesV2.length > 0
                           ? plateAppearancesV2
                           : (plateAppearance ?? [])
-                        ).map((plate) => (
-                          <li key={plate.batter_box_number}>
+                        ).map((plate, index) => (
+                          <li
+                            key={`${plate.batter_box_number ?? "na"}-${index}`}
+                          >
                             <p
                               className={`font-bold ${getBattingResultClassName(
                                 plate.batting_result,

--- a/app/components/listItem/MatchResultsItem.tsx
+++ b/app/components/listItem/MatchResultsItem.tsx
@@ -11,6 +11,10 @@ import {
 } from "@heroui/react";
 import { useRouter } from "next/navigation";
 import AppearanceTypeBadge from "@app/components/chip/AppearanceTypeBadge";
+import {
+  getBattingResultColor,
+  HIT_RESULT_COLOR,
+} from "@app/utils/battingResultColor";
 
 type GameResultItem = {
   game_result_id: number;
@@ -64,44 +68,10 @@ export default function MatchResultsItem(props: MatchResultsItemProps) {
   };
 
   const getBattingResultClassName = (battingResult: string) => {
-    const hits = [
-      "投安",
-      "捕安",
-      "一安",
-      "二安",
-      "三安",
-      "遊安",
-      "左安",
-      "中安",
-      "右安",
-      "投二",
-      "捕二",
-      "一二",
-      "二二",
-      "三二",
-      "遊二",
-      "左二",
-      "中二",
-      "右二",
-      "投三",
-      "捕三",
-      "一三",
-      "二三",
-      "三三",
-      "遊三",
-      "左三",
-      "中三",
-      "右三",
-      "投本",
-      "捕本",
-      "一本",
-      "二本",
-      "三本",
-      "遊本",
-      "左本",
-      "中本",
-      "右本",
-    ];
+    // 安打系(右中/左中/線など全方向)は共通判定で赤に。四球/死球/犠打/犠飛/打妨は青。
+    if (getBattingResultColor(battingResult) === HIT_RESULT_COLOR) {
+      return "text-red-500";
+    }
     const walks = [
       "四球",
       "死球",
@@ -122,14 +92,10 @@ export default function MatchResultsItem(props: MatchResultsItemProps) {
       "右犠飛",
       "打妨",
     ];
-
-    if (hits.includes(battingResult)) {
-      return "text-red-500";
-    } else if (walks.includes(battingResult)) {
+    if (walks.includes(battingResult)) {
       return "text-blue-400";
-    } else {
-      return "font-light";
     }
+    return "font-light";
   };
 
   const getInningPitched = (innings_pitched: number) => {

--- a/app/utils/battingResultColor.ts
+++ b/app/utils/battingResultColor.ts
@@ -1,0 +1,57 @@
+/**
+ * batting_result 文字列（"中安"・"三ゴロ"・"犠飛" 等）から表示色を決める。
+ * 試合一覧 / 試合詳細 / 打席一覧で同じ色分けロジックを使うために共通化する。
+ * - 安打系: 赤 #f31260 / 犠打・犠飛: 青 #006fee / その他: 白 #F4F4F4
+ */
+const HIT_RESULTS = [
+  "左安",
+  "中安",
+  "右安",
+  "遊安",
+  "投安",
+  "一安",
+  "二安",
+  "三安",
+  "左線安",
+  "左中安",
+  "右中安",
+  "右線安",
+  "左二",
+  "中二",
+  "右二",
+  "左線二",
+  "左中二",
+  "右中二",
+  "右線二",
+  "左三",
+  "中三",
+  "右三",
+  "左線三",
+  "左中三",
+  "右中三",
+  "右線三",
+  "左本",
+  "中本",
+  "右本",
+  "左線本",
+  "左中本",
+  "右中本",
+  "右線本",
+  "本塁打",
+  "安打",
+  "二塁打",
+  "三塁打",
+] as const;
+
+const SACRIFICE_RESULTS = ["犠打", "犠飛", "犠牲"] as const;
+
+export const HIT_RESULT_COLOR = "#f31260";
+export const SACRIFICE_RESULT_COLOR = "#006fee";
+export const DEFAULT_RESULT_COLOR = "#F4F4F4";
+
+export function getBattingResultColor(result: string): string {
+  if (HIT_RESULTS.some((hit) => result.includes(hit))) return HIT_RESULT_COLOR;
+  if (SACRIFICE_RESULTS.some((sacrifice) => result.includes(sacrifice)))
+    return SACRIFICE_RESULT_COLOR;
+  return DEFAULT_RESULT_COLOR;
+}

--- a/app/utils/plateAppearanceChips.ts
+++ b/app/utils/plateAppearanceChips.ts
@@ -1,0 +1,52 @@
+import type { PlateAppearanceV2 } from "@app/interface/plateAppearanceV2";
+import { RUNNERS_STATE_OPTIONS } from "@app/constants/runnersState";
+import { THROW_HAND_SHORT_LABELS } from "@app/constants/throwHand";
+
+const RUNNERS_STATE_LABELS: Record<string, string> = Object.fromEntries(
+  RUNNERS_STATE_OPTIONS.map((option) => [option.key, option.label]),
+);
+
+const formatCount = (
+  balls: number | null,
+  strikes: number | null,
+  outs: number | null,
+): string | null => {
+  if (balls === null && strikes === null && outs === null) return null;
+  return `B${balls ?? "-"}-S${strikes ?? "-"}-O${outs ?? "-"}`;
+};
+
+/**
+ * 打席状況系チップ（イニング / 最終カウント / ランナー状況 / 初球打ち）を
+ * 入力済みの項目だけ文字列で返す。打席カードとサマリーで共通利用する。
+ */
+export const buildSituationChips = (pa: PlateAppearanceV2): string[] => {
+  const chips: string[] = [];
+  if (pa.inning !== null) chips.push(`${pa.inning} 回`);
+  const count = formatCount(pa.final_balls, pa.final_strikes, pa.final_outs);
+  if (count) chips.push(count);
+  if (pa.runners_state) {
+    const label = RUNNERS_STATE_LABELS[pa.runners_state];
+    if (label) chips.push(label);
+  }
+  if (pa.first_pitch_swing === true) chips.push("初球○");
+  return chips;
+};
+
+/**
+ * 打球・投手系チップ（球質 / タイミング / 球種 / 投手名(利き手) / 登板状況）を
+ * 入力済みの項目だけ文字列で返す。
+ */
+export const buildPitchAndPitcherChips = (pa: PlateAppearanceV2): string[] => {
+  const chips: string[] = [];
+  if (pa.contact_quality?.name) chips.push(pa.contact_quality.name);
+  if (pa.timing?.name) chips.push(pa.timing.name);
+  if (pa.pitch_type?.name) chips.push(pa.pitch_type.name);
+  if (pa.pitcher) {
+    const hand = pa.pitcher.throw_hand
+      ? `(${THROW_HAND_SHORT_LABELS[pa.pitcher.throw_hand]})`
+      : "";
+    chips.push(`${pa.pitcher.name}${hand}`);
+  }
+  if (pa.appearance_situation?.name) chips.push(pa.appearance_situation.name);
+  return chips;
+};


### PR DESCRIPTION
## 概要

mobile [buzzbase_mobile#101](https://github.com/ippei-shimizu/buzzbase_mobile/pull/101) 追従シリーズ ([ippei-shimizu/buzzbase#397](https://github.com/ippei-shimizu/buzzbase/issues/397))。打席リスト・タブ式編集・削除と試合結果サマリーの v2 対応。**stacked PR**（base = `feature/396-plate-appearance-detail`）。

Closes ippei-shimizu/buzzbase#397

## 変更内容
- ルート再構成: `plate-appearances/`（一覧）/ `plate-appearances/new`（新規打席）/ `plate-appearances/[id]/edit`（編集）。
- 打席一覧: 記録済みカード（結果 / 打点・得点チップ / 詳細未入力バッジ / 削除）+ 末尾「結果を入力」プレースホルダ + 「入力を完了する」（パターンに応じ投手入力/まとめへ）。
- 編集: ウィザードに編集モードを追加。`PATCH /api/v2/plate_appearances/:id`。打席結果 / 打点・得点 / 詳細をタブで自由に切替え、単一の更新ボタン。
- 削除: 各カードから `DELETE /api/v2/plate_appearances/:id`。
- サマリー: `getPlateAppearancesByGame` の結果があれば打席結果チップを v2 で表示し、なければ v1 にフォールバック。

## スコープ / 制約
- 試合詳細（summary/[slug]）からの v2 打席編集導線は本 PR では未対応（フォローアップ予定）。
- サマリーのシェア文の v2 集計移行は別途（現状は battingAverage 集計値を使用）。
- 結合テストは未追加（draft）。

## 確認
- `yarn typecheck`（追加/変更ファイルにエラーなし）、`yarn lint` / `yarn format:check` パス、`yarn test` 全252件パス。
