### PR TITLE
Add: 打撃推移・防御率推移にシーズン粒度を追加（Pro）

### DIFF
--- a/app/(app)/stats/__tests__/analysisActions.test.ts
+++ b/app/(app)/stats/__tests__/analysisActions.test.ts
@@ -184,6 +184,33 @@ describe("推移グラフのシーズン粒度", () => {
     expect(calledUrl()).toContain("granularity=month");
   });
 
+  // back の era_trend は points 形式で返す。過去にここが trend 形式の想定とずれて
+  // グラフが常に空になったため、URL だけでなくパース結果まで固定する。
+  it("getEraTrend はシーズン粒度のレスポンスをそのまま points として返す", async () => {
+    mockResponse(200, eraTrend);
+
+    await expect(getEraTrend({ year: "2026" }, "season")).resolves.toEqual({
+      status: "ok",
+      data: eraTrend,
+    });
+  });
+
+  it("getEraTrend は月粒度のレスポンスをそのまま points として返す", async () => {
+    const monthEraTrend = {
+      granularity: "month",
+      points: [
+        { key: "2026-04", label: "4月", era: 3.12 },
+        { key: "2026-05", label: "5月", era: 1.98 },
+      ],
+    };
+    mockResponse(200, monthEraTrend);
+
+    await expect(getEraTrend({ year: "2026" })).resolves.toEqual({
+      status: "ok",
+      data: monthEraTrend,
+    });
+  });
+
   it.each([
     ["getBattingTrend", getBattingTrend, battingTrend],
     ["getEraTrend", getEraTrend, eraTrend],

--- a/app/(app)/stats/__tests__/analysisActions.test.ts
+++ b/app/(app)/stats/__tests__/analysisActions.test.ts
@@ -10,7 +10,9 @@ jest.mock("../../../constants/api", () => ({
 }));
 
 import {
+  getBattingTrend,
   getCountSituations,
+  getEraTrend,
   getHitDirections,
   getPitcherFaceoffs,
   getPitchTypes,
@@ -123,5 +125,115 @@ describe("Pro 限定の分析 Server Actions", () => {
       directions: [],
       home_runs: [],
     });
+  });
+});
+
+describe("推移グラフのシーズン粒度", () => {
+  const battingTrend = {
+    granularity: "season",
+    points: [
+      {
+        key: "season-1",
+        label: "2026年 春季",
+        batting_average: 0.333,
+        on_base_percentage: 0.4,
+        slugging_percentage: 0.5,
+        ops: 0.9,
+        at_bats_in_period: 30,
+        cumulative_at_bats: 30,
+      },
+    ],
+  };
+  const eraTrend = {
+    granularity: "season",
+    points: [{ key: "season-1", label: "2026年 春季", era: 2.15 }],
+  };
+
+  function calledUrl(): string {
+    return (global.fetch as jest.Mock).mock.calls[0][0] as string;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    setupAuthCookies();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("getBattingTrend は granularity を送る", async () => {
+    mockResponse(200, battingTrend);
+
+    await expect(getBattingTrend({}, "season")).resolves.toEqual({
+      status: "ok",
+      data: battingTrend,
+    });
+    expect(calledUrl()).toContain("granularity=season");
+  });
+
+  it("getEraTrend は granularity を送り、既定は月粒度", async () => {
+    mockResponse(200, eraTrend);
+    await getEraTrend({ year: "2026" }, "season");
+    expect(calledUrl()).toContain("granularity=season");
+
+    (global.fetch as jest.Mock).mockClear();
+    mockResponse(200, { granularity: "month", points: [] });
+    await getEraTrend({ year: "2026" });
+    expect(calledUrl()).toContain("granularity=month");
+  });
+
+  it.each([
+    ["getBattingTrend", getBattingTrend, battingTrend],
+    ["getEraTrend", getEraTrend, eraTrend],
+  ] as const)(
+    "%s はシーズン粒度のとき season_id を送らない（1シーズンに縮退させない）",
+    async (_name, action, body) => {
+      mockResponse(200, body);
+
+      await action({ year: "通算", seasonId: "7" }, "season");
+
+      expect(calledUrl()).not.toContain("season_id");
+      expect(calledUrl()).toContain("granularity=season");
+    },
+  );
+
+  it("getBattingTrend はシーズン粒度以外では season_id を送る", async () => {
+    mockResponse(200, battingTrend);
+
+    await getBattingTrend({ year: "通算", seasonId: "7" }, "game");
+
+    expect(calledUrl()).toContain("season_id=7");
+  });
+
+  it("getEraTrend はシーズン粒度以外では season_id を送る", async () => {
+    mockResponse(200, eraTrend);
+
+    await getEraTrend({ year: "通算", seasonId: "7" }, "month");
+
+    expect(calledUrl()).toContain("season_id=7");
+  });
+
+  it.each([
+    ["getBattingTrend", getBattingTrend],
+    ["getEraTrend", getEraTrend],
+  ] as const)(
+    "%s はシーズン粒度が 403 なら status:pro_required を返す",
+    async (_name, action) => {
+      mockResponse(403, { error: "シーズン推移は Pro プラン限定です" });
+
+      await expect(action({}, "season")).resolves.toEqual({
+        status: "pro_required",
+      });
+    },
+  );
+
+  it("getEraTrend は match_type を送らない", async () => {
+    mockResponse(200, eraTrend);
+
+    await getEraTrend({ year: "2026", matchType: "regular" });
+
+    expect(calledUrl()).not.toContain("match_type");
   });
 });

--- a/app/(app)/stats/__tests__/analysisProFeatures.test.ts
+++ b/app/(app)/stats/__tests__/analysisProFeatures.test.ts
@@ -1,0 +1,46 @@
+import {
+  DEFAULT_PRO_STATUS,
+  PRO_FEATURES,
+  type Feature,
+  type ProStatus,
+} from "@app/types/pro";
+import {
+  SEASON_TREND_FEATURES,
+  grantedProFeatures,
+} from "../analysisProFeatures";
+
+function makeProStatus(entitlements: Feature[]): ProStatus {
+  return { ...DEFAULT_PRO_STATUS, entitlements };
+}
+
+describe("grantedProFeatures", () => {
+  it("entitlement を持つ機能だけ返す", () => {
+    const proStatus = makeProStatus([
+      ...DEFAULT_PRO_STATUS.entitlements,
+      "season_transition_graph",
+    ]);
+
+    expect(
+      grantedProFeatures(proStatus, [
+        "season_transition_graph",
+        "hit_direction_average",
+      ]),
+    ).toEqual(["season_transition_graph"]);
+  });
+
+  it("無料ユーザーには Pro 機能を渡さない", () => {
+    expect(
+      grantedProFeatures(DEFAULT_PRO_STATUS, SEASON_TREND_FEATURES),
+    ).toEqual([]);
+  });
+
+  it("未認証（Pro 状態が取れない）なら無料と同じ扱いにする", () => {
+    expect(grantedProFeatures(null, SEASON_TREND_FEATURES)).toEqual([]);
+  });
+
+  it("シーズン推移は season_transition_graph を要求する", () => {
+    expect(SEASON_TREND_FEATURES).toEqual(["season_transition_graph"]);
+    // entitlement キーが back とずれていないことを型定義側の一覧で担保する。
+    expect(PRO_FEATURES).toContain("season_transition_graph");
+  });
+});

--- a/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
@@ -6,6 +6,7 @@ import { ProUpsellOverlay } from "@app/components/pro/ProUpsellOverlay";
 import { SampleDataLabel } from "@app/components/pro/SampleDataLabel";
 import { useProGatedFeatures } from "@app/hooks/pro/useProGatedFeatures";
 import { useProGatedResource } from "@app/hooks/pro/useProGatedResource";
+import { useSeasonTrendGranularity } from "@app/hooks/pro/useSeasonTrendGranularity";
 import {
   type AnalysisFilters as Filters,
   type AnalysisInitialData,
@@ -109,8 +110,6 @@ export function AnalysisContainer({
   const [pitcherAttributes, setPitcherAttributes] = useState(
     initialData.pitcherAttributes,
   );
-  const [granularity, setGranularity] =
-    useState<BattingTrendGranularity>("game");
   const [sprayChartMode, setSprayChartMode] =
     useState<SprayChartMode>("scatter");
   const [battingTrend, setBattingTrend] = useState(initialData.battingTrend);
@@ -118,6 +117,13 @@ export function AnalysisContainer({
   // 推移グラフは粒度切替で単独再取得もあるため、専用の pending でグラフだけ dim する。
   const [isTrendPending, startTrendTransition] = useTransition();
   const [yearOptions] = useState(buildYearOptions);
+
+  const { granularity, requestGranularity, resolveTrend } =
+    useSeasonTrendGranularity<BattingTrendGranularity>({
+      seasonKey: "season",
+      freeKey: "game",
+      initialGranted: initialProFeatures,
+    });
 
   const { canView, unwrap } = useProGatedFeatures(initialProFeatures);
   const canViewHitDirectionDetail = canView("hit_direction_average");
@@ -209,13 +215,16 @@ export function AnalysisContainer({
     }
     let active = true;
     startTrendTransition(async () => {
-      const data = await getBattingTrend(filters, granularity);
-      if (active) setBattingTrend(data);
+      const result = await getBattingTrend(filters, granularity);
+      if (!active) return;
+      // シーズン粒度が 403 なら resolveTrend が粒度を戻し、この effect が再実行される。
+      const data = resolveTrend(result);
+      if (data) setBattingTrend(data);
     });
     return () => {
       active = false;
     };
-  }, [filters, granularity, startTrendTransition]);
+  }, [filters, granularity, resolveTrend, startTrendTransition]);
 
   return (
     <div className="flex flex-col gap-y-5">
@@ -242,7 +251,7 @@ export function AnalysisContainer({
           <BattingTrendChart
             points={battingTrend.points}
             granularity={granularity}
-            onGranularityChange={setGranularity}
+            onGranularityChange={requestGranularity}
           />
         </div>
         <SprayChart

--- a/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
@@ -120,7 +120,6 @@ export function AnalysisContainer({
 
   const { granularity, requestGranularity, resolveTrend } =
     useSeasonTrendGranularity<BattingTrendGranularity>({
-      seasonKey: "season",
       freeKey: "game",
       initialGranted: initialProFeatures,
     });

--- a/app/(app)/stats/_components/analysis/AnalysisSection.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisSection.tsx
@@ -8,6 +8,10 @@ import {
   getPitcherFaceoffs,
   getPitchTypes,
 } from "../../analysisActions";
+import {
+  SEASON_TREND_FEATURES,
+  grantedProFeatures,
+} from "../../analysisProFeatures";
 import { getStatsFilterOptions } from "../../filterOptions";
 import { AnalysisContainer, type ProAnalysisData } from "./AnalysisContainer";
 import { AnalysisLoading } from "./AnalysisLoading";
@@ -45,9 +49,12 @@ async function resolveProAnalysis(
     proStatus?.entitlements ?? DEFAULT_PRO_STATUS.entitlements;
   const isEntitled = (feature: ProFeature) => entitlements.includes(feature);
 
-  const grantedFeatures: ProFeature[] = isEntitled("hit_direction_average")
-    ? ["hit_direction_average"]
-    : [];
+  // 推移グラフのシーズン粒度は既定粒度ではないため SSR で取得しない。閲覧可否だけ
+  // 先に確定させ、Pro ユーザーの粒度切替が一瞬 Paywall に倒れるのを防ぐ。
+  const grantedFeatures: ProFeature[] = grantedProFeatures(proStatus, [
+    "hit_direction_average",
+    ...SEASON_TREND_FEATURES,
+  ]);
 
   const [counts, pitches, faceoffs] = await Promise.all([
     isEntitled("count_situation_average") ? getCountSituations() : null,

--- a/app/(app)/stats/_components/analysis/BattingTrendChart.tsx
+++ b/app/(app)/stats/_components/analysis/BattingTrendChart.tsx
@@ -4,6 +4,7 @@ import type {
   BattingTrendPoint,
 } from "../../analysisActions";
 import { Fragment, useEffect, useState } from "react";
+import { MAX_SEASON_X_LABELS, toSeasonAxisLabel } from "./trendAxis";
 
 interface BattingTrendChartProps {
   points: BattingTrendPoint[];
@@ -51,8 +52,18 @@ const GRANULARITY_OPTIONS: readonly {
   { key: "game", label: "試合" },
   { key: "month", label: "月" },
   { key: "year", label: "年" },
+  { key: "season", label: "シーズン" },
   { key: "recent_games", label: "直近10" },
 ];
+
+// 累積と単独期間で同じ折れ線でも読み方が変わるため、粒度ごとに集計単位を明示する。
+const GRANULARITY_NOTES: Record<BattingTrendGranularity, string> = {
+  game: "開幕からの累積",
+  month: "月ごとの成績",
+  year: "年ごとの成績",
+  season: "シーズンごとの成績（シーズン跨ぎ比較）",
+  recent_games: "直近10試合の累積",
+};
 
 const formatRate = (value: number): string =>
   value.toFixed(3).replace(/^0\./, ".");
@@ -72,6 +83,7 @@ function GranularityToggle({
           <button
             key={option.key}
             type="button"
+            aria-pressed={isActive}
             onClick={() => onChange(option.key)}
             className={`rounded px-2 py-1 text-[11px] font-semibold ${
               isActive ? "bg-[#52525B] text-[#F4F4F4]" : "text-[#A1A1AA]"
@@ -87,8 +99,9 @@ function GranularityToggle({
 
 /**
  * 打撃成績の推移グラフ（4 ライン: 打率 / 出塁率 / 長打率 / OPS）。
- * granularity 切替で 試合 / 月 / 年 / 直近10 を選べる。初期表示は打率のみで、
+ * granularity 切替で 試合 / 月 / 年 / シーズン / 直近10 を選べる。初期表示は打率のみで、
  * 絞り込みから他指標を重ねられる。
+ * シーズン粒度は Pro 限定のため、選択可否の判定は onGranularityChange 側が担う。
  */
 export function BattingTrendChart({
   points,
@@ -205,7 +218,11 @@ export function BattingTrendChart({
       .join(" "),
   }));
 
-  const labelStride = Math.max(1, Math.ceil(points.length / MAX_X_LABELS));
+  const isSeason = granularity === "season";
+  const labelStride = Math.max(
+    1,
+    Math.ceil(points.length / (isSeason ? MAX_SEASON_X_LABELS : MAX_X_LABELS)),
+  );
 
   return (
     <section className="rounded-xl bg-[#3A3A3A] p-4">
@@ -440,12 +457,16 @@ export function BattingTrendChart({
                 fill="#A1A1AA"
                 fontSize={9}
               >
-                {point.label}
+                {isSeason ? toSeasonAxisLabel(point.label) : point.label}
               </text>
             );
           })}
         </svg>
       </div>
+
+      <p className="mt-2 text-center text-[11px] text-[#71717A]">
+        {GRANULARITY_NOTES[granularity]}
+      </p>
 
       <div className="mt-2 flex flex-wrap justify-center gap-3">
         {LINES.map((line) => {

--- a/app/(app)/stats/_components/analysis/BattingTrendChart.tsx
+++ b/app/(app)/stats/_components/analysis/BattingTrendChart.tsx
@@ -58,7 +58,9 @@ const GRANULARITY_OPTIONS: readonly {
 
 // 累積と単独期間で同じ折れ線でも読み方が変わるため、粒度ごとに集計単位を明示する。
 const GRANULARITY_NOTES: Record<BattingTrendGranularity, string> = {
-  game: "開幕からの累積",
+  // back は絞り込み後の全試合を累積するため、既定の「通算」では複数年をまたぐ。
+  // 期間を含む表現にすると既定表示で誤った集計単位を伝えることになる。
+  game: "各試合時点までの累積",
   month: "月ごとの成績",
   year: "年ごとの成績",
   season: "シーズンごとの成績（シーズン跨ぎ比較）",

--- a/app/(app)/stats/_components/analysis/EraTrendChart.tsx
+++ b/app/(app)/stats/_components/analysis/EraTrendChart.tsx
@@ -139,6 +139,10 @@ export function EraTrendChart({
   const labelStride = isSeason
     ? Math.max(1, Math.ceil(drawablePoints.length / MAX_SEASON_X_LABELS))
     : 1;
+  // 値ラベル（era）も X 軸と同じ本数に間引く。シーズン数が増えると点の間隔が
+  // 4 桁の数値より狭くなり、間引かないと隣と重なって読めなくなる。
+  const isLabelVisible = (index: number) =>
+    index % labelStride === 0 || index === drawablePoints.length - 1;
 
   return (
     <ChartFrame
@@ -208,13 +212,8 @@ export function EraTrendChart({
             </Fragment>
           ))}
 
-          {drawablePoints.map((point, index) => {
-            if (
-              index % labelStride !== 0 &&
-              index !== drawablePoints.length - 1
-            )
-              return null;
-            return (
+          {drawablePoints.map((point, index) =>
+            isLabelVisible(index) ? (
               <text
                 key={`xl-${point.key}`}
                 x={getX(index)}
@@ -225,23 +224,25 @@ export function EraTrendChart({
               >
                 {isSeason ? toSeasonAxisLabel(point.label) : point.label}
               </text>
-            );
-          })}
+            ) : null,
+          )}
 
-          {drawablePoints.map((point, index) => (
-            <text
-              key={`val-${point.key}`}
-              x={getX(index)}
-              // 最大値の点では getY が上端付近になりラベルが見切れるため下限を設ける。
-              y={Math.max(getY(point.era) - 10, PADDING_TOP + 9)}
-              textAnchor="middle"
-              fill="#F4F4F4"
-              fontSize={9}
-              fontWeight={600}
-            >
-              {point.era.toFixed(2)}
-            </text>
-          ))}
+          {drawablePoints.map((point, index) =>
+            isLabelVisible(index) ? (
+              <text
+                key={`val-${point.key}`}
+                x={getX(index)}
+                // 最大値の点では getY が上端付近になりラベルが見切れるため下限を設ける。
+                y={Math.max(getY(point.era) - 10, PADDING_TOP + 9)}
+                textAnchor="middle"
+                fill="#F4F4F4"
+                fontSize={9}
+                fontWeight={600}
+              >
+                {point.era.toFixed(2)}
+              </text>
+            ) : null,
+          )}
         </svg>
       </div>
 

--- a/app/(app)/stats/_components/analysis/EraTrendChart.tsx
+++ b/app/(app)/stats/_components/analysis/EraTrendChart.tsx
@@ -1,9 +1,12 @@
 "use client";
-import type { EraTrendPoint } from "../../analysisActions";
-import { Fragment } from "react";
+import type { EraTrendGranularity, EraTrendPoint } from "../../analysisActions";
+import { Fragment, type ReactNode } from "react";
+import { MAX_SEASON_X_LABELS, toSeasonAxisLabel } from "./trendAxis";
 
 interface EraTrendChartProps {
-  data: EraTrendPoint[];
+  points: EraTrendPoint[];
+  granularity: EraTrendGranularity;
+  onGranularityChange: (granularity: EraTrendGranularity) => void;
 }
 
 const CHART_WIDTH = 300;
@@ -15,38 +18,133 @@ const PADDING_BOTTOM = 24;
 const PLOT_WIDTH = CHART_WIDTH - PADDING_LEFT - PADDING_RIGHT;
 const PLOT_HEIGHT = CHART_HEIGHT - PADDING_TOP - PADDING_BOTTOM;
 
-/** 防御率推移の折れ線グラフ（月別 ERA をエリア塗りつぶし付きで描画）。 */
-export function EraTrendChart({ data }: EraTrendChartProps) {
-  // 投球が無い月などで era が null/Infinity でも安全に描けるよう有限値だけ残し、
-  // 月昇順に並べる（API のソート順に依存しない）。
-  const points = data
-    .filter((point) => Number.isFinite(point.era))
-    .sort((a, b) => a.month - b.month);
-  if (points.length === 0) return null;
+const GRANULARITY_OPTIONS: readonly {
+  key: EraTrendGranularity;
+  label: string;
+}[] = [
+  { key: "month", label: "月" },
+  { key: "season", label: "シーズン" },
+];
+
+const GRANULARITY_NOTES: Record<EraTrendGranularity, string> = {
+  month: "月ごとの防御率",
+  season: "シーズンごとの防御率（シーズン跨ぎ比較）",
+};
+
+function GranularityToggle({
+  value,
+  onChange,
+}: {
+  value: EraTrendGranularity;
+  onChange: (value: EraTrendGranularity) => void;
+}) {
+  return (
+    <div className="flex rounded-md bg-[#27272A] p-0.5">
+      {GRANULARITY_OPTIONS.map((option) => {
+        const isActive = value === option.key;
+        return (
+          <button
+            key={option.key}
+            type="button"
+            aria-pressed={isActive}
+            onClick={() => onChange(option.key)}
+            className={`rounded px-2 py-1 text-[11px] font-semibold ${
+              isActive ? "bg-[#52525B] text-[#F4F4F4]" : "text-[#A1A1AA]"
+            }`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ChartFrame({
+  granularity,
+  onGranularityChange,
+  children,
+}: {
+  granularity: EraTrendGranularity;
+  onGranularityChange: (granularity: EraTrendGranularity) => void;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-xl bg-[#3A3A3A] p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-base font-bold text-[#F4F4F4]">防御率推移</h3>
+        <GranularityToggle value={granularity} onChange={onGranularityChange} />
+      </div>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * 防御率推移の折れ線グラフ（ERA をエリア塗りつぶし付きで描画）。
+ * granularity 切替で 月 / シーズン を選べる。シーズン粒度は Pro 限定のため、
+ * 選択可否の判定は onGranularityChange 側が担う。
+ */
+export function EraTrendChart({
+  points,
+  granularity,
+  onGranularityChange,
+}: EraTrendChartProps) {
+  // 登板の無い期間などで era が null/Infinity でも安全に描けるよう有限値だけ残す。
+  // 並び順は back の集計順（月昇順 / シーズン開始順）をそのまま使う。
+  const drawablePoints = points.filter((point) => Number.isFinite(point.era));
+
+  // データが無くても粒度トグルは出す。空になった粒度から戻れなくなるのを防ぐ。
+  if (drawablePoints.length === 0) {
+    return (
+      <ChartFrame
+        granularity={granularity}
+        onGranularityChange={onGranularityChange}
+      >
+        <div className="flex flex-col items-center py-8">
+          <p className="mb-1 text-sm font-semibold text-[#A1A1AA]">
+            対象データなし
+          </p>
+          <p className="text-[11px] text-[#71717A]">
+            登板を記録すると推移が表示されます
+          </p>
+        </div>
+      </ChartFrame>
+    );
+  }
+
+  const isSeason = granularity === "season";
 
   // Math.max(..., 1) で maxEra は常に 1 以上になる。
-  const maxEra = Math.max(...points.map((point) => point.era), 1);
+  const maxEra = Math.max(...drawablePoints.map((point) => point.era), 1);
   const yTicks = [0, Math.round((maxEra / 2) * 10) / 10, Math.ceil(maxEra)];
 
   const getX = (index: number) =>
     PADDING_LEFT +
-    (points.length === 1
+    (drawablePoints.length === 1
       ? PLOT_WIDTH / 2
-      : (index / (points.length - 1)) * PLOT_WIDTH);
+      : (index / (drawablePoints.length - 1)) * PLOT_WIDTH);
   const getY = (era: number) =>
     PADDING_TOP + PLOT_HEIGHT - (era / maxEra) * PLOT_HEIGHT;
 
-  const linePath = points
+  const linePath = drawablePoints
     .map(
       (point, index) =>
         `${index === 0 ? "M" : "L"} ${getX(index)},${getY(point.era)}`,
     )
     .join(" ");
-  const areaPath = `${linePath} L ${getX(points.length - 1)},${PADDING_TOP + PLOT_HEIGHT} L ${getX(0)},${PADDING_TOP + PLOT_HEIGHT} Z`;
+  const areaPath = `${linePath} L ${getX(drawablePoints.length - 1)},${PADDING_TOP + PLOT_HEIGHT} L ${getX(0)},${PADDING_TOP + PLOT_HEIGHT} Z`;
+
+  // シーズン名は長いため、月粒度より少ない本数に間引いて重なりを避ける。
+  const labelStride = isSeason
+    ? Math.max(1, Math.ceil(drawablePoints.length / MAX_SEASON_X_LABELS))
+    : 1;
 
   return (
-    <section className="rounded-xl bg-[#3A3A3A] p-4">
-      <h3 className="mb-3 text-base font-bold text-[#F4F4F4]">防御率推移</h3>
+    <ChartFrame
+      granularity={granularity}
+      onGranularityChange={onGranularityChange}
+    >
       <div className="flex justify-center">
         <svg
           width="100%"
@@ -93,8 +191,8 @@ export function EraTrendChart({ data }: EraTrendChartProps) {
             strokeLinejoin="round"
           />
 
-          {points.map((point, index) => (
-            <Fragment key={`pt-${point.month}`}>
+          {drawablePoints.map((point, index) => (
+            <Fragment key={`pt-${point.key}`}>
               <circle
                 cx={getX(index)}
                 cy={getY(point.era)}
@@ -110,22 +208,29 @@ export function EraTrendChart({ data }: EraTrendChartProps) {
             </Fragment>
           ))}
 
-          {points.map((point, index) => (
-            <text
-              key={`xl-${point.month}`}
-              x={getX(index)}
-              y={CHART_HEIGHT - 4}
-              textAnchor="middle"
-              fill="#A1A1AA"
-              fontSize={10}
-            >
-              {point.month}月
-            </text>
-          ))}
+          {drawablePoints.map((point, index) => {
+            if (
+              index % labelStride !== 0 &&
+              index !== drawablePoints.length - 1
+            )
+              return null;
+            return (
+              <text
+                key={`xl-${point.key}`}
+                x={getX(index)}
+                y={CHART_HEIGHT - 4}
+                textAnchor="middle"
+                fill="#A1A1AA"
+                fontSize={10}
+              >
+                {isSeason ? toSeasonAxisLabel(point.label) : point.label}
+              </text>
+            );
+          })}
 
-          {points.map((point, index) => (
+          {drawablePoints.map((point, index) => (
             <text
-              key={`val-${point.month}`}
+              key={`val-${point.key}`}
               x={getX(index)}
               // 最大値の点では getY が上端付近になりラベルが見切れるため下限を設ける。
               y={Math.max(getY(point.era) - 10, PADDING_TOP + 9)}
@@ -139,6 +244,10 @@ export function EraTrendChart({ data }: EraTrendChartProps) {
           ))}
         </svg>
       </div>
-    </section>
+
+      <p className="mt-2 text-center text-[11px] text-[#71717A]">
+        {GRANULARITY_NOTES[granularity]}
+      </p>
+    </ChartFrame>
   );
 }

--- a/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
@@ -49,7 +49,6 @@ export function PitchingAnalysisContainer({
 
   const { granularity, requestGranularity, resolveTrend } =
     useSeasonTrendGranularity<EraTrendGranularity>({
-      seasonKey: "season",
       freeKey: "month",
       initialGranted: initialProFeatures,
     });

--- a/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/PitchingAnalysisContainer.tsx
@@ -1,8 +1,11 @@
 "use client";
 import type { FilterOption } from "../../statsFilterOption";
+import type { ProFeature } from "@app/types/pro";
 import { useEffect, useRef, useState, useTransition } from "react";
+import { useSeasonTrendGranularity } from "@app/hooks/pro/useSeasonTrendGranularity";
 import {
   type AnalysisFilters as Filters,
+  type EraTrendGranularity,
   type EraTrendPoint,
   getEraTrend,
 } from "../../analysisActions";
@@ -20,8 +23,10 @@ function buildYearOptions(): FilterOption[] {
 }
 
 interface PitchingAnalysisContainerProps {
-  /** SSR で取得した防御率推移の初期データ。マウント時はこれを使い再取得しない。 */
+  /** SSR で取得した防御率推移の初期データ（月粒度）。マウント時はこれを使い再取得しない。 */
   initialEraTrend: EraTrendPoint[];
+  /** SSR で閲覧可と判定された Pro 機能。クライアント判定が確定するまでの初期値。 */
+  initialProFeatures: readonly ProFeature[];
   /** サーバーで取得したシーズン/大会のフィルタ選択肢。 */
   seasonOptions: FilterOption[];
   tournamentOptions: FilterOption[];
@@ -30,6 +35,7 @@ interface PitchingAnalysisContainerProps {
 /** 投手タブの分析（フィルタ + 防御率推移グラフ）コンテナ。 */
 export function PitchingAnalysisContainer({
   initialEraTrend,
+  initialProFeatures,
   seasonOptions,
   tournamentOptions,
 }: PitchingAnalysisContainerProps) {
@@ -41,7 +47,14 @@ export function PitchingAnalysisContainer({
   const [isRefetching, startRefetch] = useTransition();
   const [yearOptions] = useState(buildYearOptions);
 
-  // 初回は SSR の initialEraTrend を使うため再取得しない（フィルタ変更時のみ取得）。
+  const { granularity, requestGranularity, resolveTrend } =
+    useSeasonTrendGranularity<EraTrendGranularity>({
+      seasonKey: "season",
+      freeKey: "month",
+      initialGranted: initialProFeatures,
+    });
+
+  // 初回は SSR の initialEraTrend を使うため再取得しない（フィルタ/粒度変更時のみ取得）。
   const didInitRef = useRef(false);
   useEffect(() => {
     if (!didInitRef.current) {
@@ -51,17 +64,30 @@ export function PitchingAnalysisContainer({
     let active = true;
     // 防御率推移は year/season/tournament のみで絞る（種別は対象外）。
     startRefetch(async () => {
-      const trend = await getEraTrend({
-        year: filters.year,
-        seasonId: filters.seasonId,
-        tournamentId: filters.tournamentId,
-      });
-      if (active) setEraTrend(trend);
+      const result = await getEraTrend(
+        {
+          year: filters.year,
+          seasonId: filters.seasonId,
+          tournamentId: filters.tournamentId,
+        },
+        granularity,
+      );
+      if (!active) return;
+      // シーズン粒度が 403 なら resolveTrend が粒度を戻し、この effect が再実行される。
+      const data = resolveTrend(result);
+      if (data) setEraTrend(data.points);
     });
     return () => {
       active = false;
     };
-  }, [filters.year, filters.seasonId, filters.tournamentId, startRefetch]);
+  }, [
+    filters.year,
+    filters.seasonId,
+    filters.tournamentId,
+    granularity,
+    resolveTrend,
+    startRefetch,
+  ]);
 
   return (
     <div className="flex flex-col gap-y-5">
@@ -76,7 +102,11 @@ export function PitchingAnalysisContainer({
       <div
         className={isRefetching ? "opacity-50 transition-opacity" : undefined}
       >
-        <EraTrendChart data={eraTrend} />
+        <EraTrendChart
+          points={eraTrend}
+          granularity={granularity}
+          onGranularityChange={requestGranularity}
+        />
       </div>
     </div>
   );

--- a/app/(app)/stats/_components/analysis/PitchingAnalysisSection.tsx
+++ b/app/(app)/stats/_components/analysis/PitchingAnalysisSection.tsx
@@ -1,5 +1,10 @@
 import { Suspense } from "react";
+import { getCachedProStatus } from "@app/(app)/pro/proStatus";
 import { getEraTrend } from "../../analysisActions";
+import {
+  SEASON_TREND_FEATURES,
+  grantedProFeatures,
+} from "../../analysisProFeatures";
 import { getStatsFilterOptions } from "../../filterOptions";
 import { AnalysisLoading } from "./AnalysisLoading";
 import { PitchingAnalysisContainer } from "./PitchingAnalysisContainer";
@@ -18,14 +23,26 @@ export function PitchingAnalysisSection() {
 }
 
 async function PitchingAnalysisDataProvider() {
-  // 防御率推移は year/season/tournament のみで絞る（既定は通算）。
-  const [initialEraTrend, filterOptions] = await Promise.all([
+  // /stats は認証チェックで既に dynamic なので、Pro 判定もサーバーで解決できる。
+  const proStatusPromise = getCachedProStatus();
+  // 防御率推移は year/season/tournament のみで絞る（既定は通算・月粒度）。
+  const [initialEraTrend, filterOptions, proFeatures] = await Promise.all([
     getEraTrend({ year: "通算" }),
     getStatsFilterOptions(),
+    // シーズン粒度を選ばせてよいかをサーバーで確定させ、クライアント判定の
+    // 待ち時間に Pro ユーザーが Paywall へ倒れるのを防ぐ。
+    proStatusPromise.then((proStatus) =>
+      grantedProFeatures(proStatus, SEASON_TREND_FEATURES),
+    ),
   ]);
+
   return (
     <PitchingAnalysisContainer
-      initialEraTrend={initialEraTrend}
+      // 既定の月粒度は Pro 限定ではないため、ここに pro_required は来ない。
+      initialEraTrend={
+        initialEraTrend.status === "ok" ? initialEraTrend.data.points : []
+      }
+      initialProFeatures={proFeatures}
       seasonOptions={filterOptions.seasonOptions}
       tournamentOptions={filterOptions.tournamentOptions}
     />

--- a/app/(app)/stats/_components/analysis/__tests__/AnalysisContainer.test.tsx
+++ b/app/(app)/stats/_components/analysis/__tests__/AnalysisContainer.test.tsx
@@ -275,6 +275,14 @@ async function renderContainer({
   });
 }
 
+/** 推移グラフの粒度トグルを押す。 */
+async function clickGranularity(label: string) {
+  const user = userEvent.setup();
+  await act(async () => {
+    await user.click(screen.getByRole("button", { name: label }));
+  });
+}
+
 /** 年度フィルタを「通算」から当年へ切り替える。 */
 async function changeYearFilter() {
   const user = userEvent.setup();
@@ -316,8 +324,8 @@ function mockNonProAnalysisActions() {
     initialData.pitcherAttributes,
   );
   (getBattingTrend as jest.Mock).mockResolvedValue({
-    granularity: "game",
-    points: [],
+    status: "ok",
+    data: { granularity: "game", points: [] },
   });
 }
 
@@ -580,6 +588,180 @@ describe("AnalysisContainer の Pro 出し分け", () => {
         screen.getByRole("button", { name: CTA_NAMES.pitchType }),
       ).toBeInTheDocument();
       expect(mockGetPitchTypes).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+const SEASON_TREND = {
+  granularity: "season" as const,
+  points: [
+    {
+      key: "season-1",
+      label: "2026春季",
+      batting_average: 0.412,
+      on_base_percentage: 0.45,
+      slugging_percentage: 0.6,
+      ops: 1.05,
+      at_bats_in_period: 34,
+      cumulative_at_bats: 34,
+    },
+  ],
+};
+
+const GRANULARITY_NOTES = {
+  game: "開幕からの累積",
+  season: "シーズンごとの成績（シーズン跨ぎ比較）",
+};
+
+/** 粒度トグルの選択状態を読む（データが無くてもトグルは出るため常に使える）。 */
+function activeGranularityLabel(): string | undefined {
+  return screen
+    .getAllByRole("button", { pressed: true })
+    .map((button) => button.textContent ?? "")
+    .at(0);
+}
+
+describe("打撃推移のシーズン粒度", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearAuthCookies();
+    setAuthCookies();
+    mockNonProAnalysisActions();
+    mockGetCountSituations.mockResolvedValue({
+      status: "ok",
+      data: REAL_COUNT_SITUATIONS,
+    });
+    mockGetPitchTypes.mockResolvedValue({
+      status: "ok",
+      data: REAL_PITCH_TYPES,
+    });
+    mockGetPitcherFaceoffs.mockResolvedValue({
+      status: "ok",
+      data: REAL_PITCHER_FACEOFFS,
+    });
+  });
+
+  describe("season_transition_graph を持つとき", () => {
+    beforeEach(() => {
+      mockGetProStatus.mockResolvedValue(makeProStatus());
+      (getBattingTrend as jest.Mock).mockResolvedValue({
+        status: "ok",
+        data: SEASON_TREND,
+      });
+    });
+
+    it("シーズンを選ぶと season 粒度で取得して描画する", async () => {
+      await renderContainer({
+        initialProFeatures: ["season_transition_graph"],
+      });
+
+      await clickGranularity("シーズン");
+
+      expect(getBattingTrend).toHaveBeenCalledWith(expect.anything(), "season");
+      expect(
+        await screen.findByText(GRANULARITY_NOTES.season),
+      ).toBeInTheDocument();
+      expect(screen.getByText("2026春季")).toBeInTheDocument();
+      expect(mockOpen).not.toHaveBeenCalled();
+    });
+
+    it("シーズン数が多いときは X 軸ラベルを間引く", async () => {
+      (getBattingTrend as jest.Mock).mockResolvedValue({
+        status: "ok",
+        data: {
+          granularity: "season",
+          points: Array.from({ length: 12 }, (_, index) => ({
+            ...SEASON_TREND.points[0],
+            key: `season-${index + 1}`,
+            label: `S${String(index + 1).padStart(2, "0")}`,
+          })),
+        },
+      });
+
+      await renderContainer({
+        initialProFeatures: ["season_transition_graph"],
+      });
+      await clickGranularity("シーズン");
+
+      // 12 シーズンなら 3 つおき + 最終シーズンだけをラベルにする。
+      expect(await screen.findByText("S01")).toBeInTheDocument();
+      expect(screen.getByText("S04")).toBeInTheDocument();
+      expect(screen.getByText("S12")).toBeInTheDocument();
+      expect(screen.queryByText("S03")).not.toBeInTheDocument();
+    });
+
+    it("クライアントの Pro 判定を待つ間もシーズンを選べる", async () => {
+      // Pro 状態のクライアント取得を宙吊りにし、SSR 済みの判定だけで操作させる。
+      mockGetProStatus.mockReturnValue(new Promise(() => {}));
+
+      await renderContainer({
+        initialProFeatures: ["season_transition_graph"],
+      });
+      await clickGranularity("シーズン");
+
+      expect(getBattingTrend).toHaveBeenCalledWith(expect.anything(), "season");
+      expect(mockOpen).not.toHaveBeenCalled();
+    });
+
+    it("サーバーに 403 で拒否されたら試合粒度へ戻し Paywall を出す", async () => {
+      (getBattingTrend as jest.Mock).mockResolvedValueOnce({
+        status: "pro_required",
+      });
+
+      await renderContainer({
+        initialProFeatures: ["season_transition_graph"],
+      });
+      await clickGranularity("シーズン");
+
+      await waitFor(() => {
+        expect(activeGranularityLabel()).toBe("試合");
+      });
+      expect(mockOpen).toHaveBeenCalledWith({
+        trigger: "season_transition_graph",
+      });
+      expect(getBattingTrend).toHaveBeenLastCalledWith(
+        expect.anything(),
+        "game",
+      );
+    });
+  });
+
+  describe("無料ユーザー", () => {
+    beforeEach(() => {
+      mockGetProStatus.mockResolvedValue(DEFAULT_PRO_STATUS);
+    });
+
+    it("シーズンを選んでも切り替えず、Paywall を出して API も叩かない", async () => {
+      await renderContainer();
+
+      await clickGranularity("シーズン");
+
+      expect(mockOpen).toHaveBeenCalledWith({
+        trigger: "season_transition_graph",
+      });
+      expect(getBattingTrend).not.toHaveBeenCalled();
+      expect(activeGranularityLabel()).toBe("試合");
+    });
+
+    it("Pro 判定が確定する前でもシーズン粒度の API を叩かない", async () => {
+      mockGetProStatus.mockReturnValue(new Promise(() => {}));
+
+      await renderContainer();
+      await clickGranularity("シーズン");
+
+      expect(getBattingTrend).not.toHaveBeenCalled();
+      expect(mockOpen).toHaveBeenCalledWith({
+        trigger: "season_transition_graph",
+      });
+    });
+
+    it("シーズン以外の粒度は従来どおり切り替えられる", async () => {
+      await renderContainer();
+
+      await clickGranularity("月");
+
+      expect(getBattingTrend).toHaveBeenCalledWith(expect.anything(), "month");
+      expect(mockOpen).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/(app)/stats/_components/analysis/__tests__/AnalysisContainer.test.tsx
+++ b/app/(app)/stats/_components/analysis/__tests__/AnalysisContainer.test.tsx
@@ -609,7 +609,7 @@ const SEASON_TREND = {
 };
 
 const GRANULARITY_NOTES = {
-  game: "開幕からの累積",
+  game: "各試合時点までの累積",
   season: "シーズンごとの成績（シーズン跨ぎ比較）",
 };
 

--- a/app/(app)/stats/_components/analysis/__tests__/PitchingAnalysisContainer.test.tsx
+++ b/app/(app)/stats/_components/analysis/__tests__/PitchingAnalysisContainer.test.tsx
@@ -1,0 +1,299 @@
+const mockOpen = jest.fn();
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: mockOpen, close: jest.fn() }),
+}));
+
+// HeroUI の Dropdown は jsdom で開けないため、選択肢をそのままボタンとして描画する。
+jest.mock("@app/components/filter/FilterChip", () => ({
+  __esModule: true,
+  default: ({
+    label,
+    options,
+    onChange,
+  }: {
+    label: string;
+    options: { key: string; label: string }[];
+    onChange: (key: string) => void;
+  }) => (
+    <>
+      {options.map((option) => (
+        <button
+          key={option.key}
+          type="button"
+          onClick={() => onChange(option.key)}
+        >
+          {label}: {option.label}
+        </button>
+      ))}
+    </>
+  ),
+}));
+
+jest.mock("@app/(app)/pro/actions", () => ({
+  getProStatus: jest.fn(),
+}));
+
+jest.mock("../../../analysisActions", () => ({
+  getEraTrend: jest.fn(),
+}));
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { getProStatus } from "@app/(app)/pro/actions";
+import { ProStatusProvider } from "@app/components/pro/ProStatusProvider";
+import {
+  DEFAULT_PRO_STATUS,
+  PRO_FEATURES,
+  type Feature,
+  type ProFeature,
+  type ProStatus,
+} from "@app/types/pro";
+import { getEraTrend } from "../../../analysisActions";
+import { PitchingAnalysisContainer } from "../PitchingAnalysisContainer";
+
+const mockGetProStatus = getProStatus as jest.MockedFunction<
+  typeof getProStatus
+>;
+const mockGetEraTrend = getEraTrend as jest.MockedFunction<typeof getEraTrend>;
+
+function setAuthCookies() {
+  document.cookie = "access-token=test-access-token";
+  document.cookie = "client=test-client";
+  document.cookie = "uid=user@example.com";
+}
+
+function clearAuthCookies() {
+  for (const name of ["access-token", "client", "uid"]) {
+    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+  }
+}
+
+function makeProStatus(): ProStatus {
+  return {
+    subscription: {
+      status: "active",
+      plan_type: "yearly",
+      platform: "web",
+      started_at: "2026-04-01T00:00:00+09:00",
+      expires_at: "2027-04-01T00:00:00+09:00",
+      pro_active: true,
+      in_trial: false,
+      in_grace_period: false,
+      days_remaining: 200,
+      is_early_subscriber: false,
+      has_used_trial: true,
+    },
+    entitlements: [
+      ...DEFAULT_PRO_STATUS.entitlements,
+      ...PRO_FEATURES,
+    ] as Feature[],
+  };
+}
+
+const MONTH_POINTS = [
+  { key: "month-04", label: "4月", era: 2.5 },
+  { key: "month-05", label: "5月", era: 3.75 },
+];
+
+const SEASON_POINTS = [
+  { key: "season-1", label: "2025秋季", era: 4.2 },
+  { key: "season-2", label: "2026春季", era: 1.85 },
+];
+
+async function renderContainer({
+  initialProFeatures = [],
+}: { initialProFeatures?: readonly ProFeature[] } = {}) {
+  await act(async () => {
+    render(
+      <ProStatusProvider>
+        <PitchingAnalysisContainer
+          initialEraTrend={MONTH_POINTS}
+          initialProFeatures={initialProFeatures}
+          seasonOptions={[]}
+          tournamentOptions={[]}
+        />
+      </ProStatusProvider>,
+    );
+  });
+}
+
+async function clickGranularity(label: string) {
+  const user = userEvent.setup();
+  await act(async () => {
+    await user.click(screen.getByRole("button", { name: label }));
+  });
+}
+
+function activeGranularityLabel(): string | undefined {
+  return screen
+    .getAllByRole("button", { pressed: true })
+    .map((button) => button.textContent ?? "")
+    .at(0);
+}
+
+describe("PitchingAnalysisContainer の防御率推移", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearAuthCookies();
+    setAuthCookies();
+    mockGetEraTrend.mockResolvedValue({
+      status: "ok",
+      data: { granularity: "season", points: SEASON_POINTS },
+    });
+  });
+
+  it("SSR 済みの月別データをそのまま描画し、マウント時に取り直さない", async () => {
+    mockGetProStatus.mockResolvedValue(makeProStatus());
+
+    await renderContainer({ initialProFeatures: ["season_transition_graph"] });
+
+    expect(screen.getByText("4月")).toBeInTheDocument();
+    expect(activeGranularityLabel()).toBe("月");
+    expect(mockGetEraTrend).not.toHaveBeenCalled();
+  });
+
+  describe("season_transition_graph を持つとき", () => {
+    beforeEach(() => {
+      mockGetProStatus.mockResolvedValue(makeProStatus());
+    });
+
+    it("シーズンを選ぶと season 粒度で取得して描画する", async () => {
+      await renderContainer({
+        initialProFeatures: ["season_transition_graph"],
+      });
+
+      await clickGranularity("シーズン");
+
+      expect(mockGetEraTrend).toHaveBeenCalledWith(expect.anything(), "season");
+      expect(await screen.findByText("2026春季")).toBeInTheDocument();
+      expect(screen.getByText("1.85")).toBeInTheDocument();
+      expect(activeGranularityLabel()).toBe("シーズン");
+      expect(mockOpen).not.toHaveBeenCalled();
+    });
+
+    it("シーズンから月へ戻せる", async () => {
+      await renderContainer({
+        initialProFeatures: ["season_transition_graph"],
+      });
+
+      await clickGranularity("シーズン");
+      mockGetEraTrend.mockResolvedValue({
+        status: "ok",
+        data: { granularity: "month", points: MONTH_POINTS },
+      });
+      await clickGranularity("月");
+
+      expect(mockGetEraTrend).toHaveBeenLastCalledWith(
+        expect.anything(),
+        "month",
+      );
+      expect(await screen.findByText("4月")).toBeInTheDocument();
+      expect(activeGranularityLabel()).toBe("月");
+    });
+
+    it("長いシーズン名は X 軸で丸めて描く", async () => {
+      mockGetEraTrend.mockResolvedValue({
+        status: "ok",
+        data: {
+          granularity: "season",
+          points: [
+            { key: "season-1", label: "2025秋季リーグ戦", era: 2.1 },
+            { key: "season-2", label: "2026春季リーグ戦", era: 3.2 },
+          ],
+        },
+      });
+
+      await renderContainer({
+        initialProFeatures: ["season_transition_graph"],
+      });
+      await clickGranularity("シーズン");
+
+      expect(await screen.findByText("2026春季…")).toBeInTheDocument();
+      expect(screen.getByText("2025秋季…")).toBeInTheDocument();
+      expect(screen.queryByText("2026春季リーグ戦")).not.toBeInTheDocument();
+    });
+
+    it("クライアントの Pro 判定を待つ間もシーズンを選べる", async () => {
+      // Pro 状態のクライアント取得を宙吊りにし、SSR 済みの判定だけで操作させる。
+      mockGetProStatus.mockReturnValue(new Promise(() => {}));
+
+      await renderContainer({
+        initialProFeatures: ["season_transition_graph"],
+      });
+      await clickGranularity("シーズン");
+
+      expect(mockGetEraTrend).toHaveBeenCalledWith(expect.anything(), "season");
+      expect(mockOpen).not.toHaveBeenCalled();
+    });
+
+    it("サーバーに 403 で拒否されたら月粒度へ戻し Paywall を出す", async () => {
+      mockGetEraTrend.mockResolvedValueOnce({ status: "pro_required" });
+      mockGetEraTrend.mockResolvedValue({
+        status: "ok",
+        data: { granularity: "month", points: MONTH_POINTS },
+      });
+
+      await renderContainer({
+        initialProFeatures: ["season_transition_graph"],
+      });
+      await clickGranularity("シーズン");
+
+      await waitFor(() => {
+        expect(activeGranularityLabel()).toBe("月");
+      });
+      expect(mockOpen).toHaveBeenCalledWith({
+        trigger: "season_transition_graph",
+      });
+      expect(mockGetEraTrend).toHaveBeenLastCalledWith(
+        expect.anything(),
+        "month",
+      );
+    });
+  });
+
+  describe("無料ユーザー", () => {
+    beforeEach(() => {
+      mockGetProStatus.mockResolvedValue(DEFAULT_PRO_STATUS);
+    });
+
+    it("シーズンを選んでも切り替えず、Paywall を出して API も叩かない", async () => {
+      await renderContainer();
+
+      await clickGranularity("シーズン");
+
+      expect(mockOpen).toHaveBeenCalledWith({
+        trigger: "season_transition_graph",
+      });
+      expect(mockGetEraTrend).not.toHaveBeenCalled();
+      expect(activeGranularityLabel()).toBe("月");
+      expect(screen.getByText("4月")).toBeInTheDocument();
+    });
+
+    it("Pro 判定が確定する前でもシーズン粒度の API を叩かない", async () => {
+      mockGetProStatus.mockReturnValue(new Promise(() => {}));
+
+      await renderContainer();
+      await clickGranularity("シーズン");
+
+      expect(mockGetEraTrend).not.toHaveBeenCalled();
+      expect(mockOpen).toHaveBeenCalledWith({
+        trigger: "season_transition_graph",
+      });
+    });
+  });
+
+  it("データが空でも粒度トグルは残す（選び直せなくならない）", async () => {
+    mockGetProStatus.mockResolvedValue(makeProStatus());
+    mockGetEraTrend.mockResolvedValue({
+      status: "ok",
+      data: { granularity: "season", points: [] },
+    });
+
+    await renderContainer({ initialProFeatures: ["season_transition_graph"] });
+    await clickGranularity("シーズン");
+
+    expect(await screen.findByText("対象データなし")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "月" })).toBeInTheDocument();
+  });
+});

--- a/app/(app)/stats/_components/analysis/__tests__/PitchingAnalysisContainer.test.tsx
+++ b/app/(app)/stats/_components/analysis/__tests__/PitchingAnalysisContainer.test.tsx
@@ -125,6 +125,14 @@ async function clickGranularity(label: string) {
   });
 }
 
+/** モック化した FilterChip が並べる選択肢ボタンを押す（例: "年度: 2025"）。 */
+async function clickFilter(name: string) {
+  const user = userEvent.setup();
+  await act(async () => {
+    await user.click(screen.getByRole("button", { name }));
+  });
+}
+
 function activeGranularityLabel(): string | undefined {
   return screen
     .getAllByRole("button", { pressed: true })
@@ -212,6 +220,75 @@ describe("PitchingAnalysisContainer の防御率推移", () => {
       expect(await screen.findByText("2026春季…")).toBeInTheDocument();
       expect(screen.getByText("2025秋季…")).toBeInTheDocument();
       expect(screen.queryByText("2026春季リーグ戦")).not.toBeInTheDocument();
+    });
+
+    // シーズン数が多いユーザーほど点の間隔が狭くなる。X 軸ラベルだけ間引いても
+    // 値ラベルが全点に出ていると 4 桁の数値同士が重なって読めなくなる。
+    it("シーズン数が多いときは値ラベルも X 軸と同じ本数に間引く", async () => {
+      const manySeasons = Array.from({ length: 8 }, (_, index) => ({
+        key: `season-${index}`,
+        label: `S${index}`,
+        era: Number((index + 1).toFixed(2)),
+      }));
+      mockGetEraTrend.mockResolvedValue({
+        status: "ok",
+        data: { granularity: "season", points: manySeasons },
+      });
+
+      await renderContainer({
+        initialProFeatures: ["season_transition_graph"],
+      });
+      await clickGranularity("シーズン");
+
+      // stride は ceil(8 / MAX_SEASON_X_LABELS) = 2。末尾は常に描く。
+      expect(await screen.findByText("1.00")).toBeInTheDocument();
+      expect(screen.getByText("3.00")).toBeInTheDocument();
+      expect(screen.getByText("8.00")).toBeInTheDocument();
+      expect(screen.queryByText("2.00")).not.toBeInTheDocument();
+      expect(screen.queryByText("4.00")).not.toBeInTheDocument();
+      expect(screen.queryByText("6.00")).not.toBeInTheDocument();
+    });
+
+    // back が将来 season 以外の粒度にも 403 を足したとき、無関係な粒度で
+    // 「月粒度へ戻す + シーズンの Paywall」が出ないことを担保する。
+    it("月粒度で 403 が返っても Paywall を出さない", async () => {
+      mockGetEraTrend.mockResolvedValue({ status: "pro_required" });
+
+      await renderContainer({
+        initialProFeatures: ["season_transition_graph"],
+      });
+      await clickFilter("年度: 2025");
+
+      await waitFor(() => {
+        expect(mockGetEraTrend).toHaveBeenCalledWith(
+          expect.anything(),
+          "month",
+        );
+      });
+      expect(mockOpen).not.toHaveBeenCalled();
+      expect(activeGranularityLabel()).toBe("月");
+      expect(screen.getByText("4月")).toBeInTheDocument();
+    });
+
+    it("月粒度の 403 でシーズン粒度をロックしない", async () => {
+      mockGetEraTrend.mockResolvedValueOnce({ status: "pro_required" });
+      mockGetEraTrend.mockResolvedValue({
+        status: "ok",
+        data: { granularity: "season", points: SEASON_POINTS },
+      });
+
+      await renderContainer({
+        initialProFeatures: ["season_transition_graph"],
+      });
+      await clickFilter("年度: 2025");
+      await clickGranularity("シーズン");
+
+      expect(mockGetEraTrend).toHaveBeenLastCalledWith(
+        expect.anything(),
+        "season",
+      );
+      expect(await screen.findByText("2026春季")).toBeInTheDocument();
+      expect(mockOpen).not.toHaveBeenCalled();
     });
 
     it("クライアントの Pro 判定を待つ間もシーズンを選べる", async () => {

--- a/app/(app)/stats/_components/analysis/__tests__/analysisSections.test.tsx
+++ b/app/(app)/stats/_components/analysis/__tests__/analysisSections.test.tsx
@@ -1,0 +1,175 @@
+jest.mock("@app/(app)/pro/proStatus", () => ({
+  getCachedProStatus: jest.fn(),
+}));
+
+jest.mock("../../../filterOptions", () => ({
+  getStatsFilterOptions: jest.fn(),
+}));
+
+jest.mock("../../../analysisActions", () => ({
+  getInitialAnalysisData: jest.fn(),
+  getCountSituations: jest.fn(),
+  getPitchTypes: jest.fn(),
+  getPitcherFaceoffs: jest.fn(),
+  getEraTrend: jest.fn(),
+}));
+
+// Server Component の配線だけを見たいので、渡し先の Client Component は空実装にする。
+jest.mock("../AnalysisContainer", () => ({
+  AnalysisContainer: () => null,
+}));
+
+jest.mock("../PitchingAnalysisContainer", () => ({
+  PitchingAnalysisContainer: () => null,
+}));
+
+import type { ReactElement } from "react";
+import { getCachedProStatus } from "@app/(app)/pro/proStatus";
+import {
+  DEFAULT_PRO_STATUS,
+  type Feature,
+  type ProFeature,
+  type ProStatus,
+} from "@app/types/pro";
+import {
+  getCountSituations,
+  getEraTrend,
+  getInitialAnalysisData,
+  getPitcherFaceoffs,
+  getPitchTypes,
+} from "../../../analysisActions";
+import { getStatsFilterOptions } from "../../../filterOptions";
+import { AnalysisSection } from "../AnalysisSection";
+import { PitchingAnalysisSection } from "../PitchingAnalysisSection";
+
+const mockGetCachedProStatus = getCachedProStatus as jest.MockedFunction<
+  typeof getCachedProStatus
+>;
+const mockGetStatsFilterOptions = getStatsFilterOptions as jest.MockedFunction<
+  typeof getStatsFilterOptions
+>;
+const mockGetInitialAnalysisData =
+  getInitialAnalysisData as jest.MockedFunction<typeof getInitialAnalysisData>;
+const mockGetCountSituations = getCountSituations as jest.MockedFunction<
+  typeof getCountSituations
+>;
+const mockGetPitchTypes = getPitchTypes as jest.MockedFunction<
+  typeof getPitchTypes
+>;
+const mockGetPitcherFaceoffs = getPitcherFaceoffs as jest.MockedFunction<
+  typeof getPitcherFaceoffs
+>;
+const mockGetEraTrend = getEraTrend as jest.MockedFunction<typeof getEraTrend>;
+
+const MONTH_POINTS = [
+  { key: "month-04", label: "4月", era: 2.5 },
+  { key: "month-05", label: "5月", era: 3.75 },
+];
+
+interface ContainerProps {
+  initialProFeatures: readonly ProFeature[];
+}
+
+interface PitchingContainerProps extends ContainerProps {
+  initialEraTrend: { key: string; label: string; era: number }[];
+}
+
+/**
+ * `<Suspense>` でラップされた非同期 Server Component を実行し、
+ * 渡し先 Client Component に与えられた props を取り出す。
+ */
+async function resolveSectionProps<P>(section: ReactElement): Promise<P> {
+  const { children } = section.props as { children: ReactElement };
+  const dataProvider = children.type as () => Promise<ReactElement>;
+  const rendered = await dataProvider();
+  return rendered.props as P;
+}
+
+function makeProStatus(entitlements: Feature[]): ProStatus {
+  return {
+    ...DEFAULT_PRO_STATUS,
+    entitlements: [...DEFAULT_PRO_STATUS.entitlements, ...entitlements],
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetStatsFilterOptions.mockResolvedValue({
+    seasonOptions: [],
+    tournamentOptions: [],
+  });
+  mockGetEraTrend.mockResolvedValue({
+    status: "ok",
+    data: { granularity: "month", points: MONTH_POINTS },
+  });
+});
+
+describe("PitchingAnalysisSection の SSR 配線", () => {
+  it("SSR で判定した Pro 機能とデフォルト粒度のデータをコンテナへ渡す", async () => {
+    mockGetCachedProStatus.mockResolvedValue(
+      makeProStatus(["season_transition_graph"]),
+    );
+
+    const props = await resolveSectionProps<PitchingContainerProps>(
+      PitchingAnalysisSection(),
+    );
+
+    expect(props.initialProFeatures).toEqual(["season_transition_graph"]);
+    expect(props.initialEraTrend).toEqual(MONTH_POINTS);
+  });
+
+  it("entitlement の無いユーザーにはシーズン粒度を許可しない", async () => {
+    mockGetCachedProStatus.mockResolvedValue(DEFAULT_PRO_STATUS);
+
+    const props = await resolveSectionProps<PitchingContainerProps>(
+      PitchingAnalysisSection(),
+    );
+
+    expect(props.initialProFeatures).toEqual([]);
+  });
+});
+
+describe("AnalysisSection の SSR 配線", () => {
+  beforeEach(() => {
+    mockGetInitialAnalysisData.mockResolvedValue({
+      headline: null,
+      runnersSituation: null,
+      additional: null,
+      hitLocations: { points: [] },
+      hitDirections: { directions: [], home_runs: [] },
+      plateBreakdown: [],
+      contactQualities: { breakdown: [], total: 0 },
+      timingBreakdown: { breakdown: [], total: 0 },
+      pitcherAttributes: {
+        by_throw_hand: [],
+        by_arm_angle: [],
+        by_velocity_zone: [],
+        by_pitcher_style: [],
+      },
+      battingTrend: { granularity: "game", points: [] },
+    });
+    mockGetCountSituations.mockResolvedValue({ status: "pro_required" });
+    mockGetPitchTypes.mockResolvedValue({ status: "pro_required" });
+    mockGetPitcherFaceoffs.mockResolvedValue({ status: "pro_required" });
+  });
+
+  // SSR で取得しない機能（シーズン粒度）も閲覧可否だけは渡す必要がある。
+  // 落とすと Pro ユーザーがクライアント判定を待つ間だけ Paywall に倒れる。
+  it("SSR で取得しないシーズン粒度も閲覧可否として渡す", async () => {
+    mockGetCachedProStatus.mockResolvedValue(
+      makeProStatus(["season_transition_graph"]),
+    );
+
+    const props = await resolveSectionProps<ContainerProps>(AnalysisSection());
+
+    expect(props.initialProFeatures).toContain("season_transition_graph");
+  });
+
+  it("entitlement の無いユーザーにはシーズン粒度を許可しない", async () => {
+    mockGetCachedProStatus.mockResolvedValue(DEFAULT_PRO_STATUS);
+
+    const props = await resolveSectionProps<ContainerProps>(AnalysisSection());
+
+    expect(props.initialProFeatures).not.toContain("season_transition_graph");
+  });
+});

--- a/app/(app)/stats/_components/analysis/__tests__/trendAxis.test.ts
+++ b/app/(app)/stats/_components/analysis/__tests__/trendAxis.test.ts
@@ -1,0 +1,27 @@
+import { MAX_SEASON_X_LABELS, toSeasonAxisLabel } from "../trendAxis";
+
+describe("toSeasonAxisLabel", () => {
+  it("収まる長さのシーズン名はそのまま返す", () => {
+    expect(toSeasonAxisLabel("2026春季")).toBe("2026春季");
+  });
+
+  it("長いシーズン名は省略記号付きで丸める", () => {
+    expect(toSeasonAxisLabel("2026春季リーグ戦")).toBe("2026春季…");
+  });
+
+  it("丸めた末尾の空白は落とす", () => {
+    expect(toSeasonAxisLabel("2026年 春季大会")).toBe("2026年…");
+  });
+
+  // シーズン名はユーザーの自由入力なので絵文字が混ざりうる。
+  it("絵文字をサロゲートペアの途中で分断しない", () => {
+    expect(toSeasonAxisLabel("⚾️🔥春季リーグ戦")).not.toContain("�");
+    expect(Array.from(toSeasonAxisLabel("🔥🔥🔥🔥🔥🔥🔥🔥"))).toHaveLength(7);
+  });
+});
+
+describe("MAX_SEASON_X_LABELS", () => {
+  it("シーズン粒度の X 軸ラベル本数の上限を持つ", () => {
+    expect(MAX_SEASON_X_LABELS).toBeGreaterThan(0);
+  });
+});

--- a/app/(app)/stats/_components/analysis/trendAxis.ts
+++ b/app/(app)/stats/_components/analysis/trendAxis.ts
@@ -5,9 +5,14 @@ const MAX_SEASON_LABEL_CHARS = 6;
 /** シーズン粒度で X 軸に出すラベルの最大本数（他粒度より少なく間引く）。 */
 export const MAX_SEASON_X_LABELS = 4;
 
-/** シーズン名を X 軸に収まる長さへ丸める。丸めた場合は末尾を省略記号にする。 */
+/**
+ * シーズン名を X 軸に収まる長さへ丸める。丸めた場合は末尾を省略記号にする。
+ * シーズン名はユーザーの自由入力で絵文字を含みうるため、String#slice ではなく
+ * コードポイント単位で切り、サロゲートペアを分断しない。
+ */
 export function toSeasonAxisLabel(label: string): string {
-  return label.length > MAX_SEASON_LABEL_CHARS
-    ? `${label.slice(0, MAX_SEASON_LABEL_CHARS).trimEnd()}…`
+  const chars = Array.from(label);
+  return chars.length > MAX_SEASON_LABEL_CHARS
+    ? `${chars.slice(0, MAX_SEASON_LABEL_CHARS).join("").trimEnd()}…`
     : label;
 }

--- a/app/(app)/stats/_components/analysis/trendAxis.ts
+++ b/app/(app)/stats/_components/analysis/trendAxis.ts
@@ -1,0 +1,13 @@
+// シーズン名は「2026年 春季大会」のようにユーザーが自由に付けるため、
+// 「4/12」「5月」といった他粒度のラベルより長く、X 軸で隣と重なりやすい。
+const MAX_SEASON_LABEL_CHARS = 6;
+
+/** シーズン粒度で X 軸に出すラベルの最大本数（他粒度より少なく間引く）。 */
+export const MAX_SEASON_X_LABELS = 4;
+
+/** シーズン名を X 軸に収まる長さへ丸める。丸めた場合は末尾を省略記号にする。 */
+export function toSeasonAxisLabel(label: string): string {
+  return label.length > MAX_SEASON_LABEL_CHARS
+    ? `${label.slice(0, MAX_SEASON_LABEL_CHARS).trimEnd()}…`
+    : label;
+}

--- a/app/(app)/stats/analysisActions.ts
+++ b/app/(app)/stats/analysisActions.ts
@@ -237,7 +237,7 @@ export interface PitcherAttributeSummaryData {
 
 /**
  * 打撃推移グラフの粒度。
- * - `game`: 開幕からの累積
+ * - `game`: 各試合時点までの累積（絞り込み後の全試合が対象で、通算なら複数年をまたぐ）
  * - `month` / `year`: その期間単独
  * - `season`: シーズン単独（シーズン跨ぎ比較。`season_transition_graph` が必要）
  * - `recent_games`: 直近10試合の累積

--- a/app/(app)/stats/analysisActions.ts
+++ b/app/(app)/stats/analysisActions.ts
@@ -99,9 +99,22 @@ export interface PlateAppearanceCategory {
   percentage: number;
 }
 
+/**
+ * 防御率推移グラフの粒度。
+ * - `month`: 月単独の ERA
+ * - `season`: シーズン単独の ERA（シーズン跨ぎ比較。`season_transition_graph` が必要）
+ */
+export type EraTrendGranularity = "month" | "season";
+
 export interface EraTrendPoint {
-  month: number;
+  key: string;
+  label: string;
   era: number;
+}
+
+export interface EraTrendData {
+  granularity: EraTrendGranularity;
+  points: EraTrendPoint[];
 }
 
 export interface ContactQualityCategory {
@@ -222,10 +235,18 @@ export interface PitcherAttributeSummaryData {
   by_pitcher_style: PitcherAttributeBucket[];
 }
 
+/**
+ * 打撃推移グラフの粒度。
+ * - `game`: 開幕からの累積
+ * - `month` / `year`: その期間単独
+ * - `season`: シーズン単独（シーズン跨ぎ比較。`season_transition_graph` が必要）
+ * - `recent_games`: 直近10試合の累積
+ */
 export type BattingTrendGranularity =
   | "game"
   | "month"
   | "year"
+  | "season"
   | "recent_games";
 
 export interface BattingTrendPoint {
@@ -267,6 +288,20 @@ function buildQuery(filters: AnalysisFilters): string {
   if (filters.tournamentId)
     params.append("tournament_id", filters.tournamentId);
   return params.toString();
+}
+
+/**
+ * シーズン粒度はシーズン跨ぎで全シーズンを比較するため、単一シーズンへの絞り込みと
+ * 併用すると 1 点に縮退する。back も season 粒度では season_id を無視するので、
+ * 送信側でも落として意図を揃える。
+ */
+function seasonAwareFilters(
+  filters: AnalysisFilters,
+  granularity: BattingTrendGranularity | EraTrendGranularity,
+): AnalysisFilters {
+  if (granularity !== "season") return filters;
+  const { seasonId: _seasonId, ...rest } = filters;
+  return rest;
 }
 
 async function fetchProGatedAnalysis<T>(
@@ -350,13 +385,17 @@ export async function getRunnersSituation(
   );
 }
 
+/**
+ * 打撃推移を取得する。`granularity: "season"` は `season_transition_graph` の
+ * entitlement が必要で、403 は pro_required として返す（他の粒度で 403 は起きない）。
+ */
 export async function getBattingTrend(
   filters: AnalysisFilters = {},
   granularity: BattingTrendGranularity = "game",
-): Promise<BattingTrendData> {
-  return fetchAnalysis<BattingTrendData>(
+): Promise<ProGatedResult<BattingTrendData>> {
+  return fetchProGatedAnalysis<BattingTrendData>(
     "batting_trend",
-    filters,
+    seasonAwareFilters(filters, granularity),
     "getBattingTrend",
     { granularity, points: [] },
     { granularity },
@@ -437,19 +476,24 @@ export async function getPitcherAttributeSummary(
   );
 }
 
+/**
+ * 防御率推移を取得する。`granularity: "season"` は `season_transition_graph` の
+ * entitlement が必要で、403 は pro_required として返す（月粒度で 403 は起きない）。
+ */
 export async function getEraTrend(
   filters: AnalysisFilters = {},
-): Promise<EraTrendPoint[]> {
+  granularity: EraTrendGranularity = "month",
+): Promise<ProGatedResult<EraTrendData>> {
   // era_trend は year/season/tournament のみで絞る。match_type は構造的に除外し、
   // 誤って matchType 付きで呼ばれても送信されないことを関数自身で保証する。
   const { matchType: _matchType, ...eraFilters } = filters;
-  const result = await fetchAnalysis<{ trend: EraTrendPoint[] }>(
+  return fetchProGatedAnalysis<EraTrendData>(
     "era_trend",
-    eraFilters,
+    seasonAwareFilters(eraFilters, granularity),
     "getEraTrend",
-    { trend: [] },
+    { granularity, points: [] },
+    { granularity },
   );
-  return result.trend ?? [];
 }
 
 export async function getPlateAppearanceBreakdown(
@@ -543,6 +587,10 @@ export async function getInitialAnalysisData(
     contactQualities,
     timingBreakdown,
     pitcherAttributes,
-    battingTrend,
+    // 既定粒度は Pro 限定ではないため、ここに pro_required は来ない。
+    battingTrend:
+      battingTrend.status === "ok"
+        ? battingTrend.data
+        : { granularity, points: [] },
   };
 }

--- a/app/(app)/stats/analysisProFeatures.ts
+++ b/app/(app)/stats/analysisProFeatures.ts
@@ -1,0 +1,25 @@
+import type { ProFeature, ProStatus } from "@app/types/pro";
+import { DEFAULT_PRO_STATUS } from "@app/types/pro";
+
+/** 推移グラフのシーズン粒度に必要な entitlement。 */
+export const SEASON_TREND_FEATURES: readonly ProFeature[] = [
+  "season_transition_graph",
+];
+
+/**
+ * サーバー側で閲覧可と判定できる Pro 機能を絞り込む。
+ * クライアントの Pro 判定が確定するまでの初期値に使い、Pro ユーザーの表示や
+ * 粒度切替が一瞬 Paywall に倒れるのを防ぐ。
+ *
+ * @param proStatus 未認証・取得失敗時は null（無料の entitlements として扱う）
+ * @param candidates 判定したい機能
+ * @returns candidates のうち閲覧できるものだけ
+ */
+export function grantedProFeatures(
+  proStatus: ProStatus | null,
+  candidates: readonly ProFeature[],
+): ProFeature[] {
+  const entitlements =
+    proStatus?.entitlements ?? DEFAULT_PRO_STATUS.entitlements;
+  return candidates.filter((feature) => entitlements.includes(feature));
+}

--- a/app/hooks/pro/useSeasonTrendGranularity.ts
+++ b/app/hooks/pro/useSeasonTrendGranularity.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import type { ProFeature, ProGatedResult } from "@app/types/pro";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+import { useProGatedFeatures } from "@app/hooks/pro/useProGatedFeatures";
+
+const SEASON_TREND_FEATURE: ProFeature = "season_transition_graph";
+
+interface UseSeasonTrendGranularityOptions<G extends string> {
+  /** シーズン跨ぎ比較を表す粒度キー。この粒度だけ Pro 限定になる。 */
+  seasonKey: G;
+  /** 無料で使える既定の粒度。初期値と、403 で拒否されたときの戻り先を兼ねる。 */
+  freeKey: G;
+  /**
+   * SSR で閲覧可と判定された Pro 機能。クライアントの Pro 判定が確定するまでの
+   * 判定に使い、Pro ユーザーの選択が一瞬 Paywall に倒れるのを防ぐ。
+   */
+  initialGranted: readonly ProFeature[];
+}
+
+interface UseSeasonTrendGranularityReturn<G extends string> {
+  granularity: G;
+  /** 粒度切替の要求。シーズン粒度を持たないユーザーには Paywall を出し、切替を行わない。 */
+  requestGranularity: (next: G) => void;
+  /**
+   * 推移データ取得結果をデータに落とす。403 なら無料粒度へ戻して Paywall を出し、
+   * 以降シーズン粒度をロックする。
+   */
+  resolveTrend: <T>(result: ProGatedResult<T>) => T | null;
+}
+
+/**
+ * 推移グラフの粒度切替を Pro ゲート付きで管理する。
+ *
+ * シーズン粒度は `season_transition_graph` を持つユーザーだけが選べる。無料ユーザーが
+ * 選ぼうとしても state を進めないため、403 になるリクエストがそもそも飛ばない。
+ * クライアントの entitlement がサーバーと食い違って 403 を踏んだ場合は、無料粒度へ
+ * 戻したうえで Paywall を出す（グラフが空のまま無言で止まるのを避ける）。
+ */
+export function useSeasonTrendGranularity<G extends string>({
+  seasonKey,
+  freeKey,
+  initialGranted,
+}: UseSeasonTrendGranularityOptions<G>): UseSeasonTrendGranularityReturn<G> {
+  const [granularity, setGranularity] = useState<G>(freeKey);
+  const { canView, unwrap } = useProGatedFeatures(initialGranted);
+  const { open } = useProUpgradeModal();
+
+  const canViewSeason = canView(SEASON_TREND_FEATURE);
+
+  const openPaywall = useCallback(
+    () => open({ trigger: SEASON_TREND_FEATURE }),
+    [open],
+  );
+
+  const requestGranularity = useCallback(
+    (next: G) => {
+      if (next === seasonKey && !canViewSeason) {
+        openPaywall();
+        return;
+      }
+      setGranularity(next);
+    },
+    [seasonKey, canViewSeason, openPaywall],
+  );
+
+  // resolveTrend は取得完了後に呼ばれる。identity が変わると呼び出し側の effect が
+  // 張り直されて進行中のレスポンスが捨てられるため、最新の関数は ref 経由で読む。
+  const latestRef = useRef({ unwrap, openPaywall });
+  useEffect(() => {
+    latestRef.current = { unwrap, openPaywall };
+  });
+
+  const resolveTrend = useCallback(
+    <T>(result: ProGatedResult<T>): T | null => {
+      const data = latestRef.current.unwrap(SEASON_TREND_FEATURE, result);
+      if (data === null) {
+        setGranularity(freeKey);
+        latestRef.current.openPaywall();
+      }
+      return data;
+    },
+    [freeKey],
+  );
+
+  return { granularity, requestGranularity, resolveTrend };
+}

--- a/app/hooks/pro/useSeasonTrendGranularity.ts
+++ b/app/hooks/pro/useSeasonTrendGranularity.ts
@@ -5,11 +5,15 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
 import { useProGatedFeatures } from "@app/hooks/pro/useProGatedFeatures";
 
+/**
+ * シーズン跨ぎ比較を表す粒度キーと、それに必要な entitlement。
+ * 打撃 / 防御率どちらの推移も back の粒度名が `season` で揃っているため、
+ * キーだけ差し替えられて entitlement とずれることが無いよう組にして固定する。
+ */
+const SEASON_KEY = "season";
 const SEASON_TREND_FEATURE: ProFeature = "season_transition_graph";
 
 interface UseSeasonTrendGranularityOptions<G extends string> {
-  /** シーズン跨ぎ比較を表す粒度キー。この粒度だけ Pro 限定になる。 */
-  seasonKey: G;
   /** 無料で使える既定の粒度。初期値と、403 で拒否されたときの戻り先を兼ねる。 */
   freeKey: G;
   /**
@@ -24,8 +28,8 @@ interface UseSeasonTrendGranularityReturn<G extends string> {
   /** 粒度切替の要求。シーズン粒度を持たないユーザーには Paywall を出し、切替を行わない。 */
   requestGranularity: (next: G) => void;
   /**
-   * 推移データ取得結果をデータに落とす。403 なら無料粒度へ戻して Paywall を出し、
-   * 以降シーズン粒度をロックする。
+   * 推移データ取得結果をデータに落とす。シーズン粒度で 403 なら無料粒度へ戻して
+   * Paywall を出し、以降シーズン粒度をロックする。
    */
   resolveTrend: <T>(result: ProGatedResult<T>) => T | null;
 }
@@ -39,7 +43,6 @@ interface UseSeasonTrendGranularityReturn<G extends string> {
  * 戻したうえで Paywall を出す（グラフが空のまま無言で止まるのを避ける）。
  */
 export function useSeasonTrendGranularity<G extends string>({
-  seasonKey,
   freeKey,
   initialGranted,
 }: UseSeasonTrendGranularityOptions<G>): UseSeasonTrendGranularityReturn<G> {
@@ -56,30 +59,32 @@ export function useSeasonTrendGranularity<G extends string>({
 
   const requestGranularity = useCallback(
     (next: G) => {
-      if (next === seasonKey && !canViewSeason) {
+      if (next === SEASON_KEY && !canViewSeason) {
         openPaywall();
         return;
       }
       setGranularity(next);
     },
-    [seasonKey, canViewSeason, openPaywall],
+    [canViewSeason, openPaywall],
   );
 
   // resolveTrend は取得完了後に呼ばれる。identity が変わると呼び出し側の effect が
-  // 張り直されて進行中のレスポンスが捨てられるため、最新の関数は ref 経由で読む。
-  const latestRef = useRef({ unwrap, openPaywall });
+  // 張り直されて進行中のレスポンスが捨てられるため、最新の値は ref 経由で読む。
+  const latestRef = useRef({ unwrap, openPaywall, granularity });
   useEffect(() => {
-    latestRef.current = { unwrap, openPaywall };
+    latestRef.current = { unwrap, openPaywall, granularity };
   });
 
   const resolveTrend = useCallback(
     <T>(result: ProGatedResult<T>): T | null => {
-      const data = latestRef.current.unwrap(SEASON_TREND_FEATURE, result);
-      if (data === null) {
-        setGranularity(freeKey);
-        latestRef.current.openPaywall();
-      }
-      return data;
+      if (result.status === "ok") return result.data;
+      // シーズン粒度以外の 403 は season_transition_graph の拒否ではない。
+      // 無関係な粒度で無料粒度へ戻したり Paywall を出したりしないよう打ち切る。
+      if (latestRef.current.granularity !== SEASON_KEY) return null;
+      latestRef.current.unwrap(SEASON_TREND_FEATURE, result);
+      setGranularity(freeKey);
+      latestRef.current.openPaywall();
+      return null;
     },
     [freeKey],
   );


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#464

## 概要

back の `granularity=season` は実装済みで mobile も対応済みだが、front の `BattingTrendChart` は 試合/月/年/直近10 のみ、`EraTrendChart` には粒度トグル自体がなかった。

作業中に **防御率グラフが空になる既存バグ**も見つかったため併せて修正している（下記）。

## 既存バグの修正: 防御率グラフが空だった

front の `EraTrendPoint` は `{ trend: [{ month, era }] }` を読んでいたが、back は `{ granularity, points: [{ key, label, era }] }` に統一済みだった。**front が未追従で ERA グラフが描画されない状態**だったため、新形状に追従させている。issue 記載外だがシーズン粒度の実装に必須のため含めた。

## 変更内容

### 新規
- `app/hooks/pro/useSeasonTrendGranularity.ts` — 推移グラフの粒度 state を Pro ゲート付きで持つ共通フック。未保有なら切替せず Paywall を開き、403 なら無料粒度へ戻して以降ロック
- `app/(app)/stats/analysisProFeatures.ts` — SSR で許可済み Pro 機能を絞る `grantedProFeatures`
- `app/(app)/stats/_components/analysis/trendAxis.ts` — シーズン名の X 軸ラベル省略と間引き

### 変更
- `analysisActions.ts` — `BattingTrendGranularity` に `season` 追加、`EraTrendGranularity` / `EraTrendData` 追加、`EraTrendPoint` を back の新形状に追従。`getBattingTrend` / `getEraTrend` を `ProGatedResult` 化し、`granularity=season` 時に `season_id` を落とす
- `BattingTrendChart.tsx` — `season` 選択肢、粒度ごとの集計単位注記、ラベル間引き、`aria-pressed`
- `EraTrendChart.tsx` — 月/シーズンのトグル新設。**空データでもトグルを残す**（従来の `return null` だとシーズンが空のとき戻れなくなるため）
- `AnalysisSection.tsx` / `PitchingAnalysisSection.tsx` — #463 の SSR パターンを踏襲し `getCachedProStatus()` を `Promise.all` に同居させる

## 挙動と API 呼び出し

| | 打撃タブ | 投手タブ |
| --- | --- | --- |
| 無料 | 「シーズン」押下 → Paywall、粒度は「試合」のまま、**API 呼び出しなし** | 同左、粒度は「月」のまま、**API 呼び出しなし** |
| Pro | `granularity=season`、`season_id` は送らない | 同上 |
| Pro だが 403 | 「試合」に戻して Paywall、以降ロック | 「月」に戻して Paywall、以降ロック |

判定確定前は SSR 済みの `initialProFeatures` を使うため、Pro ユーザーが一瞬 Paywall に倒れることはない。

## ミューテーションによる検出力の実測

17パターン中15を初回で検出。未検出だった2件はテストを追加して **17/17 検出**に。

| 変異 | 結果 |
| --- | --- |
| `season_id` を落とさない | 検出 |
| `granularity` を送らない（batting / era） | 検出 |
| 403 を `pro_required` にせず畳む | 検出 |
| 未保有でもシーズンへ切替 | 検出（無料4件） |
| SSR 判定を使わない | 検出（フラッシュ防止2件） |
| 403 でも粒度を戻さない | 検出 |
| 空データで `null` を返す（防御率） | 検出 |
| X 軸ラベルを丸めない | 初回未検出 → 長シーズン名テストを追加し検出 |
| シーズンのラベル間引きを弱める | 初回未検出 → 12シーズンの間引きテストを追加し検出 |

既知のギャップ: Server Component の配線（`grantedProFeatures` の呼び出し引数）はレンダリングテストがなく未カバー。ロジック本体は `analysisProFeatures.test.ts` で担保。

## レビューで見てほしい点

1. **`EraTrendPoint` の形状変更** — issue 記載外だが、back の統一に front が未追従で ERA グラフが空だったため必須と判断した
2. **粒度トグルにロックアイコンを出していない** — mobile と同じく押下時に Paywall。判定確定前のちらつきをゼロにする方を優先した
3. **空データ時もトグルを残す方針**（防御率） — 従来は非表示だったためレイアウト差分が出る
4. シーズン名の省略しきい値（6文字）と間引き本数（4本）は目視前提の暫定値

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（57 suites / 468 tests）


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_