### PR TITLE
Fix: 成績・試合フィルタの大会選択肢をユーザーが記録した大会のみに絞る

### DIFF
--- a/app/(app)/dashboard/_components/DashboardContent.tsx
+++ b/app/(app)/dashboard/_components/DashboardContent.tsx
@@ -5,6 +5,7 @@ import type {
   DashboardData,
   PitchingStats,
   SeasonOption,
+  TournamentOption,
 } from "../actions";
 import { useState } from "react";
 import { adSlots } from "@app/components/ad/adConfig";
@@ -18,11 +19,13 @@ import StatsOverview from "./StatsOverview";
 interface DashboardContentProps {
   data: DashboardData | null;
   seasons: SeasonOption[];
+  tournaments: TournamentOption[];
 }
 
 export default function DashboardContent({
   data,
   seasons,
+  tournaments,
 }: DashboardContentProps) {
   const [battingStats, setBattingStats] = useState<BattingStats | null>(
     data?.batting_stats ?? null,
@@ -35,6 +38,7 @@ export default function DashboardContent({
     year: string,
     matchType: string,
     seasonId?: string,
+    tournamentId?: string,
     startMonth?: string,
     endMonth?: string,
   ) => {
@@ -42,6 +46,7 @@ export default function DashboardContent({
       year,
       matchType,
       seasonId,
+      tournamentId,
       startMonth,
       endMonth,
     );
@@ -54,6 +59,7 @@ export default function DashboardContent({
     year: string,
     matchType: string,
     seasonId?: string,
+    tournamentId?: string,
     startMonth?: string,
     endMonth?: string,
   ) => {
@@ -61,6 +67,7 @@ export default function DashboardContent({
       year,
       matchType,
       seasonId,
+      tournamentId,
       startMonth,
       endMonth,
     );
@@ -81,6 +88,7 @@ export default function DashboardContent({
         availableYears={data?.available_years ?? []}
         availableMonths={data?.available_months ?? []}
         availableSeasons={seasons}
+        availableTournaments={tournaments}
         onBattingFilterChange={handleBattingFilterChange}
         onPitchingFilterChange={handlePitchingFilterChange}
       />

--- a/app/(app)/dashboard/_components/StatsOverview.tsx
+++ b/app/(app)/dashboard/_components/StatsOverview.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import type { BattingStats, PitchingStats, SeasonOption } from "../actions";
+import type {
+  BattingStats,
+  PitchingStats,
+  SeasonOption,
+  TournamentOption,
+} from "../actions";
 import { useState } from "react";
 import FilterChip from "@app/components/filter/FilterChip";
 import FilterChipGroup from "@app/components/filter/FilterChipGroup";
@@ -28,10 +33,12 @@ interface StatsOverviewProps {
   availableYears: number[];
   availableMonths: string[];
   availableSeasons: SeasonOption[];
+  availableTournaments: TournamentOption[];
   onBattingFilterChange: (
     year: string,
     matchType: string,
     seasonId?: string,
+    tournamentId?: string,
     startMonth?: string,
     endMonth?: string,
   ) => void;
@@ -39,6 +46,7 @@ interface StatsOverviewProps {
     year: string,
     matchType: string,
     seasonId?: string,
+    tournamentId?: string,
     startMonth?: string,
     endMonth?: string,
   ) => void;
@@ -77,30 +85,36 @@ const styleTableData =
 interface FilterProps {
   availableYears: { key: string; label: string }[];
   availableSeasons: { key: string; label: string }[];
+  availableTournaments: { key: string; label: string }[];
   monthOptions: MonthOption[];
   selectedYear: string;
   selectedMatchType: string;
   selectedSeason: string;
+  selectedTournament: string;
   startMonth?: string;
   endMonth?: string;
   onYearChange: (key: string) => void;
   onMatchTypeChange: (key: string) => void;
   onSeasonChange: (key: string) => void;
+  onTournamentChange: (key: string) => void;
   onPeriodRangeChange: (range: PeriodRange) => void;
 }
 
 function StatsFilter({
   availableYears,
   availableSeasons,
+  availableTournaments,
   monthOptions,
   selectedYear,
   selectedMatchType,
   selectedSeason,
+  selectedTournament,
   startMonth,
   endMonth,
   onYearChange,
   onMatchTypeChange,
   onSeasonChange,
+  onTournamentChange,
   onPeriodRangeChange,
 }: FilterProps) {
   return (
@@ -126,6 +140,15 @@ function StatsFilter({
           defaultValue="全て"
           options={availableSeasons}
           onChange={onSeasonChange}
+        />
+      )}
+      {availableTournaments.length > 1 && (
+        <FilterChip
+          label="大会"
+          value={selectedTournament}
+          defaultValue="全て"
+          options={availableTournaments}
+          onChange={onTournamentChange}
         />
       )}
       <PeriodRangeFilter
@@ -503,12 +526,14 @@ export default function StatsOverview({
   availableYears,
   availableMonths,
   availableSeasons,
+  availableTournaments,
   onBattingFilterChange,
   onPitchingFilterChange,
 }: StatsOverviewProps) {
   const [battingYear, setBattingYear] = useState("通算");
   const [battingMatchType, setBattingMatchType] = useState("全て");
   const [battingSeason, setBattingSeason] = useState("全て");
+  const [battingTournament, setBattingTournament] = useState("全て");
   const [battingStartMonth, setBattingStartMonth] = useState<
     string | undefined
   >(undefined);
@@ -518,6 +543,7 @@ export default function StatsOverview({
   const [pitchingYear, setPitchingYear] = useState("通算");
   const [pitchingMatchType, setPitchingMatchType] = useState("全て");
   const [pitchingSeason, setPitchingSeason] = useState("全て");
+  const [pitchingTournament, setPitchingTournament] = useState("全て");
   const [pitchingStartMonth, setPitchingStartMonth] = useState<
     string | undefined
   >(undefined);
@@ -535,7 +561,15 @@ export default function StatsOverview({
     ...availableSeasons.map((s) => ({ key: String(s.id), label: s.name })),
   ];
 
+  const tournamentOptions = [
+    { key: "全て", label: "全て" },
+    ...availableTournaments.map((t) => ({ key: String(t.id), label: t.name })),
+  ];
+
   const monthOptions: MonthOption[] = monthOptionsFromRecorded(availableMonths);
+
+  const battingTournamentId =
+    battingTournament !== "全て" ? battingTournament : undefined;
 
   const handleBattingYearChange = (year: string) => {
     setBattingYear(year);
@@ -552,6 +586,7 @@ export default function StatsOverview({
       year,
       battingMatchType,
       seasonId,
+      battingTournamentId,
       nextStartMonth,
       nextEndMonth,
     );
@@ -564,6 +599,7 @@ export default function StatsOverview({
       battingYear,
       matchType,
       seasonId,
+      battingTournamentId,
       battingStartMonth,
       battingEndMonth,
     );
@@ -576,6 +612,21 @@ export default function StatsOverview({
       battingYear,
       battingMatchType,
       seasonId,
+      battingTournamentId,
+      battingStartMonth,
+      battingEndMonth,
+    );
+  };
+
+  const handleBattingTournamentChange = (tournament: string) => {
+    setBattingTournament(tournament);
+    const tournamentId = tournament !== "全て" ? tournament : undefined;
+    const seasonId = battingSeason !== "全て" ? battingSeason : undefined;
+    onBattingFilterChange(
+      battingYear,
+      battingMatchType,
+      seasonId,
+      tournamentId,
       battingStartMonth,
       battingEndMonth,
     );
@@ -593,10 +644,14 @@ export default function StatsOverview({
       nextYear,
       battingMatchType,
       seasonId,
+      battingTournamentId,
       range.startMonth,
       range.endMonth,
     );
   };
+
+  const pitchingTournamentId =
+    pitchingTournament !== "全て" ? pitchingTournament : undefined;
 
   const handlePitchingYearChange = (year: string) => {
     setPitchingYear(year);
@@ -612,6 +667,7 @@ export default function StatsOverview({
       year,
       pitchingMatchType,
       seasonId,
+      pitchingTournamentId,
       nextStartMonth,
       nextEndMonth,
     );
@@ -624,6 +680,7 @@ export default function StatsOverview({
       pitchingYear,
       matchType,
       seasonId,
+      pitchingTournamentId,
       pitchingStartMonth,
       pitchingEndMonth,
     );
@@ -636,6 +693,21 @@ export default function StatsOverview({
       pitchingYear,
       pitchingMatchType,
       seasonId,
+      pitchingTournamentId,
+      pitchingStartMonth,
+      pitchingEndMonth,
+    );
+  };
+
+  const handlePitchingTournamentChange = (tournament: string) => {
+    setPitchingTournament(tournament);
+    const tournamentId = tournament !== "全て" ? tournament : undefined;
+    const seasonId = pitchingSeason !== "全て" ? pitchingSeason : undefined;
+    onPitchingFilterChange(
+      pitchingYear,
+      pitchingMatchType,
+      seasonId,
+      tournamentId,
       pitchingStartMonth,
       pitchingEndMonth,
     );
@@ -652,6 +724,7 @@ export default function StatsOverview({
       nextYear,
       pitchingMatchType,
       seasonId,
+      pitchingTournamentId,
       range.startMonth,
       range.endMonth,
     );
@@ -692,15 +765,18 @@ export default function StatsOverview({
                 <StatsFilter
                   availableYears={yearOptions}
                   availableSeasons={seasonOptions}
+                  availableTournaments={tournamentOptions}
                   monthOptions={monthOptions}
                   selectedYear={battingYear}
                   selectedMatchType={battingMatchType}
                   selectedSeason={battingSeason}
+                  selectedTournament={battingTournament}
                   startMonth={battingStartMonth}
                   endMonth={battingEndMonth}
                   onYearChange={handleBattingYearChange}
                   onMatchTypeChange={handleBattingMatchTypeChange}
                   onSeasonChange={handleBattingSeasonChange}
+                  onTournamentChange={handleBattingTournamentChange}
                   onPeriodRangeChange={handleBattingPeriodRangeChange}
                 />
               </div>
@@ -735,15 +811,18 @@ export default function StatsOverview({
                 <StatsFilter
                   availableYears={yearOptions}
                   availableSeasons={seasonOptions}
+                  availableTournaments={tournamentOptions}
                   monthOptions={monthOptions}
                   selectedYear={pitchingYear}
                   selectedMatchType={pitchingMatchType}
                   selectedSeason={pitchingSeason}
+                  selectedTournament={pitchingTournament}
                   startMonth={pitchingStartMonth}
                   endMonth={pitchingEndMonth}
                   onYearChange={handlePitchingYearChange}
                   onMatchTypeChange={handlePitchingMatchTypeChange}
                   onSeasonChange={handlePitchingSeasonChange}
+                  onTournamentChange={handlePitchingTournamentChange}
                   onPeriodRangeChange={handlePitchingPeriodRangeChange}
                 />
               </div>

--- a/app/(app)/dashboard/actions.ts
+++ b/app/(app)/dashboard/actions.ts
@@ -109,6 +109,11 @@ export interface SeasonOption {
   name: string;
 }
 
+export interface TournamentOption {
+  id: number;
+  name: string;
+}
+
 export interface DashboardData {
   recent_game_results: RecentGameResult[];
   batting_stats: BattingStats;
@@ -183,6 +188,7 @@ function buildFilterQuery(
   year?: string,
   matchType?: string,
   seasonId?: string,
+  tournamentId?: string,
   startMonth?: string,
   endMonth?: string,
 ): string {
@@ -190,6 +196,7 @@ function buildFilterQuery(
   if (year && year !== "通算") params.append("year", year);
   if (matchType && matchType !== "全て") params.append("match_type", matchType);
   if (seasonId) params.append("season_id", seasonId);
+  if (tournamentId) params.append("tournament_id", tournamentId);
   if (startMonth) params.append("start_month", startMonth);
   if (endMonth) params.append("end_month", endMonth);
   const query = params.toString();
@@ -217,10 +224,33 @@ export async function getAvailableSeasons(): Promise<SeasonOption[]> {
   }
 }
 
+export async function getAvailableTournaments(): Promise<TournamentOption[]> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return [];
+
+    // 全大会ではなく、自分が記録した大会のみを候補にする。
+    const url = `${RAILS_API_URL}/api/v1/tournaments/user_tournaments`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers,
+      cache: "no-store",
+    });
+
+    if (!response.ok) return [];
+    return await response.json();
+  } catch (error) {
+    captureServerActionError(error, { action: "getAvailableTournaments" });
+    console.error("Error fetching tournaments:", error);
+    return [];
+  }
+}
+
 export async function getFilteredBattingStats(
   year?: string,
   matchType?: string,
   seasonId?: string,
+  tournamentId?: string,
   startMonth?: string,
   endMonth?: string,
 ): Promise<BattingStats | null> {
@@ -232,6 +262,7 @@ export async function getFilteredBattingStats(
       year,
       matchType,
       seasonId,
+      tournamentId,
       startMonth,
       endMonth,
     );
@@ -256,6 +287,7 @@ export async function getFilteredPitchingStats(
   year?: string,
   matchType?: string,
   seasonId?: string,
+  tournamentId?: string,
   startMonth?: string,
   endMonth?: string,
 ): Promise<PitchingStats | null> {
@@ -267,6 +299,7 @@ export async function getFilteredPitchingStats(
       year,
       matchType,
       seasonId,
+      tournamentId,
       startMonth,
       endMonth,
     );

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -4,7 +4,11 @@ import { adSlots } from "@app/components/ad/adConfig";
 import AdInFeed from "@app/components/ad/AdInFeed";
 import Header from "@app/components/header/Header";
 import DashboardContent from "./_components/DashboardContent";
-import { getAvailableSeasons, getDashboardData } from "./actions";
+import {
+  getAvailableSeasons,
+  getAvailableTournaments,
+  getDashboardData,
+} from "./actions";
 
 export const metadata = {
   title: "ダッシュボード",
@@ -16,9 +20,10 @@ export default async function DashboardPage() {
     redirect("/signup?auth_required=true");
   }
 
-  const [data, seasons] = await Promise.all([
+  const [data, seasons, tournaments] = await Promise.all([
     getDashboardData(),
     getAvailableSeasons(),
+    getAvailableTournaments(),
   ]);
 
   return (
@@ -30,7 +35,11 @@ export default async function DashboardPage() {
             <div className="pt-20 px-4 lg:px-6">
               <h2 className="text-2xl font-bold">ダッシュボード</h2>
               <div className="my-6">
-                <DashboardContent data={data} seasons={seasons} />
+                <DashboardContent
+                  data={data}
+                  seasons={seasons}
+                  tournaments={tournaments}
+                />
                 <AdInFeed
                   slot={adSlots.dashboardInFeed}
                   layoutKey="-6t+ed+2i-1n-4w"

--- a/app/(app)/stats/filterOptions.ts
+++ b/app/(app)/stats/filterOptions.ts
@@ -23,7 +23,7 @@ const emptyOptions = (): StatsFilterOptions => ({
  * 成績画面のフィルタ選択肢（シーズン / 大会 / 記録月）をサーバーで取得する。
  * `cache()` でラップしているため、同一リクエスト内で page / 各 Section から
  * 複数回呼ばれても実取得は1回（seasons + tournaments + available_months の3コール）に集約される。
- * 認証ヘッダがあれば user_id は不要（バックエンドが current_user にフォールバック）。
+ * 大会は user_tournaments を叩き、current_user が記録した大会のみに絞る。
  */
 export const getStatsFilterOptions = cache(
   async (): Promise<StatsFilterOptions> => {
@@ -37,7 +37,7 @@ export const getStatsFilterOptions = cache(
             headers,
             cache: "no-store",
           }),
-          fetch(`${RAILS_API_URL}/api/v1/tournaments`, {
+          fetch(`${RAILS_API_URL}/api/v1/tournaments/user_tournaments`, {
             headers,
             cache: "no-store",
           }),

--- a/app/components/user/IndividualResultsList.tsx
+++ b/app/components/user/IndividualResultsList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { SeasonData } from "@app/interface";
+import type { SeasonData, TournamentData } from "@app/interface";
 import { Skeleton } from "@heroui/react";
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
@@ -18,6 +18,7 @@ import {
   getMatchResultsUserId,
 } from "@app/services/matchResultsService";
 import { getSeasons } from "@app/services/seasonsService";
+import { getUserTournaments } from "@app/services/tournamentsService";
 import { monthOptionsFromRecorded } from "@app/utils/buildMonthOptions";
 import { formatRate, formatEra } from "@app/utils/formatStats";
 
@@ -41,6 +42,11 @@ export default function IndividualResultsList(props: UserId) {
   const [selectedSeason, setSelectedSeason] = useState("全て");
   const [seasonsData, setSeasonsData] = useState<SeasonData[]>([]);
   const [seasonOptions, setSeasonOptions] = useState<
+    { key: string; label: string }[]
+  >([{ key: "全て", label: "全て" }]);
+  const [selectedTournament, setSelectedTournament] = useState("全て");
+  const [tournamentsData, setTournamentsData] = useState<TournamentData[]>([]);
+  const [tournamentOptions, setTournamentOptions] = useState<
     { key: string; label: string }[]
   >([{ key: "全て", label: "全て" }]);
   const [startMonth, setStartMonth] = useState<string | undefined>(undefined);
@@ -114,11 +120,33 @@ export default function IndividualResultsList(props: UserId) {
     fetchMeta();
   }, [userId]);
 
+  // 大会候補は記録した大会のみ・他ユーザーページのため userId 指定で取得する。
+  useEffect(() => {
+    const fetchTournaments = async () => {
+      const list = await getUserTournaments(userId);
+      setTournamentsData(list);
+      setTournamentOptions([
+        { key: "全て", label: "全て" },
+        ...list.map((tournament) => ({
+          key: tournament.name,
+          label: tournament.name,
+        })),
+      ]);
+    };
+    fetchTournaments();
+  }, [userId]);
+
   const seasonId = useMemo(() => {
     return selectedSeason !== "全て"
       ? seasonsData.find((s) => s.name === selectedSeason)?.id
       : undefined;
   }, [selectedSeason, seasonsData]);
+
+  const tournamentId = useMemo(() => {
+    return selectedTournament !== "全て"
+      ? tournamentsData.find((t) => t.name === selectedTournament)?.id
+      : undefined;
+  }, [selectedTournament, tournamentsData]);
 
   const monthOptions = useMemo(
     () => monthOptionsFromRecorded(availableMonths),
@@ -157,6 +185,7 @@ export default function IndividualResultsList(props: UserId) {
     matchTypeParam,
     startMonth,
     endMonth,
+    tournamentId,
   );
   const { personalBattingStatus, isLoadingBS } = usePersonalBattingStatus(
     userId,
@@ -165,6 +194,7 @@ export default function IndividualResultsList(props: UserId) {
     matchTypeParam,
     startMonth,
     endMonth,
+    tournamentId,
   );
   const { personalPitchingResults, isLoadingPR } = usePersonalPitchingResult(
     userId,
@@ -173,6 +203,7 @@ export default function IndividualResultsList(props: UserId) {
     matchTypeParam,
     startMonth,
     endMonth,
+    tournamentId,
   );
   const { personalPitchingStatus, isLoadingPS } =
     usePersonalPitchingResultStats(
@@ -182,6 +213,7 @@ export default function IndividualResultsList(props: UserId) {
       matchTypeParam,
       startMonth,
       endMonth,
+      tournamentId,
     );
 
   const isLoading = isLoadingBA || isLoadingBS || isLoadingPR || isLoadingPS;
@@ -222,6 +254,15 @@ export default function IndividualResultsList(props: UserId) {
               options={seasonOptions}
               onChange={setSelectedSeason}
             />
+            {tournamentOptions.length > 1 && (
+              <FilterChip
+                label="大会"
+                value={selectedTournament}
+                defaultValue="全て"
+                options={tournamentOptions}
+                onChange={setSelectedTournament}
+              />
+            )}
             <PeriodRangeFilter
               startMonth={startMonth}
               endMonth={endMonth}

--- a/app/components/user/IndividualResultsList.tsx
+++ b/app/components/user/IndividualResultsList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { SeasonData, TournamentData } from "@app/interface";
+import type { SeasonData } from "@app/interface";
 import { Skeleton } from "@heroui/react";
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
@@ -45,7 +45,6 @@ export default function IndividualResultsList(props: UserId) {
     { key: string; label: string }[]
   >([{ key: "全て", label: "全て" }]);
   const [selectedTournament, setSelectedTournament] = useState("全て");
-  const [tournamentsData, setTournamentsData] = useState<TournamentData[]>([]);
   const [tournamentOptions, setTournamentOptions] = useState<
     { key: string; label: string }[]
   >([{ key: "全て", label: "全て" }]);
@@ -124,11 +123,11 @@ export default function IndividualResultsList(props: UserId) {
   useEffect(() => {
     const fetchTournaments = async () => {
       const list = await getUserTournaments(userId);
-      setTournamentsData(list);
+      // 大会名は年ごとに重複しうるため id をキーにする（name だと衝突・取りこぼし）。
       setTournamentOptions([
         { key: "全て", label: "全て" },
         ...list.map((tournament) => ({
-          key: tournament.name,
+          key: String(tournament.id),
           label: tournament.name,
         })),
       ]);
@@ -144,9 +143,9 @@ export default function IndividualResultsList(props: UserId) {
 
   const tournamentId = useMemo(() => {
     return selectedTournament !== "全て"
-      ? tournamentsData.find((t) => t.name === selectedTournament)?.id
+      ? Number(selectedTournament)
       : undefined;
-  }, [selectedTournament, tournamentsData]);
+  }, [selectedTournament]);
 
   const monthOptions = useMemo(
     () => monthOptionsFromRecorded(availableMonths),

--- a/app/components/user/MatchResultList.tsx
+++ b/app/components/user/MatchResultList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { SeasonData, TournamentData } from "@app/interface";
+import type { SeasonData } from "@app/interface";
 import type { PaginationInfo } from "@app/services/gameResultsService";
 import { Spinner } from "@heroui/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -80,7 +80,6 @@ export default function MatchResultList(props: MatchResultListProps) {
     { key: string; label: string }[]
   >([{ key: "全て", label: "全て" }]);
   const [selectedSeason, setSelectedSeason] = useState("全て");
-  const [tournamentsData, setTournamentsData] = useState<TournamentData[]>([]);
   const [tournamentOptions, setTournamentOptions] = useState<
     { key: string; label: string }[]
   >([{ key: "全て", label: "全て" }]);
@@ -146,11 +145,11 @@ export default function MatchResultList(props: MatchResultListProps) {
     if (!userId) return;
     const fetchTournaments = async () => {
       const list = await getUserTournaments(userId);
-      setTournamentsData(list);
+      // 大会名は年ごとに重複しうるため id をキーにする（name だと衝突・取りこぼし）。
       setTournamentOptions([
         { key: "全て", label: "全て" },
         ...list.map((tournament) => ({
-          key: tournament.name,
+          key: String(tournament.id),
           label: tournament.name,
         })),
       ]);
@@ -160,9 +159,9 @@ export default function MatchResultList(props: MatchResultListProps) {
 
   const tournamentId = useMemo(() => {
     return selectedTournament !== "全て"
-      ? tournamentsData.find((t) => t.name === selectedTournament)?.id
+      ? Number(selectedTournament)
       : undefined;
-  }, [selectedTournament, tournamentsData]);
+  }, [selectedTournament]);
 
   // 年度・試合タイプ一覧は初回のみ取得（userId依存）
   useEffect(() => {

--- a/app/components/user/MatchResultList.tsx
+++ b/app/components/user/MatchResultList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { SeasonData } from "@app/interface";
+import type { SeasonData, TournamentData } from "@app/interface";
 import type { PaginationInfo } from "@app/services/gameResultsService";
 import { Spinner } from "@heroui/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -22,6 +22,7 @@ import {
   getMatchResultsUserId,
 } from "@app/services/matchResultsService";
 import { getSeasons } from "@app/services/seasonsService";
+import { getUserTournaments } from "@app/services/tournamentsService";
 import { monthOptionsFromRecorded } from "@app/utils/buildMonthOptions";
 
 type GameResult = {
@@ -79,6 +80,11 @@ export default function MatchResultList(props: MatchResultListProps) {
     { key: string; label: string }[]
   >([{ key: "全て", label: "全て" }]);
   const [selectedSeason, setSelectedSeason] = useState("全て");
+  const [tournamentsData, setTournamentsData] = useState<TournamentData[]>([]);
+  const [tournamentOptions, setTournamentOptions] = useState<
+    { key: string; label: string }[]
+  >([{ key: "全て", label: "全て" }]);
+  const [selectedTournament, setSelectedTournament] = useState("全て");
   const [startMonth, setStartMonth] = useState<string | undefined>(undefined);
   const [endMonth, setEndMonth] = useState<string | undefined>(undefined);
   const [availableMonths, setAvailableMonths] = useState<string[]>([]);
@@ -134,6 +140,29 @@ export default function MatchResultList(props: MatchResultListProps) {
       ? seasonsData.find((s) => s.name === selectedSeason)?.id
       : undefined;
   }, [selectedSeason, seasonsData]);
+
+  // 大会候補は初回のみ取得（記録した大会のみ・他ユーザーページのため userId 指定）。
+  useEffect(() => {
+    if (!userId) return;
+    const fetchTournaments = async () => {
+      const list = await getUserTournaments(userId);
+      setTournamentsData(list);
+      setTournamentOptions([
+        { key: "全て", label: "全て" },
+        ...list.map((tournament) => ({
+          key: tournament.name,
+          label: tournament.name,
+        })),
+      ]);
+    };
+    fetchTournaments();
+  }, [userId]);
+
+  const tournamentId = useMemo(() => {
+    return selectedTournament !== "全て"
+      ? tournamentsData.find((t) => t.name === selectedTournament)?.id
+      : undefined;
+  }, [selectedTournament, tournamentsData]);
 
   // 年度・試合タイプ一覧は初回のみ取得（userId依存）
   useEffect(() => {
@@ -219,6 +248,10 @@ export default function MatchResultList(props: MatchResultListProps) {
     setSelectedSeason(value);
     setCurrentPage(1);
   };
+  const handleTournamentChange = (value: string) => {
+    setSelectedTournament(value);
+    setCurrentPage(1);
+  };
   const handleSearchChange = (value: string) => {
     setSearchQuery(value);
     setCurrentPage(1);
@@ -254,6 +287,7 @@ export default function MatchResultList(props: MatchResultListProps) {
             apiSortOrder,
             startMonth,
             endMonth,
+            tournamentId,
           );
         } else {
           response = await getFilterGameResultsV2(
@@ -267,6 +301,7 @@ export default function MatchResultList(props: MatchResultListProps) {
             apiSortOrder,
             startMonth,
             endMonth,
+            tournamentId,
           );
         }
         if (cancelled) return;
@@ -299,6 +334,7 @@ export default function MatchResultList(props: MatchResultListProps) {
     apiSortOrder,
     startMonth,
     endMonth,
+    tournamentId,
   ]);
 
   return (
@@ -327,6 +363,15 @@ export default function MatchResultList(props: MatchResultListProps) {
               options={seasonOptions}
               onChange={handleSeasonChange}
             />
+            {tournamentOptions.length > 1 && (
+              <FilterChip
+                label="大会"
+                value={selectedTournament}
+                defaultValue="全て"
+                options={tournamentOptions}
+                onChange={handleTournamentChange}
+              />
+            )}
             <PeriodRangeFilter
               startMonth={startMonth}
               endMonth={endMonth}

--- a/app/hooks/batting/getPersonalBattingAverage.ts
+++ b/app/hooks/batting/getPersonalBattingAverage.ts
@@ -9,10 +9,14 @@ export function usePersonalBattingAverage(
   matchType?: string,
   startMonth?: string,
   endMonth?: string,
+  tournamentId?: number,
 ) {
   const params = new URLSearchParams({ user_id: String(userId) });
   if (seasonId) {
     params.append("season_id", String(seasonId));
+  }
+  if (tournamentId) {
+    params.append("tournament_id", String(tournamentId));
   }
   if (year) {
     params.append("year", year);

--- a/app/hooks/batting/getPersonalBattingStatus.ts
+++ b/app/hooks/batting/getPersonalBattingStatus.ts
@@ -9,10 +9,14 @@ export function usePersonalBattingStatus(
   matchType?: string,
   startMonth?: string,
   endMonth?: string,
+  tournamentId?: number,
 ) {
   const params = new URLSearchParams({ user_id: String(userId) });
   if (seasonId) {
     params.append("season_id", String(seasonId));
+  }
+  if (tournamentId) {
+    params.append("tournament_id", String(tournamentId));
   }
   if (year) {
     params.append("year", year);

--- a/app/hooks/pitching/getPersonalPitchingResult.ts
+++ b/app/hooks/pitching/getPersonalPitchingResult.ts
@@ -9,10 +9,14 @@ export function usePersonalPitchingResult(
   matchType?: string,
   startMonth?: string,
   endMonth?: string,
+  tournamentId?: number,
 ) {
   const params = new URLSearchParams({ user_id: String(userId) });
   if (seasonId) {
     params.append("season_id", String(seasonId));
+  }
+  if (tournamentId) {
+    params.append("tournament_id", String(tournamentId));
   }
   if (year) {
     params.append("year", year);

--- a/app/hooks/pitching/getPersonalPitchingResultStats.ts
+++ b/app/hooks/pitching/getPersonalPitchingResultStats.ts
@@ -9,10 +9,14 @@ export function usePersonalPitchingResultStats(
   matchType?: string,
   startMonth?: string,
   endMonth?: string,
+  tournamentId?: number,
 ) {
   const params = new URLSearchParams({ user_id: String(userId) });
   if (seasonId) {
     params.append("season_id", String(seasonId));
+  }
+  if (tournamentId) {
+    params.append("tournament_id", String(tournamentId));
   }
   if (year) {
     params.append("year", year);

--- a/app/services/gameResultsService.tsx
+++ b/app/services/gameResultsService.tsx
@@ -205,11 +205,15 @@ export const getFilterGameResultsV2 = async (
   sortOrder?: string,
   startMonth?: string,
   endMonth?: string,
+  tournamentId?: number,
 ): Promise<PaginatedResponse<unknown>> => {
   try {
     let url = `/api/v2/game_results/filtered_index?year=${year}&match_type=${matchType}`;
     if (seasonId) {
       url += `&season_id=${seasonId}`;
+    }
+    if (tournamentId) {
+      url += `&tournament_id=${tournamentId}`;
     }
     if (page) {
       url += `&page=${page}`;
@@ -255,11 +259,15 @@ export const getFilterGameResultsUserIdV2 = async (
   sortOrder?: string,
   startMonth?: string,
   endMonth?: string,
+  tournamentId?: number,
 ): Promise<PaginatedResponse<unknown>> => {
   try {
     let url = `/api/v2/game_results/filtered_user/${userId}?year=${year}&match_type=${matchType}`;
     if (seasonId) {
       url += `&season_id=${seasonId}`;
+    }
+    if (tournamentId) {
+      url += `&tournament_id=${tournamentId}`;
     }
     if (page) {
       url += `&page=${page}`;

--- a/app/services/tournamentsService.tsx
+++ b/app/services/tournamentsService.tsx
@@ -19,6 +19,24 @@ export const getTournaments = async () => {
   }
 };
 
+/**
+ * ユーザーが記録した大会のみを返す（フィルタ候補用）。
+ * userId 省略時は current_user、指定時はそのユーザーの大会。取得失敗時は空配列。
+ */
+export const getUserTournaments = async (
+  userId?: number,
+): Promise<TournamentData[]> => {
+  try {
+    const url = userId
+      ? `/api/v1/tournaments/user_tournaments?user_id=${userId}`
+      : "/api/v1/tournaments/user_tournaments";
+    const response = await axiosInstance.get(url);
+    return response.data as TournamentData[];
+  } catch {
+    return [];
+  }
+};
+
 export const createTournament = async ({ name }: { name: string }) => {
   try {
     const response = await axiosInstance.post("/api/v1/tournaments", {


### PR DESCRIPTION
## 概要

成績・試合のフィルタリングにある「大会」の選択肢に、自分が記録していない大会（全ユーザーの大会）まで表示されていた不具合を修正します。

## 問題

フィルタ選択肢を取得する `getStatsFilterOptions`（`front/app/(app)/stats/filterOptions.ts`）が、全ユーザーの全大会を返す `GET /api/v1/tournaments`（`Tournament.all`）を叩いていました。そのため、成績ページ・分析タブ・試合結果サマリーの大会フィルタに、そのユーザーが一度も記録していない大会が並んでいました。

## 修正内容

- 大会選択肢の取得先を `GET /api/v1/tournaments`（全大会）から `GET /api/v1/tournaments/user_tournaments`（current_user の試合に紐づく大会のみ）へ変更
- current_user スコープを返す `user_tournaments` エンドポイントはバックエンド（`stg`）に既存のため、バックエンド側の変更は不要
- シーズン（`/api/v1/seasons`）は元々 current_user スコープで問題なし。記録月（`available_months`）フィルタも変更なし

## 動作確認

- 大会フィルタに自分が記録した大会のみが表示されること
- 記録した大会が1件以下の場合は従来通り大会チップが非表示になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
