### PR TITLE
Perf: 成績画面のシーズン/大会一覧の重複取得を解消

### DIFF
--- a/app/(app)/stats/_components/StatsContainer.tsx
+++ b/app/(app)/stats/_components/StatsContainer.tsx
@@ -5,23 +5,15 @@ import type {
   PitchingStatsRow,
   StatsPeriod,
 } from "../actions";
-import type { SeasonData, TournamentData } from "@app/interface";
+import type { FilterOption } from "../filterOptions";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import FilterChip from "@app/components/filter/FilterChip";
 import FilterChipGroup from "@app/components/filter/FilterChipGroup";
-import { getSeasons } from "@app/services/seasonsService";
-import { getTournaments } from "@app/services/tournamentsService";
-import { getCurrentUserId } from "@app/services/userService";
 import { getBattingStats, getPitchingStats } from "../actions";
 import BattingStatsTable from "./BattingStatsTable";
 import PitchingStatsTable from "./PitchingStatsTable";
 
 type ActiveTab = "batting" | "pitching";
-
-interface FilterOption {
-  key: string;
-  label: string;
-}
 
 const DEFAULT_OPTION: FilterOption = { key: "全て", label: "全て" };
 
@@ -50,12 +42,17 @@ interface StatsContainerProps {
   analysisSlot: ReactNode;
   /** 投手タブの分析セクション（同上）。 */
   pitchingAnalysisSlot: ReactNode;
+  /** サーバーで取得したシーズン/大会のフィルタ選択肢。 */
+  seasonOptions: FilterOption[];
+  tournamentOptions: FilterOption[];
 }
 
 export default function StatsContainer({
   initialRows,
   analysisSlot,
   pitchingAnalysisSlot,
+  seasonOptions,
+  tournamentOptions,
 }: StatsContainerProps) {
   const [tab, setTab] = useState<ActiveTab>("batting");
   const [period, setPeriod] = useState<StatsPeriod>("yearly");
@@ -70,42 +67,7 @@ export default function StatsContainer({
     useState<BattingStatsRow[]>(initialRows);
   const [pitchingRows, setPitchingRows] = useState<PitchingStatsRow[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [seasonOptions, setSeasonOptions] = useState<FilterOption[]>([
-    DEFAULT_OPTION,
-  ]);
-  const [tournamentOptions, setTournamentOptions] = useState<FilterOption[]>([
-    DEFAULT_OPTION,
-  ]);
   const [yearOptions] = useState(buildYearOptions);
-
-  useEffect(() => {
-    let active = true;
-    void (async () => {
-      const userId = await getCurrentUserId();
-      const [seasons, tournaments] = await Promise.all([
-        getSeasons(userId ?? undefined),
-        getTournaments() as Promise<TournamentData[]>,
-      ]);
-      if (!active) return;
-      setSeasonOptions([
-        DEFAULT_OPTION,
-        ...seasons.map((season: SeasonData) => ({
-          key: String(season.id),
-          label: season.name,
-        })),
-      ]);
-      setTournamentOptions([
-        DEFAULT_OPTION,
-        ...tournaments.map((tournament) => ({
-          key: String(tournament.id),
-          label: tournament.name,
-        })),
-      ]);
-    })();
-    return () => {
-      active = false;
-    };
-  }, []);
 
   // 初回マウントは SSR の initialRows（打撃/年別）を使うため取得しない。
   const didInitRef = useRef(false);

--- a/app/(app)/stats/_components/StatsContainer.tsx
+++ b/app/(app)/stats/_components/StatsContainer.tsx
@@ -5,17 +5,15 @@ import type {
   PitchingStatsRow,
   StatsPeriod,
 } from "../actions";
-import type { FilterOption } from "../filterOptions";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import FilterChip from "@app/components/filter/FilterChip";
 import FilterChipGroup from "@app/components/filter/FilterChipGroup";
 import { getBattingStats, getPitchingStats } from "../actions";
+import { DEFAULT_OPTION, type FilterOption } from "../statsFilterOption";
 import BattingStatsTable from "./BattingStatsTable";
 import PitchingStatsTable from "./PitchingStatsTable";
 
 type ActiveTab = "batting" | "pitching";
-
-const DEFAULT_OPTION: FilterOption = { key: "全て", label: "全て" };
 
 const PERIOD_OPTIONS: { value: StatsPeriod; label: string }[] = [
   { value: "yearly", label: "年" },

--- a/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
@@ -1,5 +1,5 @@
 "use client";
-import type { FilterOption } from "../../filterOptions";
+import type { FilterOption } from "../../statsFilterOption";
 import { useEffect, useRef, useState, useTransition } from "react";
 import {
   type AnalysisFilters as Filters,

--- a/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
@@ -1,9 +1,6 @@
 "use client";
-import type { SeasonData, TournamentData } from "@app/interface";
+import type { FilterOption } from "../../filterOptions";
 import { useEffect, useRef, useState, useTransition } from "react";
-import { getSeasons } from "@app/services/seasonsService";
-import { getTournaments } from "@app/services/tournamentsService";
-import { getCurrentUserId } from "@app/services/userService";
 import {
   type AnalysisFilters as Filters,
   type AnalysisInitialData,
@@ -47,13 +44,6 @@ import { RunnersSituationCard } from "./RunnersSituationCard";
 import { SprayChart, type SprayChartMode } from "./SprayChart";
 import { TimingCard } from "./TimingCard";
 
-interface FilterOption {
-  key: string;
-  label: string;
-}
-
-const DEFAULT_OPTION: FilterOption = { key: "全て", label: "全て" };
-
 // Pro プラン機能のリリース前は coming soon 表示にする（mobile と同じ運用）。
 const PRO_FEATURES_COMING_SOON: boolean = true;
 
@@ -70,10 +60,17 @@ function buildYearOptions(): FilterOption[] {
 interface AnalysisContainerProps {
   /** SSR で取得した初期表示データ。マウント時はこれを使い再取得しない。 */
   initialData: AnalysisInitialData;
+  /** サーバーで取得したシーズン/大会のフィルタ選択肢。 */
+  seasonOptions: FilterOption[];
+  tournamentOptions: FilterOption[];
 }
 
 /** 打撃成績分析（基本指標 + 打球チャート + 打球方向）のコンテナ。 */
-export function AnalysisContainer({ initialData }: AnalysisContainerProps) {
+export function AnalysisContainer({
+  initialData,
+  seasonOptions,
+  tournamentOptions,
+}: AnalysisContainerProps) {
   const [filters, setFilters] = useState<Filters>({
     year: "通算",
     matchType: "",
@@ -120,42 +117,7 @@ export function AnalysisContainer({ initialData }: AnalysisContainerProps) {
   const [isRefetching, startRefetch] = useTransition();
   // 推移グラフは粒度切替で単独再取得もあるため、専用の pending でグラフだけ dim する。
   const [isTrendPending, startTrendTransition] = useTransition();
-  const [seasonOptions, setSeasonOptions] = useState<FilterOption[]>([
-    DEFAULT_OPTION,
-  ]);
-  const [tournamentOptions, setTournamentOptions] = useState<FilterOption[]>([
-    DEFAULT_OPTION,
-  ]);
   const [yearOptions] = useState(buildYearOptions);
-
-  useEffect(() => {
-    let active = true;
-    void (async () => {
-      const userId = await getCurrentUserId();
-      const [seasons, tournaments] = await Promise.all([
-        getSeasons(userId ?? undefined),
-        getTournaments() as Promise<TournamentData[]>,
-      ]);
-      if (!active) return;
-      setSeasonOptions([
-        DEFAULT_OPTION,
-        ...seasons.map((season: SeasonData) => ({
-          key: String(season.id),
-          label: season.name,
-        })),
-      ]);
-      setTournamentOptions([
-        DEFAULT_OPTION,
-        ...tournaments.map((tournament) => ({
-          key: String(tournament.id),
-          label: tournament.name,
-        })),
-      ]);
-    })();
-    return () => {
-      active = false;
-    };
-  }, []);
 
   // 初回は SSR の initialData を使うため再取得しない（フィルタ変更時のみ取得）。
   const didInitRef = useRef(false);

--- a/app/(app)/stats/_components/analysis/AnalysisSection.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisSection.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { getInitialAnalysisData } from "../../analysisActions";
+import { getStatsFilterOptions } from "../../filterOptions";
 import { AnalysisContainer } from "./AnalysisContainer";
 import { AnalysisLoading } from "./AnalysisLoading";
 
@@ -18,6 +19,15 @@ export function AnalysisSection() {
 }
 
 async function AnalysisDataProvider() {
-  const initialData = await getInitialAnalysisData();
-  return <AnalysisContainer initialData={initialData} />;
+  const [initialData, filterOptions] = await Promise.all([
+    getInitialAnalysisData(),
+    getStatsFilterOptions(),
+  ]);
+  return (
+    <AnalysisContainer
+      initialData={initialData}
+      seasonOptions={filterOptions.seasonOptions}
+      tournamentOptions={filterOptions.tournamentOptions}
+    />
+  );
 }

--- a/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
@@ -1,9 +1,6 @@
 "use client";
-import type { SeasonData, TournamentData } from "@app/interface";
+import type { FilterOption } from "../../filterOptions";
 import { useEffect, useRef, useState, useTransition } from "react";
-import { getSeasons } from "@app/services/seasonsService";
-import { getTournaments } from "@app/services/tournamentsService";
-import { getCurrentUserId } from "@app/services/userService";
 import {
   type AnalysisFilters as Filters,
   type EraTrendPoint,
@@ -11,13 +8,6 @@ import {
 } from "../../analysisActions";
 import { AnalysisFilters } from "./AnalysisFilters";
 import { EraTrendChart } from "./EraTrendChart";
-
-interface FilterOption {
-  key: string;
-  label: string;
-}
-
-const DEFAULT_OPTION: FilterOption = { key: "全て", label: "全て" };
 
 function buildYearOptions(): FilterOption[] {
   const currentYear = new Date().getFullYear();
@@ -32,11 +22,16 @@ function buildYearOptions(): FilterOption[] {
 interface PitchingAnalysisContainerProps {
   /** SSR で取得した防御率推移の初期データ。マウント時はこれを使い再取得しない。 */
   initialEraTrend: EraTrendPoint[];
+  /** サーバーで取得したシーズン/大会のフィルタ選択肢。 */
+  seasonOptions: FilterOption[];
+  tournamentOptions: FilterOption[];
 }
 
 /** 投手タブの分析（フィルタ + 防御率推移グラフ）コンテナ。 */
 export function PitchingAnalysisContainer({
   initialEraTrend,
+  seasonOptions,
+  tournamentOptions,
 }: PitchingAnalysisContainerProps) {
   const [filters, setFilters] = useState<Filters>({
     year: "通算",
@@ -44,42 +39,7 @@ export function PitchingAnalysisContainer({
   });
   const [eraTrend, setEraTrend] = useState<EraTrendPoint[]>(initialEraTrend);
   const [isRefetching, startRefetch] = useTransition();
-  const [seasonOptions, setSeasonOptions] = useState<FilterOption[]>([
-    DEFAULT_OPTION,
-  ]);
-  const [tournamentOptions, setTournamentOptions] = useState<FilterOption[]>([
-    DEFAULT_OPTION,
-  ]);
   const [yearOptions] = useState(buildYearOptions);
-
-  useEffect(() => {
-    let active = true;
-    void (async () => {
-      const userId = await getCurrentUserId();
-      const [seasons, tournaments] = await Promise.all([
-        getSeasons(userId ?? undefined),
-        getTournaments() as Promise<TournamentData[]>,
-      ]);
-      if (!active) return;
-      setSeasonOptions([
-        DEFAULT_OPTION,
-        ...seasons.map((season: SeasonData) => ({
-          key: String(season.id),
-          label: season.name,
-        })),
-      ]);
-      setTournamentOptions([
-        DEFAULT_OPTION,
-        ...tournaments.map((tournament) => ({
-          key: String(tournament.id),
-          label: tournament.name,
-        })),
-      ]);
-    })();
-    return () => {
-      active = false;
-    };
-  }, []);
 
   // 初回は SSR の initialEraTrend を使うため再取得しない（フィルタ変更時のみ取得）。
   const didInitRef = useRef(false);

--- a/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
@@ -1,5 +1,5 @@
 "use client";
-import type { FilterOption } from "../../filterOptions";
+import type { FilterOption } from "../../statsFilterOption";
 import { useEffect, useRef, useState, useTransition } from "react";
 import {
   type AnalysisFilters as Filters,

--- a/app/(app)/stats/_components/analysis/PitchingAnalysisSection.tsx
+++ b/app/(app)/stats/_components/analysis/PitchingAnalysisSection.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { getEraTrend } from "../../analysisActions";
+import { getStatsFilterOptions } from "../../filterOptions";
 import { AnalysisLoading } from "./AnalysisLoading";
 import { PitchingAnalysisContainer } from "./PitchingAnalysisContainer";
 
@@ -18,6 +19,15 @@ export function PitchingAnalysisSection() {
 
 async function PitchingAnalysisDataProvider() {
   // 防御率推移は year/season/tournament のみで絞る（既定は通算）。
-  const initialEraTrend = await getEraTrend({ year: "通算" });
-  return <PitchingAnalysisContainer initialEraTrend={initialEraTrend} />;
+  const [initialEraTrend, filterOptions] = await Promise.all([
+    getEraTrend({ year: "通算" }),
+    getStatsFilterOptions(),
+  ]);
+  return (
+    <PitchingAnalysisContainer
+      initialEraTrend={initialEraTrend}
+      seasonOptions={filterOptions.seasonOptions}
+      tournamentOptions={filterOptions.tournamentOptions}
+    />
+  );
 }

--- a/app/(app)/stats/filterOptions.ts
+++ b/app/(app)/stats/filterOptions.ts
@@ -1,0 +1,88 @@
+import type { SeasonData, TournamentData } from "@app/interface";
+import { cookies } from "next/headers";
+import { cache } from "react";
+import { captureServerActionError } from "../../../lib/sentry-helpers";
+import { RAILS_API_URL } from "../../constants/api";
+
+export interface FilterOption {
+  key: string;
+  label: string;
+}
+
+export interface StatsFilterOptions {
+  seasonOptions: FilterOption[];
+  tournamentOptions: FilterOption[];
+}
+
+const DEFAULT_OPTION: FilterOption = { key: "全て", label: "全て" };
+const EMPTY_OPTIONS: StatsFilterOptions = {
+  seasonOptions: [DEFAULT_OPTION],
+  tournamentOptions: [DEFAULT_OPTION],
+};
+
+async function getAuthHeaders(): Promise<Record<string, string> | null> {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("access-token")?.value;
+  const client = cookieStore.get("client")?.value;
+  const uid = cookieStore.get("uid")?.value;
+  if (!accessToken || !client || !uid) return null;
+  return {
+    "Content-Type": "application/json",
+    "access-token": accessToken,
+    client,
+    uid,
+  };
+}
+
+/**
+ * 成績画面のフィルタ選択肢（シーズン / 大会）をサーバーで取得する。
+ * `cache()` でラップしているため、同一リクエスト内で page / 各 Section から
+ * 複数回呼ばれても実取得は1回（seasons + tournaments の2コール）に集約される。
+ * 認証ヘッダがあれば user_id は不要（バックエンドが current_user にフォールバック）。
+ */
+export const getStatsFilterOptions = cache(
+  async (): Promise<StatsFilterOptions> => {
+    try {
+      const headers = await getAuthHeaders();
+      if (!headers) return EMPTY_OPTIONS;
+
+      const [seasonsResponse, tournamentsResponse] = await Promise.all([
+        fetch(`${RAILS_API_URL}/api/v1/seasons`, {
+          headers,
+          cache: "no-store",
+        }),
+        fetch(`${RAILS_API_URL}/api/v1/tournaments`, {
+          headers,
+          cache: "no-store",
+        }),
+      ]);
+
+      const seasons: SeasonData[] = seasonsResponse.ok
+        ? await seasonsResponse.json()
+        : [];
+      const tournaments: TournamentData[] = tournamentsResponse.ok
+        ? await tournamentsResponse.json()
+        : [];
+
+      return {
+        seasonOptions: [
+          DEFAULT_OPTION,
+          ...seasons.map((season) => ({
+            key: String(season.id),
+            label: season.name,
+          })),
+        ],
+        tournamentOptions: [
+          DEFAULT_OPTION,
+          ...tournaments.map((tournament) => ({
+            key: String(tournament.id),
+            label: tournament.name,
+          })),
+        ],
+      };
+    } catch (error) {
+      captureServerActionError(error, { action: "getStatsFilterOptions" });
+      return EMPTY_OPTIONS;
+    }
+  },
+);

--- a/app/(app)/stats/filterOptions.ts
+++ b/app/(app)/stats/filterOptions.ts
@@ -1,38 +1,20 @@
 import type { SeasonData, TournamentData } from "@app/interface";
-import { cookies } from "next/headers";
 import { cache } from "react";
+import { getAuthHeaders } from "@app/services/v2/authHeaders";
 import { captureServerActionError } from "../../../lib/sentry-helpers";
 import { RAILS_API_URL } from "../../constants/api";
-
-export interface FilterOption {
-  key: string;
-  label: string;
-}
+import { DEFAULT_OPTION, type FilterOption } from "./statsFilterOption";
 
 export interface StatsFilterOptions {
   seasonOptions: FilterOption[];
   tournamentOptions: FilterOption[];
 }
 
-const DEFAULT_OPTION: FilterOption = { key: "全て", label: "全て" };
-const EMPTY_OPTIONS: StatsFilterOptions = {
+// cache() で同一結果を共有するため、フォールバックは呼び出しごとに新規配列を返す。
+const emptyOptions = (): StatsFilterOptions => ({
   seasonOptions: [DEFAULT_OPTION],
   tournamentOptions: [DEFAULT_OPTION],
-};
-
-async function getAuthHeaders(): Promise<Record<string, string> | null> {
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get("access-token")?.value;
-  const client = cookieStore.get("client")?.value;
-  const uid = cookieStore.get("uid")?.value;
-  if (!accessToken || !client || !uid) return null;
-  return {
-    "Content-Type": "application/json",
-    "access-token": accessToken,
-    client,
-    uid,
-  };
-}
+});
 
 /**
  * 成績画面のフィルタ選択肢（シーズン / 大会）をサーバーで取得する。
@@ -44,7 +26,7 @@ export const getStatsFilterOptions = cache(
   async (): Promise<StatsFilterOptions> => {
     try {
       const headers = await getAuthHeaders();
-      if (!headers) return EMPTY_OPTIONS;
+      if (!headers) return emptyOptions();
 
       const [seasonsResponse, tournamentsResponse] = await Promise.all([
         fetch(`${RAILS_API_URL}/api/v1/seasons`, {
@@ -82,7 +64,7 @@ export const getStatsFilterOptions = cache(
       };
     } catch (error) {
       captureServerActionError(error, { action: "getStatsFilterOptions" });
-      return EMPTY_OPTIONS;
+      return emptyOptions();
     }
   },
 );

--- a/app/(app)/stats/page.tsx
+++ b/app/(app)/stats/page.tsx
@@ -4,6 +4,7 @@ import { AnalysisSection } from "./_components/analysis/AnalysisSection";
 import { PitchingAnalysisSection } from "./_components/analysis/PitchingAnalysisSection";
 import StatsContainer from "./_components/StatsContainer";
 import { getBattingStats, getIsAuthenticated } from "./actions";
+import { getStatsFilterOptions } from "./filterOptions";
 
 export const metadata = {
   title: "成績 | BUZZ BASE",
@@ -28,8 +29,12 @@ export default async function StatsPage() {
   }
 
   // タブ/期間/フィルタの切替はクライアント側 state で行うため、ここでは
-  // デフォルト（打撃・年別）の初期データのみ SSR で取得して渡す。
-  const initialRows = await getBattingStats("yearly");
+  // デフォルト（打撃・年別）の初期データとフィルタ選択肢のみ SSR で取得して渡す。
+  // getStatsFilterOptions は cache() 済みで、各分析セクションと取得が集約される。
+  const [initialRows, filterOptions] = await Promise.all([
+    getBattingStats("yearly"),
+    getStatsFilterOptions(),
+  ]);
 
   return (
     <>
@@ -41,6 +46,8 @@ export default async function StatsPage() {
               initialRows={initialRows}
               analysisSlot={<AnalysisSection />}
               pitchingAnalysisSlot={<PitchingAnalysisSection />}
+              seasonOptions={filterOptions.seasonOptions}
+              tournamentOptions={filterOptions.tournamentOptions}
             />
           </div>
         </div>

--- a/app/(app)/stats/statsFilterOption.ts
+++ b/app/(app)/stats/statsFilterOption.ts
@@ -1,0 +1,10 @@
+// 成績画面のフィルタ選択肢の型と既定値。
+// server（filterOptions.ts）/ client（各コンテナ）双方から import するため、
+// next/headers 等のサーバー専用 API は持たせない。
+export interface FilterOption {
+  key: string;
+  label: string;
+}
+
+/** シーズン/大会フィルタの既定（未絞り込み）選択肢。 */
+export const DEFAULT_OPTION: FilterOption = { key: "全て", label: "全て" };


### PR DESCRIPTION
## 対応 Issue
ippei-shimizu/buzzbase#415

## 概要
成績画面で `StatsContainer` / `AnalysisContainer` / `PitchingAnalysisContainer` が各自 `getCurrentUserId()`→`getSeasons()`→`getTournaments()` を呼んでいた重複（最大9コール）を解消する。

## 変更点
- `filterOptions.ts`（新規・server）: `getStatsFilterOptions` を `React.cache()` でラップ。cookies 認証で `/api/v1/seasons` と `/api/v1/tournaments` を取得し、`{ seasonOptions, tournamentOptions }`（`{key,label}` 整形済み）を返す。**同一リクエスト内で page / 各 Section から複数回呼ばれても実取得は1回（2コール）**に集約される。
- `page.tsx` / `AnalysisSection` / `PitchingAnalysisSection`: `getStatsFilterOptions()` を取得し、各コンテナへ props で配布。
- `StatsContainer` / `AnalysisContainer` / `PitchingAnalysisContainer`: `seasonOptions` / `tournamentOptions` を props で受け取り、`getSeasons`/`getTournaments`/`getCurrentUserId` を呼ぶ client の `useEffect` を撤去。`yearOptions`（静的）は各ローカル維持。

## バックエンド前提
`api/v1/seasons#index` / `tournaments#index` は `params[:user_id]` 省略時に `current_api_v1_user` にフォールバックするため、サーバー側は cookies 認証のみで取得可能（user_id チェーン不要）。

## 確認
- typecheck / lint / format / test(252) クリア
- `yarn build` 成功（`filterOptions.ts` は server 専用で client から未 import、`/stats` は動的ルート）
- コンテナから client の `getSeasons`/`getTournaments`/`getCurrentUserId` 呼び出しが消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
