### PR TITLE
Add: Playwright による front E2E ゴールデンパステスト基盤

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -1,0 +1,49 @@
+name: Playwright E2E
+
+# E2E はログインを伴い稼働中のバックエンドが必要なため、デプロイ済み環境
+# （ステージング等）に対して実行する。重いのでリリース系 PR と手動実行に絞る。
+# flows が安定 green になるまでは workflow_dispatch 中心で運用する。
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - "release/**"
+
+# 前提（Repository secrets）:
+#   E2E_BASE_URL : テスト対象の稼働 front URL（v1 データを seed したステージング等）
+#   E2E_EMAIL / E2E_PASSWORD : シード済みテストユーザーの認証情報
+jobs:
+  e2e:
+    name: Golden path E2E (Chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright golden paths
+        env:
+          E2E_BASE_URL: ${{ secrets.E2E_BASE_URL }}
+          E2E_EMAIL: ${{ secrets.E2E_EMAIL }}
+          E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
+        run: yarn e2e
+
+      - name: Upload Playwright report on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ next-env.d.ts
 
 # Ruby LSP cache
 .ruby-lsp/
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/e2e/01-smoke.spec.ts
+++ b/e2e/01-smoke.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "@playwright/test";
+
+// 疎通確認（土台）。signin 画面が表示され、フォームが描画されることだけを確認する。
+// これが green でないと以降のゴールデンパスは成立しない。認証・バックエンド不要。
+test("signin 画面が表示される", async ({ page }) => {
+  await page.goto("/signin");
+  await expect(page.getByRole("heading", { name: "ログイン" })).toBeVisible();
+  await expect(page.getByPlaceholder("buzzbase@example.com")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "ログインする" }),
+  ).toBeVisible();
+});

--- a/e2e/02-existing-user-stats.spec.ts
+++ b/e2e/02-existing-user-stats.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+import { login } from "./helpers/auth";
+
+// ゴールデンパス: 既存ユーザー（v1 データのみ）でログイン → 成績画面が崩れず表示される。
+// 守るリスク: v2 リファクタが既存ユーザーの集計画面を壊す後方互換リグレッション。
+test("既存ユーザーで成績画面が表示される", async ({ page }) => {
+  await login(page);
+
+  await page.goto("/stats");
+  // 成績画面が描画され、打撃成績タブ・集計テーブルが表示されることを確認する。
+  await expect(page.getByText("打撃成績")).toBeVisible();
+  await expect(page.getByText("打率")).toBeVisible();
+});

