### PR TITLE
Add: 打撃成績分析 - 詳細分析カード（球質/球種/タイミング/カウント/ランナー/対戦投手/推移）

### DIFF
--- a/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
@@ -4,18 +4,42 @@ import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import {
   type AdditionalStats,
   type AnalysisFilters as Filters,
+  type BattingTrendData,
+  type BreakdownData,
+  type CountSituations,
   getAdditionalStats,
+  getBattingTrend,
+  getContactQualityStats,
+  getCountSituations,
   getHeadlineStats,
   getHitDirections,
   getHitLocations,
+  getOutTypeBreakdown,
+  getPitcherFaceoffs,
+  getPitchTypeStats,
+  getRunnersSituation,
+  getTimingBreakdown,
   type HeadlineStats,
   type HitDirectionData,
   type HitLocationData,
+  type PitcherFaceoffData,
+  type PitchTypeData,
+  type RunnersSituationSummary,
 } from "../../analysisActions";
 import { AdditionalStatsCard } from "./AdditionalStatsCard";
 import { AnalysisFilters } from "./AnalysisFilters";
+import { BattingTrendChart } from "./BattingTrendChart";
+import {
+  ContactQualityCard,
+  CountSituationCards,
+  OutTypeCard,
+  RunnersSituationCard,
+  TimingCard,
+} from "./DetailCards";
 import { HeadlineStatsCard } from "./HeadlineStatsCard";
 import { HitDirectionTable } from "./HitDirectionTable";
+import { PitcherFaceoffList } from "./PitcherFaceoffList";
+import { PitchTypeCard } from "./PitchTypeCard";
 import { SprayChart } from "./SprayChart";
 
 function buildYears(): string[] {
@@ -42,6 +66,34 @@ export function AnalysisContainer() {
     directions: [],
     home_runs: [],
   });
+  const [contactQuality, setContactQuality] = useState<BreakdownData>({
+    breakdown: [],
+    total: 0,
+  });
+  const [timing, setTiming] = useState<BreakdownData>({
+    breakdown: [],
+    total: 0,
+  });
+  const [outType, setOutType] = useState<BreakdownData>({
+    breakdown: [],
+    total: 0,
+  });
+  const [countSituations, setCountSituations] =
+    useState<CountSituations | null>(null);
+  const [runners, setRunners] = useState<RunnersSituationSummary | null>(null);
+  const [pitchType, setPitchType] = useState<PitchTypeData>({
+    rows: [],
+    total_target_pa: 0,
+  });
+  const [pitcherFaceoffs, setPitcherFaceoffs] = useState<PitcherFaceoffData>({
+    rows: [],
+    total_target_pa: 0,
+    min_plate_appearances: 0,
+  });
+  const [battingTrend, setBattingTrend] = useState<BattingTrendData>({
+    granularity: "game",
+    points: [],
+  });
   const [isLoading, setIsLoading] = useState(true);
   const years = buildYears();
 
@@ -54,14 +106,45 @@ export function AnalysisContainer() {
       getAdditionalStats(filters),
       getHitLocations(filters),
       getHitDirections(filters),
-    ]).then(([headlineData, additionalData, locations, directions]) => {
-      if (!active) return;
-      setHeadline(headlineData);
-      setAdditional(additionalData);
-      setHitLocations(locations);
-      setHitDirections(directions);
-      setIsLoading(false);
-    });
+      getContactQualityStats(filters),
+      getTimingBreakdown(filters),
+      getOutTypeBreakdown(filters),
+      getCountSituations(filters),
+      getRunnersSituation(filters),
+      getPitchTypeStats(filters),
+      getPitcherFaceoffs(filters),
+      getBattingTrend(filters),
+    ]).then(
+      ([
+        headlineData,
+        additionalData,
+        locations,
+        directions,
+        contactQualityData,
+        timingData,
+        outTypeData,
+        countData,
+        runnersData,
+        pitchTypeData,
+        faceoffData,
+        trendData,
+      ]) => {
+        if (!active) return;
+        setHeadline(headlineData);
+        setAdditional(additionalData);
+        setHitLocations(locations);
+        setHitDirections(directions);
+        setContactQuality(contactQualityData);
+        setTiming(timingData);
+        setOutType(outTypeData);
+        setCountSituations(countData);
+        setRunners(runnersData);
+        setPitchType(pitchTypeData);
+        setPitcherFaceoffs(faceoffData);
+        setBattingTrend(trendData);
+        setIsLoading(false);
+      },
+    );
     return () => {
       active = false;
     };
