### PR TITLE
Add: 試合結果画面にサマリータブを追加（mobile準拠の集計サマリー）

### DIFF
--- a/app/(app)/game-result/lists/__tests__/GameResultTabs.test.tsx
+++ b/app/(app)/game-result/lists/__tests__/GameResultTabs.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GameResultTabs } from "../_components/GameResultTabs";
+
+jest.mock("@app/components/user/MatchResultList", () => {
+  return function MatchResultList({ userId }: { userId: number }) {
+    return (
+      <div data-testid="match-list">一覧コンテンツ (userId: {userId})</div>
+    );
+  };
+});
+
+jest.mock("../_components/GameSummaryContainer", () => ({
+  GameSummaryContainer: () => (
+    <div data-testid="summary">サマリーコンテンツ</div>
+  ),
+}));
+
+describe("GameResultTabs", () => {
+  it("サマリー / 一覧 の2タブが表示される", () => {
+    render(<GameResultTabs userId={1} adSlot="slot" adLayoutKey="key" />);
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(2);
+    expect(screen.getByText("サマリー")).toBeInTheDocument();
+    expect(screen.getByText("一覧")).toBeInTheDocument();
+  });
+
+  it("初期表示はサマリータブ（先頭）", () => {
+    render(<GameResultTabs userId={1} adSlot="slot" adLayoutKey="key" />);
+
+    expect(screen.getByTestId("summary")).toBeInTheDocument();
+    expect(screen.queryByTestId("match-list")).not.toBeInTheDocument();
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[1]).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("一覧タブをクリックすると一覧が表示される", async () => {
+    const user = userEvent.setup();
+    render(<GameResultTabs userId={1} adSlot="slot" adLayoutKey="key" />);
+
+    await user.click(screen.getByText("一覧"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("match-list")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("summary")).not.toBeInTheDocument();
+  });
+});

--- a/app/(app)/game-result/lists/__tests__/GameResultTabs.test.tsx
+++ b/app/(app)/game-result/lists/__tests__/GameResultTabs.test.tsx
@@ -68,4 +68,20 @@ describe("GameResultTabs", () => {
     });
     expect(mockCreateGameResult).toHaveBeenCalled();
   });
+
+  it("記録作成に失敗してもボタンが再操作可能に戻る", async () => {
+    const user = userEvent.setup();
+    mockCreateGameResult.mockRejectedValueOnce(new Error("failed"));
+    render(<GameResultTabs userId={1} adSlot="slot" adLayoutKey="key" />);
+
+    const recordButton = screen.getByRole("button", {
+      name: "試合結果を記録する",
+    });
+    await user.click(recordButton);
+
+    await waitFor(() => {
+      expect(recordButton).not.toBeDisabled();
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
 });

--- a/app/(app)/game-result/lists/__tests__/GameResultTabs.test.tsx
+++ b/app/(app)/game-result/lists/__tests__/GameResultTabs.test.tsx
@@ -16,25 +16,34 @@ jest.mock("../_components/GameSummaryContainer", () => ({
   ),
 }));
 
-describe("GameResultTabs", () => {
-  it("サマリー / 一覧 の2タブが表示される", () => {
-    render(<GameResultTabs userId={1} adSlot="slot" adLayoutKey="key" />);
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
 
-    const tabs = screen.getAllByRole("tab");
-    expect(tabs).toHaveLength(2);
-    expect(screen.getByText("サマリー")).toBeInTheDocument();
-    expect(screen.getByText("一覧")).toBeInTheDocument();
+const mockCreateGameResult = jest.fn();
+jest.mock("@app/services/gameResultsService", () => ({
+  createGameResult: () => mockCreateGameResult(),
+}));
+
+describe("GameResultTabs", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  it("初期表示はサマリータブ（先頭）", () => {
+  it("サマリー / 一覧 のタブと記録ボタンが表示される", () => {
+    render(<GameResultTabs userId={1} adSlot="slot" adLayoutKey="key" />);
+
+    expect(screen.getByText("サマリー")).toBeInTheDocument();
+    expect(screen.getByText("一覧")).toBeInTheDocument();
+    expect(screen.getByText("試合結果を記録する")).toBeInTheDocument();
+  });
+
+  it("初期表示はサマリータブ", () => {
     render(<GameResultTabs userId={1} adSlot="slot" adLayoutKey="key" />);
 
     expect(screen.getByTestId("summary")).toBeInTheDocument();
     expect(screen.queryByTestId("match-list")).not.toBeInTheDocument();
-
-    const tabs = screen.getAllByRole("tab");
-    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
-    expect(tabs[1]).toHaveAttribute("aria-selected", "false");
   });
 
   it("一覧タブをクリックすると一覧が表示される", async () => {
@@ -43,9 +52,20 @@ describe("GameResultTabs", () => {
 
     await user.click(screen.getByText("一覧"));
 
-    await waitFor(() => {
-      expect(screen.getByTestId("match-list")).toBeInTheDocument();
-    });
+    expect(screen.getByTestId("match-list")).toBeInTheDocument();
     expect(screen.queryByTestId("summary")).not.toBeInTheDocument();
+  });
+
+  it("記録ボタンで試合結果を作成し記録画面へ遷移する", async () => {
+    const user = userEvent.setup();
+    mockCreateGameResult.mockResolvedValueOnce({ id: 42 });
+    render(<GameResultTabs userId={1} adSlot="slot" adLayoutKey="key" />);
+
+    await user.click(screen.getByText("試合結果を記録する"));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/game-result/record");
+    });
+    expect(mockCreateGameResult).toHaveBeenCalled();
   });
 });

--- a/app/(app)/game-result/lists/__tests__/gameSummaryActions.test.ts
+++ b/app/(app)/game-result/lists/__tests__/gameSummaryActions.test.ts
@@ -1,0 +1,153 @@
+const mockGet = jest.fn();
+const mockCookieStore = { get: mockGet };
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(() => Promise.resolve(mockCookieStore)),
+}));
+
+jest.mock("../../../../constants/api", () => ({
+  RAILS_API_URL: "http://back:3000",
+}));
+
+import { getGameSummary } from "../gameSummaryActions";
+
+function setupAuthCookies() {
+  mockGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: "test-uid" },
+    };
+    return values[key];
+  });
+}
+
+const sampleSummary = {
+  win_loss: { wins: 1, losses: 0, draws: 0, total: 1, win_rate: 1.0 },
+  scoring: {
+    runs_for: 5,
+    runs_against: 3,
+    run_differential: 2,
+    avg_runs_for: 5.0,
+    avg_runs_against: 3.0,
+  },
+  recent_form: [],
+  monthly_games: [],
+  opponent_records: [],
+};
+
+describe("getGameSummary", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("認証済みなら status:ok でサマリーを返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => sampleSummary,
+    });
+
+    const result = await getGameSummary();
+
+    expect(result).toEqual({ status: "ok", data: sampleSummary });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://back:3000/api/v2/stats/game_summary",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "access-token": "test-access-token",
+          client: "test-client",
+          uid: "test-uid",
+        }),
+        cache: "no-store",
+      }),
+    );
+  });
+
+  it("フィルタをクエリパラメータに反映する（通算は送らない）", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => sampleSummary,
+    });
+
+    await getGameSummary({
+      year: "2025",
+      matchType: "regular",
+      seasonId: "3",
+      tournamentId: "7",
+    });
+
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("year=2025");
+    expect(calledUrl).toContain("match_type=regular");
+    expect(calledUrl).toContain("season_id=3");
+    expect(calledUrl).toContain("tournament_id=7");
+  });
+
+  it("year=通算 のときは year を送らない", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => sampleSummary,
+    });
+
+    await getGameSummary({ year: "通算", matchType: "" });
+
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(calledUrl).not.toContain("year=");
+    expect(calledUrl).not.toContain("match_type=");
+  });
+
+  it("403 なら status:forbidden を返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: "このアカウントは非公開です" }),
+    });
+
+    const result = await getGameSummary();
+
+    expect(result).toEqual({ status: "forbidden" });
+  });
+
+  it("認証トークンが無ければ status:unauthenticated を返す", async () => {
+    mockGet.mockReturnValue(undefined);
+
+    const result = await getGameSummary();
+
+    expect(result).toEqual({ status: "unauthenticated" });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("その他の失敗レスポンスは status:error を返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+
+    const result = await getGameSummary();
+
+    expect(result).toEqual({ status: "error" });
+  });
+
+  it("fetch が例外を投げたら status:error を返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("network"));
+
+    const result = await getGameSummary();
+
+    expect(result).toEqual({ status: "error" });
+  });
+});

