### PR TITLE
Feature: 分析フィルタにリセットボタンを追加

### DIFF
--- a/app/(app)/stats/_components/analysis/AnalysisFilters.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisFilters.tsx
@@ -52,7 +52,7 @@ export function AnalysisFilters({
     });
 
   return (
-    <FilterChipGroup>
+    <FilterChipGroup wrap>
       <FilterChip
         label="年度"
         value={filters.year ?? "通算"}

--- a/app/(app)/stats/_components/analysis/AnalysisFilters.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisFilters.tsx
@@ -22,6 +22,16 @@ const MATCH_TYPE_OPTIONS: FilterOption[] = [
   { key: "open", label: "オープン戦" },
 ];
 
+/** フィルタが既定値から変化しているか（リセットボタンの表示判定に使う）。 */
+function hasActiveFilter(filters: Filters): boolean {
+  return (
+    (filters.year ?? "通算") !== "通算" ||
+    Boolean(filters.matchType) ||
+    Boolean(filters.seasonId) ||
+    Boolean(filters.tournamentId)
+  );
+}
+
 /** 分析の絞り込み（年度 / 種別 / シーズン / 大会）。共通の FilterChip を使う。 */
 export function AnalysisFilters({
   filters,
@@ -30,6 +40,14 @@ export function AnalysisFilters({
   seasonOptions,
   tournamentOptions,
 }: AnalysisFiltersProps) {
+  const handleReset = () =>
+    onChange({
+      year: "通算",
+      matchType: "",
+      seasonId: undefined,
+      tournamentId: undefined,
+    });
+
   return (
     <FilterChipGroup>
       <FilterChip
@@ -73,6 +91,38 @@ export function AnalysisFilters({
           }
         />
       ) : null}
+      {hasActiveFilter(filters) ? (
+        <button
+          type="button"
+          onClick={handleReset}
+          aria-label="フィルターをクリア"
+          className="flex shrink-0 items-center gap-1 whitespace-nowrap px-2 py-1.5 text-xs font-medium text-[#A1A1AA]"
+        >
+          <RefreshIcon />
+          クリア
+        </button>
+      ) : null}
     </FilterChipGroup>
+  );
+}
+
+function RefreshIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+      <path d="M21 3v5h-5" />
+      <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+      <path d="M3 21v-5h5" />
+    </svg>
   );
 }

--- a/app/components/filter/FilterChipGroup.tsx
+++ b/app/components/filter/FilterChipGroup.tsx
@@ -1,8 +1,18 @@
 interface FilterChipGroupProps {
   children: React.ReactNode;
+  /** はみ出したチップを横スクロールではなく折り返して表示する。 */
+  wrap?: boolean;
 }
 
-export default function FilterChipGroup({ children }: FilterChipGroupProps) {
+export default function FilterChipGroup({
+  children,
+  wrap = false,
+}: FilterChipGroupProps) {
+  if (wrap) {
+    return (
+      <div className="flex flex-wrap gap-2 min-w-0 max-w-full">{children}</div>
+    );
+  }
   return (
     <div className="flex flex-nowrap gap-2 overflow-x-auto min-w-0 max-w-full [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden">
       {children}


### PR DESCRIPTION
## 対応 Issue
ippei-shimizu/buzzbase#412

## 概要
mobile の `FilterResetButton` と同様に、打撃分析のフィルタ（年度/種別/シーズン/大会）にリセットボタンを追加する。

## 変更点
- `AnalysisFilters.tsx` に「クリア」ボタン（refresh アイコン）を追加
- 年度=通算 / 種別=全て / シーズン=全て / 大会=全て 以外が1つでも適用されているときのみ表示
- タップで全フィルタを既定値に戻す

## 確認
- typecheck / lint / format クリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)