@@ -83,6 +166,34 @@ export function AnalysisContainer() {
             <h3 className="text-sm font-bold">打球方向</h3>
             <HitDirectionTable directions={hitDirections.directions} />
           </section>
+          <CountSituationCards
+            data={
+              countSituations ?? {
+                first_pitch: { at_bats: 0, hits: 0, batting_average: 0 },
+                favorable_count: { at_bats: 0, hits: 0, batting_average: 0 },
+                pinch_count: { at_bats: 0, hits: 0, batting_average: 0 },
+                total_target_pa: 0,
+              }
+            }
+          />
+          <RunnersSituationCard
+            data={
+              runners ?? {
+                batting_average: 0,
+                at_bats: 0,
+                hits: 0,
+                two_base_hit: 0,
+                three_base_hit: 0,
+                home_run: 0,
+              }
+            }
+          />
+          <ContactQualityCard data={contactQuality} />
+          <TimingCard data={timing} />
+          <OutTypeCard data={outType} />
+          <PitchTypeCard data={pitchType} />
+          <PitcherFaceoffList data={pitcherFaceoffs} />
+          <BattingTrendChart data={battingTrend} />
           <AdditionalStatsCard stats={additional} />
         </>
       )}

--- a/app/(app)/stats/_components/analysis/BattingTrendChart.tsx
+++ b/app/(app)/stats/_components/analysis/BattingTrendChart.tsx
@@ -1,0 +1,77 @@
+"use client";
+import type { BattingTrendData } from "../../analysisActions";
+import { formatRate } from "@app/utils/formatStats";
+
+interface BattingTrendChartProps {
+  data: BattingTrendData;
+}
+
+const WIDTH = 320;
+const HEIGHT = 140;
+const PADDING = 24;
+
+/** OPS の推移を折れ線で表示するシンプルな SVG チャート。 */
+export function BattingTrendChart({ data }: BattingTrendChartProps) {
+  const points = data.points;
+  if (points.length === 0) {
+    return (
+      <section className="rounded-xl bg-bg_sub p-4 flex flex-col gap-y-3">
+        <h3 className="text-sm font-bold">打撃推移（OPS）</h3>
+        <p className="text-sm text-zinc-500">対象データがありません。</p>
+      </section>
+    );
+  }
+
+  const values = points.map((point) => point.ops);
+  const maxValue = Math.max(...values, 0.001);
+  const innerWidth = WIDTH - PADDING * 2;
+  const innerHeight = HEIGHT - PADDING * 2;
+  const stepX = points.length > 1 ? innerWidth / (points.length - 1) : 0;
+
+  const coords = points.map((point, index) => {
+    const x = PADDING + stepX * index;
+    const y = PADDING + innerHeight * (1 - point.ops / maxValue);
+    return { x, y };
+  });
+  const polyline = coords.map((coord) => `${coord.x},${coord.y}`).join(" ");
+
+  return (
+    <section className="rounded-xl bg-bg_sub p-4 flex flex-col gap-y-3">
+      <h3 className="text-sm font-bold">打撃推移（OPS）</h3>
+      <svg
+        width={WIDTH}
+        height={HEIGHT}
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        className="max-w-full h-auto"
+      >
+        <line
+          x1={PADDING}
+          y1={HEIGHT - PADDING}
+          x2={WIDTH - PADDING}
+          y2={HEIGHT - PADDING}
+          stroke="rgba(255,255,255,0.2)"
+        />
+        {coords.length > 1 ? (
+          <polyline
+            points={polyline}
+            fill="none"
+            stroke="#d08000"
+            strokeWidth={2}
+          />
+        ) : null}
+        {coords.map((coord, index) => (
+          <circle
+            key={points[index].key}
+            cx={coord.x}
+            cy={coord.y}
+            r={3}
+            fill="#d08000"
+          />
+        ))}
+      </svg>
+      <p className="text-xs text-zinc-400 text-right">
+        最新: {formatRate(points[points.length - 1].ops)}
+      </p>
+    </section>
+  );
+}

