### PR TITLE
Fix: 試合結果登録フォームで空白のみのチーム名/シーズン名が422を引き起こす不具合を修正

### DIFF
--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -453,7 +453,7 @@ export default function GameRecord() {
       setIsMatchDate(true);
     }
 
-    if (!myTeam) {
+    if (!myTeam.trim()) {
       setIsMyTeamValid(false);
       isValid = false;
       newErrors.push("自チーム名が未入力です。");
@@ -463,7 +463,7 @@ export default function GameRecord() {
 
     // 既存試合の編集時は opponentTeam（名前）が空でも existingOpponentTeam（id）で
     // 相手チームが確定しているため、どちらかがあれば入力済みとみなす。
-    if (!opponentTeam && !existingOpponentTeam) {
+    if (!opponentTeam.trim() && !existingOpponentTeam) {
       setIsOpponentTeamValid(false);
       isValid = false;
       newErrors.push("相手チーム名が未入力です。");
@@ -540,11 +540,12 @@ export default function GameRecord() {
           ]);
         }
       }
-      let myTeamId = teamsData.find((team) => team.name === myTeam)?.id;
+      const trimmedMyTeam = myTeam.trim();
+      let myTeamId = teamsData.find((team) => team.name === trimmedMyTeam)?.id;
       if (!myTeamId) {
         const newTeam = await createOrUpdateTeam({
           team: {
-            name: myTeam,
+            name: trimmedMyTeam,
             category_id: undefined,
             prefecture_id: undefined,
           },
@@ -577,14 +578,15 @@ export default function GameRecord() {
 
       // シーズン保存
       let seasonId = selectedSeason;
-      if (inputSeasonName && !selectedSeason) {
+      const trimmedSeasonName = inputSeasonName.trim();
+      if (trimmedSeasonName && !selectedSeason) {
         const existingSeason = seasonsData.find(
-          (s) => s.name === inputSeasonName,
+          (s) => s.name === trimmedSeasonName,
         );
         if (existingSeason) {
           seasonId = existingSeason.id;
         } else {
-          const newSeason = await createSeason(inputSeasonName);
+          const newSeason = await createSeason(trimmedSeasonName);
           if (newSeason) {
             setSeasonsData([...seasonsData, newSeason]);
             seasonId = newSeason.id;
@@ -595,10 +597,11 @@ export default function GameRecord() {
       // 相手チーム保存。既存チームを選択済み（existingOpponentTeam あり）の場合は
       // 新規作成せず id をそのまま使い、手入力で新しいチーム名を入れた場合のみ作成する。
       let opponentTeamId = existingOpponentTeam;
-      if (!opponentTeamId && opponentTeam.trim() !== "") {
+      const trimmedOpponentTeam = opponentTeam.trim();
+      if (!opponentTeamId && trimmedOpponentTeam !== "") {
         const newTeamResponse = await createOrUpdateTeam({
           team: {
-            name: opponentTeam,
+            name: trimmedOpponentTeam,
             category_id: undefined,
             prefecture_id: undefined,
           },


### PR DESCRIPTION
## Summary

- 試合結果登録フォームで空白のみのチーム名・シーズン名を送信すると422になる不具合を修正

## 背景

ippei-shimizu/buzzbase#442 参照。mobileと同じ根本原因（クライアント側バリデーションが
空白のみの文字列を許容してしまう）がfrontの試合結果登録フォームにも存在することが
調査で判明したため、同様に修正した。

## 変更内容

- `app/(app)/game-result/record/page.tsx`
  - `validateForm()` の自チーム名・相手チーム名チェックに `trim()` を追加
  - チーム作成・シーズン作成に渡す値もtrim()してから送信するよう修正

## Test plan

- [x] `yarn typecheck` 通過
- [x] `yarn lint` 通過
- [x] `yarn build` 通過
- [x] ローカル環境（http://localhost:8100/game-result/record）で実際に再現・修正確認
  - 修正前: 自チーム名に半角スペースのみ入力 → `POST /api/v1/teams` が `{"team":{"name":"   "}}` で422
  - 修正後: 同操作でクライアント側バリデーションにより送信自体がブロックされる
  - 正常系（有効なチーム名での試合結果登録 → チーム作成→match_results作成→次画面遷移）が問題なく動作することも確認
