### PR TITLE
Add: Pro訴求UIコンポーネント群を追加

### DIFF
--- a/app/components/pro/ProUpgradeModal.tsx
+++ b/app/components/pro/ProUpgradeModal.tsx
@@ -16,171 +16,10 @@ import Link from "next/link";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { startProCheckout, type ProPlan } from "@app/(app)/pro/actions";
-
-interface PaywallCopy {
-  title: string;
-  description: string;
-}
-
-// trigger に応じた「なぜこのモーダルを開いたか」のコンテキスト訴求。
-// PaywallModal 時代に画面ごとに最適化していたコピーをそのまま流用。
-const PRO_PAYWALL_COPY: Record<ProFeature, PaywallCopy> = {
-  no_ads: {
-    title: "広告を非表示にして集中する",
-    description:
-      "Pro プランに加入すると、アプリ内のすべての広告が非表示になります。",
-  },
-  season_transition_graph: {
-    title: "シーズンを跨いだ成長を可視化",
-    description:
-      "過去複数シーズンの成績を折れ線グラフで比較して、長期的な成長を確認できます。",
-  },
-  grass_full_history: {
-    title: "練習履歴を全期間で確認",
-    description:
-      "草機能のヒートマップを全期間で表示。継続の積み重ねを実感できます。",
-  },
-  unlimited_practice_menus: {
-    title: "練習メニューを無制限に登録",
-    description:
-      "Pro プランなら4つ目以降の練習メニューも自由に登録・編集できます。",
-  },
-  unlimited_media_uploads: {
-    title: "動画・画像を無制限にアップロード",
-    description: "月3点までの制限を撤廃。練習映像をいくらでも保存できます。",
-  },
-  schedule_copy_next_week: {
-    title: "今週のプランを来週にまるごとコピー",
-    description:
-      "Pro プランなら今週登録した予定をワンタップで来週にコピーでき、プラン作りの手間を省けます。",
-  },
-  unlimited_menu_sets: {
-    title: "メニューセットを無制限に作成",
-    description:
-      "よく組む練習をセットにして、予定登録や週プランでそのまま使い回せます。",
-  },
-  unlimited_monthly_goals: {
-    title: "個人の期間目標を無制限に設定",
-    description:
-      "月次・週次・年間の目標を3つ以上、同時に管理できます（無料は合計2つまで）。",
-  },
-  season_goals: {
-    title: "シーズン目標を設定",
-    description:
-      "1シーズンを通した中長期目標を設定し、月次目標と紐づけて追跡できます。",
-  },
-  tournament_goals: {
-    title: "大会目標を設定",
-    description:
-      "特定の大会に向けた目標を設定し、その大会の成績で達成を追跡できます。",
-  },
-  custom_notification_messages: {
-    title: "通知メッセージをカスタマイズ",
-    description: "練習リマインドや目標達成通知の文言を自分好みに編集できます。",
-  },
-  detailed_condition_log: {
-    title: "コンディションを詳しく記録",
-    description:
-      "体調・気分・睡眠などを細かく記録し、調子の良し悪しの傾向を把握できます。",
-  },
-  unlimited_improvement_themes: {
-    title: "取り組む課題を無制限に",
-    description:
-      "複数の課題を同時に設定して、練習やノートをそれぞれの課題に束ねられます。",
-  },
-  correlation_insights: {
-    title: "練習と成績の関係を発見",
-    description:
-      "素振りや睡眠と打率の傾向を、あなたのデータから自動で読み解きます。",
-  },
-  unlimited_reflection_templates: {
-    title: "振り返りテンプレを自由に作成",
-    description:
-      "自分専用の問いかけテンプレをいくつでも作って、振り返りの質を高められます。",
-  },
-  advanced_periodic_review: {
-    title: "週次・月次の振り返りレポートを受け取る",
-    description:
-      "練習量や成績の変化、課題別の取り組み状況、練習と成績のつながりを週末・月末に自動でまとめてお届けします。",
-  },
-  note_tags: {
-    title: "野球ノートにタグを付けて整理",
-    description:
-      "Pro プランなら野球ノートにタグを付けて、後から振り返りやすく整理できます。",
-  },
-  multi_game_result_notes: {
-    title: "1つのノートに複数の試合を紐付け",
-    description:
-      "Pro プランなら1つの野球ノートに複数の試合記録を紐付けて振り返れます。",
-  },
-  multi_improvement_theme_links: {
-    title: "1つの記録に複数の課題を紐付け",
-    description:
-      "Pro プランなら練習記録・野球ノートに複数の課題を同時に紐付けて、取り組みをまとめて振り返れます。",
-  },
-  practice_menu_trend_detail: {
-    title: "メニューごとの推移を詳しく見る",
-    description:
-      "期間を絞ったグラフや数値の内訳など、メニューごとの詳細な推移をいつでも振り返れます。",
-  },
-  custom_period_goals: {
-    title: "カスタム期間で目標を設定",
-    description:
-      "「大会前3週間」のように自分で決めた期間で目標を設定し、進み具合を追跡できます。",
-  },
-  manual_metric_goals: {
-    title: "自由指標で目標を設定",
-    description:
-      "球速や体重など、アプリが自動集計できない自分だけの指標も目標にして手入力で管理できます。",
-  },
-  shadow_swing_custom_interval: {
-    title: "インターバルを自由に設定",
-    description:
-      "1秒〜20秒の全範囲でインターバルを設定できます。自分のテンポに合わせて素振りを鍛えましょう。",
-  },
-  shadow_swing_vibration: {
-    title: "バイブレーションでテンポを取る",
-    description:
-      "音を出せない場所でもバイブレーションでインターバルを把握しながら素振りできます。",
-  },
-  shadow_swing_background: {
-    title: "バックグラウンドでも継続実行",
-    description:
-      "画面ロックやアプリの切り替えで途切れず、素振りの本数と経過時間をそのまま継続できます。",
-  },
-  schedule_calendar_full_history: {
-    title: "カレンダーを全期間閲覧",
-    description:
-      "先々の予定や過去の練習プランも、月を遡らずカレンダーでいつでも確認できます。",
-  },
-  unlimited_groups: {
-    title: "グループを無制限に作成・参加",
-    description:
-      "Pro プランなら2つ目以降のグループも自由に作成・参加できます。チームを掛け持ちしているメンバーも安心です。",
-  },
-  hit_direction_average: {
-    title: "方向別の打率",
-    description: "打球を打った方向ごとの打率をヒートマップで可視化します。",
-  },
-  count_situation_average: {
-    title: "カウント別の打率",
-    description:
-      "初球・有利カウント・追い込みなど、カウント状況別の打率がわかります。",
-  },
-  pitch_type_average: {
-    title: "球種別の打率",
-    description: "ストレートや変化球など、球種ごとの得意・苦手が分析できます。",
-  },
-  pitcher_faceoff_average: {
-    title: "対戦投手別",
-    description: "対戦した投手ごとの打撃成績を一覧で確認できます。",
-  },
-};
-
-const DEFAULT_COPY: PaywallCopy = {
-  title: "BUZZ BASE Pro でもっと深く野球を",
-  description: "Pro プランで全機能のロックを解除できます。",
-};
+import {
+  DEFAULT_PAYWALL_COPY,
+  PRO_PAYWALL_COPY,
+} from "@app/components/pro/paywallCopy";
 
 const FEATURE_HIGHLIGHTS = [
   { icon: "🚫", label: "広告非表示" },
@@ -232,7 +71,7 @@ export default function ProUpgradeModal({
   const [isPending, startTransition] = useTransition();
   const [isRedirecting, setIsRedirecting] = useState(false);
 
-  const copy = (trigger && PRO_PAYWALL_COPY[trigger]) ?? DEFAULT_COPY;
+  const copy = (trigger && PRO_PAYWALL_COPY[trigger]) ?? DEFAULT_PAYWALL_COPY;
 
   const handleCheckout = () => {
     startTransition(async () => {

--- a/app/components/pro/ProUpsellCard.tsx
+++ b/app/components/pro/ProUpsellCard.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import type { ProPlan } from "@app/(app)/pro/actions";
 import type { ProFeature } from "@app/types/pro";
 import { LockClosedIcon } from "@heroicons/react/24/solid";
-import { PRO_PAYWALL_COPY } from "@app/components/pro/paywallCopy";
+import {
+  DEFAULT_PAYWALL_COPY,
+  PRO_PAYWALL_COPY,
+} from "@app/components/pro/paywallCopy";
 import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+import { trackEvent } from "@app/lib/analytics";
 
 /**
  * 訴求文言の指定方法。feature を渡せば PRO_PAYWALL_COPY から引き、個別に上書きもできる。
@@ -26,12 +31,19 @@ type ProUpsellCopyProps =
 export type ProUpsellCardProps = ProUpsellCopyProps & {
   /** CTA ボタンの文言。 */
   ctaLabel?: string;
+  /** CTA 押下時の挙動を差し替える。省略時は ProUpgradeModal を feature 付きで開く。 */
+  onCtaClick?: () => void;
+  /** ProUpgradeModal を開いたときに初期選択させる料金プラン。 */
+  defaultPlan?: ProPlan;
   /** solid: 単独設置 / translucent: ProUpsellOverlay の暗幕の上に重ねる。 */
   appearance?: "solid" | "translucent";
   className?: string;
 };
 
 const DEFAULT_CTA_LABEL = "Pro プランを見る";
+
+/** feature を持たない未実装機能の訴求もまとめて集計できるよう、既定値を入れて欠損させない。 */
+const UNSPECIFIED_FEATURE = "unspecified";
 
 const APPEARANCE_CLASS = {
   solid: "bg-sub",
@@ -49,18 +61,33 @@ export function ProUpsellCard({
   description,
   benefits,
   ctaLabel = DEFAULT_CTA_LABEL,
+  onCtaClick,
+  defaultPlan,
   appearance = "solid",
   className,
 }: ProUpsellCardProps) {
   const { open } = useProUpgradeModal();
 
-  const copy = feature ? PRO_PAYWALL_COPY[feature] : undefined;
-  const resolvedTitle = title ?? copy?.title ?? "";
-  const resolvedBenefits = benefits ?? copy?.benefits ?? [];
-  const resolvedDescription = description ?? copy?.description;
+  const copy = (feature && PRO_PAYWALL_COPY[feature]) ?? DEFAULT_PAYWALL_COPY;
+  const resolvedTitle = title ?? copy.title;
+  const resolvedBenefits = benefits ?? copy.benefits ?? [];
+  const resolvedDescription = description ?? copy.description;
+
+  const handleCtaClick = () => {
+    // 呼び出し元が挙動を差し替えても計測が落ちないよう、委譲より先にここで発火する。
+    trackEvent("pro_upsell_cta_click", {
+      feature: feature ?? UNSPECIFIED_FEATURE,
+    });
+
+    if (onCtaClick) {
+      onCtaClick();
+      return;
+    }
+    open({ trigger: feature, defaultPlan });
+  };
 
   return (
-    <section
+    <div
       className={`flex flex-col items-center gap-2 rounded-[10px] p-3.5 text-center ${APPEARANCE_CLASS[appearance]} ${className ?? ""}`}
     >
       <h3 className="flex items-center gap-1.5 text-sm font-bold text-white">
@@ -84,14 +111,16 @@ export function ProUpsellCard({
           {resolvedDescription}
         </p>
       ) : null}
+      {/* 同一ページに複数のカードが並ぶため、見出しを含めて CTA を読み分けられるようにする。 */}
       <button
         type="button"
-        onClick={() => open({ trigger: feature })}
+        aria-label={`${ctaLabel}（${resolvedTitle}）`}
+        onClick={handleCtaClick}
         className="mt-1 inline-flex items-center gap-1.5 rounded-[10px] bg-[#d08000] px-4 py-2.5 text-sm font-bold text-white transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000] focus-visible:ring-offset-2 focus-visible:ring-offset-main"
       >
         <LockClosedIcon className="h-4 w-4 shrink-0" aria-hidden />
         {ctaLabel}
       </button>
-    </section>
+    </div>
   );
 }

--- a/app/components/pro/ProUpsellCard.tsx
+++ b/app/components/pro/ProUpsellCard.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import type { ProFeature } from "@app/types/pro";
+import { LockClosedIcon } from "@heroicons/react/24/solid";
+import { PRO_PAYWALL_COPY } from "@app/components/pro/paywallCopy";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+
+/**
+ * 訴求文言の指定方法。feature を渡せば PRO_PAYWALL_COPY から引き、個別に上書きもできる。
+ * entitlement キーを持たない未実装機能では feature を省略でき、その場合 title が必須になる。
+ */
+type ProUpsellCopyProps =
+  | {
+      feature: ProFeature;
+      title?: string;
+      description?: string;
+      benefits?: string[];
+    }
+  | {
+      feature?: undefined;
+      title: string;
+      description?: string;
+      benefits?: string[];
+    };
+
+export type ProUpsellCardProps = ProUpsellCopyProps & {
+  /** CTA ボタンの文言。 */
+  ctaLabel?: string;
+  /** solid: 単独設置 / translucent: ProUpsellOverlay の暗幕の上に重ねる。 */
+  appearance?: "solid" | "translucent";
+  className?: string;
+};
+
+const DEFAULT_CTA_LABEL = "Pro プランを見る";
+
+const APPEARANCE_CLASS = {
+  solid: "bg-sub",
+  translucent: "bg-[#3A3A3A]/90 backdrop-blur-sm",
+} as const;
+
+/**
+ * Pro 専用機能の訴求カード（鍵アイコン付き見出し + メリット + CTA）。
+ * 単独カードとしても、ProUpsellOverlay の中で実 UI / サンプル UI の上に重ねる形でも使う。
+ * CTA は ProUpgradeModalProvider が常設しているモーダルを feature 付きで開く。
+ */
+export function ProUpsellCard({
+  feature,
+  title,
+  description,
+  benefits,
+  ctaLabel = DEFAULT_CTA_LABEL,
+  appearance = "solid",
+  className,
+}: ProUpsellCardProps) {
+  const { open } = useProUpgradeModal();
+
+  const copy = feature ? PRO_PAYWALL_COPY[feature] : undefined;
+  const resolvedTitle = title ?? copy?.title ?? "";
+  const resolvedBenefits = benefits ?? copy?.benefits ?? [];
+  const resolvedDescription = description ?? copy?.description;
+
+  return (
+    <section
+      className={`flex flex-col items-center gap-2 rounded-[10px] p-3.5 text-center ${APPEARANCE_CLASS[appearance]} ${className ?? ""}`}
+    >
+      <h3 className="flex items-center gap-1.5 text-sm font-bold text-white">
+        <LockClosedIcon
+          className="h-4 w-4 shrink-0 text-[#d08000]"
+          aria-hidden
+        />
+        {resolvedTitle}
+      </h3>
+      {resolvedBenefits.length > 0 ? (
+        <ul className="w-full space-y-1 text-left text-xs leading-[18px] text-zic-300">
+          {resolvedBenefits.map((benefit) => (
+            <li key={benefit} className="flex gap-1">
+              <span aria-hidden>・</span>
+              <span>{benefit}</span>
+            </li>
+          ))}
+        </ul>
+      ) : resolvedDescription ? (
+        <p className="text-left text-xs leading-[18px] text-zic-300">
+          {resolvedDescription}
+        </p>
+      ) : null}
+      <button
+        type="button"
+        onClick={() => open({ trigger: feature })}
+        className="mt-1 inline-flex items-center gap-1.5 rounded-[10px] bg-[#d08000] px-4 py-2.5 text-sm font-bold text-white transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000] focus-visible:ring-offset-2 focus-visible:ring-offset-main"
+      >
+        <LockClosedIcon className="h-4 w-4 shrink-0" aria-hidden />
+        {ctaLabel}
+      </button>
+    </section>
+  );
+}

--- a/app/components/pro/ProUpsellOverlay.tsx
+++ b/app/components/pro/ProUpsellOverlay.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import type { ProFeature } from "@app/types/pro";
+import type { ReactNode } from "react";
+import { LockClosedIcon } from "@heroicons/react/24/solid";
+import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+
+interface ProUpsellOverlayProps {
+  /** 覆う対象の Pro 機能。この entitlement を持つユーザーには children がそのまま見える。 */
+  feature: ProFeature;
+  children: ReactNode;
+  /** ロック時に暗幕の上へ重ねる要素。同一画面で CTA を1箇所に絞りたいときは badge / none にする。 */
+  lockedIndicator?: "card" | "badge" | "none";
+  /** PRO_PAYWALL_COPY の文言を上書きしたいときに指定する。 */
+  title?: string;
+  description?: string;
+  benefits?: string[];
+  ctaLabel?: string;
+  /** 暗幕の不透明度（0〜1）。数値を確実に読ませたくない箇所は高めにする。 */
+  scrimOpacity?: number;
+  className?: string;
+}
+
+const DEFAULT_SCRIM_OPACITY = 0.68;
+
+/**
+ * 無料ユーザーに見せたくない実データや、Pro 機能のサンプル UI を暗幕で覆い、
+ * 上に Pro 訴求（カード / バッジ）を重ねる。entitlement を持つ場合は children を素通しする。
+ */
+export function ProUpsellOverlay({
+  feature,
+  children,
+  lockedIndicator = "card",
+  title,
+  description,
+  benefits,
+  ctaLabel,
+  scrimOpacity = DEFAULT_SCRIM_OPACITY,
+  className,
+}: ProUpsellOverlayProps) {
+  const { hasEntitlement, isLoading } = useEntitlement();
+
+  if (hasEntitlement(feature)) return <>{children}</>;
+
+  // 判定確定前は暗幕だけの中立表示にして、Pro へ倒れた瞬間に訴求が一瞬見えるのを防ぐ。
+  const indicator = isLoading ? "none" : lockedIndicator;
+
+  return (
+    <div
+      className={`relative overflow-hidden rounded-lg ${indicator === "card" ? "min-h-[200px]" : ""} ${className ?? ""}`}
+    >
+      {/* 暗幕の裏に残る実データをスクリーンリーダー・キーボード操作からも切り離す。 */}
+      <div inert aria-hidden="true" className="pointer-events-none select-none">
+        {children}
+      </div>
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 backdrop-blur-[2px]"
+        style={{ backgroundColor: `rgba(26, 26, 26, ${scrimOpacity})` }}
+      />
+      {indicator === "card" ? (
+        <div className="absolute inset-0 flex items-center justify-center p-3">
+          <ProUpsellCard
+            feature={feature}
+            title={title}
+            description={description}
+            benefits={benefits}
+            ctaLabel={ctaLabel}
+            appearance="translucent"
+            className="w-full max-w-sm"
+          />
+        </div>
+      ) : null}
+      {indicator === "badge" ? (
+        <div className="absolute inset-0 flex items-center justify-center p-3">
+          <span className="inline-flex items-center gap-1 rounded-full bg-[#3A3A3A]/90 px-2.5 py-1 text-[11px] font-bold text-white">
+            <LockClosedIcon className="h-3 w-3 shrink-0" aria-hidden />
+            Pro限定
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/pro/ProUpsellOverlay.tsx
+++ b/app/components/pro/ProUpsellOverlay.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ProPlan } from "@app/(app)/pro/actions";
 import type { ProFeature } from "@app/types/pro";
 import type { ReactNode } from "react";
 import { LockClosedIcon } from "@heroicons/react/24/solid";
@@ -10,6 +11,12 @@ interface ProUpsellOverlayProps {
   /** 覆う対象の Pro 機能。この entitlement を持つユーザーには children がそのまま見える。 */
   feature: ProFeature;
   children: ReactNode;
+  /**
+   * ロックを解除するかどうか。省略時は feature の entitlement 判定に従う。
+   * バックエンド未実装の機能をサンプル UI で先出しする間は false を明示し、
+   * entitlement を持つ Pro ユーザーにも未完成の実 UI を見せないようにする。
+   */
+  unlocked?: boolean;
   /** ロック時に暗幕の上へ重ねる要素。同一画面で CTA を1箇所に絞りたいときは badge / none にする。 */
   lockedIndicator?: "card" | "badge" | "none";
   /** PRO_PAYWALL_COPY の文言を上書きしたいときに指定する。 */
@@ -17,6 +24,10 @@ interface ProUpsellOverlayProps {
   description?: string;
   benefits?: string[];
   ctaLabel?: string;
+  /** CTA 押下時の挙動を差し替える。省略時は ProUpgradeModal を feature 付きで開く。 */
+  onCtaClick?: () => void;
+  /** ProUpgradeModal を開いたときに初期選択させる料金プラン。 */
+  defaultPlan?: ProPlan;
   /** 暗幕の不透明度（0〜1）。数値を確実に読ませたくない箇所は高めにする。 */
   scrimOpacity?: number;
   className?: string;
@@ -24,39 +35,62 @@ interface ProUpsellOverlayProps {
 
 const DEFAULT_SCRIM_OPACITY = 0.68;
 
+const LOCKED_BADGE = (
+  <div className="absolute inset-0 flex items-center justify-center p-3">
+    <span className="inline-flex items-center gap-1 rounded-full bg-[#3A3A3A]/90 px-2.5 py-1 text-[11px] font-bold text-white">
+      <LockClosedIcon className="h-3 w-3 shrink-0" aria-hidden />
+      Pro限定
+    </span>
+  </div>
+);
+
+// children も暗幕も aria-hidden なので、視覚的な指標を出さない場合は
+// これを置かないと支援技術には理由のない空領域になる。
+const LOCKED_SCREEN_READER_NOTICE = (
+  <p className="sr-only">この内容は Pro プラン限定です</p>
+);
+
 /**
  * 無料ユーザーに見せたくない実データや、Pro 機能のサンプル UI を暗幕で覆い、
- * 上に Pro 訴求（カード / バッジ）を重ねる。entitlement を持つ場合は children を素通しする。
+ * 上に Pro 訴求（カード / バッジ）を重ねる。ロックが解除されている場合は children を素通しする。
  */
 export function ProUpsellOverlay({
   feature,
   children,
+  unlocked,
   lockedIndicator = "card",
   title,
   description,
   benefits,
   ctaLabel,
+  onCtaClick,
+  defaultPlan,
   scrimOpacity = DEFAULT_SCRIM_OPACITY,
   className,
 }: ProUpsellOverlayProps) {
   const { hasEntitlement, isLoading } = useEntitlement();
 
-  if (hasEntitlement(feature)) return <>{children}</>;
+  if (unlocked ?? hasEntitlement(feature)) return <>{children}</>;
 
+  // unlocked が明示されていれば entitlement を参照しないため、判定の確定を待つ必要はない。
+  const isResolvingEntitlement = unlocked === undefined && isLoading;
   // 判定確定前は暗幕だけの中立表示にして、Pro へ倒れた瞬間に訴求が一瞬見えるのを防ぐ。
-  const indicator = isLoading ? "none" : lockedIndicator;
+  const indicator = isResolvingEntitlement ? "none" : lockedIndicator;
 
   return (
     <div
-      className={`relative overflow-hidden rounded-lg ${indicator === "card" ? "min-h-[200px]" : ""} ${className ?? ""}`}
+      // 高さは判定確定前後で変えない。indicator ではなく lockedIndicator を見ることで
+      // 訴求カードの出現時にレイアウトシフトが起きないようにする。
+      className={`relative overflow-hidden rounded-lg ${lockedIndicator === "card" ? "min-h-[200px]" : ""} ${className ?? ""}`}
     >
       {/* 暗幕の裏に残る実データをスクリーンリーダー・キーボード操作からも切り離す。 */}
       <div inert aria-hidden="true" className="pointer-events-none select-none">
         {children}
       </div>
       <div
+        data-testid="pro-upsell-scrim"
         aria-hidden="true"
-        className="absolute inset-0 backdrop-blur-[2px]"
+        className="pointer-events-none absolute inset-0 backdrop-blur-[2px]"
         style={{ backgroundColor: `rgba(26, 26, 26, ${scrimOpacity})` }}
       />
       {indicator === "card" ? (
@@ -67,19 +101,17 @@ export function ProUpsellOverlay({
             description={description}
             benefits={benefits}
             ctaLabel={ctaLabel}
+            onCtaClick={onCtaClick}
+            defaultPlan={defaultPlan}
             appearance="translucent"
             className="w-full max-w-sm"
           />
         </div>
       ) : null}
-      {indicator === "badge" ? (
-        <div className="absolute inset-0 flex items-center justify-center p-3">
-          <span className="inline-flex items-center gap-1 rounded-full bg-[#3A3A3A]/90 px-2.5 py-1 text-[11px] font-bold text-white">
-            <LockClosedIcon className="h-3 w-3 shrink-0" aria-hidden />
-            Pro限定
-          </span>
-        </div>
-      ) : null}
+      {indicator === "badge" ? LOCKED_BADGE : null}
+      {indicator === "none" && !isResolvingEntitlement
+        ? LOCKED_SCREEN_READER_NOTICE
+        : null}
     </div>
   );
 }

--- a/app/components/pro/SampleDataLabel.tsx
+++ b/app/components/pro/SampleDataLabel.tsx
@@ -1,0 +1,20 @@
+import { EyeIcon } from "@heroicons/react/24/outline";
+
+interface SampleDataLabelProps {
+  className?: string;
+}
+
+/**
+ * サンプル UI の上に表示する見出し。
+ * 無料ユーザー向けの Pro 機能プレビューであり、本人の記録ではないことを明示する。
+ */
+export function SampleDataLabel({ className }: SampleDataLabelProps) {
+  return (
+    <p
+      className={`flex items-center gap-1.5 text-xs font-semibold text-zic-400 ${className ?? ""}`}
+    >
+      <EyeIcon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      サンプルデータ（実際の記録ではありません）
+    </p>
+  );
+}

--- a/app/components/pro/__tests__/ProUpsellCard.test.tsx
+++ b/app/components/pro/__tests__/ProUpsellCard.test.tsx
@@ -5,11 +5,22 @@ jest.mock("@app/contexts/proUpgradeModalContext", () => ({
   useProUpgradeModal: () => ({ open: openMock, close: closeMock }),
 }));
 
+jest.mock("@app/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
 import { render, screen, fireEvent } from "@testing-library/react";
-import { PRO_PAYWALL_COPY } from "../paywallCopy";
+import { trackEvent } from "@app/lib/analytics";
+import { DEFAULT_PAYWALL_COPY, PRO_PAYWALL_COPY } from "../paywallCopy";
 import { ProUpsellCard } from "../ProUpsellCard";
 
+const mockTrackEvent = trackEvent as jest.MockedFunction<typeof trackEvent>;
+
 const noteTagsCopy = PRO_PAYWALL_COPY.note_tags;
+// benefits を持たない機能。description 経路の検証に使う
+const noAdsCopy = PRO_PAYWALL_COPY.no_ads;
+
+const ctaName = (title: string) => `Pro プランを見る（${title}）`;
 
 describe("ProUpsellCard", () => {
   beforeEach(() => {
@@ -17,16 +28,27 @@ describe("ProUpsellCard", () => {
   });
 
   it("feature を渡すと PRO_PAYWALL_COPY の文言を表示する", () => {
+    render(<ProUpsellCard feature="no_ads" />);
+
+    expect(screen.getByText(noAdsCopy.title)).toBeInTheDocument();
+    expect(screen.getByText(noAdsCopy.description)).toBeInTheDocument();
+  });
+
+  it("feature の benefits があれば description の代わりに箇条書きを表示する", () => {
     render(<ProUpsellCard feature="note_tags" />);
 
-    expect(screen.getByText(noteTagsCopy.title)).toBeInTheDocument();
-    expect(screen.getByText(noteTagsCopy.description)).toBeInTheDocument();
+    for (const benefit of noteTagsCopy.benefits ?? []) {
+      expect(screen.getByText(benefit)).toBeInTheDocument();
+    }
+    expect(
+      screen.queryByText(noteTagsCopy.description),
+    ).not.toBeInTheDocument();
   });
 
   it("title / description を渡すと feature の文言より優先して表示する", () => {
     render(
       <ProUpsellCard
-        feature="note_tags"
+        feature="no_ads"
         title="独自タイトル"
         description="独自の説明"
       />,
@@ -34,37 +56,119 @@ describe("ProUpsellCard", () => {
 
     expect(screen.getByText("独自タイトル")).toBeInTheDocument();
     expect(screen.getByText("独自の説明")).toBeInTheDocument();
-    expect(screen.queryByText(noteTagsCopy.title)).not.toBeInTheDocument();
+    expect(screen.queryByText(noAdsCopy.title)).not.toBeInTheDocument();
   });
 
   it("benefits を渡すと description ではなく箇条書きを表示する", () => {
     render(
       <ProUpsellCard
-        feature="note_tags"
+        feature="no_ads"
         benefits={["タグで分類", "タグから検索"]}
       />,
     );
 
     expect(screen.getByText("タグで分類")).toBeInTheDocument();
     expect(screen.getByText("タグから検索")).toBeInTheDocument();
+    expect(screen.queryByText(noAdsCopy.description)).not.toBeInTheDocument();
+  });
+
+  it("feature も description も無い場合は共通の既定文言で本文を埋める", () => {
+    render(<ProUpsellCard title="準備中の機能" />);
+
+    expect(screen.getByText("準備中の機能")).toBeInTheDocument();
     expect(
-      screen.queryByText(noteTagsCopy.description),
-    ).not.toBeInTheDocument();
+      screen.getByText(DEFAULT_PAYWALL_COPY.description),
+    ).toBeInTheDocument();
   });
 
   it("CTA を押すと feature を trigger にして ProUpgradeModal が開く", () => {
     render(<ProUpsellCard feature="note_tags" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Pro プランを見る" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: ctaName(noteTagsCopy.title) }),
+    );
 
-    expect(openMock).toHaveBeenCalledWith({ trigger: "note_tags" });
+    expect(openMock).toHaveBeenCalledWith({
+      trigger: "note_tags",
+      defaultPlan: undefined,
+    });
+  });
+
+  it("defaultPlan を渡すとモーダルの初期プランとして引き継がれる", () => {
+    render(<ProUpsellCard feature="note_tags" defaultPlan="monthly" />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: ctaName(noteTagsCopy.title) }),
+    );
+
+    expect(openMock).toHaveBeenCalledWith({
+      trigger: "note_tags",
+      defaultPlan: "monthly",
+    });
   });
 
   it("feature を持たない場合は trigger なしで ProUpgradeModal が開く", () => {
     render(<ProUpsellCard title="準備中の機能" ctaLabel="詳しく見る" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "詳しく見る" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "詳しく見る（準備中の機能）" }),
+    );
 
-    expect(openMock).toHaveBeenCalledWith({ trigger: undefined });
+    expect(openMock).toHaveBeenCalledWith({
+      trigger: undefined,
+      defaultPlan: undefined,
+    });
+  });
+
+  it("onCtaClick を渡すと既定のモーダル起動の代わりに呼ばれる", () => {
+    const onCtaClick = jest.fn();
+    render(<ProUpsellCard feature="note_tags" onCtaClick={onCtaClick} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: ctaName(noteTagsCopy.title) }),
+    );
+
+    expect(onCtaClick).toHaveBeenCalledTimes(1);
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  it("CTA 押下を feature 付きで計測する", () => {
+    render(<ProUpsellCard feature="note_tags" />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: ctaName(noteTagsCopy.title) }),
+    );
+
+    expect(mockTrackEvent).toHaveBeenCalledWith("pro_upsell_cta_click", {
+      feature: "note_tags",
+    });
+  });
+
+  it("onCtaClick で挙動を差し替えても計測は発火する", () => {
+    render(<ProUpsellCard title="準備中の機能" onCtaClick={jest.fn()} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: ctaName("準備中の機能") }),
+    );
+
+    expect(mockTrackEvent).toHaveBeenCalledWith("pro_upsell_cta_click", {
+      feature: "unspecified",
+    });
+  });
+
+  it("CTA のアクセシブル名に見出しを含めて他ブロックと区別できる", () => {
+    render(
+      <>
+        <ProUpsellCard feature="hit_direction_average" />
+        <ProUpsellCard feature="pitch_type_average" />
+      </>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: ctaName("方向別の打率") }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: ctaName("球種別の打率") }),
+    ).toBeInTheDocument();
   });
 });

--- a/app/components/pro/__tests__/ProUpsellCard.test.tsx
+++ b/app/components/pro/__tests__/ProUpsellCard.test.tsx
@@ -1,0 +1,70 @@
+const openMock = jest.fn();
+const closeMock = jest.fn();
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: openMock, close: closeMock }),
+}));
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PRO_PAYWALL_COPY } from "../paywallCopy";
+import { ProUpsellCard } from "../ProUpsellCard";
+
+const noteTagsCopy = PRO_PAYWALL_COPY.note_tags;
+
+describe("ProUpsellCard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("feature を渡すと PRO_PAYWALL_COPY の文言を表示する", () => {
+    render(<ProUpsellCard feature="note_tags" />);
+
+    expect(screen.getByText(noteTagsCopy.title)).toBeInTheDocument();
+    expect(screen.getByText(noteTagsCopy.description)).toBeInTheDocument();
+  });
+
+  it("title / description を渡すと feature の文言より優先して表示する", () => {
+    render(
+      <ProUpsellCard
+        feature="note_tags"
+        title="独自タイトル"
+        description="独自の説明"
+      />,
+    );
+
+    expect(screen.getByText("独自タイトル")).toBeInTheDocument();
+    expect(screen.getByText("独自の説明")).toBeInTheDocument();
+    expect(screen.queryByText(noteTagsCopy.title)).not.toBeInTheDocument();
+  });
+
+  it("benefits を渡すと description ではなく箇条書きを表示する", () => {
+    render(
+      <ProUpsellCard
+        feature="note_tags"
+        benefits={["タグで分類", "タグから検索"]}
+      />,
+    );
+
+    expect(screen.getByText("タグで分類")).toBeInTheDocument();
+    expect(screen.getByText("タグから検索")).toBeInTheDocument();
+    expect(
+      screen.queryByText(noteTagsCopy.description),
+    ).not.toBeInTheDocument();
+  });
+
+  it("CTA を押すと feature を trigger にして ProUpgradeModal が開く", () => {
+    render(<ProUpsellCard feature="note_tags" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Pro プランを見る" }));
+
+    expect(openMock).toHaveBeenCalledWith({ trigger: "note_tags" });
+  });
+
+  it("feature を持たない場合は trigger なしで ProUpgradeModal が開く", () => {
+    render(<ProUpsellCard title="準備中の機能" ctaLabel="詳しく見る" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "詳しく見る" }));
+
+    expect(openMock).toHaveBeenCalledWith({ trigger: undefined });
+  });
+});

