### PR TITLE
Update: 打撃成績画面の分析ローディングをセクション内表示にする

### DIFF
--- a/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
@@ -262,7 +262,7 @@ export function AnalysisContainer() {
       />
       {isLoading ? (
         <div className="flex justify-center py-16">
-          <Spinner color="primary" label="読み込み中..." />
+          <Spinner color="primary" labelColor="primary" label="Loading" />
         </div>
       ) : (
         <>

--- a/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 import type { SeasonData, TournamentData } from "@app/interface";
+import { Spinner } from "@heroui/react";
 import { useEffect, useState } from "react";
-import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import { getSeasons } from "@app/services/seasonsService";
 import { getTournaments } from "@app/services/tournamentsService";
 import { getCurrentUserId } from "@app/services/userService";
@@ -261,7 +261,9 @@ export function AnalysisContainer() {
         tournamentOptions={tournamentOptions}
       />
       {isLoading ? (
-        <LoadingSpinner />
+        <div className="flex justify-center py-16">
+          <Spinner color="primary" label="読み込み中..." />
+        </div>
       ) : (
         <>
           <HeadlineStatsCard stats={headline} />


### PR DESCRIPTION
## 対応 Issue
ippei-shimizu/buzzbase#413

## 概要
打撃成績画面に遷移したとき、分析データの取得中に画面全体がローディング表示になりタブ・成績テーブルが隠れる問題を解消する。

## 原因
`AnalysisContainer` がマウント時の分析データ取得中に共通 `LoadingSpinner` を表示していたが、この `LoadingSpinner` は `fixed` で画面全体を覆うオーバーレイのため、タブ・テーブルまで覆われていた。

## 変更点
- `AnalysisContainer.tsx`: 全画面オーバーレイの `LoadingSpinner` を、分析エリア内に収まるインラインの HeroUI `Spinner`（`flex justify-center py-16`）に置き換え。
- ローディング中もタブ・期間トグル・成績テーブル・フィルタは常に表示される。

## 確認
- typecheck / lint / format / test(252) クリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)
