### PR TITLE
Fix: ProStatusProviderをマウントしてPro判定を有効化

### DIFF
--- a/app/(app)/__tests__/layout.test.tsx
+++ b/app/(app)/__tests__/layout.test.tsx
@@ -1,9 +1,4 @@
-const mockCookieGet = jest.fn();
 const mockGetProStatus = jest.fn();
-
-jest.mock("next/headers", () => ({
-  cookies: () => Promise.resolve({ get: mockCookieGet }),
-}));
 
 jest.mock("../pro/actions", () => ({
   getProStatus: () => mockGetProStatus(),
@@ -64,18 +59,18 @@ jest.mock("sonner", () => ({
   },
 }));
 
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, type RenderResult } from "@testing-library/react";
 import ProGate from "@app/components/pro/ProGate";
 import { useProStatus } from "@app/hooks/pro/useProStatus";
 import { DEFAULT_PRO_STATUS, type ProStatus } from "@app/types/pro";
 import AppLayout from "../layout";
 
 function ProStatusProbe() {
-  const { isPro } = useProStatus();
+  const { isPro, isLoading } = useProStatus();
 
   return (
     <div>
-      <p>{isPro ? "PRO" : "FREE"}</p>
+      <p>{isLoading ? "LOADING" : isPro ? "PRO" : "FREE"}</p>
       <ProGate
         feature="season_transition_graph"
         fallback={<p>シーズン推移グラフはロック中</p>}
@@ -86,23 +81,37 @@ function ProStatusProbe() {
   );
 }
 
-function renderLayout() {
+function layoutElement() {
   return AppLayout({ children: <ProStatusProbe /> });
 }
 
-function setAuthCookies(uid: string) {
-  mockCookieGet.mockImplementation((key: string) => {
-    const values: Record<string, { value: string }> = {
-      "access-token": { value: "test-access-token" },
-      client: { value: "test-client" },
-      uid: { value: uid },
-    };
-    return values[key];
+// Pro 状態はマウント後に Server Action で解決されるため、非同期 act で確定まで進める
+async function renderLayout() {
+  let rendered!: RenderResult;
+  await act(async () => {
+    rendered = render(layoutElement());
+  });
+
+  return rendered;
+}
+
+// ログイン/ログアウト後の router.refresh() 相当
+async function rerenderLayout(rendered: RenderResult) {
+  await act(async () => {
+    rendered.rerender(layoutElement());
   });
 }
 
+function setAuthCookies(uid: string) {
+  document.cookie = "access-token=test-access-token";
+  document.cookie = "client=test-client";
+  document.cookie = `uid=${encodeURIComponent(uid)}`;
+}
+
 function clearAuthCookies() {
-  mockCookieGet.mockReturnValue(undefined);
+  for (const name of ["access-token", "client", "uid"]) {
+    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+  }
 }
 
 const proStatus: ProStatus = {
@@ -120,13 +129,14 @@ const proStatus: ProStatus = {
 describe("AppLayout の ProStatusProvider", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    clearAuthCookies();
   });
 
   it("Pro ユーザーではレイアウト配下で Pro 判定が有効になる", async () => {
     setAuthCookies("pro-user@example.com");
     mockGetProStatus.mockResolvedValue(proStatus);
 
-    render(await renderLayout());
+    await renderLayout();
 
     expect(screen.getByText("PRO")).toBeInTheDocument();
     expect(screen.getByText("シーズン推移グラフ")).toBeInTheDocument();
@@ -136,7 +146,7 @@ describe("AppLayout の ProStatusProvider", () => {
     setAuthCookies("free-user@example.com");
     mockGetProStatus.mockResolvedValue(DEFAULT_PRO_STATUS);
 
-    render(await renderLayout());
+    await renderLayout();
 
     expect(screen.getByText("FREE")).toBeInTheDocument();
     expect(
@@ -145,22 +155,32 @@ describe("AppLayout の ProStatusProvider", () => {
   });
 
   it("未認証では Pro status API を叩かず無料状態にフォールバックする", async () => {
-    clearAuthCookies();
+    await renderLayout();
 
-    render(await renderLayout());
-
-    expect(mockGetProStatus).not.toHaveBeenCalled();
     expect(screen.getByText("FREE")).toBeInTheDocument();
+    expect(mockGetProStatus).not.toHaveBeenCalled();
     expect(
       screen.getByText("シーズン推移グラフはロック中"),
     ).toBeInTheDocument();
+  });
+
+  it("Pro 判定が確定するまではロック UI を描画しない", async () => {
+    setAuthCookies("pro-user@example.com");
+    mockGetProStatus.mockReturnValue(new Promise(() => {}));
+
+    await renderLayout();
+
+    expect(screen.getByText("LOADING")).toBeInTheDocument();
+    expect(
+      screen.queryByText("シーズン推移グラフはロック中"),
+    ).not.toBeInTheDocument();
   });
 
   it("API が失敗しても無料状態として描画する", async () => {
     setAuthCookies("pro-user@example.com");
     mockGetProStatus.mockResolvedValue(null);
 
-    render(await renderLayout());
+    await renderLayout();
 
     expect(screen.getByText("FREE")).toBeInTheDocument();
   });
@@ -169,11 +189,11 @@ describe("AppLayout の ProStatusProvider", () => {
     setAuthCookies("pro-user@example.com");
     mockGetProStatus.mockResolvedValue(proStatus);
 
-    const { rerender } = render(await renderLayout());
+    const rendered = await renderLayout();
     expect(screen.getByText("PRO")).toBeInTheDocument();
 
     clearAuthCookies();
-    rerender(await renderLayout());
+    await rerenderLayout(rendered);
 
     expect(screen.getByText("FREE")).toBeInTheDocument();
     expect(
@@ -185,14 +205,47 @@ describe("AppLayout の ProStatusProvider", () => {
     setAuthCookies("free-user@example.com");
     mockGetProStatus.mockResolvedValue(DEFAULT_PRO_STATUS);
 
-    const { rerender } = render(await renderLayout());
+    const rendered = await renderLayout();
     expect(screen.getByText("FREE")).toBeInTheDocument();
 
     setAuthCookies("pro-user@example.com");
     mockGetProStatus.mockResolvedValue(proStatus);
-    rerender(await renderLayout());
+    await rerenderLayout(rendered);
 
     expect(screen.getByText("PRO")).toBeInTheDocument();
     expect(screen.getByText("シーズン推移グラフ")).toBeInTheDocument();
+  });
+
+  it("同じユーザーのまま再レンダーされても Pro 状態を取り直さない", async () => {
+    setAuthCookies("pro-user@example.com");
+    mockGetProStatus.mockResolvedValue(proStatus);
+
+    const rendered = await renderLayout();
+    await rerenderLayout(rendered);
+
+    expect(mockGetProStatus).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("PRO")).toBeInTheDocument();
+  });
+
+  // SameSite=Strict の認証 cookie は検索結果や Stripe Checkout からの遷移では
+  // サーバーに届かない。Pro 判定をブラウザ側の cookie 起点にすることで無料表示に落ちない
+  it("サーバーに cookie が届かない流入経路でも Pro 判定が有効になる", async () => {
+    setAuthCookies("pro-user@example.com");
+    mockGetProStatus.mockResolvedValue(proStatus);
+
+    await renderLayout();
+
+    expect(mockGetProStatus).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("PRO")).toBeInTheDocument();
+  });
+
+  it("access-token が失効し uid だけ残っている場合は無料状態にする", async () => {
+    document.cookie = "uid=pro-user@example.com";
+    mockGetProStatus.mockResolvedValue(proStatus);
+
+    await renderLayout();
+
+    expect(mockGetProStatus).not.toHaveBeenCalled();
+    expect(screen.getByText("FREE")).toBeInTheDocument();
   });
 });

--- a/app/(app)/__tests__/layout.test.tsx
+++ b/app/(app)/__tests__/layout.test.tsx
@@ -1,0 +1,198 @@
+const mockCookieGet = jest.fn();
+const mockGetProStatus = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: () => Promise.resolve({ get: mockCookieGet }),
+}));
+
+jest.mock("../pro/actions", () => ({
+  getProStatus: () => mockGetProStatus(),
+}));
+
+// Pro 判定に関与しないレイアウト構成要素は素通しして、Provider の配線だけを見る
+jest.mock("@app/contexts/useAuthContext", () => ({
+  AuthProvider: function AuthProvider({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return <>{children}</>;
+  },
+}));
+
+jest.mock("@app/contexts/userContext", () => ({
+  UserProvider: function UserProvider({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return <>{children}</>;
+  },
+}));
+
+jest.mock("@app/providers", () => ({
+  Providers: function Providers({ children }: { children: React.ReactNode }) {
+    return <>{children}</>;
+  },
+}));
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: jest.fn(), close: jest.fn() }),
+}));
+
+jest.mock("../_components/SmartAppBanner", () => {
+  return function SmartAppBanner() {
+    return null;
+  };
+});
+
+jest.mock("@app/components/header/NavigationMenu", () => {
+  return function NavigationMenu() {
+    return null;
+  };
+});
+
+jest.mock("@app/components/footer/Footer", () => {
+  return function Footer() {
+    return null;
+  };
+});
+
+jest.mock("sonner", () => ({
+  Toaster: function Toaster() {
+    return null;
+  },
+}));
+
+import { render, screen } from "@testing-library/react";
+import ProGate from "@app/components/pro/ProGate";
+import { useProStatus } from "@app/hooks/pro/useProStatus";
+import { DEFAULT_PRO_STATUS, type ProStatus } from "@app/types/pro";
+import AppLayout from "../layout";
+
+function ProStatusProbe() {
+  const { isPro } = useProStatus();
+
+  return (
+    <div>
+      <p>{isPro ? "PRO" : "FREE"}</p>
+      <ProGate
+        feature="season_transition_graph"
+        fallback={<p>シーズン推移グラフはロック中</p>}
+      >
+        <p>シーズン推移グラフ</p>
+      </ProGate>
+    </div>
+  );
+}
+
+function renderLayout() {
+  return AppLayout({ children: <ProStatusProbe /> });
+}
+
+function setAuthCookies(uid: string) {
+  mockCookieGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: uid },
+    };
+    return values[key];
+  });
+}
+
+function clearAuthCookies() {
+  mockCookieGet.mockReturnValue(undefined);
+}
+
+const proStatus: ProStatus = {
+  subscription: {
+    ...DEFAULT_PRO_STATUS.subscription,
+    status: "active",
+    plan_type: "monthly",
+    platform: "web",
+    pro_active: true,
+    days_remaining: 20,
+  },
+  entitlements: [...DEFAULT_PRO_STATUS.entitlements, "season_transition_graph"],
+};
+
+describe("AppLayout の ProStatusProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("Pro ユーザーではレイアウト配下で Pro 判定が有効になる", async () => {
+    setAuthCookies("pro-user@example.com");
+    mockGetProStatus.mockResolvedValue(proStatus);
+
+    render(await renderLayout());
+
+    expect(screen.getByText("PRO")).toBeInTheDocument();
+    expect(screen.getByText("シーズン推移グラフ")).toBeInTheDocument();
+  });
+
+  it("無料ユーザーでは Pro 機能がロックされる", async () => {
+    setAuthCookies("free-user@example.com");
+    mockGetProStatus.mockResolvedValue(DEFAULT_PRO_STATUS);
+
+    render(await renderLayout());
+
+    expect(screen.getByText("FREE")).toBeInTheDocument();
+    expect(
+      screen.getByText("シーズン推移グラフはロック中"),
+    ).toBeInTheDocument();
+  });
+
+  it("未認証では Pro status API を叩かず無料状態にフォールバックする", async () => {
+    clearAuthCookies();
+
+    render(await renderLayout());
+
+    expect(mockGetProStatus).not.toHaveBeenCalled();
+    expect(screen.getByText("FREE")).toBeInTheDocument();
+    expect(
+      screen.getByText("シーズン推移グラフはロック中"),
+    ).toBeInTheDocument();
+  });
+
+  it("API が失敗しても無料状態として描画する", async () => {
+    setAuthCookies("pro-user@example.com");
+    mockGetProStatus.mockResolvedValue(null);
+
+    render(await renderLayout());
+
+    expect(screen.getByText("FREE")).toBeInTheDocument();
+  });
+
+  it("ログアウト後の再レンダーで前ユーザーの Pro 状態が残らない", async () => {
+    setAuthCookies("pro-user@example.com");
+    mockGetProStatus.mockResolvedValue(proStatus);
+
+    const { rerender } = render(await renderLayout());
+    expect(screen.getByText("PRO")).toBeInTheDocument();
+
+    clearAuthCookies();
+    rerender(await renderLayout());
+
+    expect(screen.getByText("FREE")).toBeInTheDocument();
+    expect(
+      screen.getByText("シーズン推移グラフはロック中"),
+    ).toBeInTheDocument();
+  });
+
+  it("別ユーザーでログインし直すとその Pro 状態に切り替わる", async () => {
+    setAuthCookies("free-user@example.com");
+    mockGetProStatus.mockResolvedValue(DEFAULT_PRO_STATUS);
+
+    const { rerender } = render(await renderLayout());
+    expect(screen.getByText("FREE")).toBeInTheDocument();
+
+    setAuthCookies("pro-user@example.com");
+    mockGetProStatus.mockResolvedValue(proStatus);
+    rerender(await renderLayout());
+
+    expect(screen.getByText("PRO")).toBeInTheDocument();
+    expect(screen.getByText("シーズン推移グラフ")).toBeInTheDocument();
+  });
+});

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -7,7 +7,6 @@ import { AuthProvider } from "@app/contexts/useAuthContext";
 import { UserProvider } from "@app/contexts/userContext";
 import { Providers } from "@app/providers";
 import SmartAppBanner from "./_components/SmartAppBanner";