--- a/e2e/03-record-new-game.spec.ts
+++ b/e2e/03-record-new-game.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+import { login } from "./helpers/auth";
+
+// ゴールデンパス: 新仕様の試合記録フローに入り、試合情報フォームが表示される。
+// 守るリスク: 新仕様の主導線（記録 → 試合情報入力 → 記録パターン分岐）の結合崩れ。
+test("試合記録フォームと記録パターン分岐が表示される", async ({ page }) => {
+  await login(page);
+
+  await page.goto("/game-result/record");
+  await expect(page.getByText("自チーム")).toBeVisible();
+  await expect(page.getByText("相手チーム")).toBeVisible();
+  await expect(page.getByText("球場").first()).toBeVisible();
+  await expect(page.getByText("記録パターン")).toBeVisible();
+
+  // TODO(CI iteration): 以下の深い導線を段階追加する。
+  //   1. チーム/球場/点数を入力し記録パターン（両方/打撃のみ/投球のみ）を選ぶ
+  //   2. 打席記録ウィザード（グラウンド/結果/得点）を完走する
+  //   3. 試合結果サマリーで入力した打席が表示される
+  //   座標・動的要素は data-testid 付与を前提に伸ばす。
+});

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,49 @@
+# front E2E（Playwright / ゴールデンパス）
+
+画面遷移・打席記録ウィザード・集計表示の結合バグを E2E で守る。mobile の Maestro（#380）に
+対応する Web 版。ゴールデンパスは結合の主導線と後方互換に絞る（3〜5 本）。
+
+## フロー構成
+
+| ファイル                         | 目的                                      | 守るリスク                   |
+| -------------------------------- | ----------------------------------------- | ---------------------------- |
+| `01-smoke.spec.ts`               | signin 画面の表示                         | 起動・土台の疎通（認証不要） |
+| `02-existing-user-stats.spec.ts` | 既存ユーザーでログイン → 成績画面表示     | v2 リファクタの後方互換      |
+| `03-record-new-game.spec.ts`     | 記録 → 試合情報フォーム・記録パターン分岐 | 新仕様の主導線の結合         |
+| `helpers/auth.ts`                | signin 経由のログイン共通処理             | -                            |
+
+## ローカル実行
+
+```bash
+# 初回のみブラウザを取得
+npx playwright install chromium
+
+# 稼働中の front とテストユーザーを指定して実行
+E2E_BASE_URL=http://localhost:8100 \
+E2E_EMAIL=<test-user@example.com> E2E_PASSWORD=<password> \
+  yarn e2e
+
+# UI モード（flow 作成・デバッグに便利）
+yarn e2e:ui
+
+# 疎通だけ（認証・バックエンド不要）
+E2E_BASE_URL=http://localhost:8100 yarn e2e e2e/01-smoke.spec.ts
+```
+
+## 前提
+
+- **対象環境**: `E2E_BASE_URL` に稼働中の front（ローカル docker は `http://localhost:8100`、CI はステージング等）。
+- **テストユーザー**: バックエンドに v1 データを seed 済みのアカウント。`E2E_EMAIL` / `E2E_PASSWORD` で渡す（認証フローはこのユーザーでログインする）。
+
+## CI
+
+`.github/workflows/playwright-e2e.yml`。ログインに稼働バックエンドが必要なため、デプロイ済み
+環境（`E2E_BASE_URL`）に対して実行する。重いので `workflow_dispatch` と `release/**` PR に限定。
+安定 green 後に通常 PR トリガを有効化する。
+
+## セレクタ方針と今後の拡張
+
+- 現状はロール / テキスト / placeholder セレクタ中心。
+- 打席記録ウィザードの深い導線（グラウンドタップ等の座標・動的要素）は、対象要素に
+  `data-testid` を付与してから段階的に伸ばすのが安定する（`03` の TODO 参照）。
+- `yarn e2e:ui` で実セレクタを確認しながら追加する。

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,24 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * signin 画面から UI 経由でログインする。
+ * 認証情報はシード済みテストユーザー（E2E_EMAIL / E2E_PASSWORD）を環境変数で渡す。
+ * devise_token_auth の access-token / client / uid Cookie がセットされる。
+ */
+export async function login(page: Page): Promise<void> {
+  const email = process.env.E2E_EMAIL;
+  const password = process.env.E2E_PASSWORD;
+  if (!email || !password) {
+    throw new Error(
+      "E2E_EMAIL / E2E_PASSWORD が未設定です（シード済みテストユーザーが必要）",
+    );
+  }
+
+  await page.goto("/signin");
+  await page.getByPlaceholder("buzzbase@example.com").fill(email);
+  await page.getByPlaceholder("6文字以上半角英数字のみ").fill(password);
+  await page.getByRole("button", { name: "ログインする" }).click();
+
+  // ログイン成功でマイページ（/mypage/:user_id）へ遷移する。
+  await expect(page).toHaveURL(/\/mypage\//, { timeout: 15000 });
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:ci": "jest --ci --coverage --maxWorkers=2"
+    "test:ci": "jest --ci --coverage --maxWorkers=2",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
@@ -53,6 +55,7 @@
     "swr": "^2.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.1",
     "@tailwindcss/postcss": "^4.1.18",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * front の E2E（ゴールデンパス）設定。
+ *
+ * 対象アプリの URL は E2E_BASE_URL で指定する（既定は docker の front ホストポート 8100）。
+ * ログインを伴うフローはシード済みテストユーザー（E2E_EMAIL / E2E_PASSWORD）と
+ * 到達可能なバックエンドが前提。
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: process.env.E2E_BASE_URL || "http://localhost:8100",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2551,6 +2551,13 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
+"@playwright/test@^1.49.1":
+  version "1.61.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.61.0.tgz#dcc3d43e581aab2985d70413309d89350e980ad8"
+  integrity sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==
+  dependencies:
+    playwright "1.61.0"
+
 "@prisma/instrumentation@7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@prisma/instrumentation/-/instrumentation-7.2.0.tgz#9409a436d8f98e8950c8659aeeba045c4a07e891"
@@ -6751,6 +6758,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@^2.3.3, fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -9335,6 +9347,20 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.61.0:
+  version "1.61.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.61.0.tgz#caf8078b2a39cd7738dc75ec11cb3b47f385c3f0"
+  integrity sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==
+
+playwright@1.61.0:
+  version "1.61.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.61.0.tgz#7082df3df08ffa82b11420ea5fae84a40bd16e3f"
+  integrity sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==
+  dependencies:
+    playwright-core "1.61.0"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## issue
ippei-shimizu/buzzbase#417

## 実装概要

画面遷移・打席記録ウィザード・集計表示の結合バグを Jest 単体では拾えないため、Playwright による front E2E ゴールデンパスの基盤を追加した。mobile の Maestro（#380）に対応する Web 版。

## 変更内容

- **`e2e/01-smoke.spec.ts`**: signin 画面の表示（疎通の土台・認証/バックエンド不要）
- **`e2e/02-existing-user-stats.spec.ts`**: 既存ユーザー（v1 データ）でログイン → 成績画面（打撃成績/打率）が崩れず表示（後方互換）
- **`e2e/03-record-new-game.spec.ts`**: 記録 → 試合情報フォーム・記録パターン分岐表示（新仕様の主導線）
- **`e2e/helpers/auth.ts`**: signin 経由のログイン共通処理（`/mypage/:user_id` 遷移で成功判定）
- **`playwright.config.ts`**: `E2E_BASE_URL` で対象環境指定（既定 `http://localhost:8100`）、CI は retry/trace/report 設定
- **`.github/workflows/playwright-e2e.yml`**: デプロイ済み環境に対し `yarn e2e`（ログインに稼働バックエンド要のため）。重いので `workflow_dispatch` と `release/**` PR に限定
- `e2e/README.md` / `.gitignore` / `package.json`（`e2e` スクリプト + `@playwright/test`）

## 実行・検証状況

- **lint クリーン**（`eslint e2e playwright.config.ts`）、E2E ファイルは型エラーなし（既存の `.next` 生成型エラーは本変更と無関係）。
- **green 実行は稼働環境（front + backend + seed 済みユーザー）が前提**。本 PR では未実行（E2E の性質上、対象環境での iteration が必要）。`01-smoke` は認証不要なので front 起動だけで検証可能。

## 受入基準

- [x] Playwright 導入（config + scripts + CI）
- [x] ゴールデンパス 3 本（疎通・後方互換・新仕様主導線）の雛形
- [x] README に実行手順
- [ ] **CI 安定 green は段階対応**: 初回は `workflow_dispatch` で疎通 → セレクタ調整 → 安定後に PR トリガ有効化
- [ ] 打席ウィザード完走 → サマリー表示までの深い導線は `data-testid` 付与前提で拡張（spec 内 TODO）

## 前提（CI secrets）

- `E2E_BASE_URL`: 稼働中の front（v1 データを seed したステージング等）
- `E2E_EMAIL` / `E2E_PASSWORD`: シード済みテストユーザー

## コード上の懸念点

- PR base は **`release/game-stats-202605`**（テスト対象の新仕様画面がこのリリースに存在するため）。
- 深い導線（グラウンドタップ等の座標・動的要素）は対象要素への `data-testid` 付与を前提に段階拡張する。

## 関連

QA 自動化スイート: #378（migration リハーサル）/ #379（集計 golden master）/ #380（mobile Maestro E2E）/ #381（v1 後方互換）。