--- a/app/components/pro/__tests__/ProUpsellOverlay.test.tsx
+++ b/app/components/pro/__tests__/ProUpsellOverlay.test.tsx
@@ -1,0 +1,140 @@
+const openMock = jest.fn();
+const closeMock = jest.fn();
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: openMock, close: closeMock }),
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { ProUpsellOverlay } from "../ProUpsellOverlay";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+
+function mockEntitlement({
+  granted,
+  isLoading = false,
+}: {
+  granted: boolean;
+  isLoading?: boolean;
+}) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: granted,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading,
+    hasEntitlement: jest.fn(() => granted),
+  });
+}
+
+function renderOverlay() {
+  return render(
+    <ProUpsellOverlay feature="hit_direction_average">
+      <p>打率 .333</p>
+      <button type="button">詳細を見る</button>
+    </ProUpsellOverlay>,
+  );
+}
+
+const ctaQuery = { name: "Pro プランを見る" } as const;
+
+describe("ProUpsellOverlay", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("entitlement を持つ場合、children をそのまま表示し訴求を出さない", () => {
+    mockEntitlement({ granted: true });
+
+    renderOverlay();
+
+    expect(screen.getByText("打率 .333")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "詳細を見る" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", ctaQuery)).not.toBeInTheDocument();
+  });
+
+  it("entitlement を持たない場合、暗幕と CTA 付きカードを重ねて表示する", () => {
+    mockEntitlement({ granted: false });
+
+    renderOverlay();
+
+    expect(screen.getByRole("button", ctaQuery)).toBeInTheDocument();
+    expect(screen.getByText("方向別の打率")).toBeInTheDocument();
+  });
+
+  it("覆われた children は支援技術・キーボード操作から隠れる", () => {
+    mockEntitlement({ granted: false });
+
+    renderOverlay();
+
+    const hiddenContainer = screen.getByText("打率 .333").parentElement;
+    expect(hiddenContainer).toHaveAttribute("aria-hidden", "true");
+    expect(hiddenContainer).toHaveAttribute("inert");
+    // aria-hidden 配下は role 検索の対象外になる（＝スクリーンリーダーから辿れない）
+    expect(
+      screen.queryByRole("button", { name: "詳細を見る" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("判定確定前は暗幕のみで、訴求カードをフラッシュさせない", () => {
+    mockEntitlement({ granted: false, isLoading: true });
+
+    renderOverlay();
+
+    expect(screen.queryByRole("button", ctaQuery)).not.toBeInTheDocument();
+    expect(screen.queryByText("方向別の打率")).not.toBeInTheDocument();
+    expect(screen.getByText("打率 .333").parentElement).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+
+  it("CTA を押すと feature を trigger にして ProUpgradeModal が開く", () => {
+    mockEntitlement({ granted: false });
+
+    renderOverlay();
+    fireEvent.click(screen.getByRole("button", ctaQuery));
+
+    expect(openMock).toHaveBeenCalledWith({ trigger: "hit_direction_average" });
+  });
+
+  it("lockedIndicator が badge の場合、CTA カードの代わりにバッジを表示する", () => {
+    mockEntitlement({ granted: false });
+
+    render(
+      <ProUpsellOverlay feature="hit_direction_average" lockedIndicator="badge">
+        <p>打率 .333</p>
+      </ProUpsellOverlay>,
+    );
+
+    expect(screen.getByText("Pro限定")).toBeInTheDocument();
+    expect(screen.queryByRole("button", ctaQuery)).not.toBeInTheDocument();
+  });
+
+  it("文言を上書きすると PRO_PAYWALL_COPY より優先される", () => {
+    mockEntitlement({ granted: false });
+
+    render(
+      <ProUpsellOverlay
+        feature="hit_direction_average"
+        title="方向別の打率は Pro 限定"
+        benefits={["引っ張り・流し打ちの傾向がわかる"]}
+      >
+        <p>打率 .333</p>
+      </ProUpsellOverlay>,
+    );
+
+    expect(screen.getByText("方向別の打率は Pro 限定")).toBeInTheDocument();
+    expect(
+      screen.getByText("引っ張り・流し打ちの傾向がわかる"),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/components/pro/__tests__/ProUpsellOverlay.test.tsx
+++ b/app/components/pro/__tests__/ProUpsellOverlay.test.tsx
@@ -5,136 +5,258 @@ jest.mock("@app/contexts/proUpgradeModalContext", () => ({
   useProUpgradeModal: () => ({ open: openMock, close: closeMock }),
 }));
 
-jest.mock("@app/hooks/pro/useEntitlement", () => ({
-  useEntitlement: jest.fn(),
+jest.mock("@app/(app)/pro/actions", () => ({
+  getProStatus: jest.fn(),
 }));
 
-import { render, screen, fireEvent } from "@testing-library/react";
-import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { act, render, screen, fireEvent } from "@testing-library/react";
+import { type ReactElement, type ReactNode } from "react";
+import { getProStatus } from "@app/(app)/pro/actions";
+import { ProStatusProvider } from "@app/components/pro/ProStatusProvider";
+import { DEFAULT_PRO_STATUS, type ProStatus } from "@app/types/pro";
 import { ProUpsellOverlay } from "../ProUpsellOverlay";
 
-const mockUseEntitlement = useEntitlement as jest.MockedFunction<
-  typeof useEntitlement
+const mockGetProStatus = getProStatus as jest.MockedFunction<
+  typeof getProStatus
 >;
 
-function mockEntitlement({
-  granted,
-  isLoading = false,
-}: {
-  granted: boolean;
-  isLoading?: boolean;
-}) {
-  mockUseEntitlement.mockReturnValue({
-    isPro: granted,
-    inTrial: false,
-    inGracePeriod: false,
-    isLoading,
-    hasEntitlement: jest.fn(() => granted),
+const FEATURE = "hit_direction_average";
+
+const ctaQuery = { name: "Pro プランを見る（方向別の打率）" } as const;
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <ProStatusProvider>{children}</ProStatusProvider>
+);
+
+function setAuthCookies() {
+  document.cookie = "access-token=test-access-token";
+  document.cookie = "client=test-client";
+  document.cookie = "uid=user@example.com";
+}
+
+function clearAuthCookies() {
+  for (const name of ["access-token", "client", "uid"]) {
+    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+  }
+}
+
+function makeProStatus(entitlements: string[]): ProStatus {
+  return {
+    subscription: {
+      ...DEFAULT_PRO_STATUS.subscription,
+      status: "active",
+      pro_active: true,
+    },
+    entitlements: [
+      ...DEFAULT_PRO_STATUS.entitlements,
+      ...entitlements,
+    ] as ProStatus["entitlements"],
+  };
+}
+
+/**
+ * ProStatusProvider の Server Action 解決を待って描画する。
+ * proStatus に null を渡すと未認証（＝無料確定）として扱う。
+ */
+async function renderResolved(ui: ReactElement, proStatus: ProStatus | null) {
+  if (proStatus) {
+    setAuthCookies();
+    mockGetProStatus.mockResolvedValue(proStatus);
+  }
+
+  let rendered!: ReturnType<typeof render>;
+  await act(async () => {
+    rendered = render(ui, { wrapper: Wrapper });
   });
+  return rendered;
 }
 
-function renderOverlay() {
-  return render(
-    <ProUpsellOverlay feature="hit_direction_average">
-      <p>打率 .333</p>
-      <button type="button">詳細を見る</button>
-    </ProUpsellOverlay>,
-  );
+/** Pro 判定が未確定のまま止まっている状態で描画する。 */
+async function renderPending(ui: ReactElement) {
+  setAuthCookies();
+  mockGetProStatus.mockReturnValue(new Promise(() => {}));
+
+  let rendered!: ReturnType<typeof render>;
+  await act(async () => {
+    rendered = render(ui, { wrapper: Wrapper });
+  });
+  return rendered;
 }
 
-const ctaQuery = { name: "Pro プランを見る" } as const;
+const overlay = (
+  props: Partial<React.ComponentProps<typeof ProUpsellOverlay>> = {},
+) => (
+  <ProUpsellOverlay feature={FEATURE} {...props}>
+    <p>打率 .333</p>
+    <button type="button">詳細を見る</button>
+  </ProUpsellOverlay>
+);
 
 describe("ProUpsellOverlay", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    clearAuthCookies();
   });
 
-  it("entitlement を持つ場合、children をそのまま表示し訴求を出さない", () => {
-    mockEntitlement({ granted: true });
-
-    renderOverlay();
+  it("entitlement を持つ場合、children をそのまま表示し訴求を出さない", async () => {
+    await renderResolved(overlay(), makeProStatus([FEATURE]));
 
     expect(screen.getByText("打率 .333")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "詳細を見る" }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", ctaQuery)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("pro-upsell-scrim")).not.toBeInTheDocument();
   });
 
-  it("entitlement を持たない場合、暗幕と CTA 付きカードを重ねて表示する", () => {
-    mockEntitlement({ granted: false });
+  it("entitlement を持たない場合、暗幕と CTA 付きカードを重ねて表示する", async () => {
+    await renderResolved(overlay(), null);
 
-    renderOverlay();
-
+    expect(screen.getByTestId("pro-upsell-scrim")).toBeInTheDocument();
     expect(screen.getByRole("button", ctaQuery)).toBeInTheDocument();
     expect(screen.getByText("方向別の打率")).toBeInTheDocument();
   });
 
-  it("覆われた children は支援技術・キーボード操作から隠れる", () => {
-    mockEntitlement({ granted: false });
-
-    renderOverlay();
+  it("覆われた children は支援技術・キーボード操作から隠れる", async () => {
+    await renderResolved(overlay(), null);
 
     const hiddenContainer = screen.getByText("打率 .333").parentElement;
     expect(hiddenContainer).toHaveAttribute("aria-hidden", "true");
     expect(hiddenContainer).toHaveAttribute("inert");
+    expect(hiddenContainer).toHaveClass("pointer-events-none");
     // aria-hidden 配下は role 検索の対象外になる（＝スクリーンリーダーから辿れない）
     expect(
       screen.queryByRole("button", { name: "詳細を見る" }),
     ).not.toBeInTheDocument();
   });
 
-  it("判定確定前は暗幕のみで、訴求カードをフラッシュさせない", () => {
-    mockEntitlement({ granted: false, isLoading: true });
+  describe("暗幕", () => {
+    it("children の全面を覆い、ポインタ操作を奪わない", async () => {
+      await renderResolved(overlay(), null);
 
-    renderOverlay();
+      const scrim = screen.getByTestId("pro-upsell-scrim");
+      expect(scrim).toHaveClass("absolute", "inset-0", "pointer-events-none");
+      expect(scrim).toHaveAttribute("aria-hidden", "true");
+    });
 
+    it("既定の不透明度で実データを読み取れないように塗る", async () => {
+      await renderResolved(overlay(), null);
+
+      expect(screen.getByTestId("pro-upsell-scrim")).toHaveStyle({
+        backgroundColor: "rgba(26, 26, 26, 0.68)",
+      });
+    });
+
+    it("scrimOpacity を指定すると不透明度に反映される", async () => {
+      await renderResolved(overlay({ scrimOpacity: 0.95 }), null);
+
+      expect(screen.getByTestId("pro-upsell-scrim")).toHaveStyle({
+        backgroundColor: "rgba(26, 26, 26, 0.95)",
+      });
+    });
+
+    it("訴求カードを出さない場合でも暗幕は残る", async () => {
+      await renderResolved(overlay({ lockedIndicator: "none" }), null);
+
+      expect(screen.getByTestId("pro-upsell-scrim")).toBeInTheDocument();
+    });
+  });
+
+  it("判定確定前は暗幕のみで、訴求カードをフラッシュさせない", async () => {
+    const { container } = await renderPending(overlay());
+
+    expect(screen.getByTestId("pro-upsell-scrim")).toBeInTheDocument();
     expect(screen.queryByRole("button", ctaQuery)).not.toBeInTheDocument();
     expect(screen.queryByText("方向別の打率")).not.toBeInTheDocument();
-    expect(screen.getByText("打率 .333").parentElement).toHaveAttribute(
-      "aria-hidden",
-      "true",
-    );
+    expect(
+      screen.queryByText("この内容は Pro プラン限定です"),
+    ).not.toBeInTheDocument();
+    // 判定確定後にカードが差し込まれても高さが変わらないようにしておく
+    expect(container.firstChild).toHaveClass("min-h-[200px]");
   });
 
-  it("CTA を押すと feature を trigger にして ProUpgradeModal が開く", () => {
-    mockEntitlement({ granted: false });
+  it("判定確定後もカード表示分の高さを維持したまま訴求へ切り替わる", async () => {
+    const { container } = await renderResolved(overlay(), null);
 
-    renderOverlay();
+    expect(container.firstChild).toHaveClass("min-h-[200px]");
+    expect(screen.getByRole("button", ctaQuery)).toBeInTheDocument();
+  });
+
+  it("CTA を押すと feature を trigger にして ProUpgradeModal が開く", async () => {
+    await renderResolved(overlay(), null);
+
     fireEvent.click(screen.getByRole("button", ctaQuery));
 
-    expect(openMock).toHaveBeenCalledWith({ trigger: "hit_direction_average" });
+    expect(openMock).toHaveBeenCalledWith({
+      trigger: FEATURE,
+      defaultPlan: undefined,
+    });
   });
 
-  it("lockedIndicator が badge の場合、CTA カードの代わりにバッジを表示する", () => {
-    mockEntitlement({ granted: false });
+  it("onCtaClick を渡すと既定のモーダル起動の代わりに呼ばれる", async () => {
+    const onCtaClick = jest.fn();
+    await renderResolved(overlay({ onCtaClick }), null);
 
-    render(
-      <ProUpsellOverlay feature="hit_direction_average" lockedIndicator="badge">
-        <p>打率 .333</p>
-      </ProUpsellOverlay>,
-    );
+    fireEvent.click(screen.getByRole("button", ctaQuery));
+
+    expect(onCtaClick).toHaveBeenCalledTimes(1);
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  it("lockedIndicator が badge の場合、CTA カードの代わりにバッジを表示する", async () => {
+    await renderResolved(overlay({ lockedIndicator: "badge" }), null);
 
     expect(screen.getByText("Pro限定")).toBeInTheDocument();
     expect(screen.queryByRole("button", ctaQuery)).not.toBeInTheDocument();
   });
 
-  it("文言を上書きすると PRO_PAYWALL_COPY より優先される", () => {
-    mockEntitlement({ granted: false });
+  it("lockedIndicator が none の場合でもロック中であることを支援技術へ伝える", async () => {
+    await renderResolved(overlay({ lockedIndicator: "none" }), null);
 
-    render(
-      <ProUpsellOverlay
-        feature="hit_direction_average"
-        title="方向別の打率は Pro 限定"
-        benefits={["引っ張り・流し打ちの傾向がわかる"]}
-      >
-        <p>打率 .333</p>
-      </ProUpsellOverlay>,
+    expect(
+      screen.getByText("この内容は Pro プラン限定です"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", ctaQuery)).not.toBeInTheDocument();
+    expect(screen.queryByText("Pro限定")).not.toBeInTheDocument();
+  });
+
+  it("文言を上書きすると PRO_PAYWALL_COPY より優先される", async () => {
+    await renderResolved(
+      overlay({
+        title: "方向別の打率は Pro 限定",
+        benefits: ["引っ張り・流し打ちの傾向がわかる"],
+      }),
+      null,
     );
 
     expect(screen.getByText("方向別の打率は Pro 限定")).toBeInTheDocument();
     expect(
       screen.getByText("引っ張り・流し打ちの傾向がわかる"),
     ).toBeInTheDocument();
+  });
+
+  describe("unlocked を明示した場合", () => {
+    it("false なら entitlement を持つユーザーにもロックを見せる", async () => {
+      await renderResolved(
+        overlay({ unlocked: false }),
+        makeProStatus([FEATURE]),
+      );
+
+      expect(screen.getByTestId("pro-upsell-scrim")).toBeInTheDocument();
+      expect(screen.getByRole("button", ctaQuery)).toBeInTheDocument();
+    });
+
+    it("false なら判定確定を待たずに訴求カードを出す", async () => {
+      await renderPending(overlay({ unlocked: false }));
+
+      expect(screen.getByRole("button", ctaQuery)).toBeInTheDocument();
+    });
+
+    it("true なら entitlement を持たないユーザーにも children を素通しする", async () => {
+      await renderResolved(overlay({ unlocked: true }), null);
+
+      expect(screen.getByText("打率 .333")).toBeInTheDocument();
+      expect(screen.queryByTestId("pro-upsell-scrim")).not.toBeInTheDocument();
+    });
   });
 });

--- a/app/components/pro/__tests__/SampleDataLabel.test.tsx
+++ b/app/components/pro/__tests__/SampleDataLabel.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from "@testing-library/react";
+import { SampleDataLabel } from "../SampleDataLabel";
+
+describe("SampleDataLabel", () => {
+  it("サンプルデータである旨を明示するテキストを表示する", () => {
+    render(<SampleDataLabel />);
+
+    expect(
+      screen.getByText("サンプルデータ（実際の記録ではありません）"),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/components/pro/paywallCopy.ts
+++ b/app/components/pro/paywallCopy.ts
@@ -2,8 +2,8 @@ import type { ProFeature } from "@app/types/pro";
 
 /**
  * Pro 機能ごとの訴求文言。ProUpgradeModal・ProUpsellCard・ProUpsellOverlay が同じ文言を参照する。
- * ProUpgradeModal（HeroUI / Stripe 依存の Client Component）から切り出すことで、
- * 文言だけを使いたい軽量コンポーネントがモーダル一式をバンドルに引き込まずに済む。
+ * 特定のコンポーネントに属さないドメインデータとして独立させることで、
+ * 文言の追加・修正が UI 実装から切り離され、参照側が増えても定義箇所が分散しない。
  */
 export interface PaywallCopy {
   title: string;
@@ -29,6 +29,11 @@ export const PRO_PAYWALL_COPY: Record<ProFeature, PaywallCopy> = {
     title: "練習履歴を全期間で確認",
     description:
       "草機能のヒートマップを全期間で表示。継続の積み重ねを実感できます。",
+    benefits: [
+      "直近1年を超える練習履歴もヒートマップで振り返り",
+      "去年の同じ時期と練習量を並べて比較",
+      "最も続いた期間や積み上げた日数をいつでも確認",
+    ],
   },
   unlimited_practice_menus: {
     title: "練習メニューを無制限に登録",
@@ -82,6 +87,11 @@ export const PRO_PAYWALL_COPY: Record<ProFeature, PaywallCopy> = {
     title: "練習と成績の関係を発見",
     description:
       "素振りや睡眠と打率の傾向を、あなたのデータから自動で読み解きます。",
+    benefits: [
+      "素振りの本数と打率の関係を自動で分析",
+      "睡眠やコンディションと成績のつながりを可視化",
+      "成果につながっている練習を数字で確認",
+    ],
   },
   unlimited_reflection_templates: {
     title: "振り返りテンプレを自由に作成",
@@ -97,6 +107,11 @@ export const PRO_PAYWALL_COPY: Record<ProFeature, PaywallCopy> = {
     title: "野球ノートにタグを付けて整理",
     description:
       "Pro プランなら野球ノートにタグを付けて、後から振り返りやすく整理できます。",
+    benefits: [
+      "練習の気づきや試合の振り返りをタグで分類",
+      "過去のノートをタグから素早く検索",
+      "自分専用のタグも自由に作成可能",
+    ],
   },
   multi_game_result_notes: {
     title: "1つのノートに複数の試合を紐付け",
@@ -151,6 +166,11 @@ export const PRO_PAYWALL_COPY: Record<ProFeature, PaywallCopy> = {
   hit_direction_average: {
     title: "方向別の打率",
     description: "打球を打った方向ごとの打率をヒートマップで可視化します。",
+    benefits: [
+      "引っ張り・センター返し・流し打ちの傾向が一目でわかる",
+      "方向ごとの打率をヒートマップで比較",
+      "打てていない方向を練習テーマに落とし込める",
+    ],
   },
   count_situation_average: {
     title: "カウント別の打率",

--- a/app/components/pro/paywallCopy.ts
+++ b/app/components/pro/paywallCopy.ts
@@ -1,0 +1,173 @@
+import type { ProFeature } from "@app/types/pro";
+
+/**
+ * Pro 機能ごとの訴求文言。ProUpgradeModal・ProUpsellCard・ProUpsellOverlay が同じ文言を参照する。
+ * ProUpgradeModal（HeroUI / Stripe 依存の Client Component）から切り出すことで、
+ * 文言だけを使いたい軽量コンポーネントがモーダル一式をバンドルに引き込まずに済む。
+ */
+export interface PaywallCopy {
+  title: string;
+  description: string;
+  /** 2〜4行の具体的なメリット箇条書き。指定時は description より優先して表示する。 */
+  benefits?: string[];
+}
+
+// trigger に応じた「なぜこのモーダルを開いたか」のコンテキスト訴求。
+// PaywallModal 時代に画面ごとに最適化していたコピーをそのまま流用。
+export const PRO_PAYWALL_COPY: Record<ProFeature, PaywallCopy> = {
+  no_ads: {
+    title: "広告を非表示にして集中する",
+    description:
+      "Pro プランに加入すると、アプリ内のすべての広告が非表示になります。",
+  },
+  season_transition_graph: {
+    title: "シーズンを跨いだ成長を可視化",
+    description:
+      "過去複数シーズンの成績を折れ線グラフで比較して、長期的な成長を確認できます。",
+  },
+  grass_full_history: {
+    title: "練習履歴を全期間で確認",
+    description:
+      "草機能のヒートマップを全期間で表示。継続の積み重ねを実感できます。",
+  },
+  unlimited_practice_menus: {
+    title: "練習メニューを無制限に登録",
+    description:
+      "Pro プランなら4つ目以降の練習メニューも自由に登録・編集できます。",
+  },
+  unlimited_media_uploads: {
+    title: "動画・画像を無制限にアップロード",
+    description: "月3点までの制限を撤廃。練習映像をいくらでも保存できます。",
+  },
+  schedule_copy_next_week: {
+    title: "今週のプランを来週にまるごとコピー",
+    description:
+      "Pro プランなら今週登録した予定をワンタップで来週にコピーでき、プラン作りの手間を省けます。",
+  },
+  unlimited_menu_sets: {
+    title: "メニューセットを無制限に作成",
+    description:
+      "よく組む練習をセットにして、予定登録や週プランでそのまま使い回せます。",
+  },
+  unlimited_monthly_goals: {
+    title: "個人の期間目標を無制限に設定",
+    description:
+      "月次・週次・年間の目標を3つ以上、同時に管理できます（無料は合計2つまで）。",
+  },
+  season_goals: {
+    title: "シーズン目標を設定",
+    description:
+      "1シーズンを通した中長期目標を設定し、月次目標と紐づけて追跡できます。",
+  },
+  tournament_goals: {
+    title: "大会目標を設定",
+    description:
+      "特定の大会に向けた目標を設定し、その大会の成績で達成を追跡できます。",
+  },
+  custom_notification_messages: {
+    title: "通知メッセージをカスタマイズ",
+    description: "練習リマインドや目標達成通知の文言を自分好みに編集できます。",
+  },
+  detailed_condition_log: {
+    title: "コンディションを詳しく記録",
+    description:
+      "体調・気分・睡眠などを細かく記録し、調子の良し悪しの傾向を把握できます。",
+  },
+  unlimited_improvement_themes: {
+    title: "取り組む課題を無制限に",
+    description:
+      "複数の課題を同時に設定して、練習やノートをそれぞれの課題に束ねられます。",
+  },
+  correlation_insights: {
+    title: "練習と成績の関係を発見",
+    description:
+      "素振りや睡眠と打率の傾向を、あなたのデータから自動で読み解きます。",
+  },
+  unlimited_reflection_templates: {
+    title: "振り返りテンプレを自由に作成",
+    description:
+      "自分専用の問いかけテンプレをいくつでも作って、振り返りの質を高められます。",
+  },
+  advanced_periodic_review: {
+    title: "週次・月次の振り返りレポートを受け取る",
+    description:
+      "練習量や成績の変化、課題別の取り組み状況、練習と成績のつながりを週末・月末に自動でまとめてお届けします。",
+  },
+  note_tags: {
+    title: "野球ノートにタグを付けて整理",
+    description:
+      "Pro プランなら野球ノートにタグを付けて、後から振り返りやすく整理できます。",
+  },
+  multi_game_result_notes: {
+    title: "1つのノートに複数の試合を紐付け",
+    description:
+      "Pro プランなら1つの野球ノートに複数の試合記録を紐付けて振り返れます。",
+  },
+  multi_improvement_theme_links: {
+    title: "1つの記録に複数の課題を紐付け",
+    description:
+      "Pro プランなら練習記録・野球ノートに複数の課題を同時に紐付けて、取り組みをまとめて振り返れます。",
+  },
+  practice_menu_trend_detail: {
+    title: "メニューごとの推移を詳しく見る",
+    description:
+      "期間を絞ったグラフや数値の内訳など、メニューごとの詳細な推移をいつでも振り返れます。",
+  },
+  custom_period_goals: {
+    title: "カスタム期間で目標を設定",
+    description:
+      "「大会前3週間」のように自分で決めた期間で目標を設定し、進み具合を追跡できます。",
+  },
+  manual_metric_goals: {
+    title: "自由指標で目標を設定",
+    description:
+      "球速や体重など、アプリが自動集計できない自分だけの指標も目標にして手入力で管理できます。",
+  },
+  shadow_swing_custom_interval: {
+    title: "インターバルを自由に設定",
+    description:
+      "1秒〜20秒の全範囲でインターバルを設定できます。自分のテンポに合わせて素振りを鍛えましょう。",
+  },
+  shadow_swing_vibration: {
+    title: "バイブレーションでテンポを取る",
+    description:
+      "音を出せない場所でもバイブレーションでインターバルを把握しながら素振りできます。",
+  },
+  shadow_swing_background: {
+    title: "バックグラウンドでも継続実行",
+    description:
+      "画面ロックやアプリの切り替えで途切れず、素振りの本数と経過時間をそのまま継続できます。",
+  },
+  schedule_calendar_full_history: {
+    title: "カレンダーを全期間閲覧",
+    description:
+      "先々の予定や過去の練習プランも、月を遡らずカレンダーでいつでも確認できます。",
+  },
+  unlimited_groups: {
+    title: "グループを無制限に作成・参加",
+    description:
+      "Pro プランなら2つ目以降のグループも自由に作成・参加できます。チームを掛け持ちしているメンバーも安心です。",
+  },
+  hit_direction_average: {
+    title: "方向別の打率",
+    description: "打球を打った方向ごとの打率をヒートマップで可視化します。",
+  },
+  count_situation_average: {
+    title: "カウント別の打率",
+    description:
+      "初球・有利カウント・追い込みなど、カウント状況別の打率がわかります。",
+  },
+  pitch_type_average: {
+    title: "球種別の打率",
+    description: "ストレートや変化球など、球種ごとの得意・苦手が分析できます。",
+  },
+  pitcher_faceoff_average: {
+    title: "対戦投手別",
+    description: "対戦した投手ごとの打撃成績を一覧で確認できます。",
+  },
+};
+
+export const DEFAULT_PAYWALL_COPY: PaywallCopy = {
+  title: "BUZZ BASE Pro でもっと深く野球を",
+  description: "Pro プランで全機能のロックを解除できます。",
+};

--- a/app/hooks/pro/__tests__/useEntitlement.test.tsx
+++ b/app/hooks/pro/__tests__/useEntitlement.test.tsx
@@ -108,6 +108,36 @@ describe("useEntitlement", () => {
     });
   });
 
+  describe("Pro 状態が解決したとき", () => {
+    it("isLoading が false に変わり、Pro 機能の判定が有効になる", async () => {
+      setAuthCookies();
+      let resolveProStatus!: (status: ProStatus) => void;
+      mockGetProStatus.mockReturnValue(
+        new Promise<ProStatus>((resolve) => {
+          resolveProStatus = resolve;
+        }),
+      );
+
+      let rendered!: RenderHookResult<
+        ReturnType<typeof useEntitlement>,
+        unknown
+      >;
+      await act(async () => {
+        rendered = renderHook(() => useEntitlement(), { wrapper: Wrapper });
+      });
+
+      expect(rendered.result.current.isLoading).toBe(true);
+      expect(rendered.result.current.hasEntitlement("no_ads")).toBe(false);
+
+      await act(async () => {
+        resolveProStatus(makeProActiveStatus());
+      });
+
+      expect(rendered.result.current.isLoading).toBe(false);
+      expect(rendered.result.current.hasEntitlement("no_ads")).toBe(true);
+    });
+  });
+
   describe("認証 cookie が揃っていない場合", () => {
     it("Server Action を呼ばずに無料状態で確定する", async () => {
       document.cookie = "uid=user@example.com";


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#454

## 概要

mobile は `ProUpsellCard` / `ProUpsellOverlay` / `SampleDataLabel` を前提に「サンプルを見せつつアップグレードを促す」出し分けを全 Pro 機能で行っているが、front は `ProGate` / `ProUpgradeModal` しかなくこのパターンが表現できなかった。各機能の Pro 対応をブロックしていたため、共通コンポーネントとして追加する。

## 変更内容

### 追加コンポーネント

- **`ProUpsellCard.tsx`** — 鍵アイコン + メリット箇条書き + CTA のカード
  - `feature` を渡すと `PRO_PAYWALL_COPY` から文言を自動解決。個別上書きも可能
  - copy props は判別可能ユニオンで、`feature` を渡さない場合は `title` が型レベルで必須
- **`ProUpsellOverlay.tsx`** — 子要素を暗幕 + `backdrop-blur` で覆い CTA を重ねる
  - `feature` を渡すだけで自身が `useEntitlement()` で判定する（`unlocked` / `loading` を外から受けない）
- **`SampleDataLabel.tsx`** — 「サンプルデータです」バッジ。Server Component
- **`paywallCopy.ts`**（新規・データのみ）— `PRO_PAYWALL_COPY` を `ProUpgradeModal.tsx` から切り出し

### 既存への変更

- `app/hooks/pro/useEntitlement.ts` — `isLoading` を追加（Pro 判定未確定時のフラッシュ抑止用）
- `app/components/pro/ProUpgradeModal.tsx` — `PRO_PAYWALL_COPY` を `paywallCopy.ts` へ移動（171行の移動のみ）

## 設計上の判断

- **`PRO_PAYWALL_COPY` の切り出し** — `ProUpgradeModal` は HeroUI / Stripe / sonner / Mantine を引き込むため、文言だけ使う軽量コンポーネントがそれをバンドルに巻き込むのを避けた（`.claude/rules/performance.md` のバンドルサイズ方針）
- **boolean プロップの回避** — `hideCard` → `lockedIndicator: "card" | "badge" | "none"`、`translucent` → `appearance` バリアント
- **RN → Web の置き換え** — `View`/`Text` → semantic HTML、`TouchableOpacity` → `<button type="button">`（キーボード操作可・`focus-visible:ring`）、`StyleSheet` → TailwindCSS
- **アクセシビリティ** — 覆った children を `inert` + `aria-hidden="true"` + `pointer-events-none` で包み、支援技術からも隠す（mobile の `accessibilityElementsHidden` 相当）

## 確認手順

1. `yarn typecheck` / `yarn lint` / `yarn format:check` / `yarn test` がすべて通ること
2. `ProUpsellOverlay.test.tsx` が「判定確定前にフラッシュしない」「覆った children が `getByRole` から辿れない」を検証していること

## レビューで見てほしい点

1. **`isLoading` の定義** — 現状 `ProStatusProvider` は Server Component 由来の `initialValue` を持つため「初回未確定」状態が存在せず、`isLoading` は実質「`refresh()` 実行中」を指す。`initialValue === null` を「未認証（確実に無料）」と「API 失敗（不明）」に区別する設計に踏み込むかは本 issue のスコープ外と判断した
2. **`PRO_PAYWALL_COPY` の切り出し**（既存ファイルの171行移動）を許容するか。`ProUpgradeModal.tsx` からそのまま export する案でも要件は満たせる
3. **`ProUpsellOverlay` の `feature` 必須** — mobile は `unlocked` を外から受けて entitlement キーなしでも覆えたが、front はそのケースを `ProUpsellCard` 単独設置に寄せる想定
4. **見た目は未検証** — まだどの画面にも組み込んでいないため、`scrimOpacity`（インラインの `rgba`）・`min-h-[200px]`・`backdrop-blur-[2px]` の実画面での見え方は要確認

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（43 suites / 315 tests）


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_