### PR TITLE
Update: 試合編集の球場名表示を existing_search の stadium_name に集約 (#425)

### DIFF
--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -199,16 +199,12 @@ export default function GameRecord() {
         currentUserId,
       );
       if (existingMatchResult) {
-        // stadium_id を復元する。v1 レスポンスは球場名を含まないため、
-        // 表示名は候補リストから id で best-effort に引き当てる（見つからなくても
-        // stadium_id は保持され、保存時に球場が維持される）。
+        // stadium_id と、back が解決済みで返す stadium_name を復元する。
         if (existingMatchResult.stadium_id) {
           setStadiumId(existingMatchResult.stadium_id);
-          const stadiumList = await searchStadiums({ per_page: 100 });
-          const foundStadium = stadiumList.data.find(
-            (stadium) => stadium.id === existingMatchResult.stadium_id,
-          );
-          if (foundStadium) setStadiumName(foundStadium.name);
+          if (existingMatchResult.stadium_name) {
+            setStadiumName(existingMatchResult.stadium_name);
+          }
         }
         const date = new Date(existingMatchResult.date_and_time);
         const formattedDate = `${date.getFullYear()}-${(date.getMonth() + 1)


### PR DESCRIPTION
## 概要

ippei-shimizu/buzzbase#425 対応の front 側。試合編集画面で球場名表示のために `searchStadiums({ per_page: 100 })` を追加取得し、id から名前を best-effort に引き当てていた処理を撤廃する。back が `existing_search` のレスポンスで返す `stadium_name` をそのまま使う。

base は stadium 機能を含む `release/game-stats-202605`（stg にはまだ stadium 機能が無いため）。

## 変更内容

- `record/page.tsx` の `fetchExistingMatchResult` で、`searchStadiums({ per_page: 100 })` による引き当てを削除
- 代わりに `existingMatchResult.stadium_name` を `setStadiumName` にセット
- 初期ロード / 球場検索用の `searchStadiums` は引き続き使用するため import は維持

## 解消される問題

- 登録球場が `per_page: 100` を超えると編集時に球場名が見つからずフィールドが空になる問題
- 編集画面表示時の余分な stadiums リクエスト 1 本

## 依存

- back PR ippei-shimizu/buzzbase_back#292（`existing_search` に `stadium_name` を追加）が先にデプロイされている必要がある

## テスト

- `yarn typecheck` / `yarn lint` パス

## 関連

- Issue: ippei-shimizu/buzzbase#425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
