### PR TITLE
Add: 成績・試合・ランキングに期間（年月レンジ）フィルタUIを追加

### DIFF
--- a/app/(app)/dashboard/_components/DashboardContent.tsx
+++ b/app/(app)/dashboard/_components/DashboardContent.tsx
@@ -35,8 +35,16 @@ export default function DashboardContent({
     year: string,
     matchType: string,
     seasonId?: string,
+    startMonth?: string,
+    endMonth?: string,
   ) => {
-    const filtered = await getFilteredBattingStats(year, matchType, seasonId);
+    const filtered = await getFilteredBattingStats(
+      year,
+      matchType,
+      seasonId,
+      startMonth,
+      endMonth,
+    );
     if (filtered) {
       setBattingStats(filtered);
     }
@@ -46,8 +54,16 @@ export default function DashboardContent({
     year: string,
     matchType: string,
     seasonId?: string,
+    startMonth?: string,
+    endMonth?: string,
   ) => {
-    const filtered = await getFilteredPitchingStats(year, matchType, seasonId);
+    const filtered = await getFilteredPitchingStats(
+      year,
+      matchType,
+      seasonId,
+      startMonth,
+      endMonth,
+    );
     if (filtered) {
       setPitchingStats(filtered);
     }

--- a/app/(app)/dashboard/_components/DashboardContent.tsx
+++ b/app/(app)/dashboard/_components/DashboardContent.tsx
@@ -79,6 +79,7 @@ export default function DashboardContent({
         hasBattingRecord={!!data?.batting_stats?.calculated}
         hasPitchingRecord={!!data?.pitching_stats?.calculated}
         availableYears={data?.available_years ?? []}
+        availableMonths={data?.available_months ?? []}
         availableSeasons={seasons}
         onBattingFilterChange={handleBattingFilterChange}
         onPitchingFilterChange={handlePitchingFilterChange}

--- a/app/(app)/dashboard/_components/StatsOverview.tsx
+++ b/app/(app)/dashboard/_components/StatsOverview.tsx
@@ -103,7 +103,7 @@ function StatsFilter({
   onPeriodRangeChange,
 }: FilterProps) {
   return (
-    <FilterChipGroup>
+    <FilterChipGroup wrap>
       <FilterChip
         label="年度"
         value={selectedYear}

--- a/app/(app)/dashboard/_components/StatsOverview.tsx
+++ b/app/(app)/dashboard/_components/StatsOverview.tsx
@@ -4,8 +4,15 @@ import type { BattingStats, PitchingStats, SeasonOption } from "../actions";
 import { useState } from "react";
 import FilterChip from "@app/components/filter/FilterChip";
 import FilterChipGroup from "@app/components/filter/FilterChipGroup";
+import PeriodRangeFilter, {
+  type PeriodRange,
+} from "@app/components/filter/PeriodRangeFilter";
 import StatTooltipLabel from "@app/components/table/StatTooltipLabel";
 import { INNING_FORMAT_TOOLTIP } from "@app/constants/pitchingTooltips";
+import {
+  buildMonthOptions,
+  type MonthOption,
+} from "@app/utils/buildMonthOptions";
 import { formatRate, formatRate2, formatEra } from "@app/utils/formatStats";
 import {
   normalizeBattingStats,
@@ -24,11 +31,15 @@ interface StatsOverviewProps {
     year: string,
     matchType: string,
     seasonId?: string,
+    startMonth?: string,
+    endMonth?: string,
   ) => void;
   onPitchingFilterChange: (
     year: string,
     matchType: string,
     seasonId?: string,
+    startMonth?: string,
+    endMonth?: string,
   ) => void;
 }
 
@@ -65,23 +76,31 @@ const styleTableData =
 interface FilterProps {
   availableYears: { key: string; label: string }[];
   availableSeasons: { key: string; label: string }[];
+  monthOptions: MonthOption[];
   selectedYear: string;
   selectedMatchType: string;
   selectedSeason: string;
+  startMonth?: string;
+  endMonth?: string;
   onYearChange: (key: string) => void;
   onMatchTypeChange: (key: string) => void;
   onSeasonChange: (key: string) => void;
+  onPeriodRangeChange: (range: PeriodRange) => void;
 }
 
 function StatsFilter({
   availableYears,
   availableSeasons,
+  monthOptions,
   selectedYear,
   selectedMatchType,
   selectedSeason,
+  startMonth,
+  endMonth,
   onYearChange,
   onMatchTypeChange,
   onSeasonChange,
+  onPeriodRangeChange,
 }: FilterProps) {
   return (
     <FilterChipGroup>
@@ -108,6 +127,12 @@ function StatsFilter({
           onChange={onSeasonChange}
         />
       )}
+      <PeriodRangeFilter
+        startMonth={startMonth}
+        endMonth={endMonth}
+        monthOptions={monthOptions}
+        onChange={onPeriodRangeChange}
+      />
     </FilterChipGroup>
   );
 }
@@ -482,9 +507,21 @@ export default function StatsOverview({
   const [battingYear, setBattingYear] = useState("通算");
   const [battingMatchType, setBattingMatchType] = useState("全て");
   const [battingSeason, setBattingSeason] = useState("全て");
+  const [battingStartMonth, setBattingStartMonth] = useState<
+    string | undefined
+  >(undefined);
+  const [battingEndMonth, setBattingEndMonth] = useState<string | undefined>(
+    undefined,
+  );
   const [pitchingYear, setPitchingYear] = useState("通算");
   const [pitchingMatchType, setPitchingMatchType] = useState("全て");
   const [pitchingSeason, setPitchingSeason] = useState("全て");
+  const [pitchingStartMonth, setPitchingStartMonth] = useState<
+    string | undefined
+  >(undefined);
+  const [pitchingEndMonth, setPitchingEndMonth] = useState<string | undefined>(
+    undefined,
+  );
 
   const yearOptions = [
     { key: "通算", label: "通算" },
@@ -496,40 +533,126 @@ export default function StatsOverview({
     ...availableSeasons.map((s) => ({ key: String(s.id), label: s.name })),
   ];
 
+  const monthOptions: MonthOption[] = buildMonthOptions(availableYears);
+
   const handleBattingYearChange = (year: string) => {
     setBattingYear(year);
+    // 実年を選んだら期間指定をクリアする（年度と期間は排他）。
+    const isRealYear = year !== "通算";
+    const nextStartMonth = isRealYear ? undefined : battingStartMonth;
+    const nextEndMonth = isRealYear ? undefined : battingEndMonth;
+    if (isRealYear) {
+      setBattingStartMonth(undefined);
+      setBattingEndMonth(undefined);
+    }
     const seasonId = battingSeason !== "全て" ? battingSeason : undefined;
-    onBattingFilterChange(year, battingMatchType, seasonId);
+    onBattingFilterChange(
+      year,
+      battingMatchType,
+      seasonId,
+      nextStartMonth,
+      nextEndMonth,
+    );
   };
 
   const handleBattingMatchTypeChange = (matchType: string) => {
     setBattingMatchType(matchType);
     const seasonId = battingSeason !== "全て" ? battingSeason : undefined;
-    onBattingFilterChange(battingYear, matchType, seasonId);
+    onBattingFilterChange(
+      battingYear,
+      matchType,
+      seasonId,
+      battingStartMonth,
+      battingEndMonth,
+    );
   };
 
   const handleBattingSeasonChange = (season: string) => {
     setBattingSeason(season);
     const seasonId = season !== "全て" ? season : undefined;
-    onBattingFilterChange(battingYear, battingMatchType, seasonId);
+    onBattingFilterChange(
+      battingYear,
+      battingMatchType,
+      seasonId,
+      battingStartMonth,
+      battingEndMonth,
+    );
+  };
+
+  const handleBattingPeriodRangeChange = (range: PeriodRange) => {
+    setBattingStartMonth(range.startMonth);
+    setBattingEndMonth(range.endMonth);
+    // 期間を指定したら年度は通算に戻す（年度と期間は排他）。
+    const hasPeriod = !!(range.startMonth || range.endMonth);
+    const nextYear = hasPeriod ? "通算" : battingYear;
+    if (hasPeriod) setBattingYear("通算");
+    const seasonId = battingSeason !== "全て" ? battingSeason : undefined;
+    onBattingFilterChange(
+      nextYear,
+      battingMatchType,
+      seasonId,
+      range.startMonth,
+      range.endMonth,
+    );
   };
 
   const handlePitchingYearChange = (year: string) => {
     setPitchingYear(year);
+    const isRealYear = year !== "通算";
+    const nextStartMonth = isRealYear ? undefined : pitchingStartMonth;
+    const nextEndMonth = isRealYear ? undefined : pitchingEndMonth;
+    if (isRealYear) {
+      setPitchingStartMonth(undefined);
+      setPitchingEndMonth(undefined);
+    }
     const seasonId = pitchingSeason !== "全て" ? pitchingSeason : undefined;
-    onPitchingFilterChange(year, pitchingMatchType, seasonId);
+    onPitchingFilterChange(
+      year,
+      pitchingMatchType,
+      seasonId,
+      nextStartMonth,
+      nextEndMonth,
+    );
   };
 
   const handlePitchingMatchTypeChange = (matchType: string) => {
     setPitchingMatchType(matchType);
     const seasonId = pitchingSeason !== "全て" ? pitchingSeason : undefined;
-    onPitchingFilterChange(pitchingYear, matchType, seasonId);
+    onPitchingFilterChange(
+      pitchingYear,
+      matchType,
+      seasonId,
+      pitchingStartMonth,
+      pitchingEndMonth,
+    );
   };
 
   const handlePitchingSeasonChange = (season: string) => {
     setPitchingSeason(season);
     const seasonId = season !== "全て" ? season : undefined;
-    onPitchingFilterChange(pitchingYear, pitchingMatchType, seasonId);
+    onPitchingFilterChange(
+      pitchingYear,
+      pitchingMatchType,
+      seasonId,
+      pitchingStartMonth,
+      pitchingEndMonth,
+    );
+  };
+
+  const handlePitchingPeriodRangeChange = (range: PeriodRange) => {
+    setPitchingStartMonth(range.startMonth);
+    setPitchingEndMonth(range.endMonth);
+    const hasPeriod = !!(range.startMonth || range.endMonth);
+    const nextYear = hasPeriod ? "通算" : pitchingYear;
+    if (hasPeriod) setPitchingYear("通算");
+    const seasonId = pitchingSeason !== "全て" ? pitchingSeason : undefined;
+    onPitchingFilterChange(
+      nextYear,
+      pitchingMatchType,
+      seasonId,
+      range.startMonth,
+      range.endMonth,
+    );
   };
 
   const hasBattingData = !!battingStats?.calculated;
@@ -567,12 +690,16 @@ export default function StatsOverview({
                 <StatsFilter
                   availableYears={yearOptions}
                   availableSeasons={seasonOptions}
+                  monthOptions={monthOptions}
                   selectedYear={battingYear}
                   selectedMatchType={battingMatchType}
                   selectedSeason={battingSeason}
+                  startMonth={battingStartMonth}
+                  endMonth={battingEndMonth}
                   onYearChange={handleBattingYearChange}
                   onMatchTypeChange={handleBattingMatchTypeChange}
                   onSeasonChange={handleBattingSeasonChange}
+                  onPeriodRangeChange={handleBattingPeriodRangeChange}
                 />
               </div>
               {hasBattingData && battingStats && (
@@ -606,12 +733,16 @@ export default function StatsOverview({
                 <StatsFilter
                   availableYears={yearOptions}
                   availableSeasons={seasonOptions}
+                  monthOptions={monthOptions}
                   selectedYear={pitchingYear}
                   selectedMatchType={pitchingMatchType}
                   selectedSeason={pitchingSeason}
+                  startMonth={pitchingStartMonth}
+                  endMonth={pitchingEndMonth}
                   onYearChange={handlePitchingYearChange}
                   onMatchTypeChange={handlePitchingMatchTypeChange}
                   onSeasonChange={handlePitchingSeasonChange}
+                  onPeriodRangeChange={handlePitchingPeriodRangeChange}
                 />
               </div>
               {hasPitchingData && pitchingStats && (

--- a/app/(app)/dashboard/_components/StatsOverview.tsx
+++ b/app/(app)/dashboard/_components/StatsOverview.tsx
@@ -10,7 +10,7 @@ import PeriodRangeFilter, {
 import StatTooltipLabel from "@app/components/table/StatTooltipLabel";
 import { INNING_FORMAT_TOOLTIP } from "@app/constants/pitchingTooltips";
 import {
-  buildMonthOptions,
+  monthOptionsFromRecorded,
   type MonthOption,
 } from "@app/utils/buildMonthOptions";
 import { formatRate, formatRate2, formatEra } from "@app/utils/formatStats";
@@ -26,6 +26,7 @@ interface StatsOverviewProps {
   hasBattingRecord: boolean;
   hasPitchingRecord: boolean;
   availableYears: number[];
+  availableMonths: string[];
   availableSeasons: SeasonOption[];
   onBattingFilterChange: (
     year: string,
@@ -500,6 +501,7 @@ export default function StatsOverview({
   hasBattingRecord,
   hasPitchingRecord,
   availableYears,
+  availableMonths,
   availableSeasons,
   onBattingFilterChange,
   onPitchingFilterChange,
@@ -533,7 +535,7 @@ export default function StatsOverview({
     ...availableSeasons.map((s) => ({ key: String(s.id), label: s.name })),
   ];
 
-  const monthOptions: MonthOption[] = buildMonthOptions(availableYears);
+  const monthOptions: MonthOption[] = monthOptionsFromRecorded(availableMonths);
 
   const handleBattingYearChange = (year: string) => {
     setBattingYear(year);

--- a/app/(app)/dashboard/actions.ts
+++ b/app/(app)/dashboard/actions.ts
@@ -115,6 +115,7 @@ export interface DashboardData {
   pitching_stats: PitchingStats;
   group_rankings: GroupRanking[];
   available_years: number[];
+  available_months?: string[];
 }
 
 export async function getDashboardData(

--- a/app/(app)/dashboard/actions.ts
+++ b/app/(app)/dashboard/actions.ts
@@ -182,11 +182,15 @@ function buildFilterQuery(
   year?: string,
   matchType?: string,
   seasonId?: string,
+  startMonth?: string,
+  endMonth?: string,
 ): string {
   const params = new URLSearchParams();
   if (year && year !== "通算") params.append("year", year);
   if (matchType && matchType !== "全て") params.append("match_type", matchType);
   if (seasonId) params.append("season_id", seasonId);
+  if (startMonth) params.append("start_month", startMonth);
+  if (endMonth) params.append("end_month", endMonth);
   const query = params.toString();
   return query ? `?${query}` : "";
 }
@@ -216,12 +220,20 @@ export async function getFilteredBattingStats(
   year?: string,
   matchType?: string,
   seasonId?: string,
+  startMonth?: string,
+  endMonth?: string,
 ): Promise<BattingStats | null> {
   try {
     const headers = await getAuthHeaders();
     if (!headers) return null;
 
-    const query = buildFilterQuery(year, matchType, seasonId);
+    const query = buildFilterQuery(
+      year,
+      matchType,
+      seasonId,
+      startMonth,
+      endMonth,
+    );
     const url = `${RAILS_API_URL}/api/v2/dashboard/batting_stats${query}`;
 
     const response = await fetch(url, {
@@ -243,12 +255,20 @@ export async function getFilteredPitchingStats(
   year?: string,
   matchType?: string,
   seasonId?: string,
+  startMonth?: string,
+  endMonth?: string,
 ): Promise<PitchingStats | null> {
   try {
     const headers = await getAuthHeaders();
     if (!headers) return null;
 
-    const query = buildFilterQuery(year, matchType, seasonId);
+    const query = buildFilterQuery(
+      year,
+      matchType,
+      seasonId,
+      startMonth,
+      endMonth,
+    );
     const url = `${RAILS_API_URL}/api/v2/dashboard/pitching_stats${query}`;
 
     const response = await fetch(url, {

--- a/app/(app)/game-result/lists/_components/GameSummaryContainer.tsx
+++ b/app/(app)/game-result/lists/_components/GameSummaryContainer.tsx
@@ -7,6 +7,7 @@ import type {
 } from "../gameSummaryTypes";
 import { Spinner } from "@heroui/react";
 import { useEffect, useState, useTransition } from "react";
+import { buildMonthOptions } from "@app/utils/buildMonthOptions";
 import { AnalysisFilters } from "../../../stats/_components/analysis/AnalysisFilters";
 import {
   getGameSummary,
@@ -36,6 +37,7 @@ export function GameSummaryContainer() {
   );
   const [isRefetching, startRefetch] = useTransition();
   const [yearOptions] = useState(buildYearOptions);
+  const [monthOptions] = useState(() => buildMonthOptions());
 
   // シーズン / 大会の選択肢はマウント時に1度だけ取得する。
   useEffect(() => {
@@ -94,6 +96,7 @@ export function GameSummaryContainer() {
         yearOptions={yearOptions}
         seasonOptions={seasonOptions}
         tournamentOptions={tournamentOptions}
+        monthOptions={monthOptions}
       />
       {result.status === "error" ? (
         <p className="py-10 text-center text-sm text-[#A1A1AA]">

--- a/app/(app)/game-result/lists/_components/GameSummaryContainer.tsx
+++ b/app/(app)/game-result/lists/_components/GameSummaryContainer.tsx
@@ -7,7 +7,7 @@ import type {
 } from "../gameSummaryTypes";
 import { Spinner } from "@heroui/react";
 import { useEffect, useState, useTransition } from "react";
-import { buildMonthOptions } from "@app/utils/buildMonthOptions";
+import { monthOptionsFromRecorded } from "@app/utils/buildMonthOptions";
 import { AnalysisFilters } from "../../../stats/_components/analysis/AnalysisFilters";
 import {
   getGameSummary,
@@ -35,17 +35,19 @@ export function GameSummaryContainer() {
   const [tournamentOptions, setTournamentOptions] = useState<FilterOption[]>(
     [],
   );
+  const [availableMonths, setAvailableMonths] = useState<string[]>([]);
   const [isRefetching, startRefetch] = useTransition();
   const [yearOptions] = useState(buildYearOptions);
-  const [monthOptions] = useState(() => buildMonthOptions());
+  const monthOptions = monthOptionsFromRecorded(availableMonths);
 
-  // シーズン / 大会の選択肢はマウント時に1度だけ取得する。
+  // シーズン / 大会 / 記録月の選択肢はマウント時に1度だけ取得する。
   useEffect(() => {
     let active = true;
     getGameSummaryFilterOptions().then((options) => {
       if (!active) return;
       setSeasonOptions(options.seasonOptions);
       setTournamentOptions(options.tournamentOptions);
+      setAvailableMonths(options.availableMonths);
     });
     return () => {
       active = false;

--- a/app/(app)/game-result/lists/gameSummaryActions.ts
+++ b/app/(app)/game-result/lists/gameSummaryActions.ts
@@ -21,6 +21,8 @@ function buildQuery(filters: GameSummaryFilters): string {
   if (filters.seasonId) params.append("season_id", filters.seasonId);
   if (filters.tournamentId)
     params.append("tournament_id", filters.tournamentId);
+  if (filters.startMonth) params.append("start_month", filters.startMonth);
+  if (filters.endMonth) params.append("end_month", filters.endMonth);
   return params.toString();
 }
 

--- a/app/(app)/game-result/lists/gameSummaryTypes.ts
+++ b/app/(app)/game-result/lists/gameSummaryTypes.ts
@@ -60,6 +60,8 @@ export interface GameSummaryFilters {
   matchType?: string;
   seasonId?: string;
   tournamentId?: string;
+  startMonth?: string;
+  endMonth?: string;
 }
 
 /**

--- a/app/(app)/groups/[slug]/page.tsx
+++ b/app/(app)/groups/[slug]/page.tsx
@@ -24,7 +24,7 @@ import GroupBattingRankingTable from "@app/components/table/GroupBattingRankingT
 import GroupPitchingRankingTable from "@app/components/table/GroupPitchingRankingTable";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import { getGroupDetail } from "@app/services/groupService";
-import { buildMonthOptions } from "@app/utils/buildMonthOptions";
+import { monthOptionsFromRecorded } from "@app/utils/buildMonthOptions";
 
 type GroupDetailProps = {
   params: Promise<{
@@ -87,6 +87,7 @@ type GroupsDetailData = {
   };
   id: number;
   available_years: number[];
+  available_months?: string[];
 };
 
 const MATCH_TYPE_OPTIONS = [
@@ -203,6 +204,7 @@ export default function GroupDetail(props: GroupDetailProps) {
   const [startMonth, setStartMonth] = useState<string | undefined>(undefined);
   const [endMonth, setEndMonth] = useState<string | undefined>(undefined);
   const [availableYears, setAvailableYears] = useState<number[]>([]);
+  const [availableMonths, setAvailableMonths] = useState<string[]>([]);
   const router = useRouter();
   useRequireAuth();
 
@@ -221,6 +223,7 @@ export default function GroupDetail(props: GroupDetailProps) {
         );
         setGroupData(responseGroupDetail);
         setAvailableYears(responseGroupDetail.available_years ?? []);
+        setAvailableMonths(responseGroupDetail.available_months ?? []);
 
         if (responseGroupDetail) {
           const battingStatsWithUsersData =
@@ -316,8 +319,8 @@ export default function GroupDetail(props: GroupDetailProps) {
   ]);
 
   const monthOptions = useMemo(
-    () => buildMonthOptions(availableYears),
-    [availableYears],
+    () => monthOptionsFromRecorded(availableMonths),
+    [availableMonths],
   );
 
   // 年度と期間は排他: 実年を選んだら期間をクリアする（通算選択時は据え置き）

--- a/app/(app)/groups/[slug]/page.tsx
+++ b/app/(app)/groups/[slug]/page.tsx
@@ -10,12 +10,13 @@ import {
 } from "@heroui/react";
 import { AxiosError } from "axios";
 import { useRouter } from "next/navigation";
-import React, { useEffect, useState, use } from "react";
+import React, { useEffect, useMemo, useState, use } from "react";
 import AnchorLink from "react-anchor-link-smooth-scroll";
 import { adSlots } from "@app/components/ad/adConfig";
 import AdInFeed from "@app/components/ad/AdInFeed";
 import FilterChip from "@app/components/filter/FilterChip";
 import FilterChipGroup from "@app/components/filter/FilterChipGroup";
+import PeriodRangeFilter from "@app/components/filter/PeriodRangeFilter";
 import HeaderBackLink from "@app/components/header/HeaderBackLink";
 import { MenuIcon } from "@app/components/icon/MenuIcon";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
@@ -23,6 +24,7 @@ import GroupBattingRankingTable from "@app/components/table/GroupBattingRankingT
 import GroupPitchingRankingTable from "@app/components/table/GroupPitchingRankingTable";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import { getGroupDetail } from "@app/services/groupService";
+import { buildMonthOptions } from "@app/utils/buildMonthOptions";
 
 type GroupDetailProps = {
   params: Promise<{
@@ -198,6 +200,8 @@ export default function GroupDetail(props: GroupDetailProps) {
   const [pitchingStats, setPitchingStats] = useState<PitchingStats[]>();
   const [selectedYear, setSelectedYear] = useState("通算");
   const [selectedMatchType, setSelectedMatchType] = useState("全て");
+  const [startMonth, setStartMonth] = useState<string | undefined>(undefined);
+  const [endMonth, setEndMonth] = useState<string | undefined>(undefined);
   const [availableYears, setAvailableYears] = useState<number[]>([]);
   const router = useRouter();
   useRequireAuth();
@@ -212,6 +216,8 @@ export default function GroupDetail(props: GroupDetailProps) {
           params.slug,
           year,
           matchType,
+          startMonth,
+          endMonth,
         );
         setGroupData(responseGroupDetail);
         setAvailableYears(responseGroupDetail.available_years ?? []);
@@ -300,7 +306,41 @@ export default function GroupDetail(props: GroupDetailProps) {
     };
 
     fetchData();
-  }, [selectedYear, selectedMatchType, params.slug, router]);
+  }, [
+    selectedYear,
+    selectedMatchType,
+    startMonth,
+    endMonth,
+    params.slug,
+    router,
+  ]);
+
+  const monthOptions = useMemo(
+    () => buildMonthOptions(availableYears),
+    [availableYears],
+  );
+
+  // 年度と期間は排他: 実年を選んだら期間をクリアする（通算選択時は据え置き）
+  const handleYearChange = (value: string) => {
+    setSelectedYear(value);
+    if (value !== "通算") {
+      setStartMonth(undefined);
+      setEndMonth(undefined);
+    }
+  };
+  // 期間を設定したら年度を通算へ戻す（両端クリア時は年度を据え置く）
+  const handlePeriodChange = (range: {
+    startMonth?: string;
+    endMonth?: string;
+  }) => {
+    setStartMonth(range.startMonth);
+    setEndMonth(range.endMonth);
+    if (range.startMonth || range.endMonth) {
+      setSelectedYear("通算");
+    }
+  };
+
+  const hideRankChange = Boolean(startMonth || endMonth);
 
   if (!groupData) {
     return <LoadingSpinner />;
@@ -368,7 +408,7 @@ export default function GroupDetail(props: GroupDetailProps) {
                         label: `${y}年`,
                       })),
                     ]}
-                    onChange={setSelectedYear}
+                    onChange={handleYearChange}
                   />
                   <FilterChip
                     label="種別"
@@ -376,6 +416,12 @@ export default function GroupDetail(props: GroupDetailProps) {
                     defaultValue="全て"
                     options={MATCH_TYPE_OPTIONS}
                     onChange={setSelectedMatchType}
+                  />
+                  <PeriodRangeFilter
+                    startMonth={startMonth}
+                    endMonth={endMonth}
+                    monthOptions={monthOptions}
+                    onChange={handlePeriodChange}
                   />
                 </FilterChipGroup>
               </div>
@@ -412,6 +458,7 @@ export default function GroupDetail(props: GroupDetailProps) {
                       <GroupBattingRankingTable
                         battingAverage={battingAverage}
                         battingStats={battingStats}
+                        hideRankChange={hideRankChange}
                       />
                     </div>
                   </Tab>
@@ -439,6 +486,7 @@ export default function GroupDetail(props: GroupDetailProps) {
                       <GroupPitchingRankingTable
                         pitchingAggregate={pitchingAggregate}
                         pitchingStats={pitchingStats}
+                        hideRankChange={hideRankChange}
                       />
                     </div>
                   </Tab>

--- a/app/(app)/groups/[slug]/page.tsx
+++ b/app/(app)/groups/[slug]/page.tsx
@@ -399,7 +399,7 @@ export default function GroupDetail(props: GroupDetailProps) {
                 個人成績ランキング
               </h2>
               <div className="mt-3">
-                <FilterChipGroup>
+                <FilterChipGroup wrap>
                   <FilterChip
                     label="年度"
                     value={selectedYear}

--- a/app/(app)/stats/_components/StatsContainer.tsx
+++ b/app/(app)/stats/_components/StatsContainer.tsx
@@ -8,6 +8,8 @@ import type {
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import FilterChip from "@app/components/filter/FilterChip";
 import FilterChipGroup from "@app/components/filter/FilterChipGroup";
+import PeriodRangeFilter from "@app/components/filter/PeriodRangeFilter";
+import { buildMonthOptions } from "@app/utils/buildMonthOptions";
 import { getBattingStats, getPitchingStats } from "../actions";
 import { DEFAULT_OPTION, type FilterOption } from "../statsFilterOption";
 import BattingStatsTable from "./BattingStatsTable";
@@ -61,11 +63,18 @@ export default function StatsContainer({
   const [tableTournamentId, setTableTournamentId] = useState<
     string | undefined
   >(undefined);
+  const [tableStartMonth, setTableStartMonth] = useState<string | undefined>(
+    undefined,
+  );
+  const [tableEndMonth, setTableEndMonth] = useState<string | undefined>(
+    undefined,
+  );
   const [battingRows, setBattingRows] =
     useState<BattingStatsRow[]>(initialRows);
   const [pitchingRows, setPitchingRows] = useState<PitchingStatsRow[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [yearOptions] = useState(buildYearOptions);
+  const [monthOptions] = useState(() => buildMonthOptions());
 
   // 初回マウントは SSR の initialRows（打撃/年別）を使うため取得しない。
   const didInitRef = useRef(false);
@@ -78,18 +87,53 @@ export default function StatsContainer({
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsLoading(true);
     const fetcher = tab === "batting" ? getBattingStats : getPitchingStats;
-    void fetcher(period, tableYear, tableSeasonId, tableTournamentId).then(
-      (rows) => {
-        if (!active) return;
-        if (tab === "batting") setBattingRows(rows as BattingStatsRow[]);
-        else setPitchingRows(rows as PitchingStatsRow[]);
-        setIsLoading(false);
-      },
-    );
+    void fetcher(
+      period,
+      tableYear,
+      tableSeasonId,
+      tableTournamentId,
+      tableStartMonth,
+      tableEndMonth,
+    ).then((rows) => {
+      if (!active) return;
+      if (tab === "batting") setBattingRows(rows as BattingStatsRow[]);
+      else setPitchingRows(rows as PitchingStatsRow[]);
+      setIsLoading(false);
+    });
     return () => {
       active = false;
     };
-  }, [tab, period, tableYear, tableSeasonId, tableTournamentId]);
+  }, [
+    tab,
+    period,
+    tableYear,
+    tableSeasonId,
+    tableTournamentId,
+    tableStartMonth,
+    tableEndMonth,
+  ]);
+
+  // 期間（開始/終了）と年度は排他。期間を指定したら年度を通算（未指定）に戻す。
+  const handlePeriodRangeChange = (range: {
+    startMonth?: string;
+    endMonth?: string;
+  }) => {
+    setTableStartMonth(range.startMonth);
+    setTableEndMonth(range.endMonth);
+    if (range.startMonth || range.endMonth) {
+      setTableYear(undefined);
+    }
+  };
+
+  // 実年を選んだら期間指定をクリアする（排他）。
+  const handleTableYearChange = (key: string) => {
+    const nextYear = key === "全て" ? undefined : key;
+    setTableYear(nextYear);
+    if (nextYear) {
+      setTableStartMonth(undefined);
+      setTableEndMonth(undefined);
+    }
+  };
 
   const handlePeriodChange = (next: StatsPeriod) => {
     setPeriod(next);
@@ -178,7 +222,13 @@ export default function StatsContainer({
               value={tableYear ?? "全て"}
               defaultValue="全て"
               options={yearOptions}
-              onChange={(key) => setTableYear(key === "全て" ? undefined : key)}
+              onChange={handleTableYearChange}
+            />
+            <PeriodRangeFilter
+              startMonth={tableStartMonth}
+              endMonth={tableEndMonth}
+              monthOptions={monthOptions}
+              onChange={handlePeriodRangeChange}
             />
             {seasonOptions.length > 1 ? (
               <FilterChip

--- a/app/(app)/stats/_components/StatsContainer.tsx
+++ b/app/(app)/stats/_components/StatsContainer.tsx
@@ -9,7 +9,7 @@ import { type ReactNode, useEffect, useRef, useState } from "react";
 import FilterChip from "@app/components/filter/FilterChip";
 import FilterChipGroup from "@app/components/filter/FilterChipGroup";
 import PeriodRangeFilter from "@app/components/filter/PeriodRangeFilter";
-import { buildMonthOptions } from "@app/utils/buildMonthOptions";
+import { monthOptionsFromRecorded } from "@app/utils/buildMonthOptions";
 import { getBattingStats, getPitchingStats } from "../actions";
 import { DEFAULT_OPTION, type FilterOption } from "../statsFilterOption";
 import BattingStatsTable from "./BattingStatsTable";
@@ -45,6 +45,8 @@ interface StatsContainerProps {
   /** サーバーで取得したシーズン/大会のフィルタ選択肢。 */
   seasonOptions: FilterOption[];
   tournamentOptions: FilterOption[];
+  /** 試合を記録した年月（"YYYY-MM" の降順）。期間フィルタの月候補に使う。 */
+  availableMonths: string[];
 }
 
 export default function StatsContainer({
@@ -53,6 +55,7 @@ export default function StatsContainer({
   pitchingAnalysisSlot,
   seasonOptions,
   tournamentOptions,
+  availableMonths,
 }: StatsContainerProps) {
   const [tab, setTab] = useState<ActiveTab>("batting");
   const [period, setPeriod] = useState<StatsPeriod>("yearly");
@@ -74,7 +77,9 @@ export default function StatsContainer({
   const [pitchingRows, setPitchingRows] = useState<PitchingStatsRow[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [yearOptions] = useState(buildYearOptions);
-  const [monthOptions] = useState(() => buildMonthOptions());
+  const [monthOptions] = useState(() =>
+    monthOptionsFromRecorded(availableMonths),
+  );
 
   // 初回マウントは SSR の initialRows（打撃/年別）を使うため取得しない。
   const didInitRef = useRef(false);

--- a/app/(app)/stats/_components/StatsContainer.tsx
+++ b/app/(app)/stats/_components/StatsContainer.tsx
@@ -221,7 +221,7 @@ export default function StatsContainer({
       {/* テーブル専用フィルタ（年/月以外＝年度/シーズン/大会で絞る） */}
       {showTableFilters ? (
         <div className="mb-3 flex justify-end">
-          <FilterChipGroup>
+          <FilterChipGroup wrap>
             <FilterChip
               label="年度"
               value={tableYear ?? "全て"}

--- a/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 import type { FilterOption } from "../../statsFilterOption";
 import { useEffect, useRef, useState, useTransition } from "react";
-import { buildMonthOptions } from "@app/utils/buildMonthOptions";
+import { monthOptionsFromRecorded } from "@app/utils/buildMonthOptions";
 import {
   type AnalysisFilters as Filters,
   type AnalysisInitialData,
@@ -64,6 +64,8 @@ interface AnalysisContainerProps {
   /** サーバーで取得したシーズン/大会のフィルタ選択肢。 */
   seasonOptions: FilterOption[];
   tournamentOptions: FilterOption[];
+  /** 試合を記録した年月（"YYYY-MM" の降順）。期間フィルタの月候補に使う。 */
+  availableMonths: string[];
 }
 
 /** 打撃成績分析（基本指標 + 打球チャート + 打球方向）のコンテナ。 */
@@ -71,6 +73,7 @@ export function AnalysisContainer({
   initialData,
   seasonOptions,
   tournamentOptions,
+  availableMonths,
 }: AnalysisContainerProps) {
   const [filters, setFilters] = useState<Filters>({
     year: "通算",
@@ -119,7 +122,9 @@ export function AnalysisContainer({
   // 推移グラフは粒度切替で単独再取得もあるため、専用の pending でグラフだけ dim する。
   const [isTrendPending, startTrendTransition] = useTransition();
   const [yearOptions] = useState(buildYearOptions);
-  const [monthOptions] = useState(() => buildMonthOptions());
+  const [monthOptions] = useState(() =>
+    monthOptionsFromRecorded(availableMonths),
+  );
 
   // 初回は SSR の initialData を使うため再取得しない（フィルタ変更時のみ取得）。
   const didInitRef = useRef(false);

--- a/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
@@ -1,6 +1,7 @@
 "use client";
 import type { FilterOption } from "../../statsFilterOption";
 import { useEffect, useRef, useState, useTransition } from "react";
+import { buildMonthOptions } from "@app/utils/buildMonthOptions";
 import {
   type AnalysisFilters as Filters,
   type AnalysisInitialData,
@@ -118,6 +119,7 @@ export function AnalysisContainer({
   // 推移グラフは粒度切替で単独再取得もあるため、専用の pending でグラフだけ dim する。
   const [isTrendPending, startTrendTransition] = useTransition();
   const [yearOptions] = useState(buildYearOptions);
+  const [monthOptions] = useState(() => buildMonthOptions());
 
   // 初回は SSR の initialData を使うため再取得しない（フィルタ変更時のみ取得）。
   const didInitRef = useRef(false);
@@ -213,6 +215,7 @@ export function AnalysisContainer({
         yearOptions={yearOptions}
         seasonOptions={seasonOptions}
         tournamentOptions={tournamentOptions}
+        monthOptions={monthOptions}
       />
       <div
         className={`flex flex-col gap-y-5${

--- a/app/(app)/stats/_components/analysis/AnalysisFilters.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisFilters.tsx
@@ -2,6 +2,10 @@
 import type { AnalysisFilters as Filters } from "../../analysisActions";
 import FilterChip from "@app/components/filter/FilterChip";
 import FilterChipGroup from "@app/components/filter/FilterChipGroup";
+import PeriodRangeFilter, {
+  type PeriodRange,
+} from "@app/components/filter/PeriodRangeFilter";
+import { type MonthOption } from "@app/utils/buildMonthOptions";
 
 interface FilterOption {
   key: string;
@@ -14,6 +18,7 @@ interface AnalysisFiltersProps {
   yearOptions: FilterOption[];
   seasonOptions: FilterOption[];
   tournamentOptions: FilterOption[];
+  monthOptions: MonthOption[];
   /** 種別フィルタを隠す（絞り込みに種別を使わない投手タブ向け）。 */
   hideMatchType?: boolean;
 }
@@ -30,7 +35,9 @@ function hasActiveFilter(filters: Filters): boolean {
     (filters.year ?? "通算") !== "通算" ||
     Boolean(filters.matchType) ||
     Boolean(filters.seasonId) ||
-    Boolean(filters.tournamentId)
+    Boolean(filters.tournamentId) ||
+    Boolean(filters.startMonth) ||
+    Boolean(filters.endMonth)
   );
 }
 
@@ -41,6 +48,7 @@ export function AnalysisFilters({
   yearOptions,
   seasonOptions,
   tournamentOptions,
+  monthOptions,
   hideMatchType = false,
 }: AnalysisFiltersProps) {
   const handleReset = () =>
@@ -49,7 +57,27 @@ export function AnalysisFilters({
       matchType: "",
       seasonId: undefined,
       tournamentId: undefined,
+      startMonth: undefined,
+      endMonth: undefined,
     });
+
+  // 年度と期間は排他。実年を選んだら期間を、期間を指定したら年度をクリアする。
+  const handleYearChange = (key: string) =>
+    onChange(
+      key === "通算"
+        ? { ...filters, year: key }
+        : { ...filters, year: key, startMonth: undefined, endMonth: undefined },
+    );
+
+  const handlePeriodChange = (range: PeriodRange) => {
+    const hasPeriod = Boolean(range.startMonth || range.endMonth);
+    onChange({
+      ...filters,
+      startMonth: range.startMonth,
+      endMonth: range.endMonth,
+      year: hasPeriod ? "通算" : filters.year,
+    });
+  };
 
   return (
     <FilterChipGroup wrap>
@@ -58,7 +86,13 @@ export function AnalysisFilters({
         value={filters.year ?? "通算"}
         defaultValue="通算"
         options={yearOptions}
-        onChange={(key) => onChange({ ...filters, year: key })}
+        onChange={handleYearChange}
+      />
+      <PeriodRangeFilter
+        startMonth={filters.startMonth}
+        endMonth={filters.endMonth}
+        monthOptions={monthOptions}
+        onChange={handlePeriodChange}
       />
       {hideMatchType ? null : (
         <FilterChip

--- a/app/(app)/stats/_components/analysis/AnalysisSection.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisSection.tsx
@@ -28,6 +28,7 @@ async function AnalysisDataProvider() {
       initialData={initialData}
       seasonOptions={filterOptions.seasonOptions}
       tournamentOptions={filterOptions.tournamentOptions}
+      availableMonths={filterOptions.availableMonths}
     />
   );
 }

--- a/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 import type { FilterOption } from "../../statsFilterOption";
 import { useEffect, useRef, useState, useTransition } from "react";
-import { buildMonthOptions } from "@app/utils/buildMonthOptions";
+import { monthOptionsFromRecorded } from "@app/utils/buildMonthOptions";
 import {
   type AnalysisFilters as Filters,
   type EraTrendPoint,
@@ -26,6 +26,8 @@ interface PitchingAnalysisContainerProps {
   /** サーバーで取得したシーズン/大会のフィルタ選択肢。 */
   seasonOptions: FilterOption[];
   tournamentOptions: FilterOption[];
+  /** 試合を記録した年月（"YYYY-MM" の降順）。期間フィルタの月候補に使う。 */
+  availableMonths: string[];
 }
 
 /** 投手タブの分析（フィルタ + 防御率推移グラフ）コンテナ。 */
@@ -33,6 +35,7 @@ export function PitchingAnalysisContainer({
   initialEraTrend,
   seasonOptions,
   tournamentOptions,
+  availableMonths,
 }: PitchingAnalysisContainerProps) {
   const [filters, setFilters] = useState<Filters>({
     year: "通算",
@@ -41,7 +44,9 @@ export function PitchingAnalysisContainer({
   const [eraTrend, setEraTrend] = useState<EraTrendPoint[]>(initialEraTrend);
   const [isRefetching, startRefetch] = useTransition();
   const [yearOptions] = useState(buildYearOptions);
-  const [monthOptions] = useState(() => buildMonthOptions());
+  const [monthOptions] = useState(() =>
+    monthOptionsFromRecorded(availableMonths),
+  );
 
   // 初回は SSR の initialEraTrend を使うため再取得しない（フィルタ変更時のみ取得）。
   const didInitRef = useRef(false);

--- a/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
@@ -1,6 +1,7 @@
 "use client";
 import type { FilterOption } from "../../statsFilterOption";
 import { useEffect, useRef, useState, useTransition } from "react";
+import { buildMonthOptions } from "@app/utils/buildMonthOptions";
 import {
   type AnalysisFilters as Filters,
   type EraTrendPoint,
@@ -40,6 +41,7 @@ export function PitchingAnalysisContainer({
   const [eraTrend, setEraTrend] = useState<EraTrendPoint[]>(initialEraTrend);
   const [isRefetching, startRefetch] = useTransition();
   const [yearOptions] = useState(buildYearOptions);
+  const [monthOptions] = useState(() => buildMonthOptions());
 
   // 初回は SSR の initialEraTrend を使うため再取得しない（フィルタ変更時のみ取得）。
   const didInitRef = useRef(false);
@@ -55,13 +57,22 @@ export function PitchingAnalysisContainer({
         year: filters.year,
         seasonId: filters.seasonId,
         tournamentId: filters.tournamentId,
+        startMonth: filters.startMonth,
+        endMonth: filters.endMonth,
       });
       if (active) setEraTrend(trend);
     });
     return () => {
       active = false;
     };
-  }, [filters.year, filters.seasonId, filters.tournamentId, startRefetch]);
+  }, [
+    filters.year,
+    filters.seasonId,
+    filters.tournamentId,
+    filters.startMonth,
+    filters.endMonth,
+    startRefetch,
+  ]);
 
   return (
     <div className="flex flex-col gap-y-5">
@@ -71,6 +82,7 @@ export function PitchingAnalysisContainer({
         yearOptions={yearOptions}
         seasonOptions={seasonOptions}
         tournamentOptions={tournamentOptions}
+        monthOptions={monthOptions}
         hideMatchType
       />
       <div

--- a/app/(app)/stats/_components/analysis/PitchingAnalysisSection.tsx
+++ b/app/(app)/stats/_components/analysis/PitchingAnalysisSection.tsx
@@ -28,6 +28,7 @@ async function PitchingAnalysisDataProvider() {
       initialEraTrend={initialEraTrend}
       seasonOptions={filterOptions.seasonOptions}
       tournamentOptions={filterOptions.tournamentOptions}
+      availableMonths={filterOptions.availableMonths}
     />
   );
 }

--- a/app/(app)/stats/actions.ts
+++ b/app/(app)/stats/actions.ts
@@ -85,6 +85,8 @@ export async function getBattingStats(
   year?: string,
   seasonId?: string,
   tournamentId?: string,
+  startMonth?: string,
+  endMonth?: string,
 ): Promise<BattingStatsRow[]> {
   try {
     const headers = await getAuthHeaders();
@@ -94,6 +96,8 @@ export async function getBattingStats(
     if (year && year !== "通算") params.append("year", year);
     if (seasonId) params.append("season_id", seasonId);
     if (tournamentId) params.append("tournament_id", tournamentId);
+    if (startMonth) params.append("start_month", startMonth);
+    if (endMonth) params.append("end_month", endMonth);
 
     const response = await fetch(
       `${RAILS_API_URL}/api/v2/stats/batting?${params}`,
@@ -114,6 +118,8 @@ export async function getPitchingStats(
   year?: string,
   seasonId?: string,
   tournamentId?: string,
+  startMonth?: string,
+  endMonth?: string,
 ): Promise<PitchingStatsRow[]> {
   try {
     const headers = await getAuthHeaders();
@@ -123,6 +129,8 @@ export async function getPitchingStats(
     if (year && year !== "通算") params.append("year", year);
     if (seasonId) params.append("season_id", seasonId);
     if (tournamentId) params.append("tournament_id", tournamentId);
+    if (startMonth) params.append("start_month", startMonth);
+    if (endMonth) params.append("end_month", endMonth);
 
     const response = await fetch(
       `${RAILS_API_URL}/api/v2/stats/pitching?${params}`,

--- a/app/(app)/stats/analysisActions.ts
+++ b/app/(app)/stats/analysisActions.ts
@@ -10,6 +10,8 @@ export interface AnalysisFilters {
   matchType?: string;
   seasonId?: string;
   tournamentId?: string;
+  startMonth?: string;
+  endMonth?: string;
 }
 
 export interface HeadlineStats {
@@ -260,6 +262,8 @@ function buildQuery(filters: AnalysisFilters): string {
   if (filters.seasonId) params.append("season_id", filters.seasonId);
   if (filters.tournamentId)
     params.append("tournament_id", filters.tournamentId);
+  if (filters.startMonth) params.append("start_month", filters.startMonth);
+  if (filters.endMonth) params.append("end_month", filters.endMonth);
   return params.toString();
 }
 

--- a/app/(app)/stats/filterOptions.ts
+++ b/app/(app)/stats/filterOptions.ts
@@ -8,18 +8,21 @@ import { DEFAULT_OPTION, type FilterOption } from "./statsFilterOption";
 export interface StatsFilterOptions {
   seasonOptions: FilterOption[];
   tournamentOptions: FilterOption[];
+  /** 試合を記録した年月（"YYYY-MM" の降順）。期間フィルタの月候補に使う。 */
+  availableMonths: string[];
 }
 
 // cache() で同一結果を共有するため、フォールバックは呼び出しごとに新規配列を返す。
 const emptyOptions = (): StatsFilterOptions => ({
   seasonOptions: [DEFAULT_OPTION],
   tournamentOptions: [DEFAULT_OPTION],
+  availableMonths: [],
 });
 
 /**
- * 成績画面のフィルタ選択肢（シーズン / 大会）をサーバーで取得する。
+ * 成績画面のフィルタ選択肢（シーズン / 大会 / 記録月）をサーバーで取得する。
  * `cache()` でラップしているため、同一リクエスト内で page / 各 Section から
- * 複数回呼ばれても実取得は1回（seasons + tournaments の2コール）に集約される。
+ * 複数回呼ばれても実取得は1回（seasons + tournaments + available_months の3コール）に集約される。
  * 認証ヘッダがあれば user_id は不要（バックエンドが current_user にフォールバック）。
  */
 export const getStatsFilterOptions = cache(
@@ -28,22 +31,30 @@ export const getStatsFilterOptions = cache(
       const headers = await getAuthHeaders();
       if (!headers) return emptyOptions();
 
-      const [seasonsResponse, tournamentsResponse] = await Promise.all([
-        fetch(`${RAILS_API_URL}/api/v1/seasons`, {
-          headers,
-          cache: "no-store",
-        }),
-        fetch(`${RAILS_API_URL}/api/v1/tournaments`, {
-          headers,
-          cache: "no-store",
-        }),
-      ]);
+      const [seasonsResponse, tournamentsResponse, availableMonthsResponse] =
+        await Promise.all([
+          fetch(`${RAILS_API_URL}/api/v1/seasons`, {
+            headers,
+            cache: "no-store",
+          }),
+          fetch(`${RAILS_API_URL}/api/v1/tournaments`, {
+            headers,
+            cache: "no-store",
+          }),
+          fetch(`${RAILS_API_URL}/api/v1/match_results/available_months`, {
+            headers,
+            cache: "no-store",
+          }),
+        ]);
 
       const seasons: SeasonData[] = seasonsResponse.ok
         ? await seasonsResponse.json()
         : [];
       const tournaments: TournamentData[] = tournamentsResponse.ok
         ? await tournamentsResponse.json()
+        : [];
+      const availableMonths: string[] = availableMonthsResponse.ok
+        ? await availableMonthsResponse.json()
         : [];
 
       return {
@@ -61,6 +72,7 @@ export const getStatsFilterOptions = cache(
             label: tournament.name,
           })),
         ],
+        availableMonths,
       };
     } catch (error) {
       captureServerActionError(error, { action: "getStatsFilterOptions" });

--- a/app/(app)/stats/page.tsx
+++ b/app/(app)/stats/page.tsx
@@ -48,6 +48,7 @@ export default async function StatsPage() {
               pitchingAnalysisSlot={<PitchingAnalysisSection />}
               seasonOptions={filterOptions.seasonOptions}
               tournamentOptions={filterOptions.tournamentOptions}
+              availableMonths={filterOptions.availableMonths}
             />
           </div>
         </div>

--- a/app/components/filter/PeriodRangeFilter.tsx
+++ b/app/components/filter/PeriodRangeFilter.tsx
@@ -24,11 +24,16 @@ interface PeriodRangeFilterProps {
  * 終了未指定→同月補完により、開始を選ぶだけで単月がワンタップで作れる。
  * ("YYYY-MM" は文字列比較で時系列順になる)
  */
+/** ドロップダウンの選択 key を月値へ正規化する（「指定なし」センチネルは undefined）。 */
+function toMonth(key: string): string | undefined {
+  return key && key !== UNSET_MONTH_OPTION.key ? key : undefined;
+}
+
 export function resolveStartChange(
   key: string,
   endMonth?: string,
 ): PeriodRange {
-  const startMonth = key || undefined;
+  const startMonth = toMonth(key);
   if (!startMonth) return { startMonth: undefined, endMonth };
 
   const nextEnd = !endMonth || endMonth < startMonth ? startMonth : endMonth;
@@ -44,7 +49,7 @@ export function resolveEndChange(
   key: string,
   startMonth?: string,
 ): PeriodRange {
-  const endMonth = key || undefined;
+  const endMonth = toMonth(key);
   if (!endMonth) return { startMonth, endMonth: undefined };
 
   const nextStart = startMonth && startMonth > endMonth ? endMonth : startMonth;

--- a/app/components/filter/PeriodRangeFilter.tsx
+++ b/app/components/filter/PeriodRangeFilter.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import FilterChip from "@app/components/filter/FilterChip";
+import {
+  UNSET_MONTH_OPTION,
+  type MonthOption,
+} from "@app/utils/buildMonthOptions";
+
+export interface PeriodRange {
+  startMonth?: string;
+  endMonth?: string;
+}
+
+interface PeriodRangeFilterProps {
+  startMonth?: string;
+  endMonth?: string;
+  monthOptions: MonthOption[];
+  onChange: (range: PeriodRange) => void;
+}
+
+/**
+ * 期間（開始年月〜終了年月）の絞り込み。開始 / 終了それぞれを月ドロップダウンで選ぶ。
+ * 開始が終了より後になった場合は終了を開始に合わせてクランプし、逆転レンジを防ぐ。
+ * 「指定なし」を選ぶとその端は開放端（undefined）になる。
+ */
+export default function PeriodRangeFilter({
+  startMonth,
+  endMonth,
+  monthOptions,
+  onChange,
+}: PeriodRangeFilterProps) {
+  const handleStartChange = (key: string) => {
+    const nextStart = key || undefined;
+    // 開始 > 終了 になったら終了を開始へクランプ（"YYYY-MM" は文字列比較で時系列順）
+    const nextEnd =
+      nextStart && endMonth && endMonth < nextStart ? nextStart : endMonth;
+    onChange({ startMonth: nextStart, endMonth: nextEnd });
+  };
+
+  const handleEndChange = (key: string) => {
+    const nextEnd = key || undefined;
+    const nextStart =
+      nextEnd && startMonth && startMonth > nextEnd ? nextEnd : startMonth;
+    onChange({ startMonth: nextStart, endMonth: nextEnd });
+  };
+
+  return (
+    <>
+      <FilterChip
+        label="開始"
+        value={startMonth ?? UNSET_MONTH_OPTION.key}
+        defaultValue={UNSET_MONTH_OPTION.key}
+        options={monthOptions}
+        onChange={handleStartChange}
+      />
+      <FilterChip
+        label="終了"
+        value={endMonth ?? UNSET_MONTH_OPTION.key}
+        defaultValue={UNSET_MONTH_OPTION.key}
+        options={monthOptions}
+        onChange={handleEndChange}
+      />
+    </>
+  );
+}

--- a/app/components/filter/PeriodRangeFilter.tsx
+++ b/app/components/filter/PeriodRangeFilter.tsx
@@ -19,9 +19,41 @@ interface PeriodRangeFilterProps {
 }
 
 /**
+ * 開始月を選んだときの新しいレンジを返す。
+ * 終了が未指定、または開始より前になっている場合は終了を開始へ合わせる。
+ * 終了未指定→同月補完により、開始を選ぶだけで単月がワンタップで作れる。
+ * ("YYYY-MM" は文字列比較で時系列順になる)
+ */
+export function resolveStartChange(
+  key: string,
+  endMonth?: string,
+): PeriodRange {
+  const startMonth = key || undefined;
+  if (!startMonth) return { startMonth: undefined, endMonth };
+
+  const nextEnd = !endMonth || endMonth < startMonth ? startMonth : endMonth;
+  return { startMonth, endMonth: nextEnd };
+}
+
+/**
+ * 終了月を選んだときの新しいレンジを返す。
+ * 開始が終了より後の場合のみ開始を終了へクランプする（逆転レンジ防止）。
+ * 開始が未指定なら補完しない（「〜指定月まで」の開放端を保てるようにする）。
+ */
+export function resolveEndChange(
+  key: string,
+  startMonth?: string,
+): PeriodRange {
+  const endMonth = key || undefined;
+  if (!endMonth) return { startMonth, endMonth: undefined };
+
+  const nextStart = startMonth && startMonth > endMonth ? endMonth : startMonth;
+  return { startMonth: nextStart, endMonth };
+}
+
+/**
  * 期間（開始年月〜終了年月）の絞り込み。開始 / 終了それぞれを月ドロップダウンで選ぶ。
- * 開始が終了より後になった場合は終了を開始に合わせてクランプし、逆転レンジを防ぐ。
- * 「指定なし」を選ぶとその端は開放端（undefined）になる。
+ * 開始だけ選ぶと終了も同月に補完され単月になる。「指定なし」を選ぶとその端は開放端になる。
  */
 export default function PeriodRangeFilter({
   startMonth,
@@ -29,20 +61,11 @@ export default function PeriodRangeFilter({
   monthOptions,
   onChange,
 }: PeriodRangeFilterProps) {
-  const handleStartChange = (key: string) => {
-    const nextStart = key || undefined;
-    // 開始 > 終了 になったら終了を開始へクランプ（"YYYY-MM" は文字列比較で時系列順）
-    const nextEnd =
-      nextStart && endMonth && endMonth < nextStart ? nextStart : endMonth;
-    onChange({ startMonth: nextStart, endMonth: nextEnd });
-  };
+  const handleStartChange = (key: string) =>
+    onChange(resolveStartChange(key, endMonth));
 
-  const handleEndChange = (key: string) => {
-    const nextEnd = key || undefined;
-    const nextStart =
-      nextEnd && startMonth && startMonth > nextEnd ? nextEnd : startMonth;
-    onChange({ startMonth: nextStart, endMonth: nextEnd });
-  };
+  const handleEndChange = (key: string) =>
+    onChange(resolveEndChange(key, startMonth));
 
   return (
     <>

--- a/app/components/filter/__tests__/PeriodRangeFilter.test.ts
+++ b/app/components/filter/__tests__/PeriodRangeFilter.test.ts
@@ -1,0 +1,64 @@
+import {
+  resolveEndChange,
+  resolveStartChange,
+} from "@app/components/filter/PeriodRangeFilter";
+
+describe("resolveStartChange", () => {
+  it("終了が未指定なら終了を開始へ補完し単月にする（単月ワンタップ）", () => {
+    expect(resolveStartChange("2026-06", undefined)).toEqual({
+      startMonth: "2026-06",
+      endMonth: "2026-06",
+    });
+  });
+
+  it("終了が開始より前なら終了を開始へクランプする", () => {
+    expect(resolveStartChange("2026-08", "2026-05")).toEqual({
+      startMonth: "2026-08",
+      endMonth: "2026-08",
+    });
+  });
+
+  it("終了が開始以降ならそのまま複数月レンジを保つ", () => {
+    expect(resolveStartChange("2026-05", "2026-07")).toEqual({
+      startMonth: "2026-05",
+      endMonth: "2026-07",
+    });
+  });
+
+  it("開始をクリアしても終了は維持する（開放端）", () => {
+    expect(resolveStartChange("", "2026-07")).toEqual({
+      startMonth: undefined,
+      endMonth: "2026-07",
+    });
+  });
+});
+
+describe("resolveEndChange", () => {
+  it("開始が未指定なら補完せず「〜指定月まで」の開放端を保つ", () => {
+    expect(resolveEndChange("2026-06", undefined)).toEqual({
+      startMonth: undefined,
+      endMonth: "2026-06",
+    });
+  });
+
+  it("開始が終了より後なら開始を終了へクランプする", () => {
+    expect(resolveEndChange("2026-05", "2026-08")).toEqual({
+      startMonth: "2026-05",
+      endMonth: "2026-05",
+    });
+  });
+
+  it("開始が終了以前ならそのまま複数月レンジを保つ", () => {
+    expect(resolveEndChange("2026-07", "2026-05")).toEqual({
+      startMonth: "2026-05",
+      endMonth: "2026-07",
+    });
+  });
+
+  it("終了をクリアしても開始は維持する（開放端）", () => {
+    expect(resolveEndChange("", "2026-05")).toEqual({
+      startMonth: "2026-05",
+      endMonth: undefined,
+    });
+  });
+});

--- a/app/components/filter/__tests__/PeriodRangeFilter.test.ts
+++ b/app/components/filter/__tests__/PeriodRangeFilter.test.ts
@@ -2,6 +2,7 @@ import {
   resolveEndChange,
   resolveStartChange,
 } from "@app/components/filter/PeriodRangeFilter";
+import { UNSET_MONTH_OPTION } from "@app/utils/buildMonthOptions";
 
 describe("resolveStartChange", () => {
   it("終了が未指定なら終了を開始へ補完し単月にする（単月ワンタップ）", () => {
@@ -25,8 +26,8 @@ describe("resolveStartChange", () => {
     });
   });
 
-  it("開始をクリアしても終了は維持する（開放端）", () => {
-    expect(resolveStartChange("", "2026-07")).toEqual({
+  it("開始を「指定なし」に戻しても終了は維持する（開放端）", () => {
+    expect(resolveStartChange(UNSET_MONTH_OPTION.key, "2026-07")).toEqual({
       startMonth: undefined,
       endMonth: "2026-07",
     });
@@ -55,8 +56,8 @@ describe("resolveEndChange", () => {
     });
   });
 
-  it("終了をクリアしても開始は維持する（開放端）", () => {
-    expect(resolveEndChange("", "2026-05")).toEqual({
+  it("終了を「指定なし」に戻しても開始は維持する（開放端）", () => {
+    expect(resolveEndChange(UNSET_MONTH_OPTION.key, "2026-05")).toEqual({
       startMonth: "2026-05",
       endMonth: undefined,
     });

--- a/app/components/table/GroupBattingRankingTable.tsx
+++ b/app/components/table/GroupBattingRankingTable.tsx
@@ -26,10 +26,11 @@ type BattingStats = {
 type Props = {
   battingAverage: BattingAverage[] | undefined;
   battingStats: BattingStats[] | undefined;
+  hideRankChange?: boolean;
 };
 
 export default function GroupBattingRankingTable(props: Props) {
-  const { battingAverage, battingStats } = props;
+  const { battingAverage, battingStats, hideRankChange } = props;
 
   const sortedBattingAverage = useMemo(
     () =>
@@ -140,6 +141,7 @@ export default function GroupBattingRankingTable(props: Props) {
           data={section.data}
           renderValue={section.renderValue}
           isFirst={index === 0}
+          hideRankChange={hideRankChange}
         />
       ))}
       {battingAvgSections.map((section) => (
@@ -149,6 +151,7 @@ export default function GroupBattingRankingTable(props: Props) {
           id={section.id}
           data={section.data}
           renderValue={section.renderValue}
+          hideRankChange={hideRankChange}
         />
       ))}
     </>

--- a/app/components/table/GroupPitchingRankingTable.tsx
+++ b/app/components/table/GroupPitchingRankingTable.tsx
@@ -25,10 +25,11 @@ type PitchingStats = {
 type Props = {
   pitchingAggregate: PitchingAggregate[] | undefined;
   pitchingStats: PitchingStats[] | undefined;
+  hideRankChange?: boolean;
 };
 
 export default function GroupPitchingRankingTable(props: Props) {
-  const { pitchingAggregate, pitchingStats } = props;
+  const { pitchingAggregate, pitchingStats, hideRankChange } = props;
 
   const sortedPitchingEra = useMemo(
     () => pitchingStats?.slice().sort((a, b) => a.era - b.era) || [],
@@ -136,6 +137,7 @@ export default function GroupPitchingRankingTable(props: Props) {
           data={section.data}
           renderValue={section.renderValue}
           isFirst={index === 0}
+          hideRankChange={hideRankChange}
         />
       ))}
       {pitchingAggregateSections.map((section) => (
@@ -145,6 +147,7 @@ export default function GroupPitchingRankingTable(props: Props) {
           id={section.id}
           data={section.data}
           renderValue={section.renderValue}
+          hideRankChange={hideRankChange}
         />
       ))}
     </>

--- a/app/components/table/RankingSection.tsx
+++ b/app/components/table/RankingSection.tsx
@@ -15,6 +15,7 @@ type RankingItem = {
   name: string;
   user_id: string;
   image_url: string;
+  previous_rank?: number | null;
 };
 
 type RankingSectionProps<T extends RankingItem> = {
@@ -23,7 +24,35 @@ type RankingSectionProps<T extends RankingItem> = {
   data: T[];
   renderValue: (item: T, index: number) => React.ReactNode;
   isFirst?: boolean;
+  hideRankChange?: boolean;
 };
+
+/**
+ * 前日順位との差分を「▲n / ▼n / －」で表す。
+ * previous_rank が無い（初参加など）場合は差分を出さない。
+ */
+function RankChangeBadge({
+  currentRank,
+  previousRank,
+}: {
+  currentRank: number;
+  previousRank?: number | null;
+}) {
+  if (previousRank == null) {
+    return null;
+  }
+  const change = previousRank - currentRank;
+  if (change === 0) {
+    return <span className="text-xs text-zinc-500 ml-1">－</span>;
+  }
+  const isUp = change > 0;
+  return (
+    <span className={`text-xs ml-1 ${isUp ? "text-success" : "text-danger"}`}>
+      {isUp ? "▲" : "▼"}
+      {Math.abs(change)}
+    </span>
+  );
+}
 
 export default function RankingSection<T extends RankingItem>({
   label,
@@ -31,6 +60,7 @@ export default function RankingSection<T extends RankingItem>({
   data,
   renderValue,
   isFirst = false,
+  hideRankChange = false,
 }: RankingSectionProps<T>) {
   return (
     <Table className={isFirst ? "" : "mt-8"} aria-label={label} id={id}>
@@ -45,8 +75,16 @@ export default function RankingSection<T extends RankingItem>({
             <TableCell>
               <div className="grid grid-cols-[1fr_auto] items-center ">
                 <Link href={`/mypage/${item.user_id}`} className="block">
-                  <div className="grid grid-cols-[24px_1fr_auto] items-center">
-                    <span className="text-base block mr-4">{index + 1}</span>
+                  <div className="grid grid-cols-[auto_1fr_auto] items-center">
+                    <span className="text-base flex items-center mr-4">
+                      {index + 1}
+                      {!hideRankChange && (
+                        <RankChangeBadge
+                          currentRank={index + 1}
+                          previousRank={item.previous_rank}
+                        />
+                      )}
+                    </span>
                     <User
                       name={item.name}
                       description={item.user_id}

--- a/app/components/user/IndividualResultsList.tsx
+++ b/app/components/user/IndividualResultsList.tsx
@@ -200,7 +200,7 @@ export default function IndividualResultsList(props: UserId) {
     <>
       <div className="bg-bg_sub p-4 rounded-xl lg:p-6">
         <div className="mb-5 overflow-hidden">
-          <FilterChipGroup>
+          <FilterChipGroup wrap>
             <FilterChip
               label="年度"
               value={selectedYear}

--- a/app/components/user/IndividualResultsList.tsx
+++ b/app/components/user/IndividualResultsList.tsx
@@ -13,9 +13,12 @@ import { usePersonalBattingAverage } from "@app/hooks/batting/getPersonalBatting
 import { usePersonalBattingStatus } from "@app/hooks/batting/getPersonalBattingStatus";
 import { usePersonalPitchingResult } from "@app/hooks/pitching/getPersonalPitchingResult";
 import { usePersonalPitchingResultStats } from "@app/hooks/pitching/getPersonalPitchingResultStats";
-import { getMatchResultsUserId } from "@app/services/matchResultsService";
+import {
+  getAvailableMonths,
+  getMatchResultsUserId,
+} from "@app/services/matchResultsService";
 import { getSeasons } from "@app/services/seasonsService";
-import { buildMonthOptions } from "@app/utils/buildMonthOptions";
+import { monthOptionsFromRecorded } from "@app/utils/buildMonthOptions";
 import { formatRate, formatEra } from "@app/utils/formatStats";
 
 type UserId = {
@@ -42,7 +45,7 @@ export default function IndividualResultsList(props: UserId) {
   >([{ key: "全て", label: "全て" }]);
   const [startMonth, setStartMonth] = useState<string | undefined>(undefined);
   const [endMonth, setEndMonth] = useState<string | undefined>(undefined);
-  const [availableYears, setAvailableYears] = useState<number[]>([]);
+  const [availableMonths, setAvailableMonths] = useState<string[]>([]);
 
   // シーズンデータ取得
   useEffect(() => {
@@ -81,7 +84,6 @@ export default function IndividualResultsList(props: UserId) {
           ...uniqueYears.map((y) => ({ key: String(y), label: String(y) })),
         ];
         setYearOptions(yOpts);
-        setAvailableYears(uniqueYears.map(Number));
         // 試合タイプ抽出（keyにAPI値、labelに日本語）
         const matchTypeData: AvailableMatchType[] = matchResultData.map(
           (type: { match_type: string }) => type.match_type,
@@ -99,6 +101,8 @@ export default function IndividualResultsList(props: UserId) {
           })),
         ];
         setMatchTypeOptions(mtOpts);
+        // 期間フィルタは記録のある年月だけを候補にする
+        setAvailableMonths(await getAvailableMonths(userId));
       } catch (error) {
         console.error("Failed to fetch meta:", error);
       }
@@ -113,8 +117,8 @@ export default function IndividualResultsList(props: UserId) {
   }, [selectedSeason, seasonsData]);
 
   const monthOptions = useMemo(
-    () => buildMonthOptions(availableYears),
-    [availableYears],
+    () => monthOptionsFromRecorded(availableMonths),
+    [availableMonths],
   );
 
   // 年度と期間は排他: 実年を選んだら期間をクリアする（通算選択時は据え置き）

--- a/app/components/user/IndividualResultsList.tsx
+++ b/app/components/user/IndividualResultsList.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import FilterChip from "@app/components/filter/FilterChip";
 import FilterChipGroup from "@app/components/filter/FilterChipGroup";
+import PeriodRangeFilter from "@app/components/filter/PeriodRangeFilter";
 import BattingAverageTable from "@app/components/table/BattingAverageTable";
 import PitchingRecordTable from "@app/components/table/PitchingRecordTable";
 import { usePersonalBattingAverage } from "@app/hooks/batting/getPersonalBattingAverage";
@@ -14,6 +15,7 @@ import { usePersonalPitchingResult } from "@app/hooks/pitching/getPersonalPitchi
 import { usePersonalPitchingResultStats } from "@app/hooks/pitching/getPersonalPitchingResultStats";
 import { getMatchResultsUserId } from "@app/services/matchResultsService";
 import { getSeasons } from "@app/services/seasonsService";
+import { buildMonthOptions } from "@app/utils/buildMonthOptions";
 import { formatRate, formatEra } from "@app/utils/formatStats";
 
 type UserId = {
@@ -38,6 +40,9 @@ export default function IndividualResultsList(props: UserId) {
   const [seasonOptions, setSeasonOptions] = useState<
     { key: string; label: string }[]
   >([{ key: "全て", label: "全て" }]);
+  const [startMonth, setStartMonth] = useState<string | undefined>(undefined);
+  const [endMonth, setEndMonth] = useState<string | undefined>(undefined);
+  const [availableYears, setAvailableYears] = useState<number[]>([]);
 
   // シーズンデータ取得
   useEffect(() => {
@@ -76,6 +81,7 @@ export default function IndividualResultsList(props: UserId) {
           ...uniqueYears.map((y) => ({ key: String(y), label: String(y) })),
         ];
         setYearOptions(yOpts);
+        setAvailableYears(uniqueYears.map(Number));
         // 試合タイプ抽出（keyにAPI値、labelに日本語）
         const matchTypeData: AvailableMatchType[] = matchResultData.map(
           (type: { match_type: string }) => type.match_type,
@@ -106,6 +112,31 @@ export default function IndividualResultsList(props: UserId) {
       : undefined;
   }, [selectedSeason, seasonsData]);
 
+  const monthOptions = useMemo(
+    () => buildMonthOptions(availableYears),
+    [availableYears],
+  );
+
+  // 年度と期間は排他: 実年を選んだら期間をクリアする（通算選択時は据え置き）
+  const handleYearChange = (value: string) => {
+    setSelectedYear(value);
+    if (value !== "通算") {
+      setStartMonth(undefined);
+      setEndMonth(undefined);
+    }
+  };
+  // 期間を設定したら年度を通算へ戻す（両端クリア時は年度を据え置く）
+  const handlePeriodChange = (range: {
+    startMonth?: string;
+    endMonth?: string;
+  }) => {
+    setStartMonth(range.startMonth);
+    setEndMonth(range.endMonth);
+    if (range.startMonth || range.endMonth) {
+      setSelectedYear("通算");
+    }
+  };
+
   // API送信用の値
   const yearParam = selectedYear !== "通算" ? selectedYear : undefined;
   const matchTypeParam =
@@ -116,21 +147,34 @@ export default function IndividualResultsList(props: UserId) {
     seasonId,
     yearParam,
     matchTypeParam,
+    startMonth,
+    endMonth,
   );
   const { personalBattingStatus, isLoadingBS } = usePersonalBattingStatus(
     userId,
     seasonId,
     yearParam,
     matchTypeParam,
+    startMonth,
+    endMonth,
   );
   const { personalPitchingResults, isLoadingPR } = usePersonalPitchingResult(
     userId,
     seasonId,
     yearParam,
     matchTypeParam,
+    startMonth,
+    endMonth,
   );
   const { personalPitchingStatus, isLoadingPS } =
-    usePersonalPitchingResultStats(userId, seasonId, yearParam, matchTypeParam);
+    usePersonalPitchingResultStats(
+      userId,
+      seasonId,
+      yearParam,
+      matchTypeParam,
+      startMonth,
+      endMonth,
+    );
 
   const isLoading = isLoadingBA || isLoadingBS || isLoadingPR || isLoadingPS;
 
@@ -154,7 +198,7 @@ export default function IndividualResultsList(props: UserId) {
               value={selectedYear}
               defaultValue="通算"
               options={yearOptions}
-              onChange={setSelectedYear}
+              onChange={handleYearChange}
             />
             <FilterChip
               label="種別"
@@ -169,6 +213,12 @@ export default function IndividualResultsList(props: UserId) {
               defaultValue="全て"
               options={seasonOptions}
               onChange={setSelectedSeason}
+            />
+            <PeriodRangeFilter
+              startMonth={startMonth}
+              endMonth={endMonth}
+              monthOptions={monthOptions}
+              onChange={handlePeriodChange}
             />
           </FilterChipGroup>
         </div>

--- a/app/components/user/IndividualResultsList.tsx
+++ b/app/components/user/IndividualResultsList.tsx
@@ -72,7 +72,11 @@ export default function IndividualResultsList(props: UserId) {
   useEffect(() => {
     const fetchMeta = async () => {
       try {
-        const matchResultData = await getMatchResultsUserId(userId);
+        // 試合一覧と記録月は互いに独立なので並列取得して初回のフィルタ確定を早める。
+        const [matchResultData, months] = await Promise.all([
+          getMatchResultsUserId(userId),
+          getAvailableMonths(userId),
+        ]);
         // 年度抽出
         const yearArray: AvailableYear[] = matchResultData.map(
           (result: { date_and_time: string }) =>
@@ -102,7 +106,7 @@ export default function IndividualResultsList(props: UserId) {
         ];
         setMatchTypeOptions(mtOpts);
         // 期間フィルタは記録のある年月だけを候補にする
-        setAvailableMonths(await getAvailableMonths(userId));
+        setAvailableMonths(months);
       } catch (error) {
         console.error("Failed to fetch meta:", error);
       }

--- a/app/components/user/MatchResultList.tsx
+++ b/app/components/user/MatchResultList.tsx
@@ -17,11 +17,12 @@ import {
   getFilterGameResultsUserIdV2,
 } from "@app/services/gameResultsService";
 import {
+  getAvailableMonths,
   getMatchResults,
   getMatchResultsUserId,
 } from "@app/services/matchResultsService";
 import { getSeasons } from "@app/services/seasonsService";
-import { buildMonthOptions } from "@app/utils/buildMonthOptions";
+import { monthOptionsFromRecorded } from "@app/utils/buildMonthOptions";
 
 type GameResult = {
   game_result_id: number;
@@ -80,7 +81,7 @@ export default function MatchResultList(props: MatchResultListProps) {
   const [selectedSeason, setSelectedSeason] = useState("全て");
   const [startMonth, setStartMonth] = useState<string | undefined>(undefined);
   const [endMonth, setEndMonth] = useState<string | undefined>(undefined);
-  const [availableYears, setAvailableYears] = useState<number[]>([]);
+  const [availableMonths, setAvailableMonths] = useState<string[]>([]);
   const [gameResultIndex, setGameResultIndex] = useState<GameResult[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -155,7 +156,6 @@ export default function MatchResultList(props: MatchResultListProps) {
           ...uniqueYears.map((y) => ({ key: String(y), label: String(y) })),
         ];
         setYearOptions(yOpts);
-        setAvailableYears(uniqueYears.map(Number));
         // 試合タイプ抽出（keyにAPI値、labelに日本語）
         const matchTypeData: AvailableMatchType[] = matchResultData.map(
           (type: { match_type: string }) => type.match_type,
@@ -173,6 +173,8 @@ export default function MatchResultList(props: MatchResultListProps) {
           })),
         ];
         setMatchTypeOptions(mtOpts);
+        // 期間フィルタは記録のある年月だけを候補にする
+        setAvailableMonths(await getAvailableMonths(userId));
       } catch {}
     };
     fetchMeta();
@@ -184,8 +186,8 @@ export default function MatchResultList(props: MatchResultListProps) {
     selectedMatchType === "全て" ? "全て" : selectedMatchType;
 
   const monthOptions = useMemo(
-    () => buildMonthOptions(availableYears),
-    [availableYears],
+    () => monthOptionsFromRecorded(availableMonths),
+    [availableMonths],
   );
 
   // フィルター変更時にページを1にリセットするラッパー

--- a/app/components/user/MatchResultList.tsx
+++ b/app/components/user/MatchResultList.tsx
@@ -139,12 +139,11 @@ export default function MatchResultList(props: MatchResultListProps) {
   useEffect(() => {
     const fetchMeta = async () => {
       try {
-        let matchResultData;
-        if (userId) {
-          matchResultData = await getMatchResultsUserId(userId);
-        } else {
-          matchResultData = await getMatchResults();
-        }
+        // 試合一覧と記録月は互いに独立なので並列取得して初回のフィルタ確定を早める。
+        const [matchResultData, months] = await Promise.all([
+          userId ? getMatchResultsUserId(userId) : getMatchResults(),
+          getAvailableMonths(userId),
+        ]);
         // 年度抽出
         const yearArray: AvailableYear[] = matchResultData.map(
           (result: { date_and_time: string }) =>
@@ -174,7 +173,7 @@ export default function MatchResultList(props: MatchResultListProps) {
         ];
         setMatchTypeOptions(mtOpts);
         // 期間フィルタは記録のある年月だけを候補にする
-        setAvailableMonths(await getAvailableMonths(userId));
+        setAvailableMonths(months);
       } catch {}
     };
     fetchMeta();

--- a/app/components/user/MatchResultList.tsx
+++ b/app/components/user/MatchResultList.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import AdInFeed from "@app/components/ad/AdInFeed";
 import FilterChip from "@app/components/filter/FilterChip";
 import FilterChipGroup from "@app/components/filter/FilterChipGroup";
+import PeriodRangeFilter from "@app/components/filter/PeriodRangeFilter";
 import GamePagination from "@app/components/game/GamePagination";
 import GameSearchInput from "@app/components/game/GameSearchInput";
 import GameSortSelect from "@app/components/game/GameSortSelect";
@@ -20,6 +21,7 @@ import {
   getMatchResultsUserId,
 } from "@app/services/matchResultsService";
 import { getSeasons } from "@app/services/seasonsService";
+import { buildMonthOptions } from "@app/utils/buildMonthOptions";
 
 type GameResult = {
   game_result_id: number;
@@ -76,6 +78,9 @@ export default function MatchResultList(props: MatchResultListProps) {
     { key: string; label: string }[]
   >([{ key: "全て", label: "全て" }]);
   const [selectedSeason, setSelectedSeason] = useState("全て");
+  const [startMonth, setStartMonth] = useState<string | undefined>(undefined);
+  const [endMonth, setEndMonth] = useState<string | undefined>(undefined);
+  const [availableYears, setAvailableYears] = useState<number[]>([]);
   const [gameResultIndex, setGameResultIndex] = useState<GameResult[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -150,6 +155,7 @@ export default function MatchResultList(props: MatchResultListProps) {
           ...uniqueYears.map((y) => ({ key: String(y), label: String(y) })),
         ];
         setYearOptions(yOpts);
+        setAvailableYears(uniqueYears.map(Number));
         // 試合タイプ抽出（keyにAPI値、labelに日本語）
         const matchTypeData: AvailableMatchType[] = matchResultData.map(
           (type: { match_type: string }) => type.match_type,
@@ -177,9 +183,31 @@ export default function MatchResultList(props: MatchResultListProps) {
   const apiMatchType =
     selectedMatchType === "全て" ? "全て" : selectedMatchType;
 
+  const monthOptions = useMemo(
+    () => buildMonthOptions(availableYears),
+    [availableYears],
+  );
+
   // フィルター変更時にページを1にリセットするラッパー
+  // 年度と期間は排他: 実年を選んだら期間をクリアする（通算選択時は据え置き）
   const handleYearChange = (value: string) => {
     setSelectedYear(value);
+    if (value !== "通算") {
+      setStartMonth(undefined);
+      setEndMonth(undefined);
+    }
+    setCurrentPage(1);
+  };
+  // 期間を設定したら年度を通算へ戻す（両端クリア時は年度を据え置く）
+  const handlePeriodChange = (range: {
+    startMonth?: string;
+    endMonth?: string;
+  }) => {
+    setStartMonth(range.startMonth);
+    setEndMonth(range.endMonth);
+    if (range.startMonth || range.endMonth) {
+      setSelectedYear("通算");
+    }
     setCurrentPage(1);
   };
   const handleMatchTypeChange = (value: string) => {
@@ -223,6 +251,8 @@ export default function MatchResultList(props: MatchResultListProps) {
             debouncedSearch || undefined,
             apiSortBy,
             apiSortOrder,
+            startMonth,
+            endMonth,
           );
         } else {
           response = await getFilterGameResultsV2(
@@ -234,6 +264,8 @@ export default function MatchResultList(props: MatchResultListProps) {
             debouncedSearch || undefined,
             apiSortBy,
             apiSortOrder,
+            startMonth,
+            endMonth,
           );
         }
         if (cancelled) return;
@@ -264,6 +296,8 @@ export default function MatchResultList(props: MatchResultListProps) {
     sortOrder,
     apiSortBy,
     apiSortOrder,
+    startMonth,
+    endMonth,
   ]);
 
   return (
@@ -291,6 +325,12 @@ export default function MatchResultList(props: MatchResultListProps) {
               defaultValue="全て"
               options={seasonOptions}
               onChange={handleSeasonChange}
+            />
+            <PeriodRangeFilter
+              startMonth={startMonth}
+              endMonth={endMonth}
+              monthOptions={monthOptions}
+              onChange={handlePeriodChange}
             />
           </FilterChipGroup>
           <div className="flex items-center gap-2">

--- a/app/components/user/MatchResultList.tsx
+++ b/app/components/user/MatchResultList.tsx
@@ -305,7 +305,7 @@ export default function MatchResultList(props: MatchResultListProps) {
     <>
       <div ref={listTopRef} className="bg-bg_sub p-4 rounded-xl lg:p-6">
         <div className="mb-5 overflow-hidden flex flex-col gap-3">
-          <FilterChipGroup>
+          <FilterChipGroup wrap>
             <FilterChip
               label="年度"
               value={selectedYear}

--- a/app/hooks/batting/getPersonalBattingAverage.ts
+++ b/app/hooks/batting/getPersonalBattingAverage.ts
@@ -7,6 +7,8 @@ export function usePersonalBattingAverage(
   seasonId?: number,
   year?: string,
   matchType?: string,
+  startMonth?: string,
+  endMonth?: string,
 ) {
   const params = new URLSearchParams({ user_id: String(userId) });
   if (seasonId) {
@@ -17,6 +19,12 @@ export function usePersonalBattingAverage(
   }
   if (matchType) {
     params.append("match_type", matchType);
+  }
+  if (startMonth) {
+    params.append("start_month", startMonth);
+  }
+  if (endMonth) {
+    params.append("end_month", endMonth);
   }
   const { data, error } = useSWR(
     userId

--- a/app/hooks/batting/getPersonalBattingStatus.ts
+++ b/app/hooks/batting/getPersonalBattingStatus.ts
@@ -7,6 +7,8 @@ export function usePersonalBattingStatus(
   seasonId?: number,
   year?: string,
   matchType?: string,
+  startMonth?: string,
+  endMonth?: string,
 ) {
   const params = new URLSearchParams({ user_id: String(userId) });
   if (seasonId) {
@@ -17,6 +19,12 @@ export function usePersonalBattingStatus(
   }
   if (matchType) {
     params.append("match_type", matchType);
+  }
+  if (startMonth) {
+    params.append("start_month", startMonth);
+  }
+  if (endMonth) {
+    params.append("end_month", endMonth);
   }
   const { data, error } = useSWR(
     userId

--- a/app/hooks/pitching/getPersonalPitchingResult.ts
+++ b/app/hooks/pitching/getPersonalPitchingResult.ts
@@ -7,6 +7,8 @@ export function usePersonalPitchingResult(
   seasonId?: number,
   year?: string,
   matchType?: string,
+  startMonth?: string,
+  endMonth?: string,
 ) {
   const params = new URLSearchParams({ user_id: String(userId) });
   if (seasonId) {
@@ -17,6 +19,12 @@ export function usePersonalPitchingResult(
   }
   if (matchType) {
     params.append("match_type", matchType);
+  }
+  if (startMonth) {
+    params.append("start_month", startMonth);
+  }
+  if (endMonth) {
+    params.append("end_month", endMonth);
   }
   const { data, error } = useSWR(
     userId

--- a/app/hooks/pitching/getPersonalPitchingResultStats.ts
+++ b/app/hooks/pitching/getPersonalPitchingResultStats.ts
@@ -7,6 +7,8 @@ export function usePersonalPitchingResultStats(
   seasonId?: number,
   year?: string,
   matchType?: string,
+  startMonth?: string,
+  endMonth?: string,
 ) {
   const params = new URLSearchParams({ user_id: String(userId) });
   if (seasonId) {
@@ -17,6 +19,12 @@ export function usePersonalPitchingResultStats(
   }
   if (matchType) {
     params.append("match_type", matchType);
+  }
+  if (startMonth) {
+    params.append("start_month", startMonth);
+  }
+  if (endMonth) {
+    params.append("end_month", endMonth);
   }
   const { data, error } = useSWR(
     userId

--- a/app/services/gameResultsService.tsx
+++ b/app/services/gameResultsService.tsx
@@ -203,6 +203,8 @@ export const getFilterGameResultsV2 = async (
   search?: string,
   sortBy?: string,
   sortOrder?: string,
+  startMonth?: string,
+  endMonth?: string,
 ): Promise<PaginatedResponse<unknown>> => {
   try {
     let url = `/api/v2/game_results/filtered_index?year=${year}&match_type=${matchType}`;
@@ -223,6 +225,12 @@ export const getFilterGameResultsV2 = async (
     }
     if (sortOrder) {
       url += `&sort_order=${sortOrder}`;
+    }
+    if (startMonth) {
+      url += `&start_month=${startMonth}`;
+    }
+    if (endMonth) {
+      url += `&end_month=${endMonth}`;
     }
     const response = await axiosInstance.get(url);
     return response.data;
@@ -245,6 +253,8 @@ export const getFilterGameResultsUserIdV2 = async (
   search?: string,
   sortBy?: string,
   sortOrder?: string,
+  startMonth?: string,
+  endMonth?: string,
 ): Promise<PaginatedResponse<unknown>> => {
   try {
     let url = `/api/v2/game_results/filtered_user/${userId}?year=${year}&match_type=${matchType}`;
@@ -265,6 +275,12 @@ export const getFilterGameResultsUserIdV2 = async (
     }
     if (sortOrder) {
       url += `&sort_order=${sortOrder}`;
+    }
+    if (startMonth) {
+      url += `&start_month=${startMonth}`;
+    }
+    if (endMonth) {
+      url += `&end_month=${endMonth}`;
     }
     const response = await axiosInstance.get(url);
     return response.data;

--- a/app/services/groupService.tsx
+++ b/app/services/groupService.tsx
@@ -39,11 +39,15 @@ export const getGroupDetail = async (
   id: number,
   year?: string,
   matchType?: string,
+  startMonth?: string,
+  endMonth?: string,
 ) => {
   try {
     const params = new URLSearchParams();
     if (year) params.append("year", year);
     if (matchType) params.append("match_type", matchType);
+    if (startMonth) params.append("start_month", startMonth);
+    if (endMonth) params.append("end_month", endMonth);
     const query = params.toString();
     const response = await axiosInstance.get(
       `/api/v1/groups/${id}${query ? `?${query}` : ""}`,

--- a/app/services/matchResultsService.tsx
+++ b/app/services/matchResultsService.tsx
@@ -21,6 +21,27 @@ export const getMatchResultsUserId = async (userId: number) => {
   }
 };
 
+/**
+ * 対象ユーザーが試合を記録した年月一覧を取得する。
+ * 期間フィルタの月候補（記録のある年月だけ）を作るために使う。
+ *
+ * @param userId 省略時はログインユーザー
+ * @returns "YYYY-MM" の降順配列。取得失敗時は空配列
+ */
+export const getAvailableMonths = async (
+  userId?: number,
+): Promise<string[]> => {
+  try {
+    const params = userId ? `?user_id=${userId}` : "";
+    const response = await axiosInstance.get(
+      `/api/v1/match_results/available_months${params}`,
+    );
+    return response.data as string[];
+  } catch {
+    return [];
+  }
+};
+
 export const createMatchResults = async (
   matchResultsData: MatchResultsData,
 ) => {

--- a/app/utils/__tests__/buildMonthOptions.test.ts
+++ b/app/utils/__tests__/buildMonthOptions.test.ts
@@ -1,0 +1,61 @@
+import {
+  buildMonthOptions,
+  UNSET_MONTH_OPTION,
+} from "@app/utils/buildMonthOptions";
+
+describe("buildMonthOptions", () => {
+  const RealDate = Date;
+
+  beforeAll(() => {
+    // 当月を 2026-07 に固定して、当年は当月までしか出さない挙動を検証する。
+    const fixedNow = new RealDate("2026-07-15T00:00:00+09:00");
+    global.Date = class extends RealDate {
+      constructor(...args: ConstructorParameters<typeof RealDate>) {
+        if (args.length === 0) {
+          super(fixedNow.getTime());
+          return;
+        }
+        super(...args);
+      }
+    } as DateConstructor;
+  });
+
+  afterAll(() => {
+    global.Date = RealDate;
+  });
+
+  it("先頭に「指定なし」（key 空文字）を含む", () => {
+    const options = buildMonthOptions([2026]);
+    expect(options[0]).toEqual(UNSET_MONTH_OPTION);
+    expect(options[0].key).toBe("");
+  });
+
+  it("当年は当月までしか生成しない（未来月を出さない）", () => {
+    const keys = buildMonthOptions([2026]).map((option) => option.key);
+    expect(keys).toContain("2026-07");
+    expect(keys).not.toContain("2026-08");
+    expect(keys).not.toContain("2026-12");
+  });
+
+  it("過年度は 1〜12 月すべてを新しい順で生成する", () => {
+    const keys = buildMonthOptions([2025]).map((option) => option.key);
+    // 先頭「指定なし」の直後が最新月（2026-07）で、2025 は 12→1 の降順で並ぶ
+    expect(keys).toContain("2025-12");
+    expect(keys).toContain("2025-01");
+    expect(keys.indexOf("2025-12")).toBeLessThan(keys.indexOf("2025-01"));
+  });
+
+  it("YYYY-MM 形式でゼロ埋めした key とラベルを返す", () => {
+    const january = buildMonthOptions([2025]).find(
+      (option) => option.key === "2025-01",
+    );
+    expect(january).toEqual({ key: "2025-01", label: "2025年1月" });
+  });
+
+  it("years 未指定時は当年から6年分にフォールバックする", () => {
+    const keys = buildMonthOptions().map((option) => option.key);
+    expect(keys).toContain("2026-07");
+    expect(keys).toContain("2021-01");
+    expect(keys).not.toContain("2020-12");
+  });
+});

--- a/app/utils/__tests__/buildMonthOptions.test.ts
+++ b/app/utils/__tests__/buildMonthOptions.test.ts
@@ -24,10 +24,10 @@ describe("buildMonthOptions", () => {
     global.Date = RealDate;
   });
 
-  it("先頭に「指定なし」（key 空文字）を含む", () => {
+  it("先頭に「指定なし」（非空のセンチネル key）を含む", () => {
     const options = buildMonthOptions([2026]);
     expect(options[0]).toEqual(UNSET_MONTH_OPTION);
-    expect(options[0].key).toBe("");
+    expect(options[0].key).toBe("none");
   });
 
   it("当年は当月までしか生成しない（未来月を出さない）", () => {

--- a/app/utils/__tests__/buildMonthOptions.test.ts
+++ b/app/utils/__tests__/buildMonthOptions.test.ts
@@ -1,27 +1,35 @@
 import {
   buildMonthOptions,
+  monthOptionsFromRecorded,
   UNSET_MONTH_OPTION,
 } from "@app/utils/buildMonthOptions";
 
-describe("buildMonthOptions", () => {
-  const RealDate = Date;
+describe("monthOptionsFromRecorded", () => {
+  it("記録のある年月だけを先頭「指定なし」付きで、渡された順に返す", () => {
+    expect(monthOptionsFromRecorded(["2026-06", "2026-05", "2025-12"])).toEqual(
+      [
+        UNSET_MONTH_OPTION,
+        { key: "2026-06", label: "2026年6月" },
+        { key: "2026-05", label: "2026年5月" },
+        { key: "2025-12", label: "2025年12月" },
+      ],
+    );
+  });
 
+  it("記録が無いときは「指定なし」のみ返す", () => {
+    expect(monthOptionsFromRecorded([])).toEqual([UNSET_MONTH_OPTION]);
+  });
+});
+
+describe("buildMonthOptions", () => {
   beforeAll(() => {
     // 当月を 2026-07 に固定して、当年は当月までしか出さない挙動を検証する。
-    const fixedNow = new RealDate("2026-07-15T00:00:00+09:00");
-    global.Date = class extends RealDate {
-      constructor(...args: ConstructorParameters<typeof RealDate>) {
-        if (args.length === 0) {
-          super(fixedNow.getTime());
-          return;
-        }
-        super(...args);
-      }
-    } as DateConstructor;
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-07-15T00:00:00+09:00"));
   });
 
   afterAll(() => {
-    global.Date = RealDate;
+    jest.useRealTimers();
   });
 
   it("先頭に「指定なし」（非空のセンチネル key）を含む", () => {

--- a/app/utils/__tests__/buildMonthOptions.test.ts
+++ b/app/utils/__tests__/buildMonthOptions.test.ts
@@ -1,5 +1,4 @@
 import {
-  buildMonthOptions,
   monthOptionsFromRecorded,
   UNSET_MONTH_OPTION,
 } from "@app/utils/buildMonthOptions";
@@ -18,52 +17,5 @@ describe("monthOptionsFromRecorded", () => {
 
   it("記録が無いときは「指定なし」のみ返す", () => {
     expect(monthOptionsFromRecorded([])).toEqual([UNSET_MONTH_OPTION]);
-  });
-});
-
-describe("buildMonthOptions", () => {
-  beforeAll(() => {
-    // 当月を 2026-07 に固定して、当年は当月までしか出さない挙動を検証する。
-    jest.useFakeTimers();
-    jest.setSystemTime(new Date("2026-07-15T00:00:00+09:00"));
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
-  });
-
-  it("先頭に「指定なし」（非空のセンチネル key）を含む", () => {
-    const options = buildMonthOptions([2026]);
-    expect(options[0]).toEqual(UNSET_MONTH_OPTION);
-    expect(options[0].key).toBe("none");
-  });
-
-  it("当年は当月までしか生成しない（未来月を出さない）", () => {
-    const keys = buildMonthOptions([2026]).map((option) => option.key);
-    expect(keys).toContain("2026-07");
-    expect(keys).not.toContain("2026-08");
-    expect(keys).not.toContain("2026-12");
-  });
-
-  it("過年度は 1〜12 月すべてを新しい順で生成する", () => {
-    const keys = buildMonthOptions([2025]).map((option) => option.key);
-    // 先頭「指定なし」の直後が最新月（2026-07）で、2025 は 12→1 の降順で並ぶ
-    expect(keys).toContain("2025-12");
-    expect(keys).toContain("2025-01");
-    expect(keys.indexOf("2025-12")).toBeLessThan(keys.indexOf("2025-01"));
-  });
-
-  it("YYYY-MM 形式でゼロ埋めした key とラベルを返す", () => {
-    const january = buildMonthOptions([2025]).find(
-      (option) => option.key === "2025-01",
-    );
-    expect(january).toEqual({ key: "2025-01", label: "2025年1月" });
-  });
-
-  it("years 未指定時は当年から6年分にフォールバックする", () => {
-    const keys = buildMonthOptions().map((option) => option.key);
-    expect(keys).toContain("2026-07");
-    expect(keys).toContain("2021-01");
-    expect(keys).not.toContain("2020-12");
   });
 });

--- a/app/utils/buildMonthOptions.ts
+++ b/app/utils/buildMonthOptions.ts
@@ -14,14 +14,6 @@ export const UNSET_MONTH_OPTION: MonthOption = {
 };
 
 /**
- * 期間フィルタ（開始年月 / 終了年月）のセレクタに渡す "YYYY-MM" 選択肢を生成する。
- * 対象年の範囲は available_years（API 由来）を優先し、無ければ当年から6年分にフォールバックする。
- * 直近の月が先頭に来るよう降順で並べ、当年は当月までしか出さない（未来月を選ばせない）。
- *
- * @param years データが存在する年のリスト（省略時は当年から過去6年）
- * @returns 先頭が「指定なし」、以降が新しい順の年月選択肢
- */
-/**
  * 実際に試合を記録した年月（"YYYY-MM" の降順リスト、バックエンドの available_months）から
  * 期間フィルタの選択肢を作る。記録のある年月だけを候補に出したい画面で使う。
  * 先頭は「指定なし」。入力の並び順（新しい順）をそのまま保つ。
@@ -36,30 +28,6 @@ export function monthOptionsFromRecorded(months: string[]): MonthOption[] {
       key: month,
       label: `${Number(year)}年${Number(monthNumber)}月`,
     });
-  }
-  return options;
-}
-
-export function buildMonthOptions(years?: number[]): MonthOption[] {
-  const now = new Date();
-  const currentYear = now.getFullYear();
-  const currentMonth = now.getMonth() + 1;
-
-  const baseYears =
-    years && years.length > 0
-      ? years
-      : Array.from({ length: 6 }, (_, index) => currentYear - index);
-
-  const maxYear = Math.max(...baseYears, currentYear);
-  const minYear = Math.min(...baseYears, currentYear);
-
-  const options: MonthOption[] = [UNSET_MONTH_OPTION];
-  for (let year = maxYear; year >= minYear; year--) {
-    const lastMonth = year >= currentYear ? currentMonth : 12;
-    for (let month = lastMonth; month >= 1; month--) {
-      const key = `${year}-${String(month).padStart(2, "0")}`;
-      options.push({ key, label: `${year}年${month}月` });
-    }
   }
   return options;
 }

--- a/app/utils/buildMonthOptions.ts
+++ b/app/utils/buildMonthOptions.ts
@@ -21,6 +21,25 @@ export const UNSET_MONTH_OPTION: MonthOption = {
  * @param years データが存在する年のリスト（省略時は当年から過去6年）
  * @returns 先頭が「指定なし」、以降が新しい順の年月選択肢
  */
+/**
+ * 実際に試合を記録した年月（"YYYY-MM" の降順リスト、バックエンドの available_months）から
+ * 期間フィルタの選択肢を作る。記録のある年月だけを候補に出したい画面で使う。
+ * 先頭は「指定なし」。入力の並び順（新しい順）をそのまま保つ。
+ *
+ * @param months 記録のある年月（例 ["2026-06", "2026-05"]）
+ */
+export function monthOptionsFromRecorded(months: string[]): MonthOption[] {
+  const options: MonthOption[] = [UNSET_MONTH_OPTION];
+  for (const month of months) {
+    const [year, monthNumber] = month.split("-");
+    options.push({
+      key: month,
+      label: `${Number(year)}年${Number(monthNumber)}月`,
+    });
+  }
+  return options;
+}
+
 export function buildMonthOptions(years?: number[]): MonthOption[] {
   const now = new Date();
   const currentYear = now.getFullYear();

--- a/app/utils/buildMonthOptions.ts
+++ b/app/utils/buildMonthOptions.ts
@@ -1,0 +1,39 @@
+export interface MonthOption {
+  key: string;
+  label: string;
+}
+
+/** 期間フィルタ用の「指定なし」選択肢。key は空文字（= 未指定 / 開放端）。 */
+export const UNSET_MONTH_OPTION: MonthOption = { key: "", label: "指定なし" };
+
+/**
+ * 期間フィルタ（開始年月 / 終了年月）のセレクタに渡す "YYYY-MM" 選択肢を生成する。
+ * 対象年の範囲は available_years（API 由来）を優先し、無ければ当年から6年分にフォールバックする。
+ * 直近の月が先頭に来るよう降順で並べ、当年は当月までしか出さない（未来月を選ばせない）。
+ *
+ * @param years データが存在する年のリスト（省略時は当年から過去6年）
+ * @returns 先頭が「指定なし」、以降が新しい順の年月選択肢
+ */
+export function buildMonthOptions(years?: number[]): MonthOption[] {
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth() + 1;
+
+  const baseYears =
+    years && years.length > 0
+      ? years
+      : Array.from({ length: 6 }, (_, index) => currentYear - index);
+
+  const maxYear = Math.max(...baseYears, currentYear);
+  const minYear = Math.min(...baseYears, currentYear);
+
+  const options: MonthOption[] = [UNSET_MONTH_OPTION];
+  for (let year = maxYear; year >= minYear; year--) {
+    const lastMonth = year >= currentYear ? currentMonth : 12;
+    for (let month = lastMonth; month >= 1; month--) {
+      const key = `${year}-${String(month).padStart(2, "0")}`;
+      options.push({ key, label: `${year}年${month}月` });
+    }
+  }
+  return options;
+}

--- a/app/utils/buildMonthOptions.ts
+++ b/app/utils/buildMonthOptions.ts
@@ -3,8 +3,15 @@ export interface MonthOption {
   label: string;
 }
 
-/** 期間フィルタ用の「指定なし」選択肢。key は空文字（= 未指定 / 開放端）。 */
-export const UNSET_MONTH_OPTION: MonthOption = { key: "", label: "指定なし" };
+/**
+ * 期間フィルタ用の「指定なし」選択肢（= 未指定 / 開放端）。
+ * key は空文字にしない: 共有 FilterChip の onChange が falsy な key を無視するため、
+ * 空文字だと「指定なし」に戻せなくなる。非空のセンチネル値を使う。
+ */
+export const UNSET_MONTH_OPTION: MonthOption = {
+  key: "none",
+  label: "指定なし",
+};
 
 /**
  * 期間フィルタ（開始年月 / 終了年月）のセレクタに渡す "YYYY-MM" 選択肢を生成する。


### PR DESCRIPTION
## 概要

ダッシュボード・試合結果（サマリー/一覧）・成績（打撃/投手）・グループランキング・マイページの各フィルタに「期間（開始年月〜終了年月）」の絞り込みUIを追加します。バックエンドへは `start_month` / `end_month`（`"YYYY-MM"`）で送信します。

> [!IMPORTANT]
> バックエンド（ippei-shimizu/buzzbase_back）の対応PRと合わせてマージが必要です。

## 実装方針

- **共通コンポーネント `PeriodRangeFilter`** を新設。開始/終了の月ドロップダウン2つで構成し、開始 > 終了 の逆転レンジは自動クランプ
- **`buildMonthOptions` ユーティリティ** で `YYYY-MM` の選択肢を生成（当年は当月まで、先頭に「指定なし」）
- **年度フィルタと期間フィルタは排他制御**。期間を設定すると年度を「通算」に、実年を選ぶと期間をクリア
- 新世代（Server Actions）: `analysisActions` / `gameSummaryActions` / `stats`・`dashboard` の actions のクエリ組立に配線
- 旧世代（SWR/axios）: 個人成績フック4本 / `gameResultsService` / `groupService` と各画面 state に配線
- グループランキングは期間指定時に前日比バッジを非表示（現状データに前日比は無く、将来配信時に効く前方互換実装）

## テスト

- `buildMonthOptions` の単体テストを追加
- `yarn lint` / `yarn test`（34スイート・277テスト）全通過
- `yarn typecheck` は自作の変更ファイルに型エラーなし（`.next/dev/types` の pro ページ参照は既存の生成物ノイズ、CIビルドで再生成）
