### PR TITLE
Feature: 成績画面の投手タブに防御率推移グラフ(EraTrendChart)を追加

### DIFF
--- a/app/(app)/stats/_components/StatsContainer.tsx
+++ b/app/(app)/stats/_components/StatsContainer.tsx
@@ -5,12 +5,26 @@ import type {
   PitchingStatsRow,
   StatsPeriod,
 } from "../actions";
-import Link from "next/link";
+import type { SeasonData, TournamentData } from "@app/interface";
+import { useEffect, useRef, useState } from "react";
+import FilterChip from "@app/components/filter/FilterChip";
+import FilterChipGroup from "@app/components/filter/FilterChipGroup";
+import { getSeasons } from "@app/services/seasonsService";
+import { getTournaments } from "@app/services/tournamentsService";
+import { getCurrentUserId } from "@app/services/userService";
+import { getBattingStats, getPitchingStats } from "../actions";
 import { AnalysisContainer } from "./analysis/AnalysisContainer";
 import BattingStatsTable from "./BattingStatsTable";
 import PitchingStatsTable from "./PitchingStatsTable";
 
 type ActiveTab = "batting" | "pitching";
+
+interface FilterOption {
+  key: string;
+  label: string;
+}
+
+const DEFAULT_OPTION: FilterOption = { key: "全て", label: "全て" };
 
 const PERIOD_OPTIONS: { value: StatsPeriod; label: string }[] = [
   { value: "yearly", label: "年" },
@@ -18,23 +32,115 @@ const PERIOD_OPTIONS: { value: StatsPeriod; label: string }[] = [
   { value: "daily", label: "日" },
 ];
 
-interface StatsContainerProps {
-  tab: ActiveTab;
-  period: StatsPeriod;
-  rows: BattingStatsRow[] | PitchingStatsRow[];
+function buildYearOptions(): FilterOption[] {
+  const currentYear = new Date().getFullYear();
+  const options: FilterOption[] = [DEFAULT_OPTION];
+  for (let offset = 0; offset < 6; offset += 1) {
+    const year = String(currentYear - offset);
+    options.push({ key: year, label: year });
+  }
+  return options;
 }
 
-export default function StatsContainer({
-  tab,
-  period,
-  rows,
-}: StatsContainerProps) {
+const CURRENT_YEAR = String(new Date().getFullYear());
+
+interface StatsContainerProps {
+  /** SSR で取得した打撃・年別の初期行。マウント時はこれを使い再取得しない。 */
+  initialRows: BattingStatsRow[];
+}
+
+export default function StatsContainer({ initialRows }: StatsContainerProps) {
+  const [tab, setTab] = useState<ActiveTab>("batting");
+  const [period, setPeriod] = useState<StatsPeriod>("yearly");
+  const [tableYear, setTableYear] = useState<string | undefined>(undefined);
+  const [tableSeasonId, setTableSeasonId] = useState<string | undefined>(
+    undefined,
+  );
+  const [tableTournamentId, setTableTournamentId] = useState<
+    string | undefined
+  >(undefined);
+  const [battingRows, setBattingRows] =
+    useState<BattingStatsRow[]>(initialRows);
+  const [pitchingRows, setPitchingRows] = useState<PitchingStatsRow[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [seasonOptions, setSeasonOptions] = useState<FilterOption[]>([
+    DEFAULT_OPTION,
+  ]);
+  const [tournamentOptions, setTournamentOptions] = useState<FilterOption[]>([
+    DEFAULT_OPTION,
+  ]);
+  const [yearOptions] = useState(buildYearOptions);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      const userId = await getCurrentUserId();
+      const [seasons, tournaments] = await Promise.all([
+        getSeasons(userId ?? undefined),
+        getTournaments() as Promise<TournamentData[]>,
+      ]);
+      if (!active) return;
+      setSeasonOptions([
+        DEFAULT_OPTION,
+        ...seasons.map((season: SeasonData) => ({
+          key: String(season.id),
+          label: season.name,
+        })),
+      ]);
+      setTournamentOptions([
+        DEFAULT_OPTION,
+        ...tournaments.map((tournament) => ({
+          key: String(tournament.id),
+          label: tournament.name,
+        })),
+      ]);
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // 初回マウントは SSR の initialRows（打撃/年別）を使うため取得しない。
+  const didInitRef = useRef(false);
+  useEffect(() => {
+    if (!didInitRef.current) {
+      didInitRef.current = true;
+      return;
+    }
+    let active = true;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setIsLoading(true);
+    const fetcher = tab === "batting" ? getBattingStats : getPitchingStats;
+    void fetcher(period, tableYear, tableSeasonId, tableTournamentId).then(
+      (rows) => {
+        if (!active) return;
+        if (tab === "batting") setBattingRows(rows as BattingStatsRow[]);
+        else setPitchingRows(rows as PitchingStatsRow[]);
+        setIsLoading(false);
+      },
+    );
+    return () => {
+      active = false;
+    };
+  }, [tab, period, tableYear, tableSeasonId, tableTournamentId]);
+
+  const handlePeriodChange = (next: StatsPeriod) => {
+    setPeriod(next);
+    // 月/日表示にしたとき年度/シーズン未指定なら今年で絞る（全期間の月別は煩雑なため）。
+    if (next !== "yearly" && !tableYear && !tableSeasonId) {
+      setTableYear(CURRENT_YEAR);
+    }
+  };
+
+  const showTableFilters = period !== "yearly";
+
   return (
     <div>
       {/* タブバー */}
       <div className="flex" style={{ borderBottom: "1px solid #424242" }}>
-        <Link
-          href={`/stats?tab=batting&period=${period}`}
+        <button
+          type="button"
+          onClick={() => setTab("batting")}
           className="flex-1 py-3 text-center text-sm font-semibold"
           style={{
             borderBottom:
@@ -43,9 +149,10 @@ export default function StatsContainer({
           }}
         >
           打撃
-        </Link>
-        <Link
-          href={`/stats?tab=pitching&period=${period}`}
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab("pitching")}
           className="flex-1 py-3 text-center text-sm font-semibold"
           style={{
             borderBottom:
@@ -56,7 +163,7 @@ export default function StatsContainer({
           }}
         >
           投球
-        </Link>
+        </button>
       </div>
 
       {/* 打撃タブのみ: 打球チャート・打席分析をテーブルの上に表示 */}
@@ -76,9 +183,10 @@ export default function StatsContainer({
           style={{ backgroundColor: "#3A3A3A" }}
         >
           {PERIOD_OPTIONS.map((opt) => (
-            <Link
+            <button
               key={opt.value}
-              href={`/stats?tab=${tab}&period=${opt.value}`}
+              type="button"
+              onClick={() => handlePeriodChange(opt.value)}
               className="px-3 py-1 rounded-md text-xs font-semibold transition-colors"
               style={{
                 backgroundColor:
@@ -87,17 +195,56 @@ export default function StatsContainer({
               }}
             >
               {opt.label}
-            </Link>
+            </button>
           ))}
         </div>
       </div>
 
-      {/* テーブル */}
-      {tab === "batting" ? (
-        <BattingStatsTable rows={rows as BattingStatsRow[]} />
-      ) : (
-        <PitchingStatsTable rows={rows as PitchingStatsRow[]} />
-      )}
+      {/* テーブル専用フィルタ（年/月以外＝年度/シーズン/大会で絞る） */}
+      {showTableFilters ? (
+        <div className="mb-3 flex justify-end">
+          <FilterChipGroup>
+            <FilterChip
+              label="年度"
+              value={tableYear ?? "全て"}
+              defaultValue="全て"
+              options={yearOptions}
+              onChange={(key) => setTableYear(key === "全て" ? undefined : key)}
+            />
+            {seasonOptions.length > 1 ? (
+              <FilterChip
+                label="シーズン"
+                value={tableSeasonId ?? "全て"}
+                defaultValue="全て"
+                options={seasonOptions}
+                onChange={(key) =>
+                  setTableSeasonId(key === "全て" ? undefined : key)
+                }
+              />
+            ) : null}
+            {tournamentOptions.length > 1 ? (
+              <FilterChip
+                label="大会"
+                value={tableTournamentId ?? "全て"}
+                defaultValue="全て"
+                options={tournamentOptions}
+                onChange={(key) =>
+                  setTableTournamentId(key === "全て" ? undefined : key)
+                }
+              />
+            ) : null}
+          </FilterChipGroup>
+        </div>
+      ) : null}
+
+      {/* テーブル（取得中は薄く表示する） */}
+      <div className={isLoading ? "opacity-50 transition-opacity" : undefined}>
+        {tab === "batting" ? (
+          <BattingStatsTable rows={battingRows} />
+        ) : (
+          <PitchingStatsTable rows={pitchingRows} />
+        )}
+      </div>
       {/* フッターナビとの余白 */}
       <div className="h-24 lg:h-0" />
     </div>

--- a/app/(app)/stats/_components/StatsContainer.tsx
+++ b/app/(app)/stats/_components/StatsContainer.tsx
@@ -14,6 +14,7 @@ import { getTournaments } from "@app/services/tournamentsService";
 import { getCurrentUserId } from "@app/services/userService";
 import { getBattingStats, getPitchingStats } from "../actions";
 import { AnalysisContainer } from "./analysis/AnalysisContainer";
+import { PitchingAnalysisContainer } from "./analysis/PitchingAnalysisContainer";
 import BattingStatsTable from "./BattingStatsTable";
 import PitchingStatsTable from "./PitchingStatsTable";
 
@@ -166,10 +167,17 @@ export default function StatsContainer({ initialRows }: StatsContainerProps) {
         </button>
       </div>
 
-      {/* 打撃タブのみ: 打球チャート・打席分析をテーブルの上に表示 */}
+      {/* 打撃タブ: 打球チャート・打席分析をテーブルの上に表示 */}
       {tab === "batting" ? (
         <div className="mt-5">
           <AnalysisContainer />
+        </div>
+      ) : null}
+
+      {/* 投手タブ: 防御率推移をテーブルの上に表示 */}
+      {tab === "pitching" ? (
+        <div className="mt-5">
+          <PitchingAnalysisContainer />
         </div>
       ) : null}
 

--- a/app/(app)/stats/_components/analysis/AnalysisFilters.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisFilters.tsx
@@ -14,6 +14,8 @@ interface AnalysisFiltersProps {
   yearOptions: FilterOption[];
   seasonOptions: FilterOption[];
   tournamentOptions: FilterOption[];
+  /** 種別フィルタを隠す（絞り込みに種別を使わない投手タブ向け）。 */
+  hideMatchType?: boolean;
 }
 
 const MATCH_TYPE_OPTIONS: FilterOption[] = [
@@ -29,6 +31,7 @@ export function AnalysisFilters({
   yearOptions,
   seasonOptions,
   tournamentOptions,
+  hideMatchType = false,
 }: AnalysisFiltersProps) {
   return (
     <FilterChipGroup>
@@ -39,15 +42,17 @@ export function AnalysisFilters({
         options={yearOptions}
         onChange={(key) => onChange({ ...filters, year: key })}
       />
-      <FilterChip
-        label="種別"
-        value={filters.matchType ? filters.matchType : "全て"}
-        defaultValue="全て"
-        options={MATCH_TYPE_OPTIONS}
-        onChange={(key) =>
-          onChange({ ...filters, matchType: key === "全て" ? "" : key })
-        }
-      />
+      {hideMatchType ? null : (
+        <FilterChip
+          label="種別"
+          value={filters.matchType ? filters.matchType : "全て"}
+          defaultValue="全て"
+          options={MATCH_TYPE_OPTIONS}
+          onChange={(key) =>
+            onChange({ ...filters, matchType: key === "全て" ? "" : key })
+          }
+        />
+      )}
       {seasonOptions.length > 1 ? (
         <FilterChip
           label="シーズン"

--- a/app/(app)/stats/_components/analysis/EraTrendChart.tsx
+++ b/app/(app)/stats/_components/analysis/EraTrendChart.tsx
@@ -1,0 +1,138 @@
+"use client";
+import type { EraTrendPoint } from "../../analysisActions";
+import { Fragment } from "react";
+
+interface EraTrendChartProps {
+  data: EraTrendPoint[];
+}
+
+const CHART_WIDTH = 300;
+const CHART_HEIGHT = 140;
+const PADDING_LEFT = 36;
+const PADDING_RIGHT = 16;
+const PADDING_TOP = 16;
+const PADDING_BOTTOM = 24;
+const PLOT_WIDTH = CHART_WIDTH - PADDING_LEFT - PADDING_RIGHT;
+const PLOT_HEIGHT = CHART_HEIGHT - PADDING_TOP - PADDING_BOTTOM;
+
+/** 防御率推移の折れ線グラフ（月別 ERA をエリア塗りつぶし付きで描画）。 */
+export function EraTrendChart({ data }: EraTrendChartProps) {
+  if (data.length === 0) return null;
+
+  const maxEra = Math.max(...data.map((point) => point.era), 1);
+  const eraRange = maxEra || 1;
+  const yTicks = [0, Math.round((maxEra / 2) * 10) / 10, Math.ceil(maxEra)];
+
+  const getX = (index: number) =>
+    PADDING_LEFT +
+    (data.length === 1
+      ? PLOT_WIDTH / 2
+      : (index / (data.length - 1)) * PLOT_WIDTH);
+  const getY = (era: number) =>
+    PADDING_TOP + PLOT_HEIGHT - (era / eraRange) * PLOT_HEIGHT;
+
+  const linePath = data
+    .map(
+      (point, index) =>
+        `${index === 0 ? "M" : "L"} ${getX(index)},${getY(point.era)}`,
+    )
+    .join(" ");
+  const areaPath = `${linePath} L ${getX(data.length - 1)},${PADDING_TOP + PLOT_HEIGHT} L ${getX(0)},${PADDING_TOP + PLOT_HEIGHT} Z`;
+
+  return (
+    <section className="rounded-xl bg-[#3A3A3A] p-4">
+      <h3 className="mb-3 text-base font-bold text-[#F4F4F4]">防御率推移</h3>
+      <div className="flex justify-center">
+        <svg
+          width="100%"
+          viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+          className="max-w-[400px]"
+        >
+          <defs>
+            <linearGradient id="eraAreaGrad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#006fee" stopOpacity={0.3} />
+              <stop offset="100%" stopColor="#006fee" stopOpacity={0.02} />
+            </linearGradient>
+          </defs>
+
+          {yTicks.map((tick) => (
+            <Fragment key={`y-${tick}`}>
+              <line
+                x1={PADDING_LEFT}
+                y1={getY(tick)}
+                x2={CHART_WIDTH - PADDING_RIGHT}
+                y2={getY(tick)}
+                stroke="#424242"
+                strokeWidth={0.5}
+              />
+              <text
+                x={PADDING_LEFT - 6}
+                y={getY(tick) + 3}
+                textAnchor="end"
+                fill="#71717A"
+                fontSize={10}
+              >
+                {tick.toFixed(1)}
+              </text>
+            </Fragment>
+          ))}
+
+          <path d={areaPath} fill="url(#eraAreaGrad)" />
+
+          <path
+            d={linePath}
+            fill="none"
+            stroke="#006fee"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+
+          {data.map((point, index) => (
+            <Fragment key={`pt-${point.month}`}>
+              <circle
+                cx={getX(index)}
+                cy={getY(point.era)}
+                r={4}
+                fill="#006fee"
+              />
+              <circle
+                cx={getX(index)}
+                cy={getY(point.era)}
+                r={2}
+                fill="#F4F4F4"
+              />
+            </Fragment>
+          ))}
+
+          {data.map((point, index) => (
+            <text
+              key={`xl-${point.month}`}
+              x={getX(index)}
+              y={CHART_HEIGHT - 4}
+              textAnchor="middle"
+              fill="#A1A1AA"
+              fontSize={10}
+            >
+              {point.month}月
+            </text>
+          ))}
+
+          {data.map((point, index) => (
+            <text
+              key={`val-${point.month}`}
+              x={getX(index)}
+              y={getY(point.era) - 10}
+              textAnchor="middle"
+              fill="#F4F4F4"
+              fontSize={9}
+              fontWeight={600}
+            >
+              {point.era.toFixed(2)}
+            </text>
+          ))}
+        </svg>
+      </div>
+    </section>
+  );
+}

--- a/app/(app)/stats/_components/analysis/EraTrendChart.tsx
+++ b/app/(app)/stats/_components/analysis/EraTrendChart.tsx
@@ -17,27 +17,32 @@ const PLOT_HEIGHT = CHART_HEIGHT - PADDING_TOP - PADDING_BOTTOM;
 
 /** 防御率推移の折れ線グラフ（月別 ERA をエリア塗りつぶし付きで描画）。 */
 export function EraTrendChart({ data }: EraTrendChartProps) {
-  if (data.length === 0) return null;
+  // 投球が無い月などで era が null/Infinity でも安全に描けるよう有限値だけ残し、
+  // 月昇順に並べる（API のソート順に依存しない）。
+  const points = data
+    .filter((point) => Number.isFinite(point.era))
+    .sort((a, b) => a.month - b.month);
+  if (points.length === 0) return null;
 
-  const maxEra = Math.max(...data.map((point) => point.era), 1);
-  const eraRange = maxEra || 1;
+  // Math.max(..., 1) で maxEra は常に 1 以上になる。
+  const maxEra = Math.max(...points.map((point) => point.era), 1);
   const yTicks = [0, Math.round((maxEra / 2) * 10) / 10, Math.ceil(maxEra)];
 
   const getX = (index: number) =>
     PADDING_LEFT +
-    (data.length === 1
+    (points.length === 1
       ? PLOT_WIDTH / 2
-      : (index / (data.length - 1)) * PLOT_WIDTH);
+      : (index / (points.length - 1)) * PLOT_WIDTH);
   const getY = (era: number) =>
-    PADDING_TOP + PLOT_HEIGHT - (era / eraRange) * PLOT_HEIGHT;
+    PADDING_TOP + PLOT_HEIGHT - (era / maxEra) * PLOT_HEIGHT;
 
-  const linePath = data
+  const linePath = points
     .map(
       (point, index) =>
         `${index === 0 ? "M" : "L"} ${getX(index)},${getY(point.era)}`,
     )
     .join(" ");
-  const areaPath = `${linePath} L ${getX(data.length - 1)},${PADDING_TOP + PLOT_HEIGHT} L ${getX(0)},${PADDING_TOP + PLOT_HEIGHT} Z`;
+  const areaPath = `${linePath} L ${getX(points.length - 1)},${PADDING_TOP + PLOT_HEIGHT} L ${getX(0)},${PADDING_TOP + PLOT_HEIGHT} Z`;
 
   return (
     <section className="rounded-xl bg-[#3A3A3A] p-4">
@@ -88,7 +93,7 @@ export function EraTrendChart({ data }: EraTrendChartProps) {
             strokeLinejoin="round"
           />
 
-          {data.map((point, index) => (
+          {points.map((point, index) => (
             <Fragment key={`pt-${point.month}`}>
               <circle
                 cx={getX(index)}
@@ -105,7 +110,7 @@ export function EraTrendChart({ data }: EraTrendChartProps) {
             </Fragment>
           ))}
 
-          {data.map((point, index) => (
+          {points.map((point, index) => (
             <text
               key={`xl-${point.month}`}
               x={getX(index)}
@@ -118,11 +123,12 @@ export function EraTrendChart({ data }: EraTrendChartProps) {
             </text>
           ))}
 
-          {data.map((point, index) => (
+          {points.map((point, index) => (
             <text
               key={`val-${point.month}`}
               x={getX(index)}
-              y={getY(point.era) - 10}
+              // 最大値の点では getY が上端付近になりラベルが見切れるため下限を設ける。
+              y={Math.max(getY(point.era) - 10, PADDING_TOP + 9)}
               textAnchor="middle"
               fill="#F4F4F4"
               fontSize={9}

--- a/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
@@ -96,6 +96,7 @@ export function PitchingAnalysisContainer() {
         yearOptions={yearOptions}
         seasonOptions={seasonOptions}
         tournamentOptions={tournamentOptions}
+        hideMatchType
       />
       <EraTrendChart data={eraTrend} />
     </div>

--- a/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
@@ -1,0 +1,103 @@
+"use client";
+import type { SeasonData, TournamentData } from "@app/interface";
+import { useEffect, useState } from "react";
+import { getSeasons } from "@app/services/seasonsService";
+import { getTournaments } from "@app/services/tournamentsService";
+import { getCurrentUserId } from "@app/services/userService";
+import {
+  type AnalysisFilters as Filters,
+  type EraTrendPoint,
+  getEraTrend,
+} from "../../analysisActions";
+import { AnalysisFilters } from "./AnalysisFilters";
+import { EraTrendChart } from "./EraTrendChart";
+
+interface FilterOption {
+  key: string;
+  label: string;
+}
+
+const DEFAULT_OPTION: FilterOption = { key: "全て", label: "全て" };
+
+function buildYearOptions(): FilterOption[] {
+  const currentYear = new Date().getFullYear();
+  const options: FilterOption[] = [{ key: "通算", label: "通算" }];
+  for (let offset = 0; offset < 6; offset += 1) {
+    const year = String(currentYear - offset);
+    options.push({ key: year, label: year });
+  }
+  return options;
+}
+
+/** 投手タブの分析（フィルタ + 防御率推移グラフ）コンテナ。 */
+export function PitchingAnalysisContainer() {
+  const [filters, setFilters] = useState<Filters>({
+    year: "通算",
+    matchType: "",
+  });
+  const [eraTrend, setEraTrend] = useState<EraTrendPoint[]>([]);
+  const [seasonOptions, setSeasonOptions] = useState<FilterOption[]>([
+    DEFAULT_OPTION,
+  ]);
+  const [tournamentOptions, setTournamentOptions] = useState<FilterOption[]>([
+    DEFAULT_OPTION,
+  ]);
+  const [yearOptions] = useState(buildYearOptions);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      const userId = await getCurrentUserId();
+      const [seasons, tournaments] = await Promise.all([
+        getSeasons(userId ?? undefined),
+        getTournaments() as Promise<TournamentData[]>,
+      ]);
+      if (!active) return;
+      setSeasonOptions([
+        DEFAULT_OPTION,
+        ...seasons.map((season: SeasonData) => ({
+          key: String(season.id),
+          label: season.name,
+        })),
+      ]);
+      setTournamentOptions([
+        DEFAULT_OPTION,
+        ...tournaments.map((tournament) => ({
+          key: String(tournament.id),
+          label: tournament.name,
+        })),
+      ]);
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    // 防御率推移は year/season/tournament のみで絞る（種別は対象外）。
+    void getEraTrend({
+      year: filters.year,
+      seasonId: filters.seasonId,
+      tournamentId: filters.tournamentId,
+    }).then((trend) => {
+      if (active) setEraTrend(trend);
+    });
+    return () => {
+      active = false;
+    };
+  }, [filters.year, filters.seasonId, filters.tournamentId]);
+
+  return (
+    <div className="flex flex-col gap-y-5">
+      <AnalysisFilters
+        filters={filters}
+        onChange={setFilters}
+        yearOptions={yearOptions}
+        seasonOptions={seasonOptions}
+        tournamentOptions={tournamentOptions}
+      />
+      <EraTrendChart data={eraTrend} />
+    </div>
+  );
+}

--- a/app/(app)/stats/analysisActions.ts
+++ b/app/(app)/stats/analysisActions.ts
@@ -411,10 +411,12 @@ export async function getPitcherAttributeSummary(
 export async function getEraTrend(
   filters: AnalysisFilters = {},
 ): Promise<EraTrendPoint[]> {
-  // era_trend は year/season/tournament のみで絞る（match_type は送らない）。
+  // era_trend は year/season/tournament のみで絞る。match_type は構造的に除外し、
+  // 誤って matchType 付きで呼ばれても送信されないことを関数自身で保証する。
+  const { matchType: _matchType, ...eraFilters } = filters;
   const result = await fetchAnalysis<{ trend: EraTrendPoint[] }>(
     "era_trend",
-    filters,
+    eraFilters,
     "getEraTrend",
     { trend: [] },
   );

--- a/app/(app)/stats/analysisActions.ts
+++ b/app/(app)/stats/analysisActions.ts
@@ -93,6 +93,11 @@ export interface PlateAppearanceCategory {
   percentage: number;
 }
 
+export interface EraTrendPoint {
+  month: number;
+  era: number;
+}
+
 export interface ContactQualityCategory {
   id: number;
   label: string;
@@ -401,6 +406,19 @@ export async function getPitcherAttributeSummary(
       by_pitcher_style: [],
     },
   );
+}
+
+export async function getEraTrend(
+  filters: AnalysisFilters = {},
+): Promise<EraTrendPoint[]> {
+  // era_trend は year/season/tournament のみで絞る（match_type は送らない）。
+  const result = await fetchAnalysis<{ trend: EraTrendPoint[] }>(
+    "era_trend",
+    filters,
+    "getEraTrend",
+    { trend: [] },
+  );
+  return result.trend ?? [];
 }
 
 export async function getPlateAppearanceBreakdown(

--- a/app/(app)/stats/page.tsx
+++ b/app/(app)/stats/page.tsx
@@ -1,12 +1,7 @@
-import type { StatsPeriod } from "./actions";
 import AuthRequiredOverlay from "@app/components/auth/AuthRequiredOverlay";
 import Header from "@app/components/header/Header";
 import StatsContainer from "./_components/StatsContainer";
-import {
-  getBattingStats,
-  getIsAuthenticated,
-  getPitchingStats,
-} from "./actions";
+import { getBattingStats, getIsAuthenticated } from "./actions";
 
 export const metadata = {
   title: "成績 | BUZZ BASE",
@@ -14,13 +9,7 @@ export const metadata = {
   robots: { index: false },
 };
 
-type ActiveTab = "batting" | "pitching";
-
-export default async function StatsPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ tab?: string; period?: string }>;
-}) {
+export default async function StatsPage() {
   const isAuthenticated = await getIsAuthenticated();
 
   if (!isAuthenticated) {
@@ -36,19 +25,9 @@ export default async function StatsPage({
     );
   }
 
-  const params = await searchParams;
-  const tab: ActiveTab = params.tab === "pitching" ? "pitching" : "batting";
-  const period: StatsPeriod =
-    params.period === "monthly"
-      ? "monthly"
-      : params.period === "daily"
-        ? "daily"
-        : "yearly";
-
-  const rows =
-    tab === "batting"
-      ? await getBattingStats(period)
-      : await getPitchingStats(period);
+  // タブ/期間/フィルタの切替はクライアント側 state で行うため、ここでは
+  // デフォルト（打撃・年別）の初期データのみ SSR で取得して渡す。
+  const initialRows = await getBattingStats("yearly");
 
   return (
     <>
@@ -56,7 +35,7 @@ export default async function StatsPage({
       <main className="buzz-dark min-h-full max-w-[720px] mx-auto w-full lg:m-[0_auto_0_28%]">
         <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
           <div className="pt-12 px-4 lg:px-6 lg:pb-6">
-            <StatsContainer tab={tab} period={period} rows={rows} />
+            <StatsContainer initialRows={initialRows} />
           </div>
         </div>
       </main>


### PR DESCRIPTION
## 対応 Issue
ippei-shimizu/buzzbase#410

## 概要
成績画面の**投手タブ**に、mobile と同様の**防御率推移グラフ(EraTrendChart)**を追加する。

## 変更点
- `EraTrendChart.tsx`（新規）: mobile を DOM SVG で移植。月別 ERA をエリア塗りつぶし付き折れ線で描画（青 #006fee、点・月ラベル・値ラベル付き）。
- `PitchingAnalysisContainer.tsx`（新規）: 投手タブ用のフィルタ(年度/種別/シーズン/大会)＋防御率推移。`/api/v2/stats/era_trend` を取得し、year/season/tournament のみで絞る（種別は対象外＝mobile 準拠）。
- `analysisActions.ts`: `getEraTrend` と `EraTrendPoint` 型を追加。
- `StatsContainer.tsx`: 投手タブのテーブル上部に `PitchingAnalysisContainer` を配置。

## 確認
- typecheck / lint / format / test(252) クリア

## 注意（スタックPR）
本ブランチは #411（`feature/411-stats-table-filters`）の上に積んでいます。**#411 を先にマージ**してください。マージ後、本PRの差分は release との比較で EraTrendChart 分のみになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
