### PR TITLE
Update: 打撃成績推移グラフのツールチップ タップエリアをY軸方向に拡大

### DIFF
--- a/app/(app)/stats/_components/analysis/BattingTrendChart.tsx
+++ b/app/(app)/stats/_components/analysis/BattingTrendChart.tsx
@@ -38,6 +38,8 @@ const PADDING_TOP = 16;
 const PADDING_BOTTOM = 24;
 const PLOT_WIDTH = CHART_WIDTH - PADDING_LEFT - PADDING_RIGHT;
 const PLOT_HEIGHT = CHART_HEIGHT - PADDING_TOP - PADDING_BOTTOM;
+const PLOT_RIGHT = CHART_WIDTH - PADDING_RIGHT;
+const PLOT_BOTTOM = PADDING_TOP + PLOT_HEIGHT;
 
 // X 軸ラベルは混雑回避のため最大 6 本に間引く。
 const MAX_X_LABELS = 6;
@@ -186,8 +188,6 @@ export function BattingTrendChart({
 
   // タップ領域の縦帯。隣接点との X 中点で分割し、両端はプロット境界にクランプする。
   // 点が 1 個のときはプロット幅全体を 1 帯とする。
-  const PLOT_RIGHT = CHART_WIDTH - PADDING_RIGHT;
-  const PLOT_BOTTOM = PADDING_TOP + PLOT_HEIGHT;
   const getBandX = (index: number) =>
     index === 0 ? PADDING_LEFT : (getX(index - 1) + getX(index)) / 2;
   const getBandRight = (index: number) =>

--- a/app/(app)/stats/_components/analysis/BattingTrendChart.tsx
+++ b/app/(app)/stats/_components/analysis/BattingTrendChart.tsx
@@ -342,19 +342,19 @@ export function BattingTrendChart({
               const isSelected =
                 selectedDot?.lineKey === line.key &&
                 selectedDot?.pointIndex === index;
+              const bandX = getBandX(index);
+              const bandWidth = getBandRight(index) - bandX;
+              const bandY = Math.max(PADDING_TOP, getY(point[line.key]) - 8);
               return (
                 <Fragment key={`pt-${line.key}-${index}`}>
                   {/* 点とその真下（Y 軸方向の縦帯）をタップ領域にして、点だけより
                       クリックしやすくする。複数ライン表示時は描画順で後のラインの帯が
                       前面に来る（重なり領域は後勝ち）。 */}
                   <rect
-                    x={getBandX(index)}
-                    y={Math.max(PADDING_TOP, getY(point[line.key]) - 8)}
-                    width={getBandRight(index) - getBandX(index)}
-                    height={
-                      PLOT_BOTTOM -
-                      Math.max(PADDING_TOP, getY(point[line.key]) - 8)
-                    }
+                    x={bandX}
+                    y={bandY}
+                    width={bandWidth}
+                    height={PLOT_BOTTOM - bandY}
                     fill="transparent"
                     className="cursor-pointer"
                     onClick={() => handleDotPress(line.key, index)}

--- a/app/(app)/stats/_components/analysis/BattingTrendChart.tsx
+++ b/app/(app)/stats/_components/analysis/BattingTrendChart.tsx
@@ -184,6 +184,17 @@ export function BattingTrendChart({
   const getY = (value: number) =>
     PADDING_TOP + PLOT_HEIGHT - (value / valueRange) * PLOT_HEIGHT;
 
+  // タップ領域の縦帯。隣接点との X 中点で分割し、両端はプロット境界にクランプする。
+  // 点が 1 個のときはプロット幅全体を 1 帯とする。
+  const PLOT_RIGHT = CHART_WIDTH - PADDING_RIGHT;
+  const PLOT_BOTTOM = PADDING_TOP + PLOT_HEIGHT;
+  const getBandX = (index: number) =>
+    index === 0 ? PADDING_LEFT : (getX(index - 1) + getX(index)) / 2;
+  const getBandRight = (index: number) =>
+    index === points.length - 1
+      ? PLOT_RIGHT
+      : (getX(index) + getX(index + 1)) / 2;
+
   const linePaths = visibleLines.map((line) => ({
     ...line,
     d: points
@@ -333,10 +344,17 @@ export function BattingTrendChart({
                 selectedDot?.pointIndex === index;
               return (
                 <Fragment key={`pt-${line.key}-${index}`}>
-                  <circle
-                    cx={getX(index)}
-                    cy={getY(point[line.key])}
-                    r={10}
+                  {/* 点とその真下（Y 軸方向の縦帯）をタップ領域にして、点だけより
+                      クリックしやすくする。複数ライン表示時は描画順で後のラインの帯が
+                      前面に来る（重なり領域は後勝ち）。 */}
+                  <rect
+                    x={getBandX(index)}
+                    y={Math.max(PADDING_TOP, getY(point[line.key]) - 8)}
+                    width={getBandRight(index) - getBandX(index)}
+                    height={
+                      PLOT_BOTTOM -
+                      Math.max(PADDING_TOP, getY(point[line.key]) - 8)
+                    }
                     fill="transparent"
                     className="cursor-pointer"
                     onClick={() => handleDotPress(line.key, index)}


### PR DESCRIPTION
## 概要

成績画面の打撃成績推移グラフで、ツールチップ（打率などの数値表示）のタップ判定エリアを Y 軸方向に拡大する。折れ線グラフの点だけでなく、その点の真下（縦帯）をクリック/タップしてもツールチップが表示されるようにする。

ippei-shimizu/buzzbase#419 のフロントエンド対応。

## 変更内容

- `app/(app)/stats/_components/analysis/BattingTrendChart.tsx`
  - クリック専用の透明な円（`r=10`）を、各データ点の真下に伸びる透明な縦帯 `rect` に置き換え
  - 縦帯の左右境界は隣接点との X 座標の中点で分割。両端はプロット境界にクランプ。点が 1 個のときはプロット幅全体
  - 縦帯は点のすぐ上からプロット下端まで。表示用の点（`circle`）・ツールチップの内容は変更なし
  - 複数ライン表示時、重なり領域は描画順で後のラインが優先（デフォルトは打率 1 本のみで曖昧さなし）

## 確認

- `yarn typecheck` / `yarn lint` パス
