### PR TITLE
Fix: Pro機能EpicレビューでWeb版シーズン推移グラフのentitlement未実装を解消

### DIFF
--- a/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
@@ -1,6 +1,8 @@
 "use client";
 import type { FilterOption } from "../../statsFilterOption";
 import { useEffect, useRef, useState, useTransition } from "react";
+import ProUpgradeModal from "@app/components/pro/ProUpgradeModal";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
 import {
   type AnalysisFilters as Filters,
   type AnalysisInitialData,
@@ -71,6 +73,8 @@ export function AnalysisContainer({
   seasonOptions,
   tournamentOptions,
 }: AnalysisContainerProps) {
+  const { hasEntitlement } = useEntitlement();
+  const [seasonPaywallOpen, setSeasonPaywallOpen] = useState(false);
   const [filters, setFilters] = useState<Filters>({
     year: "通算",
     matchType: "",
@@ -230,7 +234,16 @@ export function AnalysisContainer({
           <BattingTrendChart
             points={battingTrend.points}
             granularity={granularity}
-            onGranularityChange={setGranularity}
+            onGranularityChange={(next) => {
+              if (
+                next === "season" &&
+                !hasEntitlement("season_transition_graph")
+              ) {
+                setSeasonPaywallOpen(true);
+                return;
+              }
+              setGranularity(next);
+            }}
           />
         </div>
         <SprayChart
@@ -304,6 +317,11 @@ export function AnalysisContainer({
         )}
         <PitcherAttributeSummary data={pitcherAttributes} />
       </div>
+      <ProUpgradeModal
+        isOpen={seasonPaywallOpen}
+        onClose={() => setSeasonPaywallOpen(false)}
+        trigger="season_transition_graph"
+      />
     </div>
   );
 }

--- a/app/(app)/stats/_components/analysis/BattingTrendChart.tsx
+++ b/app/(app)/stats/_components/analysis/BattingTrendChart.tsx
@@ -51,6 +51,7 @@ const GRANULARITY_OPTIONS: readonly {
   { key: "game", label: "試合" },
   { key: "month", label: "月" },
   { key: "year", label: "年" },
+  { key: "season", label: "シーズン" },
   { key: "recent_games", label: "直近10" },
 ];
 

--- a/app/(app)/stats/_components/analysis/EraTrendChart.tsx
+++ b/app/(app)/stats/_components/analysis/EraTrendChart.tsx
@@ -1,9 +1,11 @@
 "use client";
-import type { EraTrendPoint } from "../../analysisActions";
+import type { EraTrendGranularity, EraTrendPoint } from "../../analysisActions";
 import { Fragment } from "react";
 
 interface EraTrendChartProps {
-  data: EraTrendPoint[];
+  points: EraTrendPoint[];
+  granularity: EraTrendGranularity;
+  onGranularityChange: (granularity: EraTrendGranularity) => void;
 }
 
 const CHART_WIDTH = 300;
@@ -15,14 +17,70 @@ const PADDING_BOTTOM = 24;
 const PLOT_WIDTH = CHART_WIDTH - PADDING_LEFT - PADDING_RIGHT;
 const PLOT_HEIGHT = CHART_HEIGHT - PADDING_TOP - PADDING_BOTTOM;
 
-/** 防御率推移の折れ線グラフ（月別 ERA をエリア塗りつぶし付きで描画）。 */
-export function EraTrendChart({ data }: EraTrendChartProps) {
-  // 投球が無い月などで era が null/Infinity でも安全に描けるよう有限値だけ残し、
-  // 月昇順に並べる（API のソート順に依存しない）。
-  const points = data
-    .filter((point) => Number.isFinite(point.era))
-    .sort((a, b) => a.month - b.month);
-  if (points.length === 0) return null;
+const GRANULARITY_OPTIONS: readonly {
+  key: EraTrendGranularity;
+  label: string;
+}[] = [
+  { key: "month", label: "月" },
+  { key: "season", label: "シーズン" },
+];
+
+function GranularityToggle({
+  value,
+  onChange,
+}: {
+  value: EraTrendGranularity;
+  onChange: (value: EraTrendGranularity) => void;
+}) {
+  return (
+    <div className="flex rounded-md bg-[#27272A] p-0.5">
+      {GRANULARITY_OPTIONS.map((option) => {
+        const isActive = value === option.key;
+        return (
+          <button
+            key={option.key}
+            type="button"
+            onClick={() => onChange(option.key)}
+            className={`rounded px-2 py-1 text-[11px] font-semibold ${
+              isActive ? "bg-[#52525B] text-[#F4F4F4]" : "text-[#A1A1AA]"
+            }`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** 防御率推移の折れ線グラフ（月別/シーズン別 ERA をエリア塗りつぶし付きで描画）。 */
+export function EraTrendChart({
+  points: rawPoints,
+  granularity,
+  onGranularityChange,
+}: EraTrendChartProps) {
+  // 投球が無い期間などで era が null/Infinity でも安全に描けるよう有限値だけ残す。
+  // 並び順は API 側（月昇順 / シーズン開始日昇順）に依存する。
+  const points = rawPoints.filter((point) => Number.isFinite(point.era));
+  const bestPoint =
+    granularity === "season" && points.length > 1
+      ? points.reduce((best, point) => (point.era < best.era ? point : best))
+      : null;
+
+  if (points.length === 0) {
+    return (
+      <section className="rounded-xl bg-[#3A3A3A] p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-base font-bold text-[#F4F4F4]">防御率推移</h3>
+          <GranularityToggle
+            value={granularity}
+            onChange={onGranularityChange}
+          />
+        </div>
+        <p className="text-sm text-[#A1A1AA]">対象データなし</p>
+      </section>
+    );
+  }
 
   // Math.max(..., 1) で maxEra は常に 1 以上になる。
   const maxEra = Math.max(...points.map((point) => point.era), 1);
@@ -46,7 +104,10 @@ export function EraTrendChart({ data }: EraTrendChartProps) {
 
   return (
     <section className="rounded-xl bg-[#3A3A3A] p-4">
-      <h3 className="mb-3 text-base font-bold text-[#F4F4F4]">防御率推移</h3>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-base font-bold text-[#F4F4F4]">防御率推移</h3>
+        <GranularityToggle value={granularity} onChange={onGranularityChange} />
+      </div>
       <div className="flex justify-center">
         <svg
           width="100%"
@@ -94,7 +155,7 @@ export function EraTrendChart({ data }: EraTrendChartProps) {
           />
 
           {points.map((point, index) => (
-            <Fragment key={`pt-${point.month}`}>
+            <Fragment key={`pt-${point.key}`}>
               <circle
                 cx={getX(index)}
                 cy={getY(point.era)}
@@ -112,20 +173,20 @@ export function EraTrendChart({ data }: EraTrendChartProps) {
 
           {points.map((point, index) => (
             <text
-              key={`xl-${point.month}`}
+              key={`xl-${point.key}`}
               x={getX(index)}
               y={CHART_HEIGHT - 4}
               textAnchor="middle"
               fill="#A1A1AA"
               fontSize={10}
             >
-              {point.month}月
+              {point.label}
             </text>
           ))}
 
           {points.map((point, index) => (
             <text
-              key={`val-${point.month}`}
+              key={`val-${point.key}`}
               x={getX(index)}
               // 最大値の点では getY が上端付近になりラベルが見切れるため下限を設ける。
               y={Math.max(getY(point.era) - 10, PADDING_TOP + 9)}
@@ -139,6 +200,12 @@ export function EraTrendChart({ data }: EraTrendChartProps) {
           ))}
         </svg>
       </div>
+
+      {bestPoint ? (
+        <p className="mt-2.5 text-xs font-semibold text-[#FFD43B]">
+          ★ 自己ベスト防御率 {bestPoint.era.toFixed(2)}（{bestPoint.label}）
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
@@ -47,21 +47,6 @@ export function PitchingAnalysisContainer({
   const [yearOptions] = useState(buildYearOptions);
   const [seasonPaywallOpen, setSeasonPaywallOpen] = useState(false);
 
-  const fetchTrend = (next: Filters, nextGranularity: EraTrendGranularity) => {
-    startRefetch(async () => {
-      // 防御率推移は year/season/tournament のみで絞る（種別は対象外）。
-      const trend = await getEraTrend(
-        {
-          year: next.year,
-          seasonId: next.seasonId,
-          tournamentId: next.tournamentId,
-        },
-        nextGranularity,
-      );
-      setEraTrend(trend);
-    });
-  };
-
   // 初回は SSR の initialEraTrend を使うため再取得しない（フィルタ変更時のみ取得）。
   const didInitRef = useRef(false);
   useEffect(() => {
@@ -69,9 +54,29 @@ export function PitchingAnalysisContainer({
       didInitRef.current = true;
       return;
     }
-    fetchTrend(filters, granularity);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchTrendはfilters/granularityと同じ値を毎回内部で使うため依存に含めない
-  }, [filters.year, filters.seasonId, filters.tournamentId, granularity]);
+    let active = true;
+    startRefetch(async () => {
+      // 防御率推移は year/season/tournament のみで絞る（種別は対象外）。
+      const trend = await getEraTrend(
+        {
+          year: filters.year,
+          seasonId: filters.seasonId,
+          tournamentId: filters.tournamentId,
+        },
+        granularity,
+      );
+      if (active) setEraTrend(trend);
+    });
+    return () => {
+      active = false;
+    };
+  }, [
+    filters.year,
+    filters.seasonId,
+    filters.tournamentId,
+    granularity,
+    startRefetch,
+  ]);
 
   const handleGranularityChange = (next: EraTrendGranularity) => {
     if (next === "season" && !hasEntitlement("season_transition_graph")) {

--- a/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
@@ -1,9 +1,12 @@
 "use client";
 import type { FilterOption } from "../../statsFilterOption";
 import { useEffect, useRef, useState, useTransition } from "react";
+import ProUpgradeModal from "@app/components/pro/ProUpgradeModal";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
 import {
   type AnalysisFilters as Filters,
-  type EraTrendPoint,
+  type EraTrendData,
+  type EraTrendGranularity,
   getEraTrend,
 } from "../../analysisActions";
 import { AnalysisFilters } from "./AnalysisFilters";
@@ -21,7 +24,7 @@ function buildYearOptions(): FilterOption[] {
 
 interface PitchingAnalysisContainerProps {
   /** SSR で取得した防御率推移の初期データ。マウント時はこれを使い再取得しない。 */
-  initialEraTrend: EraTrendPoint[];
+  initialEraTrend: EraTrendData;
   /** サーバーで取得したシーズン/大会のフィルタ選択肢。 */
   seasonOptions: FilterOption[];
   tournamentOptions: FilterOption[];
@@ -33,13 +36,31 @@ export function PitchingAnalysisContainer({
   seasonOptions,
   tournamentOptions,
 }: PitchingAnalysisContainerProps) {
+  const { hasEntitlement } = useEntitlement();
   const [filters, setFilters] = useState<Filters>({
     year: "通算",
     matchType: "",
   });
-  const [eraTrend, setEraTrend] = useState<EraTrendPoint[]>(initialEraTrend);
+  const [granularity, setGranularity] = useState<EraTrendGranularity>("month");
+  const [eraTrend, setEraTrend] = useState<EraTrendData>(initialEraTrend);
   const [isRefetching, startRefetch] = useTransition();
   const [yearOptions] = useState(buildYearOptions);
+  const [seasonPaywallOpen, setSeasonPaywallOpen] = useState(false);
+
+  const fetchTrend = (next: Filters, nextGranularity: EraTrendGranularity) => {
+    startRefetch(async () => {
+      // 防御率推移は year/season/tournament のみで絞る（種別は対象外）。
+      const trend = await getEraTrend(
+        {
+          year: next.year,
+          seasonId: next.seasonId,
+          tournamentId: next.tournamentId,
+        },
+        nextGranularity,
+      );
+      setEraTrend(trend);
+    });
+  };
 
   // 初回は SSR の initialEraTrend を使うため再取得しない（フィルタ変更時のみ取得）。
   const didInitRef = useRef(false);
@@ -48,20 +69,17 @@ export function PitchingAnalysisContainer({
       didInitRef.current = true;
       return;
     }
-    let active = true;
-    // 防御率推移は year/season/tournament のみで絞る（種別は対象外）。
-    startRefetch(async () => {
-      const trend = await getEraTrend({
-        year: filters.year,
-        seasonId: filters.seasonId,
-        tournamentId: filters.tournamentId,
-      });
-      if (active) setEraTrend(trend);
-    });
-    return () => {
-      active = false;
-    };
-  }, [filters.year, filters.seasonId, filters.tournamentId, startRefetch]);
+    fetchTrend(filters, granularity);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchTrendはfilters/granularityと同じ値を毎回内部で使うため依存に含めない
+  }, [filters.year, filters.seasonId, filters.tournamentId, granularity]);
+
+  const handleGranularityChange = (next: EraTrendGranularity) => {
+    if (next === "season" && !hasEntitlement("season_transition_graph")) {
+      setSeasonPaywallOpen(true);
+      return;
+    }
+    setGranularity(next);
+  };
 
   return (
     <div className="flex flex-col gap-y-5">
@@ -76,8 +94,17 @@ export function PitchingAnalysisContainer({
       <div
         className={isRefetching ? "opacity-50 transition-opacity" : undefined}
       >
-        <EraTrendChart data={eraTrend} />
+        <EraTrendChart
+          points={eraTrend.points}
+          granularity={granularity}
+          onGranularityChange={handleGranularityChange}
+        />
       </div>
+      <ProUpgradeModal
+        isOpen={seasonPaywallOpen}
+        onClose={() => setSeasonPaywallOpen(false)}
+        trigger="season_transition_graph"
+      />
     </div>
   );
 }

--- a/app/(app)/stats/_components/analysis/PitchingAnalysisSection.tsx
+++ b/app/(app)/stats/_components/analysis/PitchingAnalysisSection.tsx
@@ -18,9 +18,9 @@ export function PitchingAnalysisSection() {
 }
 
 async function PitchingAnalysisDataProvider() {
-  // 防御率推移は year/season/tournament のみで絞る（既定は通算）。
+  // 防御率推移は year/season/tournament のみで絞る（既定は通算・月粒度）。
   const [initialEraTrend, filterOptions] = await Promise.all([
-    getEraTrend({ year: "通算" }),
+    getEraTrend({ year: "通算" }, "month"),
     getStatsFilterOptions(),
   ]);
   return (

--- a/app/(app)/stats/analysisActions.ts
+++ b/app/(app)/stats/analysisActions.ts
@@ -93,9 +93,17 @@ export interface PlateAppearanceCategory {
   percentage: number;
 }
 
+export type EraTrendGranularity = "month" | "season";
+
 export interface EraTrendPoint {
-  month: number;
+  key: string;
+  label: string;
   era: number;
+}
+
+export interface EraTrendData {
+  granularity: EraTrendGranularity;
+  points: EraTrendPoint[];
 }
 
 export interface ContactQualityCategory {
@@ -220,6 +228,7 @@ export type BattingTrendGranularity =
   | "game"
   | "month"
   | "year"
+  | "season"
   | "recent_games";
 
 export interface BattingTrendPoint {
@@ -414,17 +423,18 @@ export async function getPitcherAttributeSummary(
 
 export async function getEraTrend(
   filters: AnalysisFilters = {},
-): Promise<EraTrendPoint[]> {
+  granularity: EraTrendGranularity = "month",
+): Promise<EraTrendData> {
   // era_trend は year/season/tournament のみで絞る。match_type は構造的に除外し、
   // 誤って matchType 付きで呼ばれても送信されないことを関数自身で保証する。
   const { matchType: _matchType, ...eraFilters } = filters;
-  const result = await fetchAnalysis<{ trend: EraTrendPoint[] }>(
+  return fetchAnalysis<EraTrendData>(
     "era_trend",
     eraFilters,
     "getEraTrend",
-    { trend: [] },
+    { granularity, points: [] },
+    { granularity },
   );
-  return result.trend ?? [];
 }
 
 export async function getPlateAppearanceBreakdown(


### PR DESCRIPTION
## 概要

issue #445（Pro機能Epicリリース前レビュー指摘の解消）のうち、「Web版にシーズン粒度・season_transition_graph entitlementの実装が一切存在しない」（DoD「iOS/Web両方で表示」未達）に対応する。

## 対応内容

- [x] `BattingTrendGranularity`に`"season"`を追加し、Web版の打撃成績推移グラフでもシーズン跨ぎ比較を選べるようにする
- [x] 防御率推移(`EraTrendChart`)にもシーズン粒度・自己ベスト表示を追加（back側のレスポンス形状変更`{trend:[{month,era}]}`→`{granularity,points:[{key,label,era}]}`に追従）
- [x] `useEntitlement("season_transition_graph")`で無料ユーザーのシーズン粒度選択を`ProUpgradeModal`へ誘導（back側は既にPro限定チェック済み）

## セルフレビュー（自動実施）で追加修正した項目

- `PitchingAnalysisContainer`のera_trend再取得で、`fetchTrend`抽出時に`active`ガードとuseEffectのcleanupが失われ、stale response raceが起きる不具合を修正（batting_trend側の既存パターンに揃えた）

## 前提として把握しておいてほしいこと

front側の他のPro機能（カウント別打率等3種）は`PRO_FEATURES_COMING_SOON`という静的フラグでcoming-soon表示にとどまっており、まだ実entitlement化されていません。season_transition_graphのみ今回リアルな`useEntitlement`ベースの出し分けにしています。この非対称自体は今回のスコープ外です。

## テスト

- `yarn typecheck` — エラーなし
- `yarn lint` — エラーなし
- `yarn test` — 301 examples, 0 failures

## 関連

- ippei-shimizu/buzzbase#445