--- a/app/(app)/stats/_components/analysis/BreakdownBars.tsx
+++ b/app/(app)/stats/_components/analysis/BreakdownBars.tsx
@@ -1,0 +1,36 @@
+"use client";
+import type { BreakdownCategory } from "../../analysisActions";
+
+interface BreakdownBarsProps {
+  breakdown: BreakdownCategory[];
+}
+
+/** 割合つきの横棒リスト（球質 / タイミング / アウト種別などの内訳表示）。 */
+export function BreakdownBars({ breakdown }: BreakdownBarsProps) {
+  if (breakdown.length === 0) {
+    return <p className="text-sm text-zinc-500">データがありません。</p>;
+  }
+  return (
+    <div className="flex flex-col gap-y-2">
+      {breakdown.map((category) => {
+        const label = category.label ?? category.category ?? "";
+        return (
+          <div key={label} className="flex flex-col gap-y-1">
+            <div className="flex justify-between text-xs">
+              <span>{label}</span>
+              <span className="text-zinc-400">
+                {category.count}件 ({Math.round(category.percentage)}%)
+              </span>
+            </div>
+            <div className="h-2 rounded-full bg-zinc-700 overflow-hidden">
+              <div
+                className="h-full bg-primary"
+                style={{ width: `${Math.min(100, category.percentage)}%` }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(app)/stats/_components/analysis/DetailCards.tsx
+++ b/app/(app)/stats/_components/analysis/DetailCards.tsx
@@ -1,0 +1,110 @@
+"use client";
+import type {
+  BreakdownData,
+  CountSituation,
+  CountSituations,
+  RunnersSituationSummary,
+} from "../../analysisActions";
+import { formatRate } from "@app/utils/formatStats";
+import { BreakdownBars } from "./BreakdownBars";
+
+function Card({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-xl bg-bg_sub p-4 flex flex-col gap-y-3">
+      <h3 className="text-sm font-bold">{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+export function ContactQualityCard({ data }: { data: BreakdownData }) {
+  return (
+    <Card title="打球の質">
+      <BreakdownBars breakdown={data.breakdown} />
+    </Card>
+  );
+}
+
+export function TimingCard({ data }: { data: BreakdownData }) {
+  return (
+    <Card title="タイミング">
+      <BreakdownBars breakdown={data.breakdown} />
+    </Card>
+  );
+}
+
+export function OutTypeCard({ data }: { data: BreakdownData }) {
+  return (
+    <Card title="アウトの内訳">
+      <BreakdownBars breakdown={data.breakdown} />
+    </Card>
+  );
+}
+
+function SituationCell({
+  label,
+  situation,
+}: {
+  label: string;
+  situation: CountSituation;
+}) {
+  return (
+    <div className="flex flex-col items-center rounded-lg bg-zinc-800 py-3">
+      <span className="text-xs text-zinc-400">{label}</span>
+      <span className="text-xl font-bold text-yellow-500">
+        {formatRate(situation.batting_average)}
+      </span>
+      <span className="text-xs text-zinc-400">
+        {situation.hits}/{situation.at_bats}
+      </span>
+    </div>
+  );
+}
+
+export function CountSituationCards({ data }: { data: CountSituations }) {
+  return (
+    <Card title="カウント別打率">
+      {data.total_target_pa === 0 ? (
+        <p className="text-sm text-zinc-500">対象データがありません。</p>
+      ) : (
+        <div className="grid grid-cols-3 gap-2">
+          <SituationCell label="初球" situation={data.first_pitch} />
+          <SituationCell
+            label="有利カウント"
+            situation={data.favorable_count}
+          />
+          <SituationCell label="追い込み" situation={data.pinch_count} />
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export function RunnersSituationCard({
+  data,
+}: {
+  data: RunnersSituationSummary;
+}) {
+  return (
+    <Card title="得点圏">
+      {data.at_bats === 0 ? (
+        <p className="text-sm text-zinc-500">対象データがありません。</p>
+      ) : (
+        <div className="flex items-end gap-x-3">
+          <span className="text-3xl font-bold text-yellow-500">
+            {formatRate(data.batting_average)}
+          </span>
+          <span className="text-sm text-zinc-400">
+            {data.hits}安打 / {data.at_bats}打数（本塁打{data.home_run}）
+          </span>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/app/(app)/stats/_components/analysis/PitchTypeCard.tsx
+++ b/app/(app)/stats/_components/analysis/PitchTypeCard.tsx
@@ -1,0 +1,57 @@
+"use client";
+import type { PitchTypeData } from "../../analysisActions";
+import { formatRate } from "@app/utils/formatStats";
+
+interface PitchTypeCardProps {
+  data: PitchTypeData;
+}
+
+/** 球種別の打撃成績テーブル（打席のある行のみ表示）。 */
+export function PitchTypeCard({ data }: PitchTypeCardProps) {
+  const rows = data.rows.filter((row) => row.plate_appearances > 0);
+  return (
+    <section className="rounded-xl bg-bg_sub p-4 flex flex-col gap-y-3">
+      <h3 className="text-sm font-bold">球種別成績</h3>
+      {rows.length === 0 ? (
+        <p className="text-sm text-zinc-500">対象データがありません。</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-zinc-400">
+                <th className="text-left py-2 pr-3 sticky left-0 bg-bg_sub">
+                  球種
+                </th>
+                <th className="text-right py-2 px-3">打席</th>
+                <th className="text-right py-2 px-3">打数</th>
+                <th className="text-right py-2 px-3">安打</th>
+                <th className="text-right py-2 px-3">打率</th>
+                <th className="text-right py-2 px-3">OPS</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.id} className="border-t border-zinc-700">
+                  <td className="text-left py-2 pr-3 font-medium sticky left-0 bg-bg_sub">
+                    {row.label}
+                  </td>
+                  <td className="text-right py-2 px-3">
+                    {row.plate_appearances}
+                  </td>
+                  <td className="text-right py-2 px-3">{row.at_bats}</td>
+                  <td className="text-right py-2 px-3">{row.hits}</td>
+                  <td className="text-right py-2 px-3">
+                    {formatRate(row.batting_average)}
+                  </td>
+                  <td className="text-right py-2 px-3">
+                    {formatRate(row.ops)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/(app)/stats/_components/analysis/PitcherFaceoffList.tsx
+++ b/app/(app)/stats/_components/analysis/PitcherFaceoffList.tsx
@@ -1,0 +1,52 @@
+"use client";
+import type { PitcherFaceoffData } from "../../analysisActions";
+import { formatRate } from "@app/utils/formatStats";
+
+interface PitcherFaceoffListProps {
+  data: PitcherFaceoffData;
+}
+
+/** 対戦投手別の打撃成績リスト。 */
+export function PitcherFaceoffList({ data }: PitcherFaceoffListProps) {
+  return (
+    <section className="rounded-xl bg-bg_sub p-4 flex flex-col gap-y-3">
+      <h3 className="text-sm font-bold">対戦投手別</h3>
+      {data.rows.length === 0 ? (
+        <p className="text-sm text-zinc-500">
+          対象データがありません（対戦数 {data.min_plate_appearances}{" "}
+          以上の投手が対象）。
+        </p>
+      ) : (
+        <div className="flex flex-col gap-y-2">
+          {data.rows.map((row) => (
+            <div
+              key={row.pitcher_id}
+              className="flex items-center justify-between rounded-lg bg-zinc-800 px-3 py-2"
+            >
+              <div className="flex flex-col">
+                <span className="text-sm font-medium">{row.pitcher_name}</span>
+                <span className="text-xs text-zinc-400">
+                  {row.plate_appearances}打席 / 最多: {row.top_result}
+                </span>
+              </div>
+              <div className="flex gap-x-4 text-right">
+                <div className="flex flex-col">
+                  <span className="text-xs text-zinc-400">打率</span>
+                  <span className="text-sm font-bold">
+                    {formatRate(row.batting_average)}
+                  </span>
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-xs text-zinc-400">OPS</span>
+                  <span className="text-sm font-bold">
+                    {formatRate(row.ops)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/(app)/stats/analysisActions.ts
+++ b/app/(app)/stats/analysisActions.ts
@@ -168,3 +168,203 @@ export async function getHitDirections(
     { directions: [], home_runs: [] },
   );
 }
+
+// ---- 詳細分析（#399） ----
+
+export interface BreakdownCategory {
+  id?: number;
+  category?: string;
+  label?: string;
+  count: number;
+  percentage: number;
+}
+
+export interface BreakdownData {
+  breakdown: BreakdownCategory[];
+  total: number;
+}
+
+export interface CountSituation {
+  at_bats: number;
+  hits: number;
+  batting_average: number;
+}
+
+export interface CountSituations {
+  first_pitch: CountSituation;
+  favorable_count: CountSituation;
+  pinch_count: CountSituation;
+  total_target_pa: number;
+}
+
+export interface RunnersSituationSummary {
+  batting_average: number;
+  at_bats: number;
+  hits: number;
+  two_base_hit: number;
+  three_base_hit: number;
+  home_run: number;
+}
+
+export interface PitchTypeRow {
+  id: number;
+  label: string;
+  plate_appearances: number;
+  at_bats: number;
+  hits: number;
+  total_bases: number;
+  batting_average: number;
+  on_base_percentage: number;
+  slugging_percentage: number;
+  ops: number;
+}
+
+export interface PitchTypeData {
+  rows: PitchTypeRow[];
+  total_target_pa: number;
+}
+
+export interface PitcherFaceoff {
+  pitcher_id: number;
+  pitcher_name: string;
+  plate_appearances: number;
+  at_bats: number;
+  hits: number;
+  batting_average: number;
+  on_base_percentage: number;
+  slugging_percentage: number;
+  ops: number;
+  top_result: string;
+}
+
+export interface PitcherFaceoffData {
+  rows: PitcherFaceoff[];
+  total_target_pa: number;
+  min_plate_appearances: number;
+}
+
+export interface BattingTrendPoint {
+  key: string;
+  label: string;
+  batting_average: number;
+  on_base_percentage: number;
+  slugging_percentage: number;
+  ops: number;
+  at_bats_in_period: number;
+  cumulative_at_bats: number;
+}
+
+export interface BattingTrendData {
+  granularity: string;
+  points: BattingTrendPoint[];
+}
+
+export async function getContactQualityStats(
+  filters: AnalysisFilters = {},
+): Promise<BreakdownData> {
+  return fetchAnalysis<BreakdownData>(
+    "contact_qualities",
+    filters,
+    "getContactQualityStats",
+    { breakdown: [], total: 0 },
+  );
+}
+
+export async function getTimingBreakdown(
+  filters: AnalysisFilters = {},
+): Promise<BreakdownData> {
+  return fetchAnalysis<BreakdownData>(
+    "timing_breakdown",
+    filters,
+    "getTimingBreakdown",
+    { breakdown: [], total: 0 },
+  );
+}
+
+export async function getOutTypeBreakdown(
+  filters: AnalysisFilters = {},
+): Promise<BreakdownData> {
+  return fetchAnalysis<BreakdownData>(
+    "out_type_breakdown",
+    filters,
+    "getOutTypeBreakdown",
+    { breakdown: [], total: 0 },
+  );
+}
+
+export async function getCountSituations(
+  filters: AnalysisFilters = {},
+): Promise<CountSituations> {
+  return fetchAnalysis<CountSituations>(
+    "count_situations",
+    filters,
+    "getCountSituations",
+    {
+      first_pitch: { at_bats: 0, hits: 0, batting_average: 0 },
+      favorable_count: { at_bats: 0, hits: 0, batting_average: 0 },
+      pinch_count: { at_bats: 0, hits: 0, batting_average: 0 },
+      total_target_pa: 0,
+    },
+  );
+}
+
+export async function getRunnersSituation(
+  filters: AnalysisFilters = {},
+): Promise<RunnersSituationSummary> {
+  return fetchAnalysis<RunnersSituationSummary>(
+    "runners_situation",
+    filters,
+    "getRunnersSituation",
+    {
+      batting_average: 0,
+      at_bats: 0,
+      hits: 0,
+      two_base_hit: 0,
+      three_base_hit: 0,
+      home_run: 0,
+    },
+  );
+}
+
+export async function getPitchTypeStats(
+  filters: AnalysisFilters = {},
+): Promise<PitchTypeData> {
+  return fetchAnalysis<PitchTypeData>(
+    "pitch_types",
+    filters,
+    "getPitchTypeStats",
+    { rows: [], total_target_pa: 0 },
+  );
+}
+
+export async function getPitcherFaceoffs(
+  filters: AnalysisFilters = {},
+): Promise<PitcherFaceoffData> {
+  return fetchAnalysis<PitcherFaceoffData>(
+    "pitcher_faceoffs",
+    filters,
+    "getPitcherFaceoffs",
+    { rows: [], total_target_pa: 0, min_plate_appearances: 0 },
+  );
+}
+
+export async function getBattingTrend(
+  filters: AnalysisFilters = {},
+  granularity: string = "game",
+): Promise<BattingTrendData> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return { granularity, points: [] };
+    const params = new URLSearchParams(buildQuery(filters));
+    params.set("granularity", granularity);
+    const response = await fetch(
+      `${RAILS_API_URL}/api/v2/stats/batting_trend?${params.toString()}`,
+      { headers, cache: "no-store" },
+    );
+    if (!response.ok) return { granularity, points: [] };
+    return (await response.json()) as BattingTrendData;
+  } catch (error) {
+    captureServerActionError(error, { action: "getBattingTrend" });
+    return { granularity, points: [] };
+  }
+}


### PR DESCRIPTION
## 概要

mobile [buzzbase_mobile#101](https://github.com/ippei-shimizu/buzzbase_mobile/pull/101) 追従シリーズ ([ippei-shimizu/buzzbase#399](https://github.com/ippei-shimizu/buzzbase/issues/399))。打撃分析の詳細カード群を実装する。**stacked PR**（base = `feature/398-stats-analysis-basics`）。シリーズ最終。

Closes ippei-shimizu/buzzbase#399

## 変更内容
- Server Actions 追加: `contact_qualities` / `timing_breakdown` / `out_type_breakdown` / `count_situations` / `runners_situation` / `pitch_types` / `pitcher_faceoffs` / `batting_trend`。
- カード: 球質・タイミング・アウト内訳（`BreakdownBars`）/ カウント別打率（初球・有利・追い込み）/ 得点圏 / 球種別成績テーブル / 対戦投手別リスト / OPS 推移チャート。
- `AnalysisContainer` に統合し、フィルタ変更でまとめて再取得して基本指標の下に表示。

## スコープ / 制約
- 投手属性別サマリ（pitcher_attribute_summary）は本 PR では未対応（型は将来追加）。
- チャートは軽量 SVG 実装。推移は OPS の折れ線のみ。
- 結合テストは未追加（draft）。

## 確認
- `yarn typecheck`（追加/変更ファイルにエラーなし）、`yarn lint` / `yarn format:check` パス、`yarn test` 全252件パス。