--- a/app/(app)/game-result/lists/__tests__/summary.test.tsx
+++ b/app/(app)/game-result/lists/__tests__/summary.test.tsx
@@ -1,0 +1,140 @@
+import type {
+  OpponentRecord,
+  RecentFormGame,
+  Scoring,
+  WinLossSummary,
+} from "../gameSummaryTypes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GameResultSummary } from "../_components/summary/GameResultSummary";
+import { OpponentRecordList } from "../_components/summary/OpponentRecordList";
+import { RecentForm } from "../_components/summary/RecentForm";
+import { ScoringStats } from "../_components/summary/ScoringStats";
+import { WinLossCards } from "../_components/summary/WinLossCards";
+
+describe("WinLossCards", () => {
+  it("勝敗数と勝率（先頭0を除去）を表示する", () => {
+    const summary: WinLossSummary = {
+      wins: 7,
+      losses: 5,
+      draws: 0,
+      total: 12,
+      win_rate: 0.583,
+    };
+    render(<WinLossCards summary={summary} />);
+
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("12試合 / 勝率")).toBeInTheDocument();
+    expect(screen.getByText(".583")).toBeInTheDocument();
+  });
+});
+
+describe("ScoringStats", () => {
+  it("得失点差がプラスのとき + を付ける", () => {
+    const scoring: Scoring = {
+      runs_for: 30,
+      runs_against: 20,
+      run_differential: 10,
+      avg_runs_for: 3.0,
+      avg_runs_against: 2.0,
+    };
+    render(<ScoringStats scoring={scoring} />);
+
+    expect(screen.getByText("+10")).toBeInTheDocument();
+  });
+
+  it("得失点差がマイナスのときは符号をそのまま表示する", () => {
+    const scoring: Scoring = {
+      runs_for: 10,
+      runs_against: 18,
+      run_differential: -8,
+      avg_runs_for: 1.0,
+      avg_runs_against: 1.8,
+    };
+    render(<ScoringStats scoring={scoring} />);
+
+    expect(screen.getByText("-8")).toBeInTheDocument();
+  });
+});
+
+describe("RecentForm", () => {
+  const baseGame: RecentFormGame = {
+    game_result_id: 1,
+    date: "07/10",
+    match_type: "regular",
+    opponent: "チームA",
+    result: "win",
+    my_score: 5,
+    opponent_score: 3,
+  };
+
+  it("空配列なら何も描画しない", () => {
+    const { container } = render(<RecentForm games={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("勝敗記号・種別ラベル・スコア・対戦相手を表示する", () => {
+    render(<RecentForm games={[baseGame]} />);
+
+    expect(screen.getByText("○")).toBeInTheDocument();
+    expect(screen.getByText("公式戦")).toBeInTheDocument();
+    expect(screen.getByText("5-3")).toBeInTheDocument();
+    expect(screen.getByText("vs チームA")).toBeInTheDocument();
+  });
+});
+
+describe("OpponentRecordList", () => {
+  function buildRecords(count: number): OpponentRecord[] {
+    return Array.from({ length: count }, (_, index) => ({
+      team_name: `チーム${index}`,
+      wins: index,
+      losses: 1,
+      draws: 0,
+      total: index + 1,
+    }));
+  }
+
+  it("3件までは展開ボタンを出さない", () => {
+    render(<OpponentRecordList records={buildRecords(3)} />);
+    expect(screen.queryByText("すべて表示 ▼")).not.toBeInTheDocument();
+  });
+
+  it("3件超は初期3件のみ表示し、展開で全件表示する", async () => {
+    const user = userEvent.setup();
+    render(<OpponentRecordList records={buildRecords(5)} />);
+
+    expect(screen.getByText("チーム0")).toBeInTheDocument();
+    expect(screen.getByText("チーム2")).toBeInTheDocument();
+    expect(screen.queryByText("チーム4")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("すべて表示 ▼"));
+
+    expect(screen.getByText("チーム4")).toBeInTheDocument();
+    expect(screen.getByText("閉じる ▲")).toBeInTheDocument();
+  });
+});
+
+describe("GameResultSummary", () => {
+  it("試合数0なら空メッセージを表示する", () => {
+    render(
+      <GameResultSummary
+        summary={{
+          win_loss: { wins: 0, losses: 0, draws: 0, total: 0, win_rate: 0 },
+          scoring: {
+            runs_for: 0,
+            runs_against: 0,
+            run_differential: 0,
+            avg_runs_for: 0,
+            avg_runs_against: 0,
+          },
+          recent_form: [],
+          monthly_games: [],
+          opponent_records: [],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("試合結果はありません。")).toBeInTheDocument();
+  });
+});

--- a/app/(app)/game-result/lists/_components/GameResultTabs.tsx
+++ b/app/(app)/game-result/lists/_components/GameResultTabs.tsx
@@ -47,7 +47,11 @@ export function GameResultTabs({
       localStorage.removeItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY);
       localStorage.removeItem(RECORD_PATTERN_STORAGE_KEY);
       router.push(`/game-result/record`);
-    } catch {}
+    } catch {
+      // 失敗時はスピナー・無効状態を解除して再操作できるようにする
+      // （成功時は遷移で unmount するため解除不要）。
+      setIsSubmitting(false);
+    }
   };
 
   return (

--- a/app/(app)/game-result/lists/_components/GameResultTabs.tsx
+++ b/app/(app)/game-result/lists/_components/GameResultTabs.tsx
@@ -1,8 +1,23 @@
 "use client";
 
-import { Tab, Tabs } from "@heroui/react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { PlusIcon } from "@app/components/icon/PlusIcon";
+import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import MatchResultList from "@app/components/user/MatchResultList";
+import {
+  GAME_RECORD_EDIT_MODE_STORAGE_KEY,
+  RECORD_PATTERN_STORAGE_KEY,
+} from "@app/constants/gameRecord";
+import { createGameResult } from "@app/services/gameResultsService";
 import { GameSummaryContainer } from "./GameSummaryContainer";
+
+type ScreenTab = "summary" | "list";
+
+const TABS: { key: ScreenTab; label: string }[] = [
+  { key: "summary", label: "サマリー" },
+  { key: "list", label: "一覧" },
+];
 
 interface GameResultTabsProps {
   userId: number;
@@ -11,32 +26,75 @@ interface GameResultTabsProps {
 }
 
 /**
- * 試合結果画面のタブ。先頭（既定）が「サマリー」、次が「一覧」。
- * HeroUI は非アクティブタブを unmount するため、一覧タブは開くまで取得しない。
+ * 試合結果画面のタブ（成績画面と同じ下線タブUI）。先頭（既定）が「サマリー」、次が「一覧」。
+ * タブ直下に mobile と同じ「試合結果を記録する」ボタンを配置する。
  */
 export function GameResultTabs({
   userId,
   adSlot,
   adLayoutKey,
 }: GameResultTabsProps) {
+  const [tab, setTab] = useState<ScreenTab>("summary");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
+
+  const handleNewRecord = async () => {
+    setIsSubmitting(true);
+    try {
+      const newGameResult = await createGameResult();
+      localStorage.setItem("gameResultId", JSON.stringify(newGameResult.id));
+      // 新規記録フローなので編集フラグと前回のパターンをクリアする。
+      localStorage.removeItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY);
+      localStorage.removeItem(RECORD_PATTERN_STORAGE_KEY);
+      router.push(`/game-result/record`);
+    } catch {}
+  };
+
   return (
-    <Tabs
-      color="primary"
-      size="lg"
-      aria-label="試合結果タブ"
-      radius="lg"
-      className="w-full grid sticky top-10 z-50"
-    >
-      <Tab key="summary" title="サマリー" className="font-bold tracking-wide">
-        <GameSummaryContainer />
-      </Tab>
-      <Tab key="list" title="一覧" className="font-bold tracking-wide">
-        <MatchResultList
-          userId={userId}
-          adSlot={adSlot}
-          adLayoutKey={adLayoutKey}
-        />
-      </Tab>
-    </Tabs>
+    <div>
+      {isSubmitting ? <LoadingSpinner /> : null}
+
+      <div className="flex" style={{ borderBottom: "1px solid #424242" }}>
+        {TABS.map((item) => (
+          <button
+            key={item.key}
+            type="button"
+            onClick={() => setTab(item.key)}
+            className="flex-1 py-3 text-center text-sm font-semibold"
+            style={{
+              borderBottom:
+                tab === item.key
+                  ? "2px solid #d08000"
+                  : "2px solid transparent",
+              color: tab === item.key ? "#F4F4F4" : "#A1A1AA",
+            }}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={handleNewRecord}
+        disabled={isSubmitting}
+        className="mt-5 flex w-full items-center justify-center gap-2 rounded-lg bg-[#d08000] py-3 font-bold text-white disabled:opacity-60"
+      >
+        <PlusIcon width="20" height="20" fill="#FFFFFF" />
+        試合結果を記録する
+      </button>
+
+      <div className="mt-5">
+        {tab === "summary" ? (
+          <GameSummaryContainer />
+        ) : (
+          <MatchResultList
+            userId={userId}
+            adSlot={adSlot}
+            adLayoutKey={adLayoutKey}
+          />
+        )}
+      </div>
+    </div>
   );
 }

--- a/app/(app)/game-result/lists/_components/GameResultTabs.tsx
+++ b/app/(app)/game-result/lists/_components/GameResultTabs.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Tab, Tabs } from "@heroui/react";
+import MatchResultList from "@app/components/user/MatchResultList";
+import { GameSummaryContainer } from "./GameSummaryContainer";
+
+interface GameResultTabsProps {
+  userId: number;
+  adSlot: string;
+  adLayoutKey: string;
+}
+
+/**
+ * 試合結果画面のタブ。先頭（既定）が「サマリー」、次が「一覧」。
+ * HeroUI は非アクティブタブを unmount するため、一覧タブは開くまで取得しない。
+ */
+export function GameResultTabs({
+  userId,
+  adSlot,
+  adLayoutKey,
+}: GameResultTabsProps) {
+  return (
+    <Tabs
+      color="primary"
+      size="lg"
+      aria-label="試合結果タブ"
+      radius="lg"
+      className="w-full grid sticky top-10 z-50"
+    >
+      <Tab key="summary" title="サマリー" className="font-bold tracking-wide">
+        <GameSummaryContainer />
+      </Tab>
+      <Tab key="list" title="一覧" className="font-bold tracking-wide">
+        <MatchResultList
+          userId={userId}
+          adSlot={adSlot}
+          adLayoutKey={adLayoutKey}
+        />
+      </Tab>
+    </Tabs>
+  );
+}

--- a/app/(app)/game-result/lists/_components/GameSummaryContainer.tsx
+++ b/app/(app)/game-result/lists/_components/GameSummaryContainer.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import type { FilterOption } from "../../../stats/statsFilterOption";
+import type {
+  GameSummaryFilters,
+  GameSummaryResult,
+} from "../gameSummaryTypes";
+import { Spinner } from "@heroui/react";
+import { useEffect, useState, useTransition } from "react";
+import { AnalysisFilters } from "../../../stats/_components/analysis/AnalysisFilters";
+import {
+  getGameSummary,
+  getGameSummaryFilterOptions,
+} from "../gameSummaryActions";
+import { GameResultSummary } from "./summary/GameResultSummary";
+
+const DEFAULT_FILTERS: GameSummaryFilters = { year: "通算", matchType: "" };
+
+function buildYearOptions(): FilterOption[] {
+  const currentYear = new Date().getFullYear();
+  const options: FilterOption[] = [{ key: "通算", label: "通算" }];
+  for (let offset = 0; offset < 6; offset += 1) {
+    const year = String(currentYear - offset);
+    options.push({ key: year, label: year });
+  }
+  return options;
+}
+
+/** サマリータブ本体。フィルタ（年度/種別/シーズン/大会）変更で再取得し、結果を表示する。 */
+export function GameSummaryContainer() {
+  const [filters, setFilters] = useState<GameSummaryFilters>(DEFAULT_FILTERS);
+  const [result, setResult] = useState<GameSummaryResult | null>(null);
+  const [seasonOptions, setSeasonOptions] = useState<FilterOption[]>([]);
+  const [tournamentOptions, setTournamentOptions] = useState<FilterOption[]>(
+    [],
+  );
+  const [isRefetching, startRefetch] = useTransition();
+  const [yearOptions] = useState(buildYearOptions);
+
+  // シーズン / 大会の選択肢はマウント時に1度だけ取得する。
+  useEffect(() => {
+    let active = true;
+    getGameSummaryFilterOptions().then((options) => {
+      if (!active) return;
+      setSeasonOptions(options.seasonOptions);
+      setTournamentOptions(options.tournamentOptions);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // 初回マウント・フィルタ変更のどちらでもサマリーを取得する（SSR initialData は持たない）。
+  useEffect(() => {
+    let active = true;
+    startRefetch(async () => {
+      const data = await getGameSummary(filters);
+      if (active) setResult(data);
+    });
+    return () => {
+      active = false;
+    };
+  }, [filters, startRefetch]);
+
+  if (!result) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner color="default" size="sm" />
+      </div>
+    );
+  }
+
+  if (result.status === "unauthenticated") {
+    return (
+      <p className="py-10 text-center text-sm text-[#A1A1AA]">
+        ログインが必要です。
+      </p>
+    );
+  }
+
+  if (result.status === "forbidden") {
+    return (
+      <p className="py-10 text-center text-sm text-[#A1A1AA]">
+        このアカウントは非公開です。
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <AnalysisFilters
+        filters={filters}
+        onChange={setFilters}
+        yearOptions={yearOptions}
+        seasonOptions={seasonOptions}
+        tournamentOptions={tournamentOptions}
+      />
+      {result.status === "error" ? (
+        <p className="py-10 text-center text-sm text-[#A1A1AA]">
+          サマリーを取得できませんでした。
+        </p>
+      ) : (
+        <div
+          className={isRefetching ? "opacity-50 transition-opacity" : undefined}
+        >
+          <GameResultSummary summary={result.data} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/game-result/lists/_components/summary/GameResultSummary.tsx
+++ b/app/(app)/game-result/lists/_components/summary/GameResultSummary.tsx
@@ -1,0 +1,31 @@
+import type { GameSummary } from "../../gameSummaryTypes";
+import { MonthlyGameChart } from "./MonthlyGameChart";
+import { OpponentRecordList } from "./OpponentRecordList";
+import { RecentForm } from "./RecentForm";
+import { ScoringStats } from "./ScoringStats";
+import { WinLossCards } from "./WinLossCards";
+
+interface GameResultSummaryProps {
+  summary: GameSummary;
+}
+
+/** 試合結果サマリーの5セクション（勝敗 / 得失点 / 直近 / 月別 / 対戦相手別）を縦に並べる。 */
+export function GameResultSummary({ summary }: GameResultSummaryProps) {
+  if (summary.win_loss.total === 0) {
+    return (
+      <p className="py-10 text-center text-sm text-[#A1A1AA]">
+        試合結果はありません。
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <WinLossCards summary={summary.win_loss} />
+      <ScoringStats scoring={summary.scoring} />
+      <RecentForm games={summary.recent_form} />
+      <MonthlyGameChart games={summary.monthly_games} />
+      <OpponentRecordList records={summary.opponent_records} />
+    </div>
+  );
+}

--- a/app/(app)/game-result/lists/_components/summary/MonthlyGameChart.tsx
+++ b/app/(app)/game-result/lists/_components/summary/MonthlyGameChart.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import type { MonthlyGame } from "../../gameSummaryTypes";
+import {
+  Bar,
+  BarChart,
+  Cell,
+  LabelList,
+  ResponsiveContainer,
+  XAxis,
+} from "recharts";
+
+interface MonthlyGameChartProps {
+  games: MonthlyGame[];
+}
+
+/** 月別試合数の棒グラフ。試合数に応じて棒の不透明度を変える（mobile と同じ見せ方）。 */
+export function MonthlyGameChart({ games }: MonthlyGameChartProps) {
+  if (games.length === 0) return null;
+
+  const maxCount = Math.max(...games.map((game) => game.count), 1);
+
+  return (
+    <section className="rounded-xl bg-bg_sub p-4">
+      <h3 className="mb-3 text-base font-bold text-[#F4F4F4]">月別試合数</h3>
+      <ResponsiveContainer width="100%" height={120}>
+        <BarChart
+          data={games}
+          margin={{ top: 16, right: 8, bottom: 0, left: 8 }}
+        >
+          <XAxis
+            dataKey="month"
+            tickFormatter={(month: number) => `${month}月`}
+            tick={{ fill: "#71717A", fontSize: 10 }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <Bar dataKey="count" radius={[3, 3, 0, 0]}>
+            {games.map((game) => (
+              <Cell
+                key={game.month}
+                fill="#d08000"
+                fillOpacity={0.5 + (game.count / maxCount) * 0.5}
+              />
+            ))}
+            <LabelList
+              dataKey="count"
+              position="top"
+              fill="#A1A1AA"
+              fontSize={9}
+            />
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </section>
+  );
+}

--- a/app/(app)/game-result/lists/_components/summary/OpponentRecordList.tsx
+++ b/app/(app)/game-result/lists/_components/summary/OpponentRecordList.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { OpponentRecord } from "../../gameSummaryTypes";
+import { useState } from "react";
+import { formatRate } from "@app/utils/formatStats";
+
+interface OpponentRecordListProps {
+  records: OpponentRecord[];
+}
+
+const INITIAL_SHOW = 3;
+
+/** 対戦相手別の勝敗・勝率。3件を超える場合は展開トグルで全件表示する。 */
+export function OpponentRecordList({ records }: OpponentRecordListProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (records.length === 0) return null;
+
+  const displayed = expanded ? records : records.slice(0, INITIAL_SHOW);
+
+  return (
+    <section className="rounded-xl bg-bg_sub p-4">
+      <h3 className="mb-3 text-base font-bold text-[#F4F4F4]">対戦相手別</h3>
+      <div className="flex flex-col gap-1.5">
+        {displayed.map((record) => {
+          const winRate =
+            record.wins + record.losses > 0
+              ? formatRate(record.wins / (record.wins + record.losses))
+              : ".000";
+          return (
+            <div
+              key={record.team_name}
+              className="flex items-center rounded-xl bg-[#3A3A3A] px-3 py-2.5"
+            >
+              <span className="flex-1 truncate text-sm text-[#F4F4F4]">
+                {record.team_name}
+              </span>
+              <span className="ml-3 text-sm font-bold text-[#f31260]">
+                {record.wins}勝
+              </span>
+              <span className="ml-3 text-sm font-bold text-[#006fee]">
+                {record.losses}敗
+              </span>
+              <span className="ml-3 text-sm font-bold text-[#6b7280]">
+                {record.draws}分
+              </span>
+              <span className="ml-3 min-w-9 text-right text-sm font-bold text-[#d08000]">
+                {winRate}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      {records.length > INITIAL_SHOW ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((prev) => !prev)}
+          className="w-full py-2 text-center text-xs text-[#71717A]"
+        >
+          {expanded ? "閉じる ▲" : "すべて表示 ▼"}
+        </button>
+      ) : null}
+    </section>
+  );
+}

--- a/app/(app)/game-result/lists/_components/summary/RecentForm.tsx
+++ b/app/(app)/game-result/lists/_components/summary/RecentForm.tsx
@@ -1,0 +1,66 @@
+import type { RecentFormGame } from "../../gameSummaryTypes";
+
+interface RecentFormProps {
+  games: RecentFormGame[];
+}
+
+const RESULT_DISPLAY: Record<string, { mark: string; color: string }> = {
+  win: { mark: "○", color: "#f31260" },
+  loss: { mark: "×", color: "#006fee" },
+  draw: { mark: "△", color: "#6b7280" },
+};
+
+const MATCH_TYPE_LABELS: Record<string, string> = {
+  regular: "公式戦",
+  open: "オープン戦",
+};
+
+/** match_type の DB 値を日本語ラベルに変換する。null / 未知の値はそのまま扱う。 */
+function matchTypeLabel(value: string | null): string | null {
+  if (value == null) return null;
+  return MATCH_TYPE_LABELS[value] ?? value;
+}
+
+/** 直近5試合を勝敗記号・種別・スコア・対戦相手で一覧表示する。 */
+export function RecentForm({ games }: RecentFormProps) {
+  if (games.length === 0) return null;
+
+  return (
+    <section className="rounded-xl bg-bg_sub p-4">
+      <h3 className="mb-3 text-base font-bold text-[#F4F4F4]">直近の試合</h3>
+      <div className="flex flex-col gap-2">
+        {games.map((game) => {
+          const display = RESULT_DISPLAY[game.result] ?? RESULT_DISPLAY.draw;
+          const typeLabel = matchTypeLabel(game.match_type);
+          return (
+            <div
+              key={game.game_result_id}
+              className="flex items-center gap-3 rounded-xl bg-[#3A3A3A] px-3 py-2.5"
+            >
+              {typeLabel ? (
+                <span className="w-16 shrink-0 truncate rounded bg-[#4A4A4A] px-1 py-0.5 text-center text-xs text-[#A1A1AA]">
+                  {typeLabel}
+                </span>
+              ) : (
+                <span className="w-16 shrink-0" />
+              )}
+              <span className="text-[13px] text-[#A1A1AA]">{game.date}</span>
+              <span
+                className="w-6 text-center text-xl font-bold"
+                style={{ color: display.color }}
+              >
+                {display.mark}
+              </span>
+              <span className="text-sm font-semibold text-[#F4F4F4]">
+                {game.my_score}-{game.opponent_score}
+              </span>
+              <span className="flex-1 truncate text-[13px] text-[#F4F4F4]">
+                vs {game.opponent}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/app/(app)/game-result/lists/_components/summary/ScoringStats.tsx
+++ b/app/(app)/game-result/lists/_components/summary/ScoringStats.tsx
@@ -1,0 +1,49 @@
+import type { Scoring } from "../../gameSummaryTypes";
+
+interface ScoringStatsProps {
+  scoring: Scoring;
+}
+
+/** 総得点 / 総失点 / 得失点差の3カードを表示する。得失点差は符号で色分けする。 */
+export function ScoringStats({ scoring }: ScoringStatsProps) {
+  const diffColor =
+    scoring.run_differential > 0
+      ? "#f31260"
+      : scoring.run_differential < 0
+        ? "#006fee"
+        : "#6b7280";
+  const diffPrefix = scoring.run_differential > 0 ? "+" : "";
+
+  return (
+    <section className="rounded-xl bg-bg_sub p-4">
+      <h3 className="mb-3 text-base font-bold text-[#F4F4F4]">得失点</h3>
+      <div className="grid grid-cols-3 gap-2">
+        <div className="flex flex-col items-center rounded-xl bg-[#3A3A3A] p-3">
+          <span className="text-sm text-[#A1A1AA]">総得点</span>
+          <span className="text-xl font-bold text-[#f31260]">
+            {scoring.runs_for}
+          </span>
+          <span className="mt-0.5 text-[13px] text-[#A1A1AA]">
+            平均 {scoring.avg_runs_for}
+          </span>
+        </div>
+        <div className="flex flex-col items-center rounded-xl bg-[#3A3A3A] p-3">
+          <span className="text-sm text-[#A1A1AA]">総失点</span>
+          <span className="text-xl font-bold text-[#006fee]">
+            {scoring.runs_against}
+          </span>
+          <span className="mt-0.5 text-[13px] text-[#A1A1AA]">
+            平均 {scoring.avg_runs_against}
+          </span>
+        </div>
+        <div className="flex flex-col items-center rounded-xl bg-[#3A3A3A] p-3">
+          <span className="text-sm text-[#A1A1AA]">得失点差</span>
+          <span className="text-xl font-bold" style={{ color: diffColor }}>
+            {diffPrefix}
+            {scoring.run_differential}
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/(app)/game-result/lists/_components/summary/WinLossCards.tsx
+++ b/app/(app)/game-result/lists/_components/summary/WinLossCards.tsx
@@ -1,0 +1,86 @@
+import type { WinLossSummary } from "../../gameSummaryTypes";
+import { formatRate } from "@app/utils/formatStats";
+
+interface WinLossCardsProps {
+  summary: WinLossSummary;
+}
+
+interface ResultCard {
+  label: string;
+  value: number;
+  color: string;
+}
+
+interface BarSegment {
+  key: string;
+  pct: number;
+  color: string;
+}
+
+/** 勝/敗/分の3カードと勝率、勝敗比率の横積みバーを表示する。 */
+export function WinLossCards({ summary }: WinLossCardsProps) {
+  const total = summary.wins + summary.losses + summary.draws;
+  const cards: ResultCard[] = [
+    { label: "勝利", value: summary.wins, color: "#f31260" },
+    { label: "敗北", value: summary.losses, color: "#006fee" },
+    { label: "引分", value: summary.draws, color: "#6b7280" },
+  ];
+  const segments: BarSegment[] = [
+    {
+      key: "win",
+      pct: total > 0 ? (summary.wins / total) * 100 : 0,
+      color: "#f31260",
+    },
+    {
+      key: "loss",
+      pct: total > 0 ? (summary.losses / total) * 100 : 0,
+      color: "#006fee",
+    },
+    {
+      key: "draw",
+      pct: total > 0 ? (summary.draws / total) * 100 : 0,
+      color: "#6b7280",
+    },
+  ];
+
+  return (
+    <section className="rounded-xl bg-bg_sub p-4">
+      <div className="grid grid-cols-3 gap-2">
+        {cards.map((card) => (
+          <div
+            key={card.label}
+            className="flex flex-col items-center rounded-xl bg-[#3A3A3A] p-3"
+          >
+            <span className="text-sm text-[#A1A1AA]">{card.label}</span>
+            <span
+              className="text-[22px] font-bold"
+              style={{ color: card.color }}
+            >
+              {card.value}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="mt-3 flex items-center justify-between">
+        <span className="text-sm text-[#A1A1AA]">{total}試合 / 勝率</span>
+        <span className="text-sm font-bold text-[#d08000]">
+          {formatRate(summary.win_rate)}
+        </span>
+      </div>
+      <div className="mt-1 flex h-1.5 overflow-hidden rounded bg-[#424242]">
+        {segments.map((segment) =>
+          segment.pct > 0 ? (
+            <div
+              key={segment.key}
+              className="h-full"
+              style={{
+                width: `${segment.pct}%`,
+                backgroundColor: segment.color,
+              }}
+            />
+          ) : null,
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/(app)/game-result/lists/gameSummaryActions.ts
+++ b/app/(app)/game-result/lists/gameSummaryActions.ts
@@ -1,0 +1,61 @@
+"use server";
+
+import type {
+  GameSummary,
+  GameSummaryFilters,
+  GameSummaryResult,
+} from "./gameSummaryTypes";
+import { getAuthHeaders } from "@app/services/v2/authHeaders";
+import { captureServerActionError } from "../../../../lib/sentry-helpers";
+import { RAILS_API_URL } from "../../../constants/api";
+import {
+  getStatsFilterOptions,
+  type StatsFilterOptions,
+} from "../../stats/filterOptions";
+
+function buildQuery(filters: GameSummaryFilters): string {
+  const params = new URLSearchParams();
+  if (filters.year && filters.year !== "通算")
+    params.append("year", filters.year);
+  if (filters.matchType) params.append("match_type", filters.matchType);
+  if (filters.seasonId) params.append("season_id", filters.seasonId);
+  if (filters.tournamentId)
+    params.append("tournament_id", filters.tournamentId);
+  return params.toString();
+}
+
+/**
+ * 試合結果サマリー（勝敗・得失点・直近試合・月別試合数・対戦相手別）を取得する。
+ * 認証ヘッダの current_user を対象にするため user_id は送らない。
+ * 非公開アカウント時の 403 と未認証を呼び出し側で区別できるよう判別ユニオンを返す。
+ */
+export async function getGameSummary(
+  filters: GameSummaryFilters = {},
+): Promise<GameSummaryResult> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return { status: "unauthenticated" };
+
+    const query = buildQuery(filters);
+    const response = await fetch(
+      `${RAILS_API_URL}/api/v2/stats/game_summary${query ? `?${query}` : ""}`,
+      { headers, cache: "no-store" },
+    );
+
+    if (response.status === 403) return { status: "forbidden" };
+    if (!response.ok) return { status: "error" };
+    return { status: "ok", data: (await response.json()) as GameSummary };
+  } catch (error) {
+    captureServerActionError(error, { action: "getGameSummary" });
+    return { status: "error" };
+  }
+}
+
+/**
+ * サマリーのフィルタ選択肢（シーズン / 大会）をクライアントから取得するための
+ * Server Action ラッパー。`getStatsFilterOptions` は next/headers を使う
+ * サーバー専用モジュールのため、Client Component から直接呼べない。
+ */
+export async function getGameSummaryFilterOptions(): Promise<StatsFilterOptions> {
+  return getStatsFilterOptions();
+}

--- a/app/(app)/game-result/lists/gameSummaryTypes.ts
+++ b/app/(app)/game-result/lists/gameSummaryTypes.ts
@@ -1,0 +1,73 @@
+// 試合結果サマリー（GET /api/v2/stats/game_summary）の型。
+// server（gameSummaryActions.ts）/ client（各 Presentational）双方から import するため、
+// next/headers 等のサーバー専用 API は持たせない。mobile types/stats.ts と同一構造。
+
+export interface WinLossSummary {
+  wins: number;
+  losses: number;
+  draws: number;
+  total: number;
+  /** 勝率（0.0〜1.0、小数3桁）。 */
+  win_rate: number;
+}
+
+export interface Scoring {
+  runs_for: number;
+  runs_against: number;
+  run_differential: number;
+  avg_runs_for: number;
+  avg_runs_against: number;
+}
+
+export interface RecentFormGame {
+  game_result_id: number;
+  /** "MM/dd" 形式（年なし）。 */
+  date: string;
+  /** "regular" / "open" / null。 */
+  match_type: string | null;
+  opponent: string;
+  result: "win" | "loss" | "draw";
+  my_score: number;
+  opponent_score: number;
+}
+
+export interface MonthlyGame {
+  /** 1〜12。 */
+  month: number;
+  count: number;
+}
+
+export interface OpponentRecord {
+  team_name: string;
+  wins: number;
+  losses: number;
+  draws: number;
+  total: number;
+}
+
+export interface GameSummary {
+  win_loss: WinLossSummary;
+  scoring: Scoring;
+  recent_form: RecentFormGame[];
+  monthly_games: MonthlyGame[];
+  opponent_records: OpponentRecord[];
+}
+
+/** サマリーの絞り込み条件。自分の試合一覧画面なので user_id は扱わない（current_user にフォールバック）。 */
+export interface GameSummaryFilters {
+  year?: string;
+  /** "regular" / "open"（空文字は未絞り込み）。 */
+  matchType?: string;
+  seasonId?: string;
+  tournamentId?: string;
+}
+
+/**
+ * Server Action の戻り値。403（非公開アカウント）と未認証・その他失敗を
+ * UI 側で区別できるよう判別ユニオンにする。
+ */
+export type GameSummaryResult =
+  | { status: "ok"; data: GameSummary }
+  | { status: "forbidden" }
+  | { status: "unauthenticated" }
+  | { status: "error" };

--- a/app/(app)/game-result/lists/page.tsx
+++ b/app/(app)/game-result/lists/page.tsx
@@ -1,26 +1,15 @@
 "use client";
 
-import { Button } from "@heroui/react";
-import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { adSlots } from "@app/components/ad/adConfig";
 import AdInFeed from "@app/components/ad/AdInFeed";
 import Header from "@app/components/header/Header";
-import { PlusIcon } from "@app/components/icon/PlusIcon";
-import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
-import {
-  GAME_RECORD_EDIT_MODE_STORAGE_KEY,
-  RECORD_PATTERN_STORAGE_KEY,
-} from "@app/constants/gameRecord";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
-import { createGameResult } from "@app/services/gameResultsService";
 import { getCurrentUserId } from "@app/services/userService";
 import { GameResultTabs } from "./_components/GameResultTabs";
 
 export default function GameResultList() {
   const [currentUserId, setCurrentUserId] = useState(0);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const router = useRouter();
   useRequireAuth();
 
   const fetchData = async () => {
@@ -35,47 +24,21 @@ export default function GameResultList() {
     fetchData();
   }, []);
 
-  const handleNewRecord = async () => {
-    setIsSubmitting(true);
-    try {
-      const newGameResult = await createGameResult();
-      localStorage.setItem("gameResultId", JSON.stringify(newGameResult.id));
-      // 新規記録フローなので編集フラグと前回のパターンをクリアする。
-      localStorage.removeItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY);
-      localStorage.removeItem(RECORD_PATTERN_STORAGE_KEY);
-      router.push(`/game-result/record`);
-    } catch {}
-  };
   return (
     <>
       <Header />
-      {isSubmitting && <LoadingSpinner />}
       <main className="h-full max-w-[720px] mx-auto w-full lg:m-[0_auto_0_28%]">
         <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
-          <div className="pt-16 px-4 lg:px-6 lg:pb-6">
-            <h2 className="text-2xl font-bold mt-10">試合一覧</h2>
-            <Button
-              color="primary"
-              variant="solid"
-              radius="full"
-              endContent={<PlusIcon width="22" height="22" fill="#F4F4F4" />}
-              className="fixed top-[calc(var(--smart-banner-height,0px)+4rem)] right-4 z-50 font-medium lg:absolute lg:top-16 lg:z-10"
-              onPress={handleNewRecord}
-              isDisabled={isSubmitting}
-            >
-              新規追加
-            </Button>
-            <div className="mt-5 grid gap-y-5">
-              <GameResultTabs
-                userId={currentUserId}
-                adSlot={adSlots.gameResultListMiddleInFeed}
-                adLayoutKey="-6t+ed+2i-1n-4w"
-              />
-              <AdInFeed
-                slot={adSlots.gameResultListInFeed}
-                layoutKey="-6t+ed+2i-1n-4w"
-              />
-            </div>
+          <div className="pt-12 px-4 lg:px-6 lg:pb-6">
+            <GameResultTabs
+              userId={currentUserId}
+              adSlot={adSlots.gameResultListMiddleInFeed}
+              adLayoutKey="-6t+ed+2i-1n-4w"
+            />
+            <AdInFeed
+              slot={adSlots.gameResultListInFeed}
+              layoutKey="-6t+ed+2i-1n-4w"
+            />
           </div>
         </div>
       </main>

--- a/app/(app)/game-result/lists/page.tsx
+++ b/app/(app)/game-result/lists/page.tsx
@@ -8,7 +8,6 @@ import AdInFeed from "@app/components/ad/AdInFeed";
 import Header from "@app/components/header/Header";
 import { PlusIcon } from "@app/components/icon/PlusIcon";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
-import MatchResultList from "@app/components/user/MatchResultList";
 import {
   GAME_RECORD_EDIT_MODE_STORAGE_KEY,
   RECORD_PATTERN_STORAGE_KEY,
@@ -16,6 +15,7 @@ import {
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import { createGameResult } from "@app/services/gameResultsService";
 import { getCurrentUserId } from "@app/services/userService";
+import { GameResultTabs } from "./_components/GameResultTabs";
 
 export default function GameResultList() {
   const [currentUserId, setCurrentUserId] = useState(0);
@@ -66,7 +66,7 @@ export default function GameResultList() {
               新規追加
             </Button>
             <div className="mt-5 grid gap-y-5">
-              <MatchResultList
+              <GameResultTabs
                 userId={currentUserId}
                 adSlot={adSlots.gameResultListMiddleInFeed}
                 adLayoutKey="-6t+ed+2i-1n-4w"

--- a/app/components/header/NavigationItems.tsx
+++ b/app/components/header/NavigationItems.tsx
@@ -23,7 +23,7 @@ const NavigationItems = (): NavigationItem[] => {
     },
     {
       href: isLoggedIn ? "/game-result/lists" : "/signup?auth_required=true",
-      label: "試合一覧",
+      label: "試合結果",
       icon: BallIcon,
       authRequired: !isLoggedIn,
     },


### PR DESCRIPTION
## 概要

ippei-shimizu/buzzbase#418 対応。front の試合結果画面（`/game-result/lists`）に、mobile と同等の集計サマリー機能を追加し、「サマリー」「一覧」をタブで切り替えられるようにしました。デフォルトはサマリータブです。

> [!NOTE]
> ベースブランチは `release/game-stats-202605` です。バックエンド（`GET /api/v2/stats/game_summary`）は同リリースに実装済みのものを利用しており、API側の変更はありません。

## 変更内容

- 試合一覧ページに HeroUI `Tabs` を導入し、先頭（既定）を「サマリー」、次を「一覧」（既存 `MatchResultList`）に分割
- サマリーは mobile の構成に準拠した5セクションを表示
  - 勝敗（勝/敗/分 + 勝率 + 勝敗比率バー）
  - 得失点（総得点/総失点/得失点差、符号で色分け）
  - 直近の試合（最新5件、○×△・種別・スコア・対戦相手）
  - 月別試合数（recharts `BarChart`、試合数に応じた不透明度）
  - 対戦相手別（勝敗・勝率、3件超は展開トグル）
- 年度/種別/シーズン/大会の4フィルタは既存 stats 画面の `AnalysisFilters` を流用
- データ取得は Server Action（`getGameSummary`）。403（非公開）/未認証/エラーを判別ユニオンで分岐

## 実装メモ

- `match_type` は既存 front/mobile と統一して英語キー（`regular`/`open`）を送信
- フィルタ選択肢（シーズン/大会）は `next/headers` を使うサーバー専用モジュールのため、`"use server"` ラッパー（`getGameSummaryFilterOptions`）経由でクライアントから取得
- 既存の `/game-result/summary`（1試合ごとの詳細）とは別物で、本機能は一覧ページ内のタブとして追加

## テスト

- `yarn typecheck` / `yarn lint` パス
- 追加テスト（18件）パス
  - Server Action（200/403/401/500/例外、クエリ生成）
  - タブ切り替え（既定サマリー、一覧クリックで切替、`aria-selected`）
  - 各セクションの表示・色分岐・展開トグル・空表示

## 動作確認

- [ ] `/game-result/lists` で初期表示が「サマリー」になる
- [ ] 5セクションが表示される
- [ ] 4フィルタの変更で再取得・dim される
- [ ] 「一覧」タブに切り替えられる
- [ ] 試合0件時に空表示になる