-import { getCachedProStatus, getProIdentityKey } from "./pro/proStatus";
 
 export const metadata: Metadata = {
   title: {
@@ -17,22 +16,15 @@ export const metadata: Metadata = {
   description: "BUZZ BASE - 野球の個人成績をランキング形式で共有できるアプリ",
 };
 
-export default async function AppLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const [proStatus, proIdentityKey] = await Promise.all([
-    getCachedProStatus(),
-    getProIdentityKey(),
-  ]);
-
+// Pro 状態の取得は ProStatusProvider 側（クライアント）に任せ、ここでは cookies() を読まない。
+// 読むと配下 105 ルートすべてが dynamic 扱いになり、コラム記事やツールなど
+// データ取得のない静的ページまでビルド時プリレンダリングを失う。
+export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <AuthProvider>
       <UserProvider>
         <Providers>
-          {/* key を identity に紐付け、ログイン/ログアウト後の再レンダーで Provider ごと作り直す */}
-          <ProStatusProvider key={proIdentityKey} initialValue={proStatus}>
+          <ProStatusProvider>
             <SmartAppBanner />
             {children}
             <NavigationMenu />

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -2,10 +2,12 @@ import type { Metadata } from "next";
 import { Toaster } from "sonner";
 import Footer from "@app/components/footer/Footer";
 import NavigationMenu from "@app/components/header/NavigationMenu";
+import { ProStatusProvider } from "@app/components/pro/ProStatusProvider";
 import { AuthProvider } from "@app/contexts/useAuthContext";
 import { UserProvider } from "@app/contexts/userContext";
 import { Providers } from "@app/providers";
 import SmartAppBanner from "./_components/SmartAppBanner";
+import { getCachedProStatus, getProIdentityKey } from "./pro/proStatus";
 
 export const metadata: Metadata = {
   title: {
@@ -15,16 +17,28 @@ export const metadata: Metadata = {
   description: "BUZZ BASE - 野球の個人成績をランキング形式で共有できるアプリ",
 };
 
-export default function AppLayout({ children }: { children: React.ReactNode }) {
+export default async function AppLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [proStatus, proIdentityKey] = await Promise.all([
+    getCachedProStatus(),
+    getProIdentityKey(),
+  ]);
+
   return (
     <AuthProvider>
       <UserProvider>
         <Providers>
-          <SmartAppBanner />
-          {children}
-          <NavigationMenu />
-          <Footer />
-          <Toaster position="top-right" richColors />
+          {/* key を identity に紐付け、ログイン/ログアウト後の再レンダーで Provider ごと作り直す */}
+          <ProStatusProvider key={proIdentityKey} initialValue={proStatus}>
+            <SmartAppBanner />
+            {children}
+            <NavigationMenu />
+            <Footer />
+            <Toaster position="top-right" richColors />
+          </ProStatusProvider>
         </Providers>
       </UserProvider>
     </AuthProvider>

--- a/app/(app)/pro/__tests__/actions.test.ts
+++ b/app/(app)/pro/__tests__/actions.test.ts
@@ -13,7 +13,7 @@ jest.mock("../../../../lib/sentry-helpers", () => ({
   captureServerActionError: jest.fn(),
 }));
 
-import { startProCheckout } from "../actions";
+import { getProStatus, startProCheckout } from "../actions";
 
 function setupAuthCookies() {
   mockGet.mockImplementation((key: string) => {
@@ -25,6 +25,56 @@ function setupAuthCookies() {
     return values[key];
   });
 }
+
+describe("getProStatus", () => {
+  const consoleErrorSpy = jest
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("401 のときはログを出さずに null を返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    });
+
+    await expect(getProStatus()).resolves.toBeNull();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("401 以外のエラーはログに残して null を返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    await expect(getProStatus()).resolves.toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it("タイムアウト用の AbortSignal を渡す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ subscription: {}, entitlements: [] }),
+    });
+
+    await getProStatus();
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
 
 describe("startProCheckout", () => {
   const originalAppUrl = process.env.APP_URL;

--- a/app/(app)/pro/__tests__/proStatus.test.ts
+++ b/app/(app)/pro/__tests__/proStatus.test.ts
@@ -10,7 +10,7 @@ jest.mock("../actions", () => ({
 }));
 
 import { DEFAULT_PRO_STATUS, type ProStatus } from "@app/types/pro";
-import { getCachedProStatus, getProIdentityKey } from "../proStatus";
+import { getCachedProStatus } from "../proStatus";
 
 function setAuthCookies(uid = "user@example.com") {
   mockCookieGet.mockImplementation((key: string) => {
@@ -58,23 +58,5 @@ describe("getCachedProStatus", () => {
 
     await expect(getCachedProStatus()).resolves.toBeNull();
     expect(mockGetProStatus).not.toHaveBeenCalled();
-  });
-});
-
-describe("getProIdentityKey", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it("ログイン中は uid を返す", async () => {
-    setAuthCookies("pro-user@example.com");
-
-    await expect(getProIdentityKey()).resolves.toBe("pro-user@example.com");
-  });
-
-  it("未認証なら anonymous を返す", async () => {
-    mockCookieGet.mockReturnValue(undefined);
-
-    await expect(getProIdentityKey()).resolves.toBe("anonymous");
   });
 });

--- a/app/(app)/pro/__tests__/proStatus.test.ts
+++ b/app/(app)/pro/__tests__/proStatus.test.ts
@@ -1,0 +1,80 @@
+const mockCookieGet = jest.fn();
+const mockGetProStatus = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: () => Promise.resolve({ get: mockCookieGet }),
+}));
+
+jest.mock("../actions", () => ({
+  getProStatus: () => mockGetProStatus(),
+}));
+
+import { DEFAULT_PRO_STATUS, type ProStatus } from "@app/types/pro";
+import { getCachedProStatus, getProIdentityKey } from "../proStatus";
+
+function setAuthCookies(uid = "user@example.com") {
+  mockCookieGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: uid },
+    };
+    return values[key];
+  });
+}
+
+const proStatus: ProStatus = {
+  subscription: {
+    ...DEFAULT_PRO_STATUS.subscription,
+    status: "active",
+    pro_active: true,
+  },
+  entitlements: [...DEFAULT_PRO_STATUS.entitlements, "no_ads"],
+};
+
+describe("getCachedProStatus", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("認証済みなら Pro 状態を返す", async () => {
+    setAuthCookies();
+    mockGetProStatus.mockResolvedValueOnce(proStatus);
+
+    await expect(getCachedProStatus()).resolves.toEqual(proStatus);
+  });
+
+  it("認証 cookie が無いときは API を呼ばずに null を返す", async () => {
+    mockCookieGet.mockReturnValue(undefined);
+
+    await expect(getCachedProStatus()).resolves.toBeNull();
+    expect(mockGetProStatus).not.toHaveBeenCalled();
+  });
+
+  it("認証 cookie が一部だけのときも API を呼ばずに null を返す", async () => {
+    mockCookieGet.mockImplementation((key: string) =>
+      key === "uid" ? { value: "user@example.com" } : undefined,
+    );
+
+    await expect(getCachedProStatus()).resolves.toBeNull();
+    expect(mockGetProStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe("getProIdentityKey", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("ログイン中は uid を返す", async () => {
+    setAuthCookies("pro-user@example.com");
+
+    await expect(getProIdentityKey()).resolves.toBe("pro-user@example.com");
+  });
+
+  it("未認証なら anonymous を返す", async () => {
+    mockCookieGet.mockReturnValue(undefined);
+
+    await expect(getProIdentityKey()).resolves.toBe("anonymous");
+  });
+});

--- a/app/(app)/pro/actions.ts
+++ b/app/(app)/pro/actions.ts
@@ -9,6 +9,9 @@ import { cookies } from "next/headers";
 import { captureServerActionError } from "../../../lib/sentry-helpers";
 import { RAILS_API_URL } from "../../constants/api";
 
+// Rails 側が詰まったときにレンダーや Server Action を無期限に待たせないための上限。
+const PRO_API_TIMEOUT_MS = 5000;
+
 async function getAuthHeaders(): Promise<Record<string, string> | null> {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get("access-token")?.value;
@@ -38,7 +41,12 @@ export async function getProStatus(): Promise<ProStatus | null> {
       method: "GET",
       headers,
       cache: "no-store",
+      signal: AbortSignal.timeout(PRO_API_TIMEOUT_MS),
     });
+
+    // 401 はトークン失効という想定内の状態。全ページのレンダーごとに記録すると
+    // 本当のエラーが埋もれるため、無料状態へのフォールバックだけ行う。
+    if (response.status === 401) return null;
 
     if (!response.ok) {
       console.error("Pro status API error:", response.status);
@@ -65,7 +73,10 @@ export async function getEntitlements(): Promise<EntitlementCheck[] | null> {
       method: "GET",
       headers,
       cache: "no-store",
+      signal: AbortSignal.timeout(PRO_API_TIMEOUT_MS),
     });
+
+    if (response.status === 401) return null;
 
     if (!response.ok) {
       console.error("Pro entitlements API error:", response.status);

--- a/app/(app)/pro/page.tsx
+++ b/app/(app)/pro/page.tsx
@@ -7,7 +7,7 @@ import HeroSection from "./_components/HeroSection";
 import PricingCards from "./_components/PricingCards";
 import Screenshots from "./_components/Screenshots";
 import Testimonials from "./_components/Testimonials";
-import { getProStatus } from "./actions";
+import { getCachedProStatus } from "./proStatus";
 
 export const metadata: Metadata = {
   title: "BUZZ BASE Pro — 記録を、成長へ。",
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
 };
 
 export default async function ProLandingPage() {
-  const status = await getProStatus();
+  const status = await getCachedProStatus();
   if (status?.subscription.pro_active) {
     redirect("/account/subscription");
   }

--- a/app/(app)/pro/proStatus.ts
+++ b/app/(app)/pro/proStatus.ts
@@ -3,37 +3,20 @@ import { cookies } from "next/headers";
 import { cache } from "react";
 import { getProStatus } from "./actions";
 
-const ANONYMOUS_IDENTITY_KEY = "anonymous";
-
-async function readAuthCookies() {
-  const cookieStore = await cookies();
-
-  return {
-    accessToken: cookieStore.get("access-token")?.value,
-    client: cookieStore.get("client")?.value,
-    uid: cookieStore.get("uid")?.value,
-  };
-}
-
 /**
  * Pro 状態をリクエスト単位でメモ化して取得する。
- * layout と page が同一リクエストで呼んでも API アクセスは1回に収まる。
+ * 同一リクエストで複数の Server Component が呼んでも API アクセスは1回に収まる。
  * 未認証時は API を叩かずに null を返す（UI 側で無料状態にフォールバックする）。
+ *
+ * 静的生成を捨てられないルートからは呼ばないこと。cookies() を読んだ時点で
+ * そのルートは dynamic 扱いになる。
  */
 export const getCachedProStatus = cache(async (): Promise<ProStatus | null> => {
-  const { accessToken, client, uid } = await readAuthCookies();
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("access-token")?.value;
+  const client = cookieStore.get("client")?.value;
+  const uid = cookieStore.get("uid")?.value;
   if (!accessToken || !client || !uid) return null;
 
   return getProStatus();
-});
-
-/**
- * ログイン中ユーザーを識別する文字列。未認証なら固定値を返す。
- * ProStatusProvider の key に使い、ログイン/ログアウトで Provider を作り直して
- * 前のユーザーの Pro 状態が client state に残るのを防ぐ。
- */
-export const getProIdentityKey = cache(async (): Promise<string> => {
-  const { uid } = await readAuthCookies();
-
-  return uid ?? ANONYMOUS_IDENTITY_KEY;
 });

--- a/app/(app)/pro/proStatus.ts
+++ b/app/(app)/pro/proStatus.ts
@@ -1,0 +1,39 @@
+import type { ProStatus } from "../../types/pro";
+import { cookies } from "next/headers";
+import { cache } from "react";
+import { getProStatus } from "./actions";
+
+const ANONYMOUS_IDENTITY_KEY = "anonymous";
+
+async function readAuthCookies() {
+  const cookieStore = await cookies();
+
+  return {
+    accessToken: cookieStore.get("access-token")?.value,
+    client: cookieStore.get("client")?.value,
+    uid: cookieStore.get("uid")?.value,
+  };
+}
+
+/**
+ * Pro 状態をリクエスト単位でメモ化して取得する。
+ * layout と page が同一リクエストで呼んでも API アクセスは1回に収まる。
+ * 未認証時は API を叩かずに null を返す（UI 側で無料状態にフォールバックする）。
+ */
+export const getCachedProStatus = cache(async (): Promise<ProStatus | null> => {
+  const { accessToken, client, uid } = await readAuthCookies();
+  if (!accessToken || !client || !uid) return null;
+
+  return getProStatus();
+});
+
+/**
+ * ログイン中ユーザーを識別する文字列。未認証なら固定値を返す。
+ * ProStatusProvider の key に使い、ログイン/ログアウトで Provider を作り直して
+ * 前のユーザーの Pro 状態が client state に残るのを防ぐ。
+ */
+export const getProIdentityKey = cache(async (): Promise<string> => {
+  const { uid } = await readAuthCookies();
+
+  return uid ?? ANONYMOUS_IDENTITY_KEY;
+});

--- a/app/components/auth/GoogleLoginButton.tsx
+++ b/app/components/auth/GoogleLoginButton.tsx
@@ -3,7 +3,7 @@
 import type { CredentialResponse } from "@react-oauth/google";
 import { GoogleLogin } from "@react-oauth/google";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { startTransition, useState } from "react";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import { useAuthContext } from "@app/contexts/useAuthContext";
@@ -24,10 +24,13 @@ export default function GoogleLoginButton({
   const router = useRouter();
 
   // 認証 cookie はクライアント側で書き換わるため、遷移だけでは Server Component の
-  // レンダー結果（Pro 状態など）が前のユーザーのまま残る。refresh で作り直す。
+  // レンダー結果が前のユーザーのまま残る。refresh で作り直す。
+  // 単一 transition にまとめて遷移先の RSC を2回取りに行かないようにする。
   const navigateAfterAuth = (path: string) => {
-    router.push(path);
-    router.refresh();
+    startTransition(() => {
+      router.push(path);
+      router.refresh();
+    });
   };
 
   const handleSuccess = async (credentialResponse: CredentialResponse) => {

--- a/app/components/auth/GoogleLoginButton.tsx
+++ b/app/components/auth/GoogleLoginButton.tsx
@@ -23,6 +23,13 @@ export default function GoogleLoginButton({
   const { setIsLoggedIn } = useAuthContext();
   const router = useRouter();
 
+  // 認証 cookie はクライアント側で書き換わるため、遷移だけでは Server Component の
+  // レンダー結果（Pro 状態など）が前のユーザーのまま残る。refresh で作り直す。
+  const navigateAfterAuth = (path: string) => {
+    router.push(path);
+    router.refresh();
+  };
+
   const handleSuccess = async (credentialResponse: CredentialResponse) => {
     if (!credentialResponse.credential) {
       setErrors(["Googleログインに失敗しました"]);
@@ -37,7 +44,7 @@ export default function GoogleLoginButton({
 
       if (response.data.requires_username) {
         trackEvent("sign_up", { method: "google" });
-        router.push("/register-username");
+        navigateAfterAuth("/register-username");
         setIsLoggedIn(true);
       } else {
         // requires_username=false はバックエンドが既存ユーザーと判断したことを意味する。
@@ -45,9 +52,9 @@ export default function GoogleLoginButton({
         trackEvent("login", { method: "google" });
         const userData = await getUserData();
         if (userData && userData.user_id) {
-          router.push(`/mypage/${userData.user_id}`);
+          navigateAfterAuth(`/mypage/${userData.user_id}`);
         } else {
-          router.push("/register-username");
+          navigateAfterAuth("/register-username");
         }
         setIsLoggedIn(true);
       }

--- a/app/components/auth/Logout.tsx
+++ b/app/components/auth/Logout.tsx
@@ -13,6 +13,9 @@ export default function Logout() {
       await signOut();
       setIsLoggedIn(false);
       router.push("/signin?logout=success");
+      // 認証 cookie 削除後も Server Component のレンダー結果（Pro 状態など）は
+      // ログイン中のまま残るため、明示的に作り直す。
+      router.refresh();
     } catch (error) {
       Sentry.captureException(error, {
         tags: { source: "logout" },

--- a/app/components/auth/Logout.tsx
+++ b/app/components/auth/Logout.tsx
@@ -1,6 +1,7 @@
 "use client";
 import * as Sentry from "@sentry/nextjs";
 import { useRouter } from "next/navigation";
+import { startTransition } from "react";
 import { useAuthContext } from "@app/contexts/useAuthContext";
 import { signOut } from "@app/services/authService";
 
@@ -12,10 +13,13 @@ export default function Logout() {
     try {
       await signOut();
       setIsLoggedIn(false);
-      router.push("/signin?logout=success");
-      // 認証 cookie 削除後も Server Component のレンダー結果（Pro 状態など）は
-      // ログイン中のまま残るため、明示的に作り直す。
-      router.refresh();
+      // 認証 cookie 削除後も Server Component のレンダー結果はログイン中のまま
+      // 残るため、明示的に作り直す。
+      // 単一 transition にまとめて遷移先の RSC を2回取りに行かないようにする。
+      startTransition(() => {
+        router.push("/signin?logout=success");
+        router.refresh();
+      });
     } catch (error) {
       Sentry.captureException(error, {
         tags: { source: "logout" },

--- a/app/components/auth/SignIn.tsx
+++ b/app/components/auth/SignIn.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { AxiosError } from "axios";
 import { useRouter } from "next/navigation";
-import { useCallback, useMemo, useState } from "react";
+import { startTransition, useCallback, useMemo, useState } from "react";
 import EmailInput from "@app/components/auth/EmailInput";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import GoogleLoginButton from "@app/components/auth/GoogleLoginButton";
@@ -32,10 +32,13 @@ export default function SignIn() {
     setIsPasswordVisible(!isPasswordVisible);
 
   // 認証 cookie はクライアント側で書き換わるため、遷移だけでは Server Component の
-  // レンダー結果（Pro 状態など）が前のユーザーのまま残る。refresh で作り直す。
+  // レンダー結果が前のユーザーのまま残る。refresh で作り直す。
+  // 単一 transition にまとめて遷移先の RSC を2回取りに行かないようにする。
   const navigateAfterAuth = (path: string) => {
-    router.push(path);
-    router.refresh();
+    startTransition(() => {
+      router.push(path);
+      router.refresh();
+    });
   };
 
   const setErrorsWithTimeout = (newErrors: React.SetStateAction<string[]>) => {

--- a/app/components/auth/SignIn.tsx
+++ b/app/components/auth/SignIn.tsx
@@ -31,6 +31,13 @@ export default function SignIn() {
   const togglePasswordVisibility = () =>
     setIsPasswordVisible(!isPasswordVisible);
 
+  // 認証 cookie はクライアント側で書き換わるため、遷移だけでは Server Component の
+  // レンダー結果（Pro 状態など）が前のユーザーのまま残る。refresh で作り直す。
+  const navigateAfterAuth = (path: string) => {
+    router.push(path);
+    router.refresh();
+  };
+
   const setErrorsWithTimeout = (newErrors: React.SetStateAction<string[]>) => {
     setErrors(newErrors);
     setTimeout(() => {
@@ -49,10 +56,10 @@ export default function SignIn() {
       const userData = await getUserData();
       if (userData && userData.user_id) {
         setIsLoggedIn(true);
-        router.push(`/mypage/${userData.user_id}`);
+        navigateAfterAuth(`/mypage/${userData.user_id}`);
       } else {
         setIsLoggedIn(true);
-        router.push("/register-username");
+        navigateAfterAuth("/register-username");
       }
     } catch (error: unknown) {
       if (error instanceof AxiosError && error.response?.data?.errors) {

--- a/app/components/pro/ProGate.tsx
+++ b/app/components/pro/ProGate.tsx
@@ -37,8 +37,12 @@ export default function ProGate({
   fallback,
   renderLockedTrigger,
 }: ProGateProps) {
-  const { hasEntitlement } = useEntitlement();
+  const { hasEntitlement, isLoading } = useEntitlement();
   const { open } = useProUpgradeModal();
+
+  // Pro 判定が確定するまで何も出さない。先に無料扱いで描画すると、
+  // 加入済みユーザーにロック UI が一瞬見えてしまう。
+  if (isLoading) return null;
 
   if (hasEntitlement(feature)) return <>{children}</>;
 

--- a/app/components/pro/ProStatusProvider.tsx
+++ b/app/components/pro/ProStatusProvider.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import Cookies from "js-cookie";
 import {
   createContext,
   useCallback,
+  useEffect,
   useMemo,
   useState,
   useTransition,
@@ -11,8 +13,11 @@ import {
 import { getProStatus } from "@app/(app)/pro/actions";
 import { DEFAULT_PRO_STATUS, type ProStatus } from "@app/types/pro";
 
+const ANONYMOUS_IDENTITY = "anonymous";
+
 interface ProStatusContextValue {
   proStatus: ProStatus;
+  isLoading: boolean;
   isRefreshing: boolean;
   refresh: () => void;
 }
@@ -21,36 +26,81 @@ export const ProStatusContext = createContext<ProStatusContextValue | null>(
   null,
 );
 
-interface ProStatusProviderProps {
-  initialValue: ProStatus | null;
-  children: ReactNode;
+interface ResolvedProStatus {
+  identity: string;
+  proStatus: ProStatus | null;
+}
+
+/**
+ * ブラウザの認証 cookie からログイン中ユーザーの識別子を読む。
+ * 3点セットが揃わなければ未認証扱い: uid だけ残って access-token が失効した状態を
+ * ログイン中と誤判定すると、失効後も前の Pro 状態を保持し続けてしまう。
+ * サーバー実行時（静的生成・SSR）は常に anonymous を返し、hydration 前後で
+ * isLoading の初期値が食い違わないようにする。
+ */
+function readClientIdentity(): string {
+  if (typeof document === "undefined") return ANONYMOUS_IDENTITY;
+
+  const accessToken = Cookies.get("access-token");
+  const client = Cookies.get("client");
+  const uid = Cookies.get("uid");
+  if (!accessToken || !client || !uid) return ANONYMOUS_IDENTITY;
+
+  return uid;
 }
 
 /**
  * Pro 状態をアプリ配下に配布する Context Provider。
- * Server Component で getProStatus() の戻り値を initialValue として渡し、
- * クライアント側では refresh() でサーバーアクションを再実行できる。
- * initialValue が null（未認証や API 失敗）なら無料状態として扱う。
+ *
+ * Pro 状態はサーバーでは取得しない。(app)/layout.tsx で cookies() を読むと
+ * コラム記事やツールなど配下の静的ページがすべて dynamic 扱いになり、
+ * ビルド時プリレンダリングと CDN 配信を失うため。
+ * 認証 cookie は SameSite=Strict で、検索結果や Stripe Checkout からの
+ * トップレベル遷移ではそもそもサーバーに届かず信用できない。一方 Server Action は
+ * 同一サイト起点の POST なので cookie が必ず送られる。
+ *
+ * 判定が確定するまでは isLoading: true とし、Pro 加入者にロック UI を見せない。
  */
-export function ProStatusProvider({
-  initialValue,
-  children,
-}: ProStatusProviderProps) {
-  const [proStatus, setProStatus] = useState<ProStatus>(
-    initialValue ?? DEFAULT_PRO_STATUS,
-  );
-  const [isPending, startTransition] = useTransition();
+export function ProStatusProvider({ children }: { children: ReactNode }) {
+  const [resolved, setResolved] = useState<ResolvedProStatus | null>(null);
+  const [isRefreshing, startRefresh] = useTransition();
+
+  // ログイン/ログアウト直後の router.refresh() でこの Provider も再レンダーされる。
+  // そこで識別子の変化を拾い、前ユーザーの Pro 状態を持ち越さない。
+  const identity = readClientIdentity();
+  const isStale = resolved !== null && resolved.identity !== identity;
+
+  useEffect(() => {
+    let active = true;
+    // 未認証なら API を叩かずに無料状態で確定させる
+    const pending =
+      identity === ANONYMOUS_IDENTITY ? Promise.resolve(null) : getProStatus();
+
+    void pending.then((next) => {
+      if (active) setResolved({ identity, proStatus: next });
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [identity]);
 
   const refresh = useCallback(() => {
-    startTransition(async () => {
+    startRefresh(async () => {
       const next = await getProStatus();
-      if (next) setProStatus(next);
+      if (next)
+        setResolved({ identity: readClientIdentity(), proStatus: next });
     });
   }, []);
 
   const value = useMemo<ProStatusContextValue>(
-    () => ({ proStatus, isRefreshing: isPending, refresh }),
-    [proStatus, isPending, refresh],
+    () => ({
+      proStatus: (isStale ? null : resolved?.proStatus) ?? DEFAULT_PRO_STATUS,
+      isLoading: resolved === null || isStale,
+      isRefreshing,
+      refresh,
+    }),
+    [resolved, isStale, isRefreshing, refresh],
   );
 
   return (

--- a/app/components/pro/__tests__/ProGate.test.tsx
+++ b/app/components/pro/__tests__/ProGate.test.tsx
@@ -17,11 +17,12 @@ const mockUseEntitlement = useEntitlement as jest.MockedFunction<
   typeof useEntitlement
 >;
 
-function mockEntitlement(granted: boolean) {
+function mockEntitlement(granted: boolean, isLoading = false) {
   mockUseEntitlement.mockReturnValue({
     isPro: granted,
     inTrial: false,
     inGracePeriod: false,
+    isLoading,
     hasEntitlement: jest.fn(() => granted),
   });
 }
@@ -68,6 +69,24 @@ describe("ProGate", () => {
     );
 
     expect(screen.getByText("Locked Notice")).toBeInTheDocument();
+    expect(screen.queryByText("Pro Content")).not.toBeInTheDocument();
+  });
+
+  it("Pro 判定が未確定の間は fallback もロックトリガーも出さない", () => {
+    mockEntitlement(false, true);
+
+    render(
+      <ProGate
+        feature="season_transition_graph"
+        fallback={<div>Locked Notice</div>}
+        renderLockedTrigger={() => <button type="button">ロック解除</button>}
+      >
+        <div>Pro Content</div>
+      </ProGate>,
+    );
+
+    expect(screen.queryByText("Locked Notice")).not.toBeInTheDocument();
+    expect(screen.queryByText("ロック解除")).not.toBeInTheDocument();
     expect(screen.queryByText("Pro Content")).not.toBeInTheDocument();
   });
 

--- a/app/hooks/pro/__tests__/useEntitlement.test.tsx
+++ b/app/hooks/pro/__tests__/useEntitlement.test.tsx
@@ -1,13 +1,29 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook, type RenderHookResult } from "@testing-library/react";
 import { type ReactNode } from "react";
+import { getProStatus } from "@app/(app)/pro/actions";
 import { ProStatusProvider } from "@app/components/pro/ProStatusProvider";
 import { useEntitlement } from "@app/hooks/pro/useEntitlement";
 import { DEFAULT_PRO_STATUS, type ProStatus } from "@app/types/pro";
 
-// Server Action はテストでは呼ばれないが、モジュール解決のためにモック
 jest.mock("@app/(app)/pro/actions", () => ({
   getProStatus: jest.fn(),
 }));
+
+const mockGetProStatus = getProStatus as jest.MockedFunction<
+  typeof getProStatus
+>;
+
+function setAuthCookies() {
+  document.cookie = "access-token=test-access-token";
+  document.cookie = "client=test-client";
+  document.cookie = "uid=user@example.com";
+}
+
+function clearAuthCookies() {
+  for (const name of ["access-token", "client", "uid"]) {
+    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+  }
+}
 
 function makeProActiveStatus(): ProStatus {
   return {
@@ -33,17 +49,34 @@ function makeProActiveStatus(): ProStatus {
   };
 }
 
-function wrapperWith(initialValue: ProStatus | null) {
-  const Wrapper = ({ children }: { children: ReactNode }) => (
-    <ProStatusProvider initialValue={initialValue}>
-      {children}
-    </ProStatusProvider>
-  );
-  Wrapper.displayName = "TestProStatusWrapper";
-  return Wrapper;
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <ProStatusProvider>{children}</ProStatusProvider>
+);
+Wrapper.displayName = "TestProStatusWrapper";
+
+// Pro 状態はマウント後に Server Action で解決されるため、非同期 act で確定まで進める
+async function renderEntitlement(proStatus: ProStatus | null) {
+  if (proStatus) {
+    setAuthCookies();
+    mockGetProStatus.mockResolvedValue(proStatus);
+  }
+
+  let rendered!: RenderHookResult<ReturnType<typeof useEntitlement>, unknown>;
+  await act(async () => {
+    rendered = renderHook(() => useEntitlement(), { wrapper: Wrapper });
+  });
+
+  expect(rendered.result.current.isLoading).toBe(false);
+
+  return rendered.result;
 }
 
 describe("useEntitlement", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearAuthCookies();
+  });
+
   describe("Provider が無い場合", () => {
     it("無料機能には true、Pro 機能には false を返す", () => {
       const { result } = renderHook(() => useEntitlement());
@@ -53,14 +86,49 @@ describe("useEntitlement", () => {
         false,
       );
       expect(result.current.isPro).toBe(false);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("Pro 状態が未解決の場合", () => {
+    it("isLoading: true のまま無料状態を返す", async () => {
+      setAuthCookies();
+      mockGetProStatus.mockReturnValue(new Promise(() => {}));
+
+      let rendered!: RenderHookResult<
+        ReturnType<typeof useEntitlement>,
+        unknown
+      >;
+      await act(async () => {
+        rendered = renderHook(() => useEntitlement(), { wrapper: Wrapper });
+      });
+
+      expect(rendered.result.current.isLoading).toBe(true);
+      expect(rendered.result.current.isPro).toBe(false);
+    });
+  });
+
+  describe("認証 cookie が揃っていない場合", () => {
+    it("Server Action を呼ばずに無料状態で確定する", async () => {
+      document.cookie = "uid=user@example.com";
+
+      let rendered!: RenderHookResult<
+        ReturnType<typeof useEntitlement>,
+        unknown
+      >;
+      await act(async () => {
+        rendered = renderHook(() => useEntitlement(), { wrapper: Wrapper });
+      });
+
+      expect(mockGetProStatus).not.toHaveBeenCalled();
+      expect(rendered.result.current.isLoading).toBe(false);
+      expect(rendered.result.current.isPro).toBe(false);
     });
   });
 
   describe("無料ユーザー (status: free)", () => {
-    it("無料機能には true、Pro 機能には false を返す", () => {
-      const { result } = renderHook(() => useEntitlement(), {
-        wrapper: wrapperWith(null),
-      });
+    it("無料機能には true、Pro 機能には false を返す", async () => {
+      const result = await renderEntitlement(null);
 
       expect(result.current.hasEntitlement("basic_game_record")).toBe(true);
       expect(result.current.hasEntitlement("calculation_tools")).toBe(true);
@@ -75,10 +143,8 @@ describe("useEntitlement", () => {
   describe("Pro ユーザー (status: active)", () => {
     const proStatus = makeProActiveStatus();
 
-    it("無料機能・Pro 機能のいずれも true を返す", () => {
-      const { result } = renderHook(() => useEntitlement(), {
-        wrapper: wrapperWith(proStatus),
-      });
+    it("無料機能・Pro 機能のいずれも true を返す", async () => {
+      const result = await renderEntitlement(proStatus);
 
       expect(result.current.hasEntitlement("basic_game_record")).toBe(true);
       expect(result.current.hasEntitlement("no_ads")).toBe(true);
@@ -91,10 +157,8 @@ describe("useEntitlement", () => {
       expect(result.current.isPro).toBe(true);
     });
 
-    it("entitlements に含まれない Pro 機能には false を返す", () => {
-      const { result } = renderHook(() => useEntitlement(), {
-        wrapper: wrapperWith(proStatus),
-      });
+    it("entitlements に含まれない Pro 機能には false を返す", async () => {
+      const result = await renderEntitlement(proStatus);
 
       // proStatus.entitlements には 'detailed_condition_log' が含まれていない
       expect(result.current.hasEntitlement("detailed_condition_log")).toBe(
@@ -104,7 +168,7 @@ describe("useEntitlement", () => {
   });
 
   describe("トライアル中ユーザー", () => {
-    it("inTrial: true、isPro: true を返す", () => {
+    it("inTrial: true、isPro: true を返す", async () => {
       const trialStatus: ProStatus = {
         subscription: {
           ...DEFAULT_PRO_STATUS.subscription,
@@ -117,9 +181,7 @@ describe("useEntitlement", () => {
         entitlements: [...DEFAULT_PRO_STATUS.entitlements, "no_ads"],
       };
 
-      const { result } = renderHook(() => useEntitlement(), {
-        wrapper: wrapperWith(trialStatus),
-      });
+      const result = await renderEntitlement(trialStatus);
 
       expect(result.current.isPro).toBe(true);
       expect(result.current.inTrial).toBe(true);
@@ -128,7 +190,7 @@ describe("useEntitlement", () => {
   });
 
   describe("グレースピリオド中ユーザー (cancelled)", () => {
-    it("inGracePeriod: true、isPro: true を返す", () => {
+    it("inGracePeriod: true、isPro: true を返す", async () => {
       const cancelledStatus: ProStatus = {
         subscription: {
           ...DEFAULT_PRO_STATUS.subscription,
@@ -141,9 +203,7 @@ describe("useEntitlement", () => {
         entitlements: [...DEFAULT_PRO_STATUS.entitlements, "no_ads"],
       };
 
-      const { result } = renderHook(() => useEntitlement(), {
-        wrapper: wrapperWith(cancelledStatus),
-      });
+      const result = await renderEntitlement(cancelledStatus);
 
       expect(result.current.isPro).toBe(true);
       expect(result.current.inGracePeriod).toBe(true);

--- a/app/hooks/pro/useEntitlement.ts
+++ b/app/hooks/pro/useEntitlement.ts
@@ -8,6 +8,8 @@ interface UseEntitlementReturn {
   isPro: boolean;
   inTrial: boolean;
   inGracePeriod: boolean;
+  /** Pro 判定が未確定の間だけ true。ロック UI のちらつきを避ける判断に使う。 */
+  isLoading: boolean;
   hasEntitlement: (feature: Feature) => boolean;
 }
 
@@ -17,7 +19,7 @@ interface UseEntitlementReturn {
  * back の Entitlement#has_entitlement? と同じロジックを表現する。
  */
 export function useEntitlement(): UseEntitlementReturn {
-  const { proStatus, isPro } = useProStatus();
+  const { proStatus, isPro, isLoading } = useProStatus();
 
   const hasEntitlement = useCallback(
     (feature: Feature): boolean => {
@@ -31,6 +33,7 @@ export function useEntitlement(): UseEntitlementReturn {
     isPro,
     inTrial: proStatus.subscription.in_trial,
     inGracePeriod: proStatus.subscription.in_grace_period,
+    isLoading,
     hasEntitlement,
   };
 }

--- a/app/hooks/pro/useProStatus.ts
+++ b/app/hooks/pro/useProStatus.ts
@@ -7,6 +7,8 @@ import { DEFAULT_PRO_STATUS, type ProStatus } from "@app/types/pro";
 interface UseProStatusReturn {
   proStatus: ProStatus;
   isPro: boolean;
+  /** Pro 状態の取得が完了しておらず、無料/Pro を判定できない間だけ true。 */
+  isLoading: boolean;
   isRefreshing: boolean;
   refresh: () => void;
 }
@@ -22,15 +24,16 @@ export function useProStatus(): UseProStatusReturn {
     return {
       proStatus: DEFAULT_PRO_STATUS,
       isPro: false,
+      isLoading: false,
       isRefreshing: false,
       refresh: () => {},
     };
   }
 
-  const { proStatus, isRefreshing, refresh } = ctx;
+  const { proStatus, isLoading, isRefreshing, refresh } = ctx;
   // サーバー側で「期限内かつ Pro 扱いの status」を判定済みのフラグを単一の真実とする。
   // 期限切れの cancelled / billing_issue で誤って true にならないようにするため。
   const isPro = proStatus.subscription.pro_active;
 
-  return { proStatus, isPro, isRefreshing, refresh };
+  return { proStatus, isPro, isLoading, isRefreshing, refresh };
 }


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#451

## 概要

`app/components/pro/ProStatusProvider.tsx` はどのレイアウトにもマウントされておらず、`useProStatus()` が常に `DEFAULT_PRO_STATUS`（無料）を返していた。そのため `useEntitlement()` / `ProGate` は完全なデッドコードで、front の Pro ゲーティングが1つも機能していなかった。

`app/(app)/layout.tsx` で Provider をマウントし、配下全体で Pro 判定が効くようにする。

## 変更内容

- `app/(app)/pro/proStatus.ts`（新規）
  - `getCachedProStatus()` — `React.cache()` でリクエスト単位にメモ化。認証3 cookie（access-token / client / uid）が揃っていなければ API を叩かず `null` を返す
  - `getProIdentityKey()` — Provider の再マウントキー用（未認証は `"anonymous"`）
  - `"use server"` ファイルは export がすべて Server Action 扱いになり `cache()` を置けないため、別モジュールに切り出している
- `app/(app)/layout.tsx` — async Server Component 化し、`Promise.all` で Pro 状態と identity key を取得して `<ProStatusProvider>` で `Providers` 配下をラップ
- `app/(app)/pro/page.tsx` — `getProStatus()` → `getCachedProStatus()` に変更し、layout と同一リクエスト内の API アクセスを1回に集約
- `app/components/auth/{SignIn,GoogleLoginButton,Logout}.tsx` — 認証 cookie は js-cookie でクライアント側更新されるため `router.push` だけでは共有レイアウト（Server Component）が再レンダーされず Pro 状態が古いまま残る。押下後に `router.refresh()` を追加
- テスト2ファイル（計11ケース）を追加

## 確認手順

1. `yarn typecheck` / `yarn lint` / `yarn format:check` / `yarn test` がすべて通ること
2. `app/(app)/__tests__/layout.test.tsx` が「Provider が実際にマウントされ、配下で Pro 判定が効くこと」を検証していること（issue の本体）
3. ログアウト・別ユーザー再ログインで前ユーザーの Pro 状態が残らないこと

## レビューで見てほしい点

1. `getProIdentityKey` は uid（メールアドレス）を React key として RSC ペイロードに出す。cookie で既にクライアントが保持している値なので新たな漏洩はないと判断したが、ハッシュ化すべきか
2. `key` による Provider 再マウントで、identity 変更時にレイアウト配下の client state がすべてリセットされる。ログイン/ログアウト時のみのため意図通りと判断している
3. layout での `await` が認証済みユーザーの全ページレンダーをブロックする。Provider の `initialValue` が必要なため Suspense で逃がせない構造
4. 認証コンポーネント3ファイルへの `router.refresh()` 追加は issue の「ログイン/ログアウト遷移時に Pro 状態が古いまま残らないように」を満たすための変更。cookie 設定をサーバー側に移すなら不要になる
5. `React.cache()` のメモ化自体はテストで直接検証できていない（jest 環境の `cache` はディスパッチャ不在時に素通しになるため）。ガードと委譲の振る舞いをテストしている

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（41 suites / 312 tests）


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_