### PR TITLE
Add: 対戦投手別に投手属性（チーム名・左右・タイプ・球速帯）を表示

### DIFF
--- a/app/(app)/stats/_components/analysis/PitcherFaceoffList.tsx
+++ b/app/(app)/stats/_components/analysis/PitcherFaceoffList.tsx
@@ -10,6 +10,14 @@ interface PitcherFaceoffListProps {
   totalTargetPa: number;
 }
 
+const formatThrowHand = (
+  throwHand: PitcherFaceoff["throw_hand"],
+): string | null => {
+  if (throwHand === "right") return "右投げ";
+  if (throwHand === "left") return "左投げ";
+  return null;
+};
+
 /** 対戦投手別の打撃成績一覧。各行タップで詳細グリッドを展開する。 */
 export function PitcherFaceoffList({
   rows,
@@ -46,6 +54,12 @@ export function PitcherFaceoffList({
 
       {rows.map((row) => {
         const isExpanded = expandedId === row.pitcher_id;
+        const attributes = [
+          row.team_name,
+          formatThrowHand(row.throw_hand),
+          row.pitcher_style,
+          row.velocity_zone,
+        ].filter(Boolean);
         return (
           <div key={row.pitcher_id}>
             <button
@@ -58,6 +72,11 @@ export function PitcherFaceoffList({
                 <p className="mb-0.5 truncate text-sm font-semibold text-[#F4F4F4]">
                   {isExpanded ? "▼" : "▶"} {row.pitcher_name}
                 </p>
+                {attributes.length > 0 ? (
+                  <p className="mb-0.5 truncate text-[11px] text-[#A1A1AA]">
+                    {attributes.join("・")}
+                  </p>
+                ) : null}
                 <p className="text-[11px] text-[#A1A1AA]">
                   {row.plate_appearances}対戦
                 </p>

--- a/app/(app)/stats/analysisActions.ts
+++ b/app/(app)/stats/analysisActions.ts
@@ -166,6 +166,10 @@ export interface PitchTypeData {
 export interface PitcherFaceoff {
   pitcher_id: number;
   pitcher_name: string;
+  team_name: string | null;
+  throw_hand: "right" | "left" | null;
+  pitcher_style: string | null;
+  velocity_zone: string | null;
   plate_appearances: number;
   at_bats: number;
   hits: number;


### PR DESCRIPTION
## 概要

分析画面「対戦投手別」で、投手名の横（下）に所属チーム名・どっち投げ・投手タイプ・球速帯を表示する。

ippei-shimizu/buzzbase#421 のフロントエンド対応。バックエンドのレスポンス拡張（ippei-shimizu/buzzbase_back#290）に対応する。

## 変更内容

- `app/(app)/stats/analysisActions.ts`
  - `PitcherFaceoff` 型に `team_name` / `throw_hand` / `pitcher_style` / `velocity_zone`（いずれも nullable）を追加
- `app/(app)/stats/_components/analysis/PitcherFaceoffList.tsx`
  - 投手名の下に「所属チーム名・右投げ/左投げ・投手タイプ・球速帯」を `・` 区切りで併記
  - 未設定（null）の項目は非表示

## 確認

- `yarn typecheck` / `yarn lint` パス
