### PR TITLE
Fix: PR #363 レビュー指摘対応（打席採番/打撃チップ/相手チーム/色判定/投手取得）

### DIFF
--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
@@ -56,8 +56,9 @@ export function PitcherSelector({
   const [editingPitcher, setEditingPitcher] = useState<Pitcher | null>(null);
 
   useEffect(() => {
-    // クライアント側で名前検索するため、ページネーション先頭のみだと
-    // 投手が多いユーザーで取りこぼす。十分大きい per_page で全件に近い件数を取得する。
+    // クライアント側で名前検索するため、ページネーション先頭のみだと投手が多いユーザーで
+    // 取りこぼす。1ユーザーの登録投手は 200 件を超えない想定で全件取得とみなす
+    // （超える運用が出たらサーバーサイド検索へ移行する）。
     getPitchers({ per_page: 200 }).then((response) =>
       setPitchers(response.data),
     );

--- a/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/detail/PitcherSelector.tsx
@@ -56,7 +56,11 @@ export function PitcherSelector({
   const [editingPitcher, setEditingPitcher] = useState<Pitcher | null>(null);
 
   useEffect(() => {
-    getPitchers({}).then((response) => setPitchers(response.data));
+    // クライアント側で名前検索するため、ページネーション先頭のみだと
+    // 投手が多いユーザーで取りこぼす。十分大きい per_page で全件に近い件数を取得する。
+    getPitchers({ per_page: 200 }).then((response) =>
+      setPitchers(response.data),
+    );
     getTeams().then(setTeams);
   }, []);
 

--- a/app/(app)/game-result/plate-appearances/new/page.tsx
+++ b/app/(app)/game-result/plate-appearances/new/page.tsx
@@ -28,7 +28,14 @@ export default function NewPlateAppearancePage() {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setGameResultId(id);
     getPlateAppearancesByGame(id).then((plateAppearances) => {
-      setBatterBoxNumber(plateAppearances.length + 1);
+      // 件数ベースだと途中の打席を削除した際に既存番号と衝突するため、
+      // 既存の最大 batter_box_number + 1 で採番する。
+      const maxBatterBoxNumber = plateAppearances.reduce(
+        (max, plateAppearance) =>
+          Math.max(max, plateAppearance.batter_box_number),
+        0,
+      );
+      setBatterBoxNumber(maxBatterBoxNumber + 1);
     });
     getCurrentUserId().then((userId) => {
       checkExistingMatchResults(id, userId).then((matchResult) => {

--- a/app/(app)/game-result/plate-appearances/page.tsx
+++ b/app/(app)/game-result/plate-appearances/page.tsx
@@ -62,6 +62,15 @@ export default function PlateAppearanceListPage() {
     })();
   }, [router]);
 
+  // 件数ベースだと途中の打席を削除した際に既存番号と衝突するため、
+  // 既存の最大 batter_box_number + 1 を次の採番に使う。
+  const nextBatterBoxNumber =
+    plateAppearances.reduce(
+      (max, plateAppearance) =>
+        Math.max(max, plateAppearance.batter_box_number),
+      0,
+    ) + 1;
+
   // 新規記録時は「両方」パターンのときだけ投手成績入力へ進む。
   const goNewComplete = () => {
     router.push(readRecordPattern() === "both" ? PITCHING_PATH : SUMMARY_PATH);
@@ -99,7 +108,7 @@ export default function PlateAppearanceListPage() {
                   </p>
                 ) : null}
                 <AddPlateAppearanceCard
-                  batterBoxNumber={plateAppearances.length + 1}
+                  batterBoxNumber={nextBatterBoxNumber}
                   onAdd={() =>
                     router.push("/game-result/plate-appearances/new")
                   }

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -357,9 +357,19 @@ export default function GameRecord() {
   };
 
   // 相手チーム設定
-  const handleOpponentTeamChange = (teamName: React.Key | null) => {
-    setExistingOpponentTeam(Number(teamName));
-    setOpponentTeam(teamName as string);
+  const handleOpponentTeamChange = (teamKey: React.Key | null) => {
+    if (teamKey === null) {
+      setExistingOpponentTeam(undefined);
+      return;
+    }
+    // teamKey は選択された既存チームの id。id 文字列をそのまま opponentTeam に
+    // 入れると保存時に名前として createOrUpdateTeam へ渡り不正なチームが作られるため、
+    // id を保持しつつ表示名はチーム一覧から解決する。
+    setExistingOpponentTeam(Number(teamKey));
+    const selectedTeam = teamsData.find(
+      (team) => String(team.id) === String(teamKey),
+    );
+    setOpponentTeam(selectedTeam?.name ?? "");
   };
 
   const handleTournamentInputChange = (value: string) => {
@@ -582,9 +592,10 @@ export default function GameRecord() {
         }
       }
 
-      // 相手チーム保存
-      let opponentTeamId;
-      if (typeof opponentTeam === "string") {
+      // 相手チーム保存。既存チームを選択済み（existingOpponentTeam あり）の場合は
+      // 新規作成せず id をそのまま使い、手入力で新しいチーム名を入れた場合のみ作成する。
+      let opponentTeamId = existingOpponentTeam;
+      if (!opponentTeamId && opponentTeam.trim() !== "") {
         const newTeamResponse = await createOrUpdateTeam({
           team: {
             name: opponentTeam,
@@ -593,10 +604,6 @@ export default function GameRecord() {
           },
         });
         opponentTeamId = newTeamResponse.data.id;
-      } else {
-        opponentTeamId = teamsData.find(
-          (team) => team.name === opponentTeam,
-        )?.id;
       }
       const matchResultData = {
         match_result: {

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -465,7 +465,9 @@ export default function GameRecord() {
       setIsMyTeamValid(true);
     }
 
-    if (!opponentTeam) {
+    // 既存試合の編集時は opponentTeam（名前）が空でも existingOpponentTeam（id）で
+    // 相手チームが確定しているため、どちらかがあれば入力済みとみなす。
+    if (!opponentTeam && !existingOpponentTeam) {
       setIsOpponentTeamValid(false);
       isValid = false;
       newErrors.push("相手チーム名が未入力です。");

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -359,7 +359,9 @@ export default function GameRecord() {
   // 相手チーム設定
   const handleOpponentTeamChange = (teamKey: React.Key | null) => {
     if (teamKey === null) {
+      // クリア時は id と名前の両方を空にして、選択済みチーム名が残らないようにする。
       setExistingOpponentTeam(undefined);
+      setOpponentTeam("");
       return;
     }
     // teamKey は選択された既存チームの id。id 文字列をそのまま opponentTeam に

--- a/app/(app)/game-result/summary/[slug]/page.tsx
+++ b/app/(app)/game-result/summary/[slug]/page.tsx
@@ -216,22 +216,16 @@ export default function ResultsSummary() {
 
   // 打席
   const getBattingResultClassName = (battingResult: string) => {
-    // 安打系(右中/左中/線など全方向)は共通判定で赤に。四球/死球/犠打/犠飛/打妨は青。
-    if (getBattingResultColor(battingResult) === HIT_RESULT_COLOR) {
+    // 安打系(右中/左中/線など全方向)は赤、犠打・犠飛は共通の部分一致判定で青にする。
+    const resultColor = getBattingResultColor(battingResult);
+    if (resultColor === HIT_RESULT_COLOR) {
       return "text-red-500";
     }
-    const walks = [
-      "四球",
-      "死球",
-      "投犠",
-      "捕犠",
-      "一犠",
-      "二犠",
-      "三犠",
-      "遊犠",
-      "打妨",
-    ];
-    if (walks.includes(battingResult)) {
+    if (resultColor === SACRIFICE_RESULT_COLOR) {
+      return "text-blue-400";
+    }
+    // 四球・死球・打妨は安打でも犠打でもないが青で表示する。
+    if (["四球", "死球", "打妨"].some((walk) => battingResult.includes(walk))) {
       return "text-blue-400";
     }
     return "";

--- a/app/(app)/game-result/summary/[slug]/page.tsx
+++ b/app/(app)/game-result/summary/[slug]/page.tsx
@@ -46,6 +46,7 @@ import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceServi
 import {
   getBattingResultColor,
   HIT_RESULT_COLOR,
+  SACRIFICE_RESULT_COLOR,
 } from "@app/utils/battingResultColor";
 import { PlateAppearanceSummaryCard } from "../_components/PlateAppearanceSummaryCard";
 
@@ -390,21 +391,22 @@ export default function ResultsSummary() {
                     <div key={batting.id}>
                       <p className="text-xs text-zinc-400">打撃</p>
                       <ul className="flex flex-wrap gap-2 mt-2">
-                        {plateAppearance ? (
-                          plateAppearance.map((plate) => (
-                            <li key={plate.batter_box_number}>
-                              <p
-                                className={`font-bold ${getBattingResultClassName(
-                                  plate.batting_result,
-                                )}`}
-                              >
-                                {plate.batting_result}
-                              </p>
-                            </li>
-                          ))
-                        ) : (
-                          <></>
-                        )}
+                        {(plateAppearancesV2.length > 0
+                          ? plateAppearancesV2
+                          : (plateAppearance ?? [])
+                        ).map((plate, index) => (
+                          <li
+                            key={`${plate.batter_box_number ?? "na"}-${index}`}
+                          >
+                            <p
+                              className={`font-bold ${getBattingResultClassName(
+                                plate.batting_result,
+                              )}`}
+                            >
+                              {plate.batting_result}
+                            </p>
+                          </li>
+                        ))}
                       </ul>
                       <div className="mt-1.5 grid grid-cols-3 gap-x-3 gap-y-1">
                         <div className="flex items-center">

--- a/app/(app)/game-result/summary/page.tsx
+++ b/app/(app)/game-result/summary/page.tsx
@@ -180,31 +180,16 @@ export default function ResultsSummary() {
 
   // 打席
   const getBattingResultClassName = (battingResult: string) => {
-    // 安打系(右中/左中/線など全方向)は共通判定で赤に。四球/死球/犠打/犠飛/打妨は青。
-    if (getBattingResultColor(battingResult) === HIT_RESULT_COLOR) {
+    // 安打系(右中/左中/線など全方向)は赤、犠打・犠飛は共通の部分一致判定で青にする。
+    const resultColor = getBattingResultColor(battingResult);
+    if (resultColor === HIT_RESULT_COLOR) {
       return "text-red-500";
     }
-    const walks = [
-      "四球",
-      "死球",
-      "投犠打",
-      "捕犠打",
-      "一犠打",
-      "二犠打",
-      "三犠打",
-      "遊犠打",
-      "投犠飛",
-      "捕犠飛",
-      "一犠飛",
-      "二犠飛",
-      "三犠飛",
-      "遊犠飛",
-      "左犠飛",
-      "中犠飛",
-      "右犠飛",
-      "打妨",
-    ];
-    if (walks.includes(battingResult)) {
+    if (resultColor === SACRIFICE_RESULT_COLOR) {
+      return "text-blue-400";
+    }
+    // 四球・死球・打妨は安打でも犠打でもないが青で表示する。
+    if (["四球", "死球", "打妨"].some((walk) => battingResult.includes(walk))) {
       return "text-blue-400";
     }
     return "";

--- a/app/(app)/game-result/summary/page.tsx
+++ b/app/(app)/game-result/summary/page.tsx
@@ -30,6 +30,7 @@ import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceServi
 import {
   getBattingResultColor,
   HIT_RESULT_COLOR,
+  SACRIFICE_RESULT_COLOR,
 } from "@app/utils/battingResultColor";
 import { PlateAppearanceSummaryCard } from "./_components/PlateAppearanceSummaryCard";
 


### PR DESCRIPTION
## 概要

PR #363（Release: 試合・成績機能アップデート）のレビュー指摘のうち、front 側で対応可能な 5 件を修正する。マージ先は release ブランチ `release/game-stats-202605`。

## 対応した指摘

### Critical

- **打席 batter_box_number の重複**
  件数ベース（`length + 1`）採番をやめ、既存の最大 `batter_box_number + 1` に変更。途中の打席を削除した後の新規記録で番号が衝突する問題を解消（`plate-appearances/new/page.tsx`, `plate-appearances/page.tsx`）。
- **試合詳細ページの打撃結果チップが v1 のみ表示**
  `summary/[slug]/page.tsx` の打撃結果チップを `summary/page.tsx` と同じ v2 優先表示に統一。新形式（v2 のみ）試合でチップが表示されない不整合を解消。

### High

- **既存相手チーム選択時の teams テーブル汚染**
  ドロップダウンから既存チームを選択すると id 文字列（例 `"42"`）が `createOrUpdateTeam` に name として渡り不正なチームが作成されていた。選択時は id を保持しつつ表示名をチーム一覧から解決し、保存時は `existingOpponentTeam` がある場合は作成をスキップするよう修正（`record/page.tsx`）。
- **犠打・犠飛の青色表示が不整合**
  両 summary ページの独自 walks 配列（短縮形／長形式）をやめ、`getBattingResultColor` の部分一致判定（`SACRIFICE_RESULT_COLOR`）に統一。`投犠打` 等で画面間の色差異が出る問題を解消。

### Medium

- **PitcherSelector が投手一覧の先頭ページのみ取得**
  `getPitchers({ per_page: 200 })` を指定し、投手が多いユーザーでクライアント検索が取りこぼす問題を緩和。

## 未対応（別 issue 化）

- **球場名解決の追加リクエスト** — 正攻法はバックエンドの serializer に `stadium_name` を含める改修のため、別途バックエンド issue として起票する。現状は best-effort フォールバックで動作する。

## 確認

- `yarn typecheck` / `yarn lint` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
