### PR TITLE
Add: パスワードリセット申請・完了ページを追加

### DIFF
--- a/app/(app)/password-reset/layout.tsx
+++ b/app/(app)/password-reset/layout.tsx
@@ -1,0 +1,22 @@
+import { type Metadata } from "next";
+import Header from "@app/components/header/Header";
+
+export const metadata: Metadata = {
+  title: "パスワードの再設定",
+  description: "「BUZZ BASE」のパスワード再設定用のメールを送信します。",
+};
+
+export default function PasswordResetLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Header />
+      <div className="h-full buzz-dark flex flex-col w-full min-h-screen bg-main">
+        <main className="h-full">{children}</main>
+      </div>
+    </>
+  );
+}

--- a/app/(app)/password-reset/layout.tsx
+++ b/app/(app)/password-reset/layout.tsx
@@ -4,6 +4,9 @@ import Header from "@app/components/header/Header";
 export const metadata: Metadata = {
   title: "パスワードの再設定",
   description: "「BUZZ BASE」のパスワード再設定用のメールを送信します。",
+  robots: {
+    index: false,
+  },
 };
 
 export default function PasswordResetLayout({

--- a/app/(app)/password-reset/page.tsx
+++ b/app/(app)/password-reset/page.tsx
@@ -1,0 +1,31 @@
+import Image from "next/image";
+import Link from "next/link";
+import PasswordResetRequestForm from "@app/components/auth/PasswordResetRequestForm";
+
+export default function Page() {
+  return (
+    <>
+      <Image
+        src="/images/logo-bg.png"
+        alt=""
+        width={500}
+        height={400}
+        className="absolute opacity-[0.03] -left-28 -top-10 lg:left-24 lg:w-[620px]"
+      />
+      <div className="h-full flex flex-col items-center justify-center px-4">
+        <div className="w-11/12 max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+          <h2 className="text-2xl font-bold mb-4">パスワードの再設定</h2>
+          <p className="text-sm text-zinc-400 mb-8">
+            ご登録のメールアドレスを入力してください。パスワード再設定用のリンクをお送りします。
+          </p>
+          <PasswordResetRequestForm />
+          <p className="text-sm text-zinc-400 mt-8 text-center">
+            <Link href="/signin" className="text-yellow-500">
+              ログイン画面に戻る
+            </Link>
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(app)/reset-password/layout.tsx
+++ b/app/(app)/reset-password/layout.tsx
@@ -4,6 +4,9 @@ import Header from "@app/components/header/Header";
 export const metadata: Metadata = {
   title: "新しいパスワードの設定",
   description: "「BUZZ BASE」の新しいパスワードを設定します。",
+  robots: {
+    index: false,
+  },
 };
 
 export default function ResetPasswordLayout({

--- a/app/(app)/reset-password/layout.tsx
+++ b/app/(app)/reset-password/layout.tsx
@@ -1,0 +1,22 @@
+import { type Metadata } from "next";
+import Header from "@app/components/header/Header";
+
+export const metadata: Metadata = {
+  title: "新しいパスワードの設定",
+  description: "「BUZZ BASE」の新しいパスワードを設定します。",
+};
+
+export default function ResetPasswordLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Header />
+      <div className="h-full buzz-dark flex flex-col w-full min-h-screen bg-main">
+        <main className="h-full">{children}</main>
+      </div>
+    </>
+  );
+}

--- a/app/(app)/reset-password/page.tsx
+++ b/app/(app)/reset-password/page.tsx
@@ -1,13 +1,18 @@
-"use client";
-import { useSearchParams } from "next/navigation";
-import { Suspense } from "react";
 import ResetPasswordForm from "@app/components/auth/ResetPasswordForm";
 
-function ResetPasswordContent() {
-  const searchParams = useSearchParams();
-  const accessToken = searchParams.get("access-token");
-  const client = searchParams.get("client");
-  const uid = searchParams.get("uid");
+interface PageProps {
+  searchParams: Promise<{
+    "access-token"?: string;
+    client?: string;
+    uid?: string;
+  }>;
+}
+
+export default async function Page({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const accessToken = params["access-token"];
+  const client = params.client;
+  const uid = params.uid;
   const hasValidToken = !!(accessToken && client && uid);
 
   return (
@@ -23,19 +28,5 @@ function ResetPasswordContent() {
         )}
       </div>
     </div>
-  );
-}
-
-export default function Page() {
-  return (
-    <Suspense
-      fallback={
-        <div className="h-full flex items-center justify-center">
-          読み込み中...
-        </div>
-      }
-    >
-      <ResetPasswordContent />
-    </Suspense>
   );
 }

--- a/app/(app)/reset-password/page.tsx
+++ b/app/(app)/reset-password/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+import ResetPasswordForm from "@app/components/auth/ResetPasswordForm";
+
+function ResetPasswordContent() {
+  const searchParams = useSearchParams();
+  const accessToken = searchParams.get("access-token");
+  const client = searchParams.get("client");
+  const uid = searchParams.get("uid");
+  const hasValidToken = !!(accessToken && client && uid);
+
+  return (
+    <div className="h-full flex flex-col items-center justify-center px-4">
+      <div className="w-11/12 max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <h2 className="text-2xl font-bold mb-9">新しいパスワードの設定</h2>
+        {hasValidToken ? (
+          <ResetPasswordForm authHeaders={{ accessToken, client, uid }} />
+        ) : (
+          <p className="text-sm text-gray-200">
+            このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URLをご確認ください。
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense
+      fallback={
+        <div className="h-full flex items-center justify-center">
+          読み込み中...
+        </div>
+      }
+    >
+      <ResetPasswordContent />
+    </Suspense>
+  );
+}

--- a/app/components/auth/PasswordResetRequestForm.tsx
+++ b/app/components/auth/PasswordResetRequestForm.tsx
@@ -1,0 +1,73 @@
+"use client";
+import { useCallback, useMemo, useState } from "react";
+import EmailInput from "@app/components/auth/EmailInput";
+import SubmitButton from "@app/components/button/SendButton";
+import { requestPasswordReset } from "@app/services/authService";
+
+// アカウント列挙・認証方式の推測を防ぐため、送信成功・失敗やアカウントの有無に
+// かかわらず常に同じ文言を表示する。
+const GENERIC_MESSAGE =
+  "ご入力いただいたメールアドレス宛にパスワード再設定のご案内をお送りしました（該当するアカウントが存在する場合）。メールをご確認ください。";
+
+export default function PasswordResetRequestForm() {
+  const [email, setEmail] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const validateEmail = useCallback(
+    (email: string) => email.match(/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i),
+    [],
+  );
+
+  const isInvalid = useMemo(() => {
+    if (email === "") return false;
+    return validateEmail(email) ? false : true;
+  }, [email, validateEmail]);
+
+  const isFormValid = useMemo(
+    () => email !== "" && !!validateEmail(email),
+    [email, validateEmail],
+  );
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!isFormValid || isLoading) return;
+    setIsLoading(true);
+    try {
+      await requestPasswordReset(email);
+    } catch {
+      // 成否にかかわらず同一文言を表示するため、ここではエラー内容を利用しない
+    } finally {
+      setIsLoading(false);
+      setIsSubmitted(true);
+    }
+  };
+
+  if (isSubmitted) {
+    return <p className="text-sm text-gray-200">{GENERIC_MESSAGE}</p>;
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col justify-end gap-y-4">
+      <EmailInput
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        className="caret-zinc-400 bg-main rounded-2xl"
+        type="email"
+        label="メールアドレス"
+        placeholder="buzzbase@example.com"
+        labelPlacement="outside"
+        isInvalid={isInvalid}
+        color={isInvalid ? "danger" : "default"}
+        variant={"bordered"}
+        errorMessage={isInvalid ? "有効なメールアドレスを入力してください" : ""}
+      />
+      <SubmitButton
+        className="bg-yellow-500 text-white h-auto text-base mt-6 mx-auto py-2.5 px-12 rounded-full block font-semibold"
+        type="submit"
+        text="送信する"
+        disabled={!isFormValid || isLoading}
+      />
+    </form>
+  );
+}

--- a/app/components/auth/ResetPasswordForm.tsx
+++ b/app/components/auth/ResetPasswordForm.tsx
@@ -1,0 +1,122 @@
+"use client";
+import type { ResetPasswordAuthHeaders } from "@app/interface";
+import { AxiosError } from "axios";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import ErrorMessages from "@app/components/auth/ErrorMessages";
+import PasswordConfirmInput from "@app/components/auth/PasswordConfirmInput";
+import PasswordInput from "@app/components/auth/PasswordInput";
+import SubmitButton from "@app/components/button/SendButton";
+import { resetPassword } from "@app/services/authService";
+
+interface Props {
+  authHeaders: ResetPasswordAuthHeaders;
+}
+
+export default function ResetPasswordForm({ authHeaders }: Props) {
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [isConfirmVisible, setIsConfirmVisible] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isCompleted, setIsCompleted] = useState(false);
+  const router = useRouter();
+
+  const validatePassword = (value: string) => /^[a-zA-Z\d]{6,}$/.test(value);
+
+  const isInvalidPassword = useMemo(
+    () => password !== "" && !validatePassword(password),
+    [password],
+  );
+
+  const isFormValid = useMemo(
+    () => validatePassword(password) && passwordConfirmation === password,
+    [password, passwordConfirmation],
+  );
+
+  const setErrorsWithTimeout = (newErrors: string[]) => {
+    setErrors(newErrors);
+    setTimeout(() => setErrors([]), 5000);
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (isLoading) return;
+    if (!validatePassword(password)) {
+      setErrorsWithTimeout(["6文字以上の半角英数字で入力してください"]);
+      return;
+    }
+    if (password !== passwordConfirmation) {
+      setErrorsWithTimeout(["確認用パスワードが一致しません"]);
+      return;
+    }
+
+    setIsLoading(true);
+    setErrors([]);
+    try {
+      await resetPassword({ password, passwordConfirmation }, authHeaders);
+      setIsCompleted(true);
+      setTimeout(() => router.push("/signin"), 3000);
+    } catch (error) {
+      if (error instanceof AxiosError && error.response?.data?.errors) {
+        setErrorsWithTimeout(error.response.data.errors);
+      } else {
+        setErrorsWithTimeout([
+          "パスワードの再設定に失敗しました。もう一度お試しください。",
+        ]);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isCompleted) {
+    return (
+      <p className="text-sm text-yellow-500">
+        パスワードを更新しました。ログイン画面に移動します。
+      </p>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col justify-end gap-y-4">
+      <ErrorMessages errors={errors} />
+      <PasswordInput
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="caret-zinc-400 bg-main rounded-2xl"
+        label="新しいパスワード"
+        placeholder="6文字以上半角英数字のみ"
+        labelPlacement="outside"
+        isInvalid={isInvalidPassword}
+        isPasswordVisible={isPasswordVisible}
+        togglePasswordVisibility={() => setIsPasswordVisible((v) => !v)}
+        color={isInvalidPassword ? "danger" : "default"}
+        variant={"bordered"}
+        errorMessage={
+          isInvalidPassword ? "6文字以上で半角英数字のみ有効です" : ""
+        }
+        type={isPasswordVisible ? "text" : "password"}
+      />
+      <PasswordConfirmInput
+        value={passwordConfirmation}
+        onChange={(e) => setPasswordConfirmation(e.target.value)}
+        className="caret-zinc-400 bg-main rounded-2xl"
+        label="新しいパスワード（確認用）"
+        placeholder="もう一度入力してください"
+        labelPlacement="outside"
+        isConfirmVisible={isConfirmVisible}
+        toggleConfirmVisibility={() => setIsConfirmVisible((v) => !v)}
+        variant={"bordered"}
+        type={isConfirmVisible ? "text" : "password"}
+      />
+      <SubmitButton
+        className="bg-yellow-500 text-white h-auto text-base mt-6 mx-auto py-2.5 px-12 rounded-full block font-semibold"
+        type="submit"
+        text="パスワードを変更する"
+        disabled={!isFormValid || isLoading}
+      />
+    </form>
+  );
+}

--- a/app/components/auth/ResetPasswordForm.tsx
+++ b/app/components/auth/ResetPasswordForm.tsx
@@ -2,7 +2,7 @@
 import type { ResetPasswordAuthHeaders } from "@app/interface";
 import { AxiosError } from "axios";
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import PasswordConfirmInput from "@app/components/auth/PasswordConfirmInput";
 import PasswordInput from "@app/components/auth/PasswordInput";
@@ -22,6 +22,12 @@ export default function ResetPasswordForm({ authHeaders }: Props) {
   const [isLoading, setIsLoading] = useState(false);
   const [isCompleted, setIsCompleted] = useState(false);
   const router = useRouter();
+
+  // access-token/client/uidはprops経由で既に保持しているため、ブラウザ履歴・
+  // リファラにワンタイムトークンが残らないようマウント後にURLから除去する。
+  useEffect(() => {
+    window.history.replaceState(null, "", window.location.pathname);
+  }, []);
 
   const validatePassword = (value: string) => /^[a-zA-Z\d]{6,}$/.test(value);
 

--- a/app/components/auth/ResetPasswordForm.tsx
+++ b/app/components/auth/ResetPasswordForm.tsx
@@ -59,8 +59,20 @@ export default function ResetPasswordForm({ authHeaders }: Props) {
       setIsCompleted(true);
       setTimeout(() => router.push("/signin"), 3000);
     } catch (error) {
-      if (error instanceof AxiosError && error.response?.data?.errors) {
-        setErrorsWithTimeout(error.response.data.errors);
+      // PUT /api/v1/auth/password のバリデーションエラーは devise_token_auth の
+      // resource_errors ヘルパーにより { フィールド名: [...], full_messages: [...] }
+      // というハッシュ形式で返るため、full_messages を優先的に取り出す
+      // （フラットな配列を前提にすると ErrorMessages 側の map でクラッシュする）。
+      if (error instanceof AxiosError) {
+        const responseErrors = error.response?.data?.errors;
+        const messages: string[] =
+          responseErrors?.full_messages ||
+          (Array.isArray(responseErrors) ? responseErrors : []);
+        setErrorsWithTimeout(
+          messages.length > 0
+            ? messages
+            : ["パスワードの再設定に失敗しました。もう一度お試しください。"],
+        );
       } else {
         setErrorsWithTimeout([
           "パスワードの再設定に失敗しました。もう一度お試しください。",

--- a/app/components/auth/SignIn.tsx
+++ b/app/components/auth/SignIn.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { AxiosError } from "axios";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 import EmailInput from "@app/components/auth/EmailInput";
@@ -174,6 +175,12 @@ export default function SignIn() {
           }
           type={isPasswordVisible ? "text" : "password"}
         />
+        <Link
+          href="/password-reset"
+          className="text-sm text-yellow-500 text-right"
+        >
+          パスワードをお忘れですか？
+        </Link>
         <SubmitButton
           className="bg-yellow-500 text-white h-auto text-base mt-6 mx-auto py-2.5 px-12 rounded-full block font-semibold"
           type="submit"

--- a/app/interface/index.ts
+++ b/app/interface/index.ts
@@ -10,6 +10,20 @@ export interface SignInData {
   password: string;
 }
 
+export interface ResetPasswordData {
+  password: string;
+  passwordConfirmation: string;
+}
+
+// パスワード再設定メールのリンクから受け取るワンタイムトークン。
+// ログイン中セッションのCookieと混同しないよう、PUT /api/v1/auth/passwordの
+// リクエストヘッダーへ明示的に渡す。
+export interface ResetPasswordAuthHeaders {
+  accessToken: string;
+  client: string;
+  uid: string;
+}
+
 export interface EmailInputProps {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;

--- a/app/services/authService.tsx
+++ b/app/services/authService.tsx
@@ -73,9 +73,16 @@ export const resendConfirmation = async (email: string) => {
 };
 
 export const requestPasswordReset = async (email: string) => {
+  // 本番環境変数は末尾スラッシュ付きで設定される場合があり、単純な文字列結合だと
+  // "https://buzzbase.jp//reset-password" のような二重スラッシュになり
+  // devise_token_authのredirect_whitelistの完全一致チェックに失敗しうるため除去する。
+  const baseUrl = (process.env.NEXT_PUBLIC_METADATA_BASE_URL || "").replace(
+    /\/+$/,
+    "",
+  );
   const response = await axiosInstance.post("/api/v1/auth/password", {
     email,
-    redirect_url: `${process.env.NEXT_PUBLIC_METADATA_BASE_URL}/reset-password`,
+    redirect_url: `${baseUrl}/reset-password`,
   });
 
   return response;

--- a/app/services/authService.tsx
+++ b/app/services/authService.tsx
@@ -1,5 +1,11 @@
-import type { SignInData, SignUpData } from "@app/interface";
+import type {
+  ResetPasswordAuthHeaders,
+  ResetPasswordData,
+  SignInData,
+  SignUpData,
+} from "@app/interface";
 import type { AxiosResponseHeaders, RawAxiosResponseHeaders } from "axios";
+import axios from "axios";
 import Cookies from "js-cookie";
 import axiosInstance from "@app/utils/axiosInstance";
 
@@ -62,6 +68,39 @@ export const resendConfirmation = async (email: string) => {
     email: email,
     redirect_url: process.env.NEXT_PUBLIC_CONFIRM_SUCCESS_URL,
   });
+
+  return response;
+};
+
+export const requestPasswordReset = async (email: string) => {
+  const response = await axiosInstance.post("/api/v1/auth/password", {
+    email,
+    redirect_url: `${process.env.NEXT_PUBLIC_METADATA_BASE_URL}/reset-password`,
+  });
+
+  return response;
+};
+
+// パスワード再設定リンクのワンタイムトークンで認証するため、ログイン中セッションの
+// Cookieを自動付与するaxiosInstanceは使わず、素のaxiosでヘッダーを明示的に指定する。
+export const resetPassword = async (
+  data: ResetPasswordData,
+  authHeaders: ResetPasswordAuthHeaders,
+) => {
+  const response = await axios.put(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/password`,
+    {
+      password: data.password,
+      password_confirmation: data.passwordConfirmation,
+    },
+    {
+      headers: {
+        "access-token": authHeaders.accessToken,
+        client: authHeaders.client,
+        uid: authHeaders.uid,
+      },
+    },
+  );
 
   return response;
 };


### PR DESCRIPTION
## Summary

- ログイン画面にパスワードを忘れた場合の導線を追加
- パスワードリセット申請ページ（/password-reset）を追加
- パスワードリセット完了ページ（/reset-password）を追加

## 背景

ippei-shimizu/buzzbase#441 参照。back側でCustomPasswordsControllerによる
ホスト検証・アカウント列挙対策を実装済み（ippei-shimizu/buzzbase_back#321）。
front側にはパスワードリセットの導線・ページが一切存在しなかったため追加した。

**注記**: 当初はmobileユーザーもこの/reset-passwordページに遷移させる
想定だったが、mobile側は新規登録時のメールアドレス確認
（buzzbase://confirmation-success）と挙動を揃えるため、ネイティブ
ディープリンク（buzzbase://reset-password）でアプリ内完結する方式に
変更した（ippei-shimizu/buzzbase_mobile#162）。そのためこのページは
front発のパスワードリセット申請（Webユーザー）専用となる。

## 変更内容

- `app/interface/index.ts`: ResetPasswordData / ResetPasswordAuthHeaders型を追加
- `app/services/authService.tsx`: requestPasswordReset（POST /api/v1/auth/password）、
  resetPassword（PUT /api/v1/auth/password）を追加。resetPasswordはメールリンクの
  ワンタイムトークンで認証するため、ログイン中セッションのCookieを自動付与する
  axiosInstanceは使わず素のaxiosでヘッダーを指定する
- `app/components/auth/SignIn.tsx`: 「パスワードをお忘れですか？」リンクを追加
- `app/(app)/password-reset/`: リセット申請ページ（新規）。送信成否にかかわらず
  同一文言を表示し、アカウント列挙・認証方式の推測を防ぐ
- `app/(app)/reset-password/`: リセット完了ページ（新規）。メールリンクの
  access-token/client/uidをクエリパラメータから読み取る

## Test plan

- [x] `yarn typecheck` / `yarn lint` / `yarn build` 通過
- [x] ローカル環境で実際にフローを検証済み: /password-reset で申請
      → letter_openerでメール確認（日本語・redirect_url正しく反映）
      → メールのリンクをクリック → /reset-password に正しくリダイレクト
      （access-token等のクエリパラメータ付き）→ 新パスワード設定
      → ログアウト後、新パスワードでログイン成功
