### PR TITLE
Add: Pro 加入状態管理画面（/account/subscription）を新設

### DIFF
--- a/app/(app)/account/subscription/__tests__/actions.test.ts
+++ b/app/(app)/account/subscription/__tests__/actions.test.ts
@@ -1,0 +1,161 @@
+const mockGet = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: () => Promise.resolve({ get: mockGet }),
+}));
+
+jest.mock("../../../../constants/api", () => ({
+  RAILS_API_URL: "http://back:3000",
+}));
+
+jest.mock("../../../../../lib/sentry-helpers", () => ({
+  captureServerActionError: jest.fn(),
+}));
+
+import { cancelWebSubscription } from "../actions";
+
+function setupAuthCookies() {
+  mockGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: "test-uid" },
+    };
+    return values[key];
+  });
+}
+
+describe("cancelWebSubscription", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  it("認証済みなら DELETE /api/v1/pro/subscription を叩いて成功を返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ message: "解約申請を受け付けました" }),
+    });
+
+    await expect(cancelWebSubscription()).resolves.toEqual({ ok: true });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://back:3000/api/v1/pro/subscription",
+      expect.objectContaining({
+        method: "DELETE",
+        headers: expect.objectContaining({
+          "access-token": "test-access-token",
+          client: "test-client",
+          uid: "test-uid",
+        }),
+      }),
+    );
+  });
+
+  it("未認証 cookie のときは fetch せずに unauthorized を返す", async () => {
+    mockGet.mockReturnValue(undefined);
+
+    await expect(cancelWebSubscription()).resolves.toEqual({
+      ok: false,
+      error: "unauthorized",
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("401 のとき unauthorized を返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    });
+
+    await expect(cancelWebSubscription()).resolves.toEqual({
+      ok: false,
+      error: "unauthorized",
+    });
+  });
+
+  it("422 no_active_subscription を区別して返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      json: async () => ({ error: "no_active_subscription" }),
+    });
+
+    await expect(cancelWebSubscription()).resolves.toEqual({
+      ok: false,
+      error: "no_active_subscription",
+    });
+  });
+
+  it("502 stripe_api_error を区別して返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      json: async () => ({ error: "stripe_api_error" }),
+    });
+
+    await expect(cancelWebSubscription()).resolves.toEqual({
+      ok: false,
+      error: "stripe_api_error",
+    });
+  });
+
+  it("想定外のエラーコードは unknown に畳む", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "internal_server_error" }),
+    });
+
+    await expect(cancelWebSubscription()).resolves.toEqual({
+      ok: false,
+      error: "unknown",
+    });
+  });
+
+  it("JSON でないエラーレスポンスでも unknown を返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error("not json");
+      },
+    });
+
+    await expect(cancelWebSubscription()).resolves.toEqual({
+      ok: false,
+      error: "unknown",
+    });
+  });
+
+  it("fetch が throw したら unknown を返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("network"));
+
+    await expect(cancelWebSubscription()).resolves.toEqual({
+      ok: false,
+      error: "unknown",
+    });
+  });
+
+  it("タイムアウト用の AbortSignal を渡す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+
+    await cancelWebSubscription();
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/app/(app)/account/subscription/__tests__/page.test.tsx
+++ b/app/(app)/account/subscription/__tests__/page.test.tsx
@@ -1,0 +1,294 @@
+const mockCookieGet = jest.fn();
+const mockRedirect = jest.fn((path: string) => {
+  throw new Error(`NEXT_REDIRECT:${path}`);
+});
+const mockRefresh = jest.fn();
+const mockGetCachedProStatus = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: () => Promise.resolve({ get: mockCookieGet }),
+}));
+
+jest.mock("next/navigation", () => ({
+  redirect: (path: string) => mockRedirect(path),
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+jest.mock("@app/(app)/pro/proStatus", () => ({
+  getCachedProStatus: () => mockGetCachedProStatus(),
+}));
+
+jest.mock("@app/components/header/Header", () => ({
+  __esModule: true,
+  default: () => <header />,
+}));
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  DEFAULT_PRO_STATUS,
+  type ProStatus,
+  type ProSubscription,
+  type SubscriptionStatus,
+} from "@app/types/pro";
+import AccountSubscriptionPage from "../page";
+
+function setAuthCookies() {
+  mockCookieGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: "user@example.com" },
+    };
+    return values[key];
+  });
+}
+
+function buildStatus(subscription: Partial<ProSubscription>): ProStatus {
+  return {
+    ...DEFAULT_PRO_STATUS,
+    subscription: { ...DEFAULT_PRO_STATUS.subscription, ...subscription },
+  };
+}
+
+async function renderPage(subscription: Partial<ProSubscription>) {
+  setAuthCookies();
+  mockGetCachedProStatus.mockResolvedValueOnce(buildStatus(subscription));
+  render(await AccountSubscriptionPage());
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("未認証", () => {
+  it("認証 cookie が無ければ加入状態を取得せずにリダイレクトする", async () => {
+    mockCookieGet.mockReturnValue(undefined);
+
+    await expect(AccountSubscriptionPage()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mockRedirect).toHaveBeenCalledWith("/signup?auth_required=true");
+    expect(mockGetCachedProStatus).not.toHaveBeenCalled();
+  });
+
+  it("認証 cookie が一部だけでもリダイレクトする", async () => {
+    mockCookieGet.mockImplementation((key: string) =>
+      key === "access-token" ? { value: "test-access-token" } : undefined,
+    );
+
+    await expect(AccountSubscriptionPage()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mockRedirect).toHaveBeenCalledWith("/signup?auth_required=true");
+  });
+});
+
+describe("status ごとの表示", () => {
+  const cases: {
+    status: SubscriptionStatus;
+    label: string;
+    description: string;
+    badgeClass: string;
+  }[] = [
+    {
+      status: "free",
+      label: "無料プラン",
+      description: "Pro に加入するとすべての機能を利用できます。",
+      badgeClass: "bg-[#6b7280]",
+    },
+    {
+      status: "trial",
+      label: "無料トライアル中",
+      description: "期間中はいつでも解約できます。",
+      badgeClass: "bg-[#3b82f6]",
+    },
+    {
+      status: "active",
+      label: "Pro 加入中",
+      description: "Pro 機能をすべてご利用いただけます。",
+      badgeClass: "bg-[#10b981]",
+    },
+    {
+      status: "cancelled",
+      label: "解約済み（期間内）",
+      description: "次回更新日まで Pro 機能を利用できます。",
+      badgeClass: "bg-[#f59e0b]",
+    },
+    {
+      status: "billing_issue",
+      label: "決済に問題があります",
+      description: "お支払い情報を更新してください。",
+      badgeClass: "bg-[#ef4444]",
+    },
+    {
+      status: "expired",
+      label: "Pro 期間終了",
+      description: "再加入すると過去のデータも引き続き閲覧できます。",
+      badgeClass: "bg-[#6b7280]",
+    },
+    {
+      status: "pending",
+      label: "処理中",
+      description: "決済処理が完了するまでお待ちください。",
+      badgeClass: "bg-[#6b7280]",
+    },
+  ];
+
+  it.each(cases)(
+    "status=$status は「$label」を表示する",
+    async ({ status, label, description, badgeClass }) => {
+      await renderPage({ status });
+
+      const badge = screen.getByText(label);
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveClass(badgeClass);
+      expect(screen.getByText(description)).toBeInTheDocument();
+    },
+  );
+
+  it("プラン種別を日本語ラベルで表示する", async () => {
+    await renderPage({ status: "active", plan_type: "yearly" });
+
+    expect(screen.getByText("年額プラン")).toBeInTheDocument();
+  });
+});
+
+describe("加入 CTA", () => {
+  it.each<SubscriptionStatus>(["free", "expired"])(
+    "status=%s は Pro 加入導線を表示する",
+    async (status) => {
+      await renderPage({ status });
+
+      expect(
+        screen.getByRole("link", { name: "Pro に加入する" }),
+      ).toHaveAttribute("href", "/pro");
+    },
+  );
+
+  it.each<SubscriptionStatus>([
+    "trial",
+    "active",
+    "cancelled",
+    "billing_issue",
+    "pending",
+  ])("status=%s は Pro 加入導線を表示しない", async (status) => {
+    await renderPage({ status });
+
+    expect(
+      screen.queryByRole("link", { name: "Pro に加入する" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("期限の表示", () => {
+  it("次回更新日と残り日数を表示する", async () => {
+    await renderPage({
+      status: "active",
+      expires_at: "2026-06-30T00:00:00+09:00",
+      days_remaining: 5,
+    });
+
+    expect(screen.getByText("次回更新日")).toBeInTheDocument();
+    expect(screen.getByText("2026/6/30")).toBeInTheDocument();
+    expect(screen.getByText("残り5日")).toBeInTheDocument();
+  });
+
+  it.each<SubscriptionStatus>(["cancelled", "expired"])(
+    "status=%s は「利用期限」として表示する",
+    async (status) => {
+      await renderPage({ status, expires_at: "2026-06-30T00:00:00+09:00" });
+
+      expect(screen.getByText("利用期限")).toBeInTheDocument();
+      expect(screen.queryByText("次回更新日")).not.toBeInTheDocument();
+    },
+  );
+
+  it("expires_at が無ければプレースホルダを表示し、残り日数は出さない", async () => {
+    await renderPage({ status: "free" });
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.queryByText("残り日数")).not.toBeInTheDocument();
+  });
+});
+
+describe("加入媒体ごとの解約案内", () => {
+  it("platform=ios は Web から解約できないことと Apple の導線を案内する", async () => {
+    await renderPage({ status: "active", platform: "ios" });
+
+    expect(
+      screen.getByText(/Web からは解約できません/, { exact: false }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: "Apple のサブスクリプション管理を開く",
+      }),
+    ).toHaveAttribute("href", "https://apps.apple.com/account/subscriptions");
+  });
+
+  it("platform=android は Google Play の導線を案内する", async () => {
+    await renderPage({ status: "active", platform: "android" });
+
+    expect(
+      screen.getByText(/Web からは解約できません/, { exact: false }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Google Play の定期購入を開く" }),
+    ).toHaveAttribute(
+      "href",
+      "https://play.google.com/store/account/subscriptions",
+    );
+  });
+
+  it("platform=web はストアへの誘導をせず問い合わせ導線を出す", async () => {
+    await renderPage({ status: "active", platform: "web" });
+
+    expect(
+      screen.queryByText(/Web からは解約できません/),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "お問い合わせ" })).toHaveAttribute(
+      "href",
+      "/contact",
+    );
+  });
+
+  it("加入媒体が不明なら解約案内を出さない", async () => {
+    await renderPage({ status: "active", platform: null });
+
+    expect(
+      screen.queryByRole("region", { name: "解約について" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("期限切れなら解約案内を出さない", async () => {
+    await renderPage({ status: "expired", platform: "ios" });
+
+    expect(
+      screen.queryByRole("region", { name: "解約について" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("取得失敗", () => {
+  it("無料プランとして描画せず、再試行導線を出す", async () => {
+    setAuthCookies();
+    mockGetCachedProStatus.mockResolvedValueOnce(null);
+
+    render(await AccountSubscriptionPage());
+
+    expect(screen.queryByText("無料プラン")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Pro に加入する" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "加入状態を取得できませんでした",
+    );
+    expect(screen.getByRole("button", { name: "再試行" })).toBeInTheDocument();
+  });
+
+  it("再試行ボタンでサーバー側の再取得を促す", async () => {
+    setAuthCookies();
+    mockGetCachedProStatus.mockResolvedValueOnce(null);
+
+    render(await AccountSubscriptionPage());
+    await userEvent.click(screen.getByRole("button", { name: "再試行" }));
+
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/(app)/account/subscription/__tests__/page.test.tsx
+++ b/app/(app)/account/subscription/__tests__/page.test.tsx
@@ -3,7 +3,8 @@ const mockRedirect = jest.fn((path: string) => {
   throw new Error(`NEXT_REDIRECT:${path}`);
 });
 const mockRefresh = jest.fn();
-const mockGetCachedProStatus = jest.fn();
+const mockGetCachedProStatusResult = jest.fn();
+const mockCancelWebSubscription = jest.fn();
 
 jest.mock("next/headers", () => ({
   cookies: () => Promise.resolve({ get: mockCookieGet }),
@@ -15,7 +16,11 @@ jest.mock("next/navigation", () => ({
 }));
 
 jest.mock("@app/(app)/pro/proStatus", () => ({
-  getCachedProStatus: () => mockGetCachedProStatus(),
+  getCachedProStatusResult: () => mockGetCachedProStatusResult(),
+}));
+
+jest.mock("../actions", () => ({
+  cancelWebSubscription: () => mockCancelWebSubscription(),
 }));
 
 jest.mock("@app/components/header/Header", () => ({
@@ -23,7 +28,7 @@ jest.mock("@app/components/header/Header", () => ({
   default: () => <header />,
 }));
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   DEFAULT_PRO_STATUS,
@@ -31,7 +36,7 @@ import {
   type ProSubscription,
   type SubscriptionStatus,
 } from "@app/types/pro";
-import AccountSubscriptionPage from "../page";
+import AccountSubscriptionPage, { metadata } from "../page";
 
 function setAuthCookies() {
   mockCookieGet.mockImplementation((key: string) => {
@@ -53,12 +58,37 @@ function buildStatus(subscription: Partial<ProSubscription>): ProStatus {
 
 async function renderPage(subscription: Partial<ProSubscription>) {
   setAuthCookies();
-  mockGetCachedProStatus.mockResolvedValueOnce(buildStatus(subscription));
+  mockGetCachedProStatusResult.mockResolvedValueOnce({
+    status: "ok",
+    proStatus: buildStatus(subscription),
+  });
   render(await AccountSubscriptionPage());
 }
 
+async function renderLoadFailure(reason: "unauthorized" | "error") {
+  setAuthCookies();
+  mockGetCachedProStatusResult.mockResolvedValueOnce({ status: reason });
+  render(await AccountSubscriptionPage());
+}
+
+const cancelSection = () =>
+  screen.queryByRole("region", { name: "解約について" });
+
+const billingSection = () =>
+  screen.queryByRole("region", { name: "お支払い情報の更新" });
+
 beforeEach(() => {
   jest.clearAllMocks();
+});
+
+describe("メタデータ", () => {
+  it("加入内容を含むため検索エンジンに登録させない", () => {
+    expect(metadata.robots).toEqual({ index: false });
+  });
+
+  it("タイトルを設定する", () => {
+    expect(metadata.title).toBe("サブスクリプション管理");
+  });
 });
 
 describe("未認証", () => {
@@ -67,7 +97,7 @@ describe("未認証", () => {
 
     await expect(AccountSubscriptionPage()).rejects.toThrow("NEXT_REDIRECT");
     expect(mockRedirect).toHaveBeenCalledWith("/signup?auth_required=true");
-    expect(mockGetCachedProStatus).not.toHaveBeenCalled();
+    expect(mockGetCachedProStatusResult).not.toHaveBeenCalled();
   });
 
   it("認証 cookie が一部だけでもリダイレクトする", async () => {
@@ -83,48 +113,56 @@ describe("未認証", () => {
 describe("status ごとの表示", () => {
   const cases: {
     status: SubscriptionStatus;
+    pro_active: boolean;
     label: string;
     description: string;
     badgeClass: string;
   }[] = [
     {
       status: "free",
+      pro_active: false,
       label: "無料プラン",
       description: "Pro に加入するとすべての機能を利用できます。",
       badgeClass: "bg-[#6b7280]",
     },
     {
       status: "trial",
+      pro_active: true,
       label: "無料トライアル中",
       description: "期間中はいつでも解約できます。",
       badgeClass: "bg-[#3b82f6]",
     },
     {
       status: "active",
+      pro_active: true,
       label: "Pro 加入中",
       description: "Pro 機能をすべてご利用いただけます。",
       badgeClass: "bg-[#10b981]",
     },
     {
       status: "cancelled",
+      pro_active: true,
       label: "解約済み（期間内）",
       description: "次回更新日まで Pro 機能を利用できます。",
       badgeClass: "bg-[#f59e0b]",
     },
     {
       status: "billing_issue",
+      pro_active: true,
       label: "決済に問題があります",
       description: "お支払い情報を更新してください。",
       badgeClass: "bg-[#ef4444]",
     },
     {
       status: "expired",
+      pro_active: false,
       label: "Pro 期間終了",
       description: "再加入すると過去のデータも引き続き閲覧できます。",
       badgeClass: "bg-[#6b7280]",
     },
     {
       status: "pending",
+      pro_active: false,
       label: "処理中",
       description: "決済処理が完了するまでお待ちください。",
       badgeClass: "bg-[#6b7280]",
@@ -133,8 +171,8 @@ describe("status ごとの表示", () => {
 
   it.each(cases)(
     "status=$status は「$label」を表示する",
-    async ({ status, label, description, badgeClass }) => {
-      await renderPage({ status });
+    async ({ status, pro_active, label, description, badgeClass }) => {
+      await renderPage({ status, pro_active });
 
       const badge = screen.getByText(label);
       expect(badge).toBeInTheDocument();
@@ -143,11 +181,88 @@ describe("status ごとの表示", () => {
     },
   );
 
-  it("プラン種別を日本語ラベルで表示する", async () => {
-    await renderPage({ status: "active", plan_type: "yearly" });
+  it.each([
+    { plan_type: "monthly" as const, label: "月額プラン" },
+    { plan_type: "yearly" as const, label: "年額プラン" },
+  ])(
+    "plan_type=$plan_type を「$label」と表示する",
+    async ({ plan_type, label }) => {
+      await renderPage({ status: "active", pro_active: true, plan_type });
 
-    expect(screen.getByText("年額プラン")).toBeInTheDocument();
+      expect(screen.getByText(label)).toBeInTheDocument();
+    },
+  );
+});
+
+// status は加入中のままでも pro_active が落ちている状態は webhook 到達前・失敗時に必ず通る。
+describe("pro_active=false のときの表示", () => {
+  const cases: {
+    status: SubscriptionStatus;
+    description: string;
+  }[] = [
+    {
+      status: "trial",
+      description:
+        "無料トライアル期間は終了しています。引き続き利用するには Pro に加入してください。",
+    },
+    {
+      status: "active",
+      description:
+        "ご利用期間は終了しています。お支払い後の反映には時間がかかる場合があります。",
+    },
+    {
+      status: "cancelled",
+      description:
+        "ご利用期間は終了しています。再加入すると引き続き Pro 機能を利用できます。",
+    },
+    {
+      status: "billing_issue",
+      description:
+        "お支払いを確認できず、Pro 機能のご利用は停止しています。お支払い情報を更新してください。",
+    },
+  ];
+
+  it.each(cases)(
+    "status=$status + pro_active=false は利用終了として説明する",
+    async ({ status, description }) => {
+      await renderPage({
+        status,
+        pro_active: false,
+        expires_at: "2025-01-01T00:00:00+09:00",
+        days_remaining: 0,
+      });
+
+      expect(screen.getByText(description)).toBeInTheDocument();
+    },
+  );
+
+  it("status=cancelled + 期限切れでも「次回更新日まで利用できます」とは言わない", async () => {
+    await renderPage({
+      status: "cancelled",
+      pro_active: false,
+      expires_at: "2025-01-01T00:00:00+09:00",
+      days_remaining: 0,
+    });
+
+    expect(
+      screen.queryByText("次回更新日まで Pro 機能を利用できます。"),
+    ).not.toBeInTheDocument();
   });
+
+  it.each<SubscriptionStatus>(["trial", "active", "cancelled"])(
+    "status=%s でも pro_active=false なら残り日数を出さない",
+    async (status) => {
+      await renderPage({
+        status,
+        pro_active: false,
+        expires_at: "2025-01-01T00:00:00+09:00",
+        days_remaining: 12,
+      });
+
+      expect(screen.queryByText("残り日数")).not.toBeInTheDocument();
+      expect(screen.queryByText("12日")).not.toBeInTheDocument();
+    },
+  );
 });
 
 describe("加入 CTA", () => {
@@ -169,7 +284,7 @@ describe("加入 CTA", () => {
     "billing_issue",
     "pending",
   ])("status=%s は Pro 加入導線を表示しない", async (status) => {
-    await renderPage({ status });
+    await renderPage({ status, pro_active: true });
 
     expect(
       screen.queryByRole("link", { name: "Pro に加入する" }),
@@ -181,13 +296,38 @@ describe("期限の表示", () => {
   it("次回更新日と残り日数を表示する", async () => {
     await renderPage({
       status: "active",
+      pro_active: true,
       expires_at: "2026-06-30T00:00:00+09:00",
       days_remaining: 5,
     });
 
     expect(screen.getByText("次回更新日")).toBeInTheDocument();
     expect(screen.getByText("2026/6/30")).toBeInTheDocument();
-    expect(screen.getByText("残り5日")).toBeInTheDocument();
+    expect(screen.getByText("残り日数")).toBeInTheDocument();
+    expect(screen.getByText("5日")).toBeInTheDocument();
+  });
+
+  it("残り日数が 0 でも行を出す（back は下限 0 を返す）", async () => {
+    await renderPage({
+      status: "active",
+      pro_active: true,
+      expires_at: "2026-06-30T00:00:00+09:00",
+      days_remaining: 0,
+    });
+
+    expect(screen.getByText("残り日数")).toBeInTheDocument();
+    expect(screen.getByText("0日")).toBeInTheDocument();
+  });
+
+  it("「残り日数: 残り0日」のように二重表現しない", async () => {
+    await renderPage({
+      status: "active",
+      pro_active: true,
+      expires_at: "2026-06-30T00:00:00+09:00",
+      days_remaining: 0,
+    });
+
+    expect(screen.queryByText("残り0日")).not.toBeInTheDocument();
   });
 
   it.each<SubscriptionStatus>(["cancelled", "expired"])(
@@ -206,71 +346,322 @@ describe("期限の表示", () => {
     expect(screen.getByText("—")).toBeInTheDocument();
     expect(screen.queryByText("残り日数")).not.toBeInTheDocument();
   });
+
+  it("expires_at が壊れていればプレースホルダを表示する", async () => {
+    await renderPage({ status: "active", pro_active: true, expires_at: "－" });
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
 });
 
 describe("加入媒体ごとの解約案内", () => {
-  it("platform=ios は Web から解約できないことと Apple の導線を案内する", async () => {
-    await renderPage({ status: "active", platform: "ios" });
+  it("platform=ios は Apple の解約手順を4ステップで案内する", async () => {
+    await renderPage({ status: "active", pro_active: true, platform: "ios" });
 
+    const section = cancelSection();
+    expect(section).toBeInTheDocument();
     expect(
-      screen.getByText(/Web からは解約できません/, { exact: false }),
+      within(section!).getByText(/Web からは解約できません/, { exact: false }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", {
-        name: "Apple のサブスクリプション管理を開く",
-      }),
-    ).toHaveAttribute("href", "https://apps.apple.com/account/subscriptions");
+
+    const steps = within(section!).getAllByRole("listitem");
+    expect(steps.map((step) => step.textContent)).toEqual([
+      "「設定」アプリを開く",
+      "上部のあなたの名前（Apple ID）をタップ",
+      "「サブスクリプション」をタップ",
+      "「BUZZ BASE Pro」を選び、解約を完了",
+    ]);
   });
 
-  it("platform=android は Google Play の導線を案内する", async () => {
-    await renderPage({ status: "active", platform: "android" });
+  it("platform=ios は Apple の管理画面を別タブで開く", async () => {
+    await renderPage({ status: "active", pro_active: true, platform: "ios" });
 
+    const link = screen.getByRole("link", {
+      name: "Apple のサブスクリプション管理を開く",
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://apps.apple.com/account/subscriptions",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("platform=android は Google Play の解約手順を4ステップで案内する", async () => {
+    await renderPage({
+      status: "active",
+      pro_active: true,
+      platform: "android",
+    });
+
+    const section = cancelSection();
+    expect(section).toBeInTheDocument();
     expect(
-      screen.getByText(/Web からは解約できません/, { exact: false }),
+      within(section!).getByText(/Web からは解約できません/, { exact: false }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: "Google Play の定期購入を開く" }),
-    ).toHaveAttribute(
+
+    const steps = within(section!).getAllByRole("listitem");
+    expect(steps.map((step) => step.textContent)).toEqual([
+      "Google Play ストアを開く",
+      "右上のプロフィールアイコンをタップ",
+      "「お支払いと定期購入」→「定期購入」をタップ",
+      "「BUZZ BASE Pro」を選び、解約を完了",
+    ]);
+  });
+
+  it("platform=android は Google Play を別タブで開く", async () => {
+    await renderPage({
+      status: "active",
+      pro_active: true,
+      platform: "android",
+    });
+
+    const link = screen.getByRole("link", {
+      name: "Google Play の定期購入を開く",
+    });
+    expect(link).toHaveAttribute(
       "href",
       "https://play.google.com/store/account/subscriptions",
     );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 
-  it("platform=web はストアへの誘導をせず問い合わせ導線を出す", async () => {
-    await renderPage({ status: "active", platform: "web" });
+  it("platform=web はこの画面で解約できることを案内する（特商法表記と一致）", async () => {
+    await renderPage({ status: "active", pro_active: true, platform: "web" });
 
+    const section = cancelSection();
+    expect(section).toBeInTheDocument();
     expect(
-      screen.queryByText(/Web からは解約できません/),
+      within(section!).getByText(/この画面からいつでも解約できます/),
+    ).toBeInTheDocument();
+    expect(
+      within(section!).queryByText(/準備中/, { exact: false }),
     ).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "お問い合わせ" })).toHaveAttribute(
-      "href",
-      "/contact",
+    expect(
+      within(section!).getByRole("button", { name: "この画面で解約する" }),
+    ).toBeInTheDocument();
+  });
+
+  it("加入媒体が不明でも案内を消さず、問い合わせ導線を出す", async () => {
+    await renderPage({ status: "active", pro_active: true, platform: null });
+
+    const section = cancelSection();
+    expect(section).toBeInTheDocument();
+    expect(
+      within(section!).getByText(/ご加入の媒体を判別できませんでした/),
+    ).toBeInTheDocument();
+
+    const link = within(section!).getByRole("link", { name: "お問い合わせ" });
+    expect(link).toHaveAttribute("href", "/contact");
+    expect(link).not.toHaveAttribute("target");
+    expect(link).not.toHaveAttribute("rel");
+    expect(
+      within(section!).queryByRole("button", { name: "この画面で解約する" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it.each<SubscriptionStatus>([
+    "free",
+    "cancelled",
+    "billing_issue",
+    "expired",
+    "pending",
+  ])("status=%s には解約案内を出さない", async (status) => {
+    await renderPage({ status, platform: "ios" });
+
+    expect(cancelSection()).not.toBeInTheDocument();
+  });
+});
+
+describe("Web 解約", () => {
+  async function openCancelDialog() {
+    await renderPage({ status: "active", pro_active: true, platform: "web" });
+    await userEvent.click(
+      screen.getByRole("button", { name: "この画面で解約する" }),
+    );
+  }
+
+  it("確認ダイアログを開くまでは解約 API を叩かない", async () => {
+    await renderPage({ status: "active", pro_active: true, platform: "web" });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(mockCancelWebSubscription).not.toHaveBeenCalled();
+  });
+
+  it("確認ダイアログで次回更新日まで使えることを明示する", async () => {
+    await openCancelDialog();
+
+    const dialog = screen.getByRole("dialog");
+    expect(
+      within(dialog).getByText(/次回更新日までは引き続きご利用いただけます/),
+    ).toBeInTheDocument();
+    expect(mockCancelWebSubscription).not.toHaveBeenCalled();
+  });
+
+  it("閉じるボタンで解約せずにダイアログを閉じる", async () => {
+    await openCancelDialog();
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "閉じる",
+      }),
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(mockCancelWebSubscription).not.toHaveBeenCalled();
+  });
+
+  it("解約を確定すると API を呼び、完了と再取得を行う", async () => {
+    mockCancelWebSubscription.mockResolvedValue({ ok: true });
+    await openCancelDialog();
+
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "解約する",
+      }),
+    );
+
+    expect(mockCancelWebSubscription).toHaveBeenCalledTimes(1);
+    expect(
+      await screen.findByText("解約申請を受け付けました"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("次回更新日まで引き続き Pro 機能をご利用いただけます。"),
+    ).toBeInTheDocument();
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("有効な契約が無いときは解約済み・別媒体の可能性を伝える", async () => {
+    mockCancelWebSubscription.mockResolvedValue({
+      ok: false,
+      error: "no_active_subscription",
+    });
+    await openCancelDialog();
+
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "解約する",
+      }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "解約できるご契約が見つかりませんでした",
+    );
+    expect(
+      screen.queryByText("解約申請を受け付けました"),
+    ).not.toBeInTheDocument();
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it("決済サービス障害のときは課金が継続していることを伝える", async () => {
+    mockCancelWebSubscription.mockResolvedValue({
+      ok: false,
+      error: "stripe_api_error",
+    });
+    await openCancelDialog();
+
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "解約する",
+      }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "決済サービスとの通信に失敗しました",
+    );
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it("トークン失効のときは再ログインを促す", async () => {
+    mockCancelWebSubscription.mockResolvedValue({
+      ok: false,
+      error: "unauthorized",
+    });
+    await openCancelDialog();
+
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "解約する",
+      }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "ログインの有効期限が切れています",
     );
   });
+});
 
-  it("加入媒体が不明なら解約案内を出さない", async () => {
-    await renderPage({ status: "active", platform: null });
+describe("支払い情報の更新案内", () => {
+  it.each<SubscriptionStatus>([
+    "free",
+    "trial",
+    "active",
+    "cancelled",
+    "expired",
+    "pending",
+  ])("status=%s には出さない", async (status) => {
+    await renderPage({ status, platform: "web" });
 
-    expect(
-      screen.queryByRole("region", { name: "解約について" }),
-    ).not.toBeInTheDocument();
+    expect(billingSection()).not.toBeInTheDocument();
   });
 
-  it("期限切れなら解約案内を出さない", async () => {
-    await renderPage({ status: "expired", platform: "ios" });
+  it("platform=web はメールからのカード更新を案内する", async () => {
+    await renderPage({ status: "billing_issue", platform: "web" });
 
+    const section = billingSection();
+    expect(section).toBeInTheDocument();
     expect(
-      screen.queryByRole("region", { name: "解約について" }),
-    ).not.toBeInTheDocument();
+      within(section!).getByText(/クレジットカードの決済に失敗しています/),
+    ).toBeInTheDocument();
+    expect(
+      within(section!).getByRole("link", {
+        name: "メールが見つからない場合はお問い合わせ",
+      }),
+    ).toHaveAttribute("href", "/contact");
+  });
+
+  it("platform=ios は Apple のお支払い情報へ誘導する", async () => {
+    await renderPage({ status: "billing_issue", platform: "ios" });
+
+    const link = screen.getByRole("link", {
+      name: "Apple のお支払い情報を開く",
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://apps.apple.com/account/billing",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("platform=android は Google Play のお支払い方法へ誘導する", async () => {
+    await renderPage({ status: "billing_issue", platform: "android" });
+
+    const link = screen.getByRole("link", {
+      name: "Google Play のお支払い方法を開く",
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://play.google.com/store/paymentmethods",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("媒体不明でも行き止まりにせず問い合わせ導線を出す", async () => {
+    await renderPage({ status: "billing_issue", platform: null });
+
+    const section = billingSection();
+    expect(section).toBeInTheDocument();
+    expect(
+      within(section!).getByRole("link", { name: "お問い合わせ" }),
+    ).toHaveAttribute("href", "/contact");
   });
 });
 
 describe("取得失敗", () => {
   it("無料プランとして描画せず、再試行導線を出す", async () => {
-    setAuthCookies();
-    mockGetCachedProStatus.mockResolvedValueOnce(null);
-
-    render(await AccountSubscriptionPage());
+    await renderLoadFailure("error");
 
     expect(screen.queryByText("無料プラン")).not.toBeInTheDocument();
     expect(
@@ -283,12 +674,31 @@ describe("取得失敗", () => {
   });
 
   it("再試行ボタンでサーバー側の再取得を促す", async () => {
-    setAuthCookies();
-    mockGetCachedProStatus.mockResolvedValueOnce(null);
-
-    render(await AccountSubscriptionPage());
+    await renderLoadFailure("error");
     await userEvent.click(screen.getByRole("button", { name: "再試行" }));
 
     expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("通信障害でも再ログイン導線を併記する", async () => {
+    await renderLoadFailure("error");
+
+    expect(
+      screen.getByRole("link", { name: "ログインし直す" }),
+    ).toHaveAttribute("href", "/signin");
+  });
+
+  it("トークン失効なら再試行させず再ログインへ誘導する", async () => {
+    await renderLoadFailure("unauthorized");
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "ログインの有効期限が切れています",
+    );
+    expect(
+      screen.queryByRole("button", { name: "再試行" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "ログインし直す" }),
+    ).toHaveAttribute("href", "/signin");
   });
 });

--- a/app/(app)/account/subscription/_components/BillingIssueGuide.tsx
+++ b/app/(app)/account/subscription/_components/BillingIssueGuide.tsx
@@ -1,0 +1,70 @@
+import type { Platform, ProSubscription } from "@app/types/pro";
+import GuideSection, { type GuideContent } from "./GuideSection";
+
+// 支払い方法を保持しているのは決済プロバイダ側なので、更新手続きは媒体ごとの管理画面で行う。
+const PAYMENT_UPDATE_GUIDE: Record<Platform, GuideContent> = {
+  web: {
+    description:
+      "クレジットカードの決済に失敗しています。決済サービス（Stripe）からお送りしているお支払い手続きのご案内メールから、カード情報を更新してください。",
+    steps: [
+      "「BUZZ BASE のお支払いに関するお知らせ」メールを開く",
+      "メール内のお支払いページのリンクを開く",
+      "有効なクレジットカード情報を入力して支払いを完了",
+    ],
+    link: { href: "/contact", label: "メールが見つからない場合はお問い合わせ" },
+  },
+  ios: {
+    description:
+      "Apple ID の決済に失敗しています。iPhone / iPad の設定からお支払い情報を更新してください。",
+    steps: [
+      "「設定」アプリを開く",
+      "上部のあなたの名前（Apple ID）をタップ",
+      "「お支払いと配送先」をタップ",
+      "有効なお支払い方法に更新",
+    ],
+    link: {
+      href: "https://apps.apple.com/account/billing",
+      label: "Apple のお支払い情報を開く",
+    },
+  },
+  android: {
+    description:
+      "Google Play の決済に失敗しています。Google Play のお支払い方法を更新してください。",
+    steps: [
+      "Google Play ストアを開く",
+      "右上のプロフィールアイコンをタップ",
+      "「お支払いと定期購入」→「お支払い方法」をタップ",
+      "有効なお支払い方法に更新",
+    ],
+    link: {
+      href: "https://play.google.com/store/paymentmethods",
+      label: "Google Play のお支払い方法を開く",
+    },
+  },
+};
+
+const UNKNOWN_PLATFORM_GUIDE: GuideContent = {
+  description:
+    "お支払いを確認できませんでした。ご加入の媒体を判別できないため、お手続き方法をご案内できません。お問い合わせください。",
+  steps: [],
+  link: { href: "/contact", label: "お問い合わせ" },
+};
+
+/**
+ * billing_issue のときに、加入媒体ごとの支払い情報の更新先を案内するセクション。
+ * 放置すると Pro が失効するため、最優先の導線として状態カードの直下に置く。
+ */
+export default function BillingIssueGuide({
+  subscription,
+}: {
+  subscription: ProSubscription;
+}) {
+  if (subscription.status !== "billing_issue") return null;
+
+  const { platform } = subscription;
+  const content = platform
+    ? PAYMENT_UPDATE_GUIDE[platform]
+    : UNKNOWN_PLATFORM_GUIDE;
+
+  return <GuideSection title="お支払い情報の更新" content={content} />;
+}

--- a/app/(app)/account/subscription/_components/CancelGuide.tsx
+++ b/app/(app)/account/subscription/_components/CancelGuide.tsx
@@ -1,0 +1,95 @@
+import type {
+  Platform,
+  ProSubscription,
+  SubscriptionStatus,
+} from "@app/types/pro";
+import Link from "next/link";
+
+interface CancelGuideContent {
+  description: string;
+  steps: string[];
+  link: { href: string; label: string };
+}
+
+// 解約手続きは加入した媒体でしか行えない。ストア課金の解約 UI は Web から呼び出せないため、
+// それぞれの管理画面へ誘導する。
+const CANCEL_GUIDE: Record<Platform, CancelGuideContent> = {
+  web: {
+    description:
+      "Web（クレジットカード）でご加入中です。この画面からの解約手続きは現在準備中のため、解約をご希望の場合はお問い合わせください。",
+    steps: [],
+    link: { href: "/contact", label: "お問い合わせ" },
+  },
+  ios: {
+    description:
+      "iOS アプリ内課金でご加入中のため、Web からは解約できません。iPhone / iPad の設定から手続きしてください。",
+    steps: [
+      "「設定」アプリを開く",
+      "上部のあなたの名前（Apple ID）をタップ",
+      "「サブスクリプション」をタップ",
+      "「BUZZ BASE Pro」を選び、解約を完了",
+    ],
+    link: {
+      href: "https://apps.apple.com/account/subscriptions",
+      label: "Apple のサブスクリプション管理を開く",
+    },
+  },
+  android: {
+    description:
+      "Google Play でご加入中のため、Web からは解約できません。Google Play の定期購入から手続きしてください。",
+    steps: [
+      "Google Play ストアを開く",
+      "右上のプロフィールアイコンをタップ",
+      "「お支払いと定期購入」→「定期購入」をタップ",
+      "「BUZZ BASE Pro」を選び、解約を完了",
+    ],
+    link: {
+      href: "https://play.google.com/store/account/subscriptions",
+      label: "Google Play の定期購入を開く",
+    },
+  },
+};
+
+// 解約できるのは期間内の加入状態のときだけ。解約済み・期限切れには案内を出さない。
+const CANCELLABLE_STATUSES: SubscriptionStatus[] = ["trial", "active"];
+
+/**
+ * 加入媒体ごとの解約手順を案内するセクション。
+ * 解約可能な状態かつ加入媒体が判明しているときだけ描画する。
+ */
+export default function CancelGuide({
+  subscription,
+}: {
+  subscription: ProSubscription;
+}) {
+  const { platform, status } = subscription;
+  if (platform === null || !CANCELLABLE_STATUSES.includes(status)) return null;
+
+  const content = CANCEL_GUIDE[platform];
+  const isExternal = content.link.href.startsWith("http");
+
+  return (
+    <section aria-label="解約について" className="rounded-xl bg-sub p-4">
+      <h2 className="text-sm font-bold text-white">解約について</h2>
+      <p className="mt-2 text-sm leading-5 text-zic-300">
+        {content.description}
+      </p>
+      {content.steps.length > 0 ? (
+        <ol className="mt-3 list-decimal space-y-1 rounded-lg bg-main p-3 pl-7 text-sm text-zic-200">
+          {content.steps.map((step) => (
+            <li key={step}>{step}</li>
+          ))}
+        </ol>
+      ) : null}
+      <Link
+        href={content.link.href}
+        className="mt-3 inline-block text-sm font-semibold text-[#d08000] underline"
+        {...(isExternal
+          ? { target: "_blank", rel: "noopener noreferrer" }
+          : {})}
+      >
+        {content.link.label}
+      </Link>
+    </section>
+  );
+}

--- a/app/(app)/account/subscription/_components/CancelGuide.tsx
+++ b/app/(app)/account/subscription/_components/CancelGuide.tsx
@@ -3,22 +3,17 @@ import type {
   ProSubscription,
   SubscriptionStatus,
 } from "@app/types/pro";
-import Link from "next/link";
+import CancelWebSubscription from "./CancelWebSubscription";
+import GuideSection, { type GuideContent } from "./GuideSection";
 
-interface CancelGuideContent {
-  description: string;
-  steps: string[];
-  link: { href: string; label: string };
-}
-
-// 解約手続きは加入した媒体でしか行えない。ストア課金の解約 UI は Web から呼び出せないため、
-// それぞれの管理画面へ誘導する。
-const CANCEL_GUIDE: Record<Platform, CancelGuideContent> = {
+// ストア課金の解約 UI は Web から呼び出せないため、それぞれの管理画面へ誘導する。
+// Web（Stripe）だけは back の DELETE /api/v1/pro/subscription でこの画面から完結できる。
+const CANCEL_GUIDE: Record<Platform, GuideContent> = {
   web: {
     description:
-      "Web（クレジットカード）でご加入中です。この画面からの解約手続きは現在準備中のため、解約をご希望の場合はお問い合わせください。",
+      "Web（クレジットカード）でご加入中です。この画面からいつでも解約できます。解約後も次回更新日までは Pro 機能をご利用いただけます。",
     steps: [],
-    link: { href: "/contact", label: "お問い合わせ" },
+    link: null,
   },
   ios: {
     description:
@@ -50,12 +45,22 @@ const CANCEL_GUIDE: Record<Platform, CancelGuideContent> = {
   },
 };
 
+// back は Stripe Checkout 完了時点では platform を保存せず、決済プロバイダの webhook 到達で
+// 初めて確定する。未登録 product の場合は恒久的に null のままにもなりうるため、
+// 「媒体不明」を無表示にせず問い合わせ導線へ倒す。
+const UNKNOWN_PLATFORM_GUIDE: GuideContent = {
+  description:
+    "ご加入の媒体を判別できませんでした。ご加入直後は反映までお時間がかかる場合があります。時間をおいても変わらない場合や解約をご希望の場合はお問い合わせください。",
+  steps: [],
+  link: { href: "/contact", label: "お問い合わせ" },
+};
+
 // 解約できるのは期間内の加入状態のときだけ。解約済み・期限切れには案内を出さない。
 const CANCELLABLE_STATUSES: SubscriptionStatus[] = ["trial", "active"];
 
 /**
- * 加入媒体ごとの解約手順を案内するセクション。
- * 解約可能な状態かつ加入媒体が判明しているときだけ描画する。
+ * 加入媒体ごとの解約手段を案内するセクション。
+ * 解約可能な状態のときだけ描画し、Web 加入者にはこの画面で完結する解約ボタンを出す。
  */
 export default function CancelGuide({
   subscription,
@@ -63,33 +68,13 @@ export default function CancelGuide({
   subscription: ProSubscription;
 }) {
   const { platform, status } = subscription;
-  if (platform === null || !CANCELLABLE_STATUSES.includes(status)) return null;
+  if (!CANCELLABLE_STATUSES.includes(status)) return null;
 
-  const content = CANCEL_GUIDE[platform];
-  const isExternal = content.link.href.startsWith("http");
+  const content = platform ? CANCEL_GUIDE[platform] : UNKNOWN_PLATFORM_GUIDE;
 
   return (
-    <section aria-label="解約について" className="rounded-xl bg-sub p-4">
-      <h2 className="text-sm font-bold text-white">解約について</h2>
-      <p className="mt-2 text-sm leading-5 text-zic-300">
-        {content.description}
-      </p>
-      {content.steps.length > 0 ? (
-        <ol className="mt-3 list-decimal space-y-1 rounded-lg bg-main p-3 pl-7 text-sm text-zic-200">
-          {content.steps.map((step) => (
-            <li key={step}>{step}</li>
-          ))}
-        </ol>
-      ) : null}
-      <Link
-        href={content.link.href}
-        className="mt-3 inline-block text-sm font-semibold text-[#d08000] underline"
-        {...(isExternal
-          ? { target: "_blank", rel: "noopener noreferrer" }
-          : {})}
-      >
-        {content.link.label}
-      </Link>
-    </section>
+    <GuideSection title="解約について" content={content}>
+      {platform === "web" ? <CancelWebSubscription /> : null}
+    </GuideSection>
   );
 }

--- a/app/(app)/account/subscription/_components/CancelWebSubscription.tsx
+++ b/app/(app)/account/subscription/_components/CancelWebSubscription.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import {
+  cancelWebSubscription,
+  type CancelWebSubscriptionError,
+} from "../actions";
+
+const ERROR_MESSAGES: Record<CancelWebSubscriptionError, string> = {
+  unauthorized:
+    "ログインの有効期限が切れています。再度ログインしてからお試しください。",
+  no_active_subscription:
+    "解約できるご契約が見つかりませんでした。すでに解約手続きが完了しているか、別の媒体でご加入の可能性があります。",
+  stripe_api_error:
+    "決済サービスとの通信に失敗しました。時間をおいて再度お試しください。課金は継続しています。",
+  unknown: "解約手続きに失敗しました。時間をおいて再度お試しください。",
+};
+
+/**
+ * Web（Stripe）加入者がこの画面から解約するためのボタンと確認ダイアログ。
+ * back は cancel_at_period_end で受け付けるため、解約後も次回更新日までは Pro 機能を使える。
+ * その旨を確認時と完了時の両方で明示する。
+ */
+export default function CancelWebSubscription() {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [isDone, setIsDone] = useState(false);
+  const [error, setError] = useState<CancelWebSubscriptionError | null>(null);
+  const [isCancelling, startTransition] = useTransition();
+
+  const openDialog = () => {
+    setIsDone(false);
+    setError(null);
+    setIsOpen(true);
+  };
+
+  const closeDialog = () => {
+    if (isCancelling) return;
+    setIsOpen(false);
+  };
+
+  const handleCancel = () => {
+    setError(null);
+    startTransition(async () => {
+      const result = await cancelWebSubscription();
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      setIsDone(true);
+      // 解約申請は Stripe 側で受理済み。反映済みの加入状態を Server Component 側から取り直す。
+      router.refresh();
+    });
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openDialog}
+        className="mt-3 rounded-lg border border-[#ef4444] px-4 py-2 text-sm font-bold text-[#ef4444] transition-opacity hover:opacity-80"
+      >
+        この画面で解約する
+      </button>
+
+      {isOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6"
+          onKeyDown={(event) => {
+            if (event.key === "Escape") closeDialog();
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={
+              isDone ? "解約申請を受け付けました" : "Pro プランの解約"
+            }
+            className="w-full max-w-[400px] rounded-xl bg-main p-6"
+          >
+            {isDone ? (
+              <>
+                <h3 className="text-base font-bold text-white">
+                  解約申請を受け付けました
+                </h3>
+                <p className="mt-3 text-sm leading-6 text-zic-300">
+                  次回更新日まで引き続き Pro 機能をご利用いただけます。
+                </p>
+                <div className="mt-5 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={closeDialog}
+                    className="rounded-lg bg-[#d08000] px-4 py-2 text-sm font-bold text-white"
+                  >
+                    閉じる
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <h3 className="text-base font-bold text-white">
+                  Pro プランの解約
+                </h3>
+                <p className="mt-3 text-sm leading-6 text-zic-300">
+                  解約すると次回更新日以降は Pro
+                  機能が利用できなくなります。次回更新日までは引き続きご利用いただけます（日割りでの返金は行いません）。
+                </p>
+                {error ? (
+                  <p
+                    role="alert"
+                    className="mt-3 rounded-lg bg-[#7f1d1d] p-3 text-sm leading-5 text-white"
+                  >
+                    {ERROR_MESSAGES[error]}
+                  </p>
+                ) : null}
+                <div className="mt-5 flex justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={closeDialog}
+                    disabled={isCancelling}
+                    className="rounded-lg px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+                  >
+                    閉じる
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleCancel}
+                    disabled={isCancelling}
+                    className="rounded-lg bg-[#d08000] px-4 py-2 text-sm font-bold text-white disabled:opacity-50"
+                  >
+                    {isCancelling ? "解約手続き中…" : "解約する"}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/app/(app)/account/subscription/_components/GuideSection.tsx
+++ b/app/(app)/account/subscription/_components/GuideSection.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+
+export interface GuideLink {
+  href: string;
+  label: string;
+}
+
+export interface GuideContent {
+  description: string;
+  steps: string[];
+  link: GuideLink | null;
+}
+
+/**
+ * 解約方法・支払い情報の更新先といった手続き案内を共通レイアウトで描画するセクション。
+ * title は見出しと同時に region 名にもなるため、画面内で一意な文言を渡すこと。
+ * children には案内文の下に置く操作系（アプリ内で完結する解約ボタンなど）を渡す。
+ */
+export default function GuideSection({
+  title,
+  content,
+  children,
+}: {
+  title: string;
+  content: GuideContent;
+  children?: ReactNode;
+}) {
+  // ストアの管理画面など外部サイトは別タブで開く。内部遷移で開くと戻り導線を失う。
+  const isExternal = content.link?.href.startsWith("http") ?? false;
+
+  return (
+    <section aria-label={title} className="rounded-xl bg-sub p-4">
+      <h2 className="text-sm font-bold text-white">{title}</h2>
+      <p className="mt-2 text-sm leading-5 text-zic-300">
+        {content.description}
+      </p>
+      {content.steps.length > 0 ? (
+        <ol className="mt-3 list-decimal space-y-1 rounded-lg bg-main p-3 pl-7 text-sm text-zic-200">
+          {content.steps.map((step) => (
+            <li key={step}>{step}</li>
+          ))}
+        </ol>
+      ) : null}
+      {children}
+      {content.link ? (
+        <Link
+          href={content.link.href}
+          className="mt-3 inline-block text-sm font-semibold text-[#d08000] underline"
+          {...(isExternal
+            ? { target: "_blank", rel: "noopener noreferrer" }
+            : {})}
+        >
+          {content.link.label}
+        </Link>
+      ) : null}
+    </section>
+  );
+}

--- a/app/(app)/account/subscription/_components/SubscriptionLoadError.tsx
+++ b/app/(app)/account/subscription/_components/SubscriptionLoadError.tsx
@@ -1,14 +1,41 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 /**
  * Pro 状態の取得に失敗したときの表示。
  * 無料プランとして描画すると課金中のユーザーに解約されたと誤認させるため、
- * 取得できなかったことを明示して再試行だけを促す。
+ * 取得できなかったことを明示する。
+ *
+ * トークン失効（unauthorized）のときは router.refresh() しても同じ失効 cookie を送るだけで
+ * 復帰できないため、再試行ではなく再ログインへ誘導する。
  */
-export default function SubscriptionLoadError() {
+export default function SubscriptionLoadError({
+  reason,
+}: {
+  reason: "unauthorized" | "error";
+}) {
   const router = useRouter();
+
+  if (reason === "unauthorized") {
+    return (
+      <section role="alert" className="rounded-xl bg-sub p-4">
+        <h2 className="text-sm font-bold text-white">
+          加入状態を取得できませんでした
+        </h2>
+        <p className="mt-2 text-sm leading-5 text-zic-300">
+          ログインの有効期限が切れています。再度ログインしてください。ご加入内容が変更されたわけではありません。
+        </p>
+        <Link
+          href="/signin"
+          className="mt-3 inline-block rounded-lg bg-[#d08000] px-4 py-2 text-sm font-bold text-white transition-opacity hover:opacity-90"
+        >
+          ログインし直す
+        </Link>
+      </section>
+    );
+  }
 
   return (
     <section role="alert" className="rounded-xl bg-sub p-4">
@@ -18,13 +45,21 @@ export default function SubscriptionLoadError() {
       <p className="mt-2 text-sm leading-5 text-zic-300">
         通信環境をご確認のうえ、再試行してください。ご加入内容が変更されたわけではありません。
       </p>
-      <button
-        type="button"
-        onClick={() => router.refresh()}
-        className="mt-3 rounded-lg bg-[#d08000] px-4 py-2 text-sm font-bold text-white transition-opacity hover:opacity-90"
-      >
-        再試行
-      </button>
+      <div className="mt-3 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => router.refresh()}
+          className="rounded-lg bg-[#d08000] px-4 py-2 text-sm font-bold text-white transition-opacity hover:opacity-90"
+        >
+          再試行
+        </button>
+        <Link
+          href="/signin"
+          className="text-sm font-semibold text-[#d08000] underline"
+        >
+          ログインし直す
+        </Link>
+      </div>
     </section>
   );
 }

--- a/app/(app)/account/subscription/_components/SubscriptionLoadError.tsx
+++ b/app/(app)/account/subscription/_components/SubscriptionLoadError.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+/**
+ * Pro 状態の取得に失敗したときの表示。
+ * 無料プランとして描画すると課金中のユーザーに解約されたと誤認させるため、
+ * 取得できなかったことを明示して再試行だけを促す。
+ */
+export default function SubscriptionLoadError() {
+  const router = useRouter();
+
+  return (
+    <section role="alert" className="rounded-xl bg-sub p-4">
+      <h2 className="text-sm font-bold text-white">
+        加入状態を取得できませんでした
+      </h2>
+      <p className="mt-2 text-sm leading-5 text-zic-300">
+        通信環境をご確認のうえ、再試行してください。ご加入内容が変更されたわけではありません。
+      </p>
+      <button
+        type="button"
+        onClick={() => router.refresh()}
+        className="mt-3 rounded-lg bg-[#d08000] px-4 py-2 text-sm font-bold text-white transition-opacity hover:opacity-90"
+      >
+        再試行
+      </button>
+    </section>
+  );
+}

--- a/app/(app)/account/subscription/_components/SubscriptionOverview.tsx
+++ b/app/(app)/account/subscription/_components/SubscriptionOverview.tsx
@@ -1,12 +1,13 @@
 import type { ProSubscription, SubscriptionStatus } from "@app/types/pro";
 import Link from "next/link";
+import BillingIssueGuide from "./BillingIssueGuide";
 import CancelGuide from "./CancelGuide";
 import SubscriptionStatusCard from "./SubscriptionStatusCard";
 
 const JOINABLE_STATUSES: SubscriptionStatus[] = ["free", "expired"];
 
 /**
- * 加入状態カード・加入 CTA・解約案内をまとめた本体表示。
+ * 加入状態カード・加入 CTA・支払い更新案内・解約案内をまとめた本体表示。
  */
 export default function SubscriptionOverview({
   subscription,
@@ -16,6 +17,7 @@ export default function SubscriptionOverview({
   return (
     <div className="flex flex-col gap-4">
       <SubscriptionStatusCard subscription={subscription} />
+      <BillingIssueGuide subscription={subscription} />
       {JOINABLE_STATUSES.includes(subscription.status) ? (
         <Link
           href="/pro"

--- a/app/(app)/account/subscription/_components/SubscriptionOverview.tsx
+++ b/app/(app)/account/subscription/_components/SubscriptionOverview.tsx
@@ -1,0 +1,30 @@
+import type { ProSubscription, SubscriptionStatus } from "@app/types/pro";
+import Link from "next/link";
+import CancelGuide from "./CancelGuide";
+import SubscriptionStatusCard from "./SubscriptionStatusCard";
+
+const JOINABLE_STATUSES: SubscriptionStatus[] = ["free", "expired"];
+
+/**
+ * 加入状態カード・加入 CTA・解約案内をまとめた本体表示。
+ */
+export default function SubscriptionOverview({
+  subscription,
+}: {
+  subscription: ProSubscription;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <SubscriptionStatusCard subscription={subscription} />
+      {JOINABLE_STATUSES.includes(subscription.status) ? (
+        <Link
+          href="/pro"
+          className="rounded-lg bg-[#d08000] px-4 py-3 text-center text-sm font-bold text-white transition-opacity hover:opacity-90"
+        >
+          Pro に加入する
+        </Link>
+      ) : null}
+      <CancelGuide subscription={subscription} />
+    </div>
+  );
+}

--- a/app/(app)/account/subscription/_components/SubscriptionStatusCard.tsx
+++ b/app/(app)/account/subscription/_components/SubscriptionStatusCard.tsx
@@ -7,6 +7,12 @@ import type {
 interface StatusContent {
   label: string;
   description: string;
+  /**
+   * pro_active === false のときに description を差し替える文言。
+   * status を expired へ倒すのは webhook 頼みで定期ジョブが無いため、
+   * 「期限は過ぎたが status は加入中のまま」という状態を必ず通る。
+   */
+  inactiveDescription?: string;
   badgeClass: string;
 }
 
@@ -19,22 +25,30 @@ const STATUS_CONTENT: Record<SubscriptionStatus, StatusContent> = {
   trial: {
     label: "無料トライアル中",
     description: "期間中はいつでも解約できます。",
+    inactiveDescription:
+      "無料トライアル期間は終了しています。引き続き利用するには Pro に加入してください。",
     badgeClass: "bg-[#3b82f6]",
   },
   active: {
     label: "Pro 加入中",
     description: "Pro 機能をすべてご利用いただけます。",
+    inactiveDescription:
+      "ご利用期間は終了しています。お支払い後の反映には時間がかかる場合があります。",
     badgeClass: "bg-[#10b981]",
   },
   cancelled: {
     label: "解約済み（期間内）",
     description: "次回更新日まで Pro 機能を利用できます。",
+    inactiveDescription:
+      "ご利用期間は終了しています。再加入すると引き続き Pro 機能を利用できます。",
     badgeClass: "bg-[#f59e0b]",
   },
   billing_issue: {
     // モバイルは App Store 固定の文言だが、Web には Stripe 加入者も来るため媒体を限定しない。
     label: "決済に問題があります",
     description: "お支払い情報を更新してください。",
+    inactiveDescription:
+      "お支払いを確認できず、Pro 機能のご利用は停止しています。お支払い情報を更新してください。",
     badgeClass: "bg-[#ef4444]",
   },
   expired: {
@@ -78,7 +92,8 @@ function formatDate(iso: string | null): string {
 
 /**
  * Pro 加入状態を表示するカード。
- * status ごとにバッジ色・見出し・説明文を出し分け、期限日と残り日数を添える。
+ * status ごとにバッジ色・見出しを出し分けつつ、説明文と残り日数は
+ * Server が判定した pro_active を単一の真実として扱う。
  */
 export default function SubscriptionStatusCard({
   subscription,
@@ -86,12 +101,19 @@ export default function SubscriptionStatusCard({
   subscription: ProSubscription;
 }) {
   const content = STATUS_CONTENT[subscription.status];
+  const description =
+    !subscription.pro_active && content.inactiveDescription
+      ? content.inactiveDescription
+      : content.description;
   const planLabel = subscription.plan_type
     ? PLAN_LABEL[subscription.plan_type]
     : null;
   const metaLabel = EXPIRY_META_STATUSES.includes(subscription.status)
     ? "利用期限"
     : "次回更新日";
+  // 利用できない状態で「残りN日」を出すと、使えるはずの期間が残っていると誤解させる。
+  const showDaysRemaining =
+    subscription.pro_active && subscription.days_remaining !== null;
 
   return (
     <section
@@ -111,9 +133,7 @@ export default function SubscriptionStatusCard({
         ) : null}
       </div>
 
-      <p className="mt-2 text-sm leading-5 text-zic-300">
-        {content.description}
-      </p>
+      <p className="mt-2 text-sm leading-5 text-zic-300">{description}</p>
 
       <dl className="mt-3 border-t border-zinc-600 pt-2 text-sm">
         <div className="flex items-center justify-between py-1">
@@ -122,11 +142,11 @@ export default function SubscriptionStatusCard({
             {formatDate(subscription.expires_at)}
           </dd>
         </div>
-        {subscription.days_remaining !== null ? (
+        {showDaysRemaining ? (
           <div className="flex items-center justify-between py-1">
             <dt className="text-xs text-zic-400">残り日数</dt>
             <dd className="font-semibold text-white">
-              残り{subscription.days_remaining}日
+              {subscription.days_remaining}日
             </dd>
           </div>
         ) : null}

--- a/app/(app)/account/subscription/_components/SubscriptionStatusCard.tsx
+++ b/app/(app)/account/subscription/_components/SubscriptionStatusCard.tsx
@@ -1,0 +1,136 @@
+import type {
+  PlanType,
+  ProSubscription,
+  SubscriptionStatus,
+} from "@app/types/pro";
+
+interface StatusContent {
+  label: string;
+  description: string;
+  badgeClass: string;
+}
+
+const STATUS_CONTENT: Record<SubscriptionStatus, StatusContent> = {
+  free: {
+    label: "無料プラン",
+    description: "Pro に加入するとすべての機能を利用できます。",
+    badgeClass: "bg-[#6b7280]",
+  },
+  trial: {
+    label: "無料トライアル中",
+    description: "期間中はいつでも解約できます。",
+    badgeClass: "bg-[#3b82f6]",
+  },
+  active: {
+    label: "Pro 加入中",
+    description: "Pro 機能をすべてご利用いただけます。",
+    badgeClass: "bg-[#10b981]",
+  },
+  cancelled: {
+    label: "解約済み（期間内）",
+    description: "次回更新日まで Pro 機能を利用できます。",
+    badgeClass: "bg-[#f59e0b]",
+  },
+  billing_issue: {
+    // モバイルは App Store 固定の文言だが、Web には Stripe 加入者も来るため媒体を限定しない。
+    label: "決済に問題があります",
+    description: "お支払い情報を更新してください。",
+    badgeClass: "bg-[#ef4444]",
+  },
+  expired: {
+    label: "Pro 期間終了",
+    description: "再加入すると過去のデータも引き続き閲覧できます。",
+    badgeClass: "bg-[#6b7280]",
+  },
+  pending: {
+    label: "処理中",
+    description: "決済処理が完了するまでお待ちください。",
+    badgeClass: "bg-[#6b7280]",
+  },
+};
+
+const PLAN_LABEL: Record<PlanType, string> = {
+  monthly: "月額プラン",
+  yearly: "年額プラン",
+};
+
+// 期限を過ぎた状態では「次に課金される日」ではなく「いつまで使えたか」を示す。
+const EXPIRY_META_STATUSES: SubscriptionStatus[] = ["cancelled", "expired"];
+
+const EMPTY_VALUE = "—";
+
+// サーバー側のタイムゾーンに依存せず、モバイル（端末ローカル = JST 想定）と同じ日付を出す。
+const DATE_FORMATTER = new Intl.DateTimeFormat("ja-JP", {
+  timeZone: "Asia/Tokyo",
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+});
+
+function formatDate(iso: string | null): string {
+  if (!iso) return EMPTY_VALUE;
+
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return EMPTY_VALUE;
+
+  return DATE_FORMATTER.format(date);
+}
+
+/**
+ * Pro 加入状態を表示するカード。
+ * status ごとにバッジ色・見出し・説明文を出し分け、期限日と残り日数を添える。
+ */
+export default function SubscriptionStatusCard({
+  subscription,
+}: {
+  subscription: ProSubscription;
+}) {
+  const content = STATUS_CONTENT[subscription.status];
+  const planLabel = subscription.plan_type
+    ? PLAN_LABEL[subscription.plan_type]
+    : null;
+  const metaLabel = EXPIRY_META_STATUSES.includes(subscription.status)
+    ? "利用期限"
+    : "次回更新日";
+
+  return (
+    <section
+      aria-label="サブスクリプション状態"
+      className="rounded-xl bg-sub p-4"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className={`rounded-full px-2.5 py-1 text-xs font-bold text-white ${content.badgeClass}`}
+        >
+          {content.label}
+        </span>
+        {planLabel ? (
+          <span className="text-sm font-semibold text-zic-300">
+            {planLabel}
+          </span>
+        ) : null}
+      </div>
+
+      <p className="mt-2 text-sm leading-5 text-zic-300">
+        {content.description}
+      </p>
+
+      <dl className="mt-3 border-t border-zinc-600 pt-2 text-sm">
+        <div className="flex items-center justify-between py-1">
+          <dt className="text-xs text-zic-400">{metaLabel}</dt>
+          <dd className="font-semibold text-white">
+            {formatDate(subscription.expires_at)}
+          </dd>
+        </div>
+        {subscription.days_remaining !== null ? (
+          <div className="flex items-center justify-between py-1">
+            <dt className="text-xs text-zic-400">残り日数</dt>
+            <dd className="font-semibold text-white">
+              残り{subscription.days_remaining}日
+            </dd>
+          </div>
+        ) : null}
+      </dl>
+    </section>
+  );
+}

--- a/app/(app)/account/subscription/actions.ts
+++ b/app/(app)/account/subscription/actions.ts
@@ -1,0 +1,73 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { captureServerActionError } from "../../../../lib/sentry-helpers";
+import { RAILS_API_URL } from "../../../constants/api";
+
+// Rails 側が詰まったときに Server Action を無期限に待たせないための上限。
+const CANCEL_API_TIMEOUT_MS = 10000;
+
+async function getAuthHeaders(): Promise<Record<string, string> | null> {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("access-token")?.value;
+  const client = cookieStore.get("client")?.value;
+  const uid = cookieStore.get("uid")?.value;
+
+  if (!accessToken || !client || !uid) return null;
+
+  return {
+    "Content-Type": "application/json",
+    "access-token": accessToken,
+    client,
+    uid,
+  };
+}
+
+export type CancelWebSubscriptionError =
+  | "unauthorized"
+  | "no_active_subscription"
+  | "stripe_api_error"
+  | "unknown";
+
+export type CancelWebSubscriptionResult =
+  | { ok: true }
+  | { ok: false; error: CancelWebSubscriptionError };
+
+/**
+ * Web（Stripe）で加入したサブスクリプションの解約を申請する。
+ * back は cancel_at_period_end を立てるだけで即時失効はしないため、成功後も
+ * 次回更新日までは Pro 機能を利用できる。ローカルの status は Stripe webhook 経由で
+ * 追って正規化されるので、呼び出し側は解約直後に再取得しても cancelled とは限らない。
+ *
+ * ストア課金（ios / android）は Stripe サブスクリプションを持たず
+ * no_active_subscription になるため、このアクションを呼んではいけない。
+ */
+export async function cancelWebSubscription(): Promise<CancelWebSubscriptionResult> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return { ok: false, error: "unauthorized" };
+
+    const response = await fetch(`${RAILS_API_URL}/api/v1/pro/subscription`, {
+      method: "DELETE",
+      headers,
+      signal: AbortSignal.timeout(CANCEL_API_TIMEOUT_MS),
+    });
+
+    if (response.ok) return { ok: true };
+    if (response.status === 401) return { ok: false, error: "unauthorized" };
+
+    const body = (await response.json().catch(() => ({}))) as {
+      error?: string;
+    };
+    if (body.error === "no_active_subscription") {
+      return { ok: false, error: "no_active_subscription" };
+    }
+    if (body.error === "stripe_api_error") {
+      return { ok: false, error: "stripe_api_error" };
+    }
+    return { ok: false, error: "unknown" };
+  } catch (error) {
+    captureServerActionError(error, { action: "cancelWebSubscription" });
+    return { ok: false, error: "unknown" };
+  }
+}

--- a/app/(app)/account/subscription/page.tsx
+++ b/app/(app)/account/subscription/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { getCachedProStatus } from "@app/(app)/pro/proStatus";
+import { getCachedProStatusResult } from "@app/(app)/pro/proStatus";
 import Header from "@app/components/header/Header";
 import SubscriptionLoadError from "./_components/SubscriptionLoadError";
 import SubscriptionOverview from "./_components/SubscriptionOverview";
@@ -21,9 +21,9 @@ export default async function AccountSubscriptionPage() {
     redirect("/signup?auth_required=true");
   }
 
-  // 認証済みで null が返るのは API 障害かトークン失効。無料状態にフォールバックすると
-  // 課金中のユーザーに未加入と誤表示するため、取得失敗として扱う。
-  const proStatus = await getCachedProStatus();
+  // 認証済みで取得できないのは API 障害かトークン失効。無料状態にフォールバックすると
+  // 課金中のユーザーに未加入と誤表示するため、失敗理由ごとの導線を出す。
+  const result = await getCachedProStatusResult();
 
   return (
     <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
@@ -35,10 +35,12 @@ export default async function AccountSubscriptionPage() {
               サブスクリプション管理
             </h1>
             <div className="my-6">
-              {proStatus ? (
-                <SubscriptionOverview subscription={proStatus.subscription} />
+              {result.status === "ok" ? (
+                <SubscriptionOverview
+                  subscription={result.proStatus.subscription}
+                />
               ) : (
-                <SubscriptionLoadError />
+                <SubscriptionLoadError reason={result.status} />
               )}
             </div>
           </div>

--- a/app/(app)/account/subscription/page.tsx
+++ b/app/(app)/account/subscription/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { getCachedProStatus } from "@app/(app)/pro/proStatus";
+import Header from "@app/components/header/Header";
+import SubscriptionLoadError from "./_components/SubscriptionLoadError";
+import SubscriptionOverview from "./_components/SubscriptionOverview";
+
+export const metadata: Metadata = {
+  title: "サブスクリプション管理",
+  robots: { index: false },
+};
+
+export default async function AccountSubscriptionPage() {
+  const cookieStore = await cookies();
+  const hasAuthCookies =
+    Boolean(cookieStore.get("access-token")) &&
+    Boolean(cookieStore.get("client")) &&
+    Boolean(cookieStore.get("uid"));
+  if (!hasAuthCookies) {
+    redirect("/signup?auth_required=true");
+  }
+
+  // 認証済みで null が返るのは API 障害かトークン失効。無料状態にフォールバックすると
+  // 課金中のユーザーに未加入と誤表示するため、取得失敗として扱う。
+  const proStatus = await getCachedProStatus();
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            <h1 className="text-2xl font-bold text-white">
+              サブスクリプション管理
+            </h1>
+            <div className="my-6">
+              {proStatus ? (
+                <SubscriptionOverview subscription={proStatus.subscription} />
+              ) : (
+                <SubscriptionLoadError />
+              )}
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/(app)/pro/__tests__/actions.test.ts
+++ b/app/(app)/pro/__tests__/actions.test.ts
@@ -13,7 +13,7 @@ jest.mock("../../../../lib/sentry-helpers", () => ({
   captureServerActionError: jest.fn(),
 }));
 
-import { getProStatus, startProCheckout } from "../actions";
+import { getProStatus, getProStatusResult, startProCheckout } from "../actions";
 
 function setupAuthCookies() {
   mockGet.mockImplementation((key: string) => {
@@ -73,6 +73,76 @@ describe("getProStatus", () => {
 
     const [, init] = (global.fetch as jest.Mock).mock.calls[0];
     expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("getProStatusResult", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("未認証 cookie のときは fetch せずに unauthorized を返す", async () => {
+    mockGet.mockReturnValue(undefined);
+
+    await expect(getProStatusResult()).resolves.toEqual({
+      status: "unauthorized",
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("401 は通信障害と区別して unauthorized を返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    });
+
+    await expect(getProStatusResult()).resolves.toEqual({
+      status: "unauthorized",
+    });
+  });
+
+  it("5xx は error を返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    await expect(getProStatusResult()).resolves.toEqual({ status: "error" });
+  });
+
+  it("fetch が throw したら error を返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("network"));
+
+    await expect(getProStatusResult()).resolves.toEqual({ status: "error" });
+  });
+
+  it("成功時は取得した Pro 状態を ok として返す", async () => {
+    setupAuthCookies();
+    const proStatus = { subscription: { status: "active" }, entitlements: [] };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => proStatus,
+    });
+
+    await expect(getProStatusResult()).resolves.toEqual({
+      status: "ok",
+      proStatus,
+    });
   });
 });
 

--- a/app/(app)/pro/__tests__/proStatus.test.ts
+++ b/app/(app)/pro/__tests__/proStatus.test.ts
@@ -1,16 +1,16 @@
 const mockCookieGet = jest.fn();
-const mockGetProStatus = jest.fn();
+const mockGetProStatusResult = jest.fn();
 
 jest.mock("next/headers", () => ({
   cookies: () => Promise.resolve({ get: mockCookieGet }),
 }));
 
 jest.mock("../actions", () => ({
-  getProStatus: () => mockGetProStatus(),
+  getProStatusResult: () => mockGetProStatusResult(),
 }));
 
 import { DEFAULT_PRO_STATUS, type ProStatus } from "@app/types/pro";
-import { getCachedProStatus } from "../proStatus";
+import { getCachedProStatus, getCachedProStatusResult } from "../proStatus";
 
 function setAuthCookies(uid = "user@example.com") {
   mockCookieGet.mockImplementation((key: string) => {
@@ -39,7 +39,7 @@ describe("getCachedProStatus", () => {
 
   it("認証済みなら Pro 状態を返す", async () => {
     setAuthCookies();
-    mockGetProStatus.mockResolvedValueOnce(proStatus);
+    mockGetProStatusResult.mockResolvedValueOnce({ status: "ok", proStatus });
 
     await expect(getCachedProStatus()).resolves.toEqual(proStatus);
   });
@@ -48,7 +48,7 @@ describe("getCachedProStatus", () => {
     mockCookieGet.mockReturnValue(undefined);
 
     await expect(getCachedProStatus()).resolves.toBeNull();
-    expect(mockGetProStatus).not.toHaveBeenCalled();
+    expect(mockGetProStatusResult).not.toHaveBeenCalled();
   });
 
   it("認証 cookie が一部だけのときも API を呼ばずに null を返す", async () => {
@@ -57,6 +57,37 @@ describe("getCachedProStatus", () => {
     );
 
     await expect(getCachedProStatus()).resolves.toBeNull();
-    expect(mockGetProStatus).not.toHaveBeenCalled();
+    expect(mockGetProStatusResult).not.toHaveBeenCalled();
+  });
+
+  it("取得に失敗したときは null を返す", async () => {
+    setAuthCookies();
+    mockGetProStatusResult.mockResolvedValueOnce({ status: "error" });
+
+    await expect(getCachedProStatus()).resolves.toBeNull();
+  });
+});
+
+describe("getCachedProStatusResult", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("認証 cookie が無いときは API を呼ばずに unauthorized を返す", async () => {
+    mockCookieGet.mockReturnValue(undefined);
+
+    await expect(getCachedProStatusResult()).resolves.toEqual({
+      status: "unauthorized",
+    });
+    expect(mockGetProStatusResult).not.toHaveBeenCalled();
+  });
+
+  it("失敗理由を畳まずにそのまま返す", async () => {
+    setAuthCookies();
+    mockGetProStatusResult.mockResolvedValueOnce({ status: "error" });
+
+    await expect(getCachedProStatusResult()).resolves.toEqual({
+      status: "error",
+    });
   });
 });

--- a/app/(app)/pro/actions.ts
+++ b/app/(app)/pro/actions.ts
@@ -29,13 +29,24 @@ async function getAuthHeaders(): Promise<Record<string, string> | null> {
 }
 
 /**
- * 現在ユーザーの Pro 加入状態と保有 entitlement を取得する。
- * 未認証・API 失敗時は null を返す。UI 側で DEFAULT_PRO_STATUS にフォールバックする想定。
+ * Pro 加入状態の取得結果。
+ * トークン失効（unauthorized）と通信・サーバー障害（error）はユーザーが取るべき行動が
+ * 「再ログイン」と「再試行」で異なるため、null に畳まず呼び出し側で区別できるようにする。
  */
-export async function getProStatus(): Promise<ProStatus | null> {
+export type ProStatusResult =
+  | { status: "ok"; proStatus: ProStatus }
+  | { status: "unauthorized" }
+  | { status: "error" };
+
+/**
+ * 現在ユーザーの Pro 加入状態と保有 entitlement を、失敗理由付きで取得する。
+ * 加入状態そのものをユーザーに提示する画面（サブスクリプション管理など）は、
+ * 失敗を無料状態に倒さずこの戻り値で文言を出し分けること。
+ */
+export async function getProStatusResult(): Promise<ProStatusResult> {
   try {
     const headers = await getAuthHeaders();
-    if (!headers) return null;
+    if (!headers) return { status: "unauthorized" };
 
     const response = await fetch(`${RAILS_API_URL}/api/v1/pro/status`, {
       method: "GET",
@@ -45,19 +56,32 @@ export async function getProStatus(): Promise<ProStatus | null> {
     });
 
     // 401 はトークン失効という想定内の状態。全ページのレンダーごとに記録すると
-    // 本当のエラーが埋もれるため、無料状態へのフォールバックだけ行う。
-    if (response.status === 401) return null;
+    // 本当のエラーが埋もれるため、ログには残さない。
+    if (response.status === 401) return { status: "unauthorized" };
 
     if (!response.ok) {
       console.error("Pro status API error:", response.status);
-      return null;
+      return { status: "error" };
     }
 
-    return (await response.json()) as ProStatus;
+    return { status: "ok", proStatus: (await response.json()) as ProStatus };
   } catch (error) {
     captureServerActionError(error, { action: "getProStatus" });
-    return null;
+    return { status: "error" };
   }
+}
+
+/**
+ * 現在ユーザーの Pro 加入状態と保有 entitlement を取得する。
+ * 未認証・API 失敗時は null を返す。
+ *
+ * null は「加入状態が不明」であって「無料」ではない。DEFAULT_PRO_STATUS へ倒してよいのは
+ * 訴求 LP のように加入状態を断定しない読み取り専用画面だけで、加入状態や課金内容を
+ * ユーザーに提示する画面は getProStatusResult() で失敗理由まで受け取ること。
+ */
+export async function getProStatus(): Promise<ProStatus | null> {
+  const result = await getProStatusResult();
+  return result.status === "ok" ? result.proStatus : null;
 }
 
 /**

--- a/app/(app)/pro/proStatus.ts
+++ b/app/(app)/pro/proStatus.ts
@@ -1,22 +1,36 @@
 import type { ProStatus } from "../../types/pro";
 import { cookies } from "next/headers";
 import { cache } from "react";
-import { getProStatus } from "./actions";
+import { getProStatusResult, type ProStatusResult } from "./actions";
 
 /**
- * Pro 状態をリクエスト単位でメモ化して取得する。
+ * Pro 状態を失敗理由付きで、リクエスト単位にメモ化して取得する。
  * 同一リクエストで複数の Server Component が呼んでも API アクセスは1回に収まる。
- * 未認証時は API を叩かずに null を返す（UI 側で無料状態にフォールバックする）。
+ * cookie が揃っていなければ API を叩かずに unauthorized を返す。
  *
  * 静的生成を捨てられないルートからは呼ばないこと。cookies() を読んだ時点で
  * そのルートは dynamic 扱いになる。
  */
-export const getCachedProStatus = cache(async (): Promise<ProStatus | null> => {
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get("access-token")?.value;
-  const client = cookieStore.get("client")?.value;
-  const uid = cookieStore.get("uid")?.value;
-  if (!accessToken || !client || !uid) return null;
+export const getCachedProStatusResult = cache(
+  async (): Promise<ProStatusResult> => {
+    const cookieStore = await cookies();
+    const accessToken = cookieStore.get("access-token")?.value;
+    const client = cookieStore.get("client")?.value;
+    const uid = cookieStore.get("uid")?.value;
+    if (!accessToken || !client || !uid) return { status: "unauthorized" };
 
-  return getProStatus();
-});
+    return getProStatusResult();
+  },
+);
+
+/**
+ * Pro 状態をリクエスト単位でメモ化して取得する。取得できなければ null。
+ *
+ * null は「加入状態が不明」であって「無料」ではない。DEFAULT_PRO_STATUS へ倒してよいのは
+ * 訴求 LP のように加入状態を断定しない読み取り専用画面だけで、加入状態や課金内容を
+ * ユーザーに提示する画面は getCachedProStatusResult() で unauthorized / error を区別すること。
+ */
+export const getCachedProStatus = async (): Promise<ProStatus | null> => {
+  const result = await getCachedProStatusResult();
+  return result.status === "ok" ? result.proStatus : null;
+};


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#455

## 概要

`/pro` と `/pro/success` から `/account/subscription` へリンクしているが該当ページが存在せず、**Pro ユーザーが `/pro` を開くと 404 にリダイレクトされる**状態だった。

## 変更内容（すべて新規）

- `app/(app)/account/subscription/page.tsx` — Server Component。認証 cookie 3点を検証し欠けていれば redirect。`getCachedProStatus()` が `null` なら取得失敗として分岐。`robots: { index: false }`
- `_components/SubscriptionStatusCard.tsx` — `Record<SubscriptionStatus, StatusContent>` で **7 status を型により網羅**
- `_components/SubscriptionOverview.tsx` / `CancelGuide.tsx` / `SubscriptionLoadError.tsx`
- `__tests__/page.test.tsx` — ページ経由の結合テスト28本

## 7 status の出し分け（mobile と突き合わせ済み）

| status | label | badge |
| --- | --- | --- |
| free | 無料プラン | `#6b7280` |
| trial | 無料トライアル中 | `#3b82f6` |
| active | Pro 加入中 | `#10b981` |
| cancelled | 解約済み（期間内） | `#f59e0b` |
| billing_issue | 決済に問題があります | `#ef4444` |
| expired | Pro 期間終了 | `#6b7280` |
| pending | 処理中 | `#6b7280` |

メタ行の出し分け（`cancelled`/`expired` は「利用期限」、他は「次回更新日」）も mobile と一致。日付は `Intl.DateTimeFormat("ja-JP", { timeZone: "Asia/Tokyo" })` でサーバー TZ が UTC でも JST 表示になるよう明示している。

## API 失敗時の挙動

`getCachedProStatus()` が `null`（API 障害 / タイムアウト / 401 失効）を返した場合、**`DEFAULT_PRO_STATUS` にフォールバックしない**。`role="alert"` で「加入状態を取得できませんでした」「ご加入内容が変更されたわけではありません」+ 再試行ボタンを出す。無料プラン表記も加入 CTA も一切出さない。

課金ユーザーに解約されたと誤認させないための措置。

## platform 別の解約導線（土台）

解約処理自体は #456 で実装するため、ここでは案内まで。

| platform | 内容 |
| --- | --- |
| ios | 設定アプリの4ステップ + App Store のサブスクリプション設定へのリンク |
| android | 同様 + Google Play へのリンク |
| web | ストア誘導なし。「準備中」+ `/contact` 導線（#456 で実解約 UI に差し替え） |

`platform === null` または status が `trial`/`active` 以外ならセクション自体を出さない（mobile と同じ）。

## ビルド検証（ベースライン比較）

| | static | dynamic |
| --- | --- | --- |
| 変更後 | **89** | 43 |
| ベースライン（`app/(app)/account` を削除して測定） | **89** | 42 |

静的ルートは89のまま減っておらず、増えた dynamic は新ページ1本のみ。他ルートへの波及なし。

## ミューテーションによる検出力の実測（16/16 KILLED）

取得失敗時の無料フォールバック / バッジ色 / ラベル / CTA の出し分け / 解約案内の status ガード / platform 判定 / 認証判定 / 日付の timeZone / 再試行の `router.refresh()` など16パターンすべて検出。

## レビューで見てほしい点

1. **`billing_issue` の description を mobile から意図的にずらした** — mobile は「App Store の決済情報を更新してください。」だが、Web には Stripe 加入者も来るため媒体を限定しない文言にした。mobile 側も将来 platform 別にするか要判断
2. `platform === "web"` の解約案内が現状「準備中 + お問い合わせ」であること（過剰約束にならないよう配慮）
3. 未認証時に `redirect("/signup?auth_required=true")` としたのは既存ページ踏襲だが、Pro 管理画面としては `/signin` の方が自然かもしれない
4. `proxy.ts` にこのルートを追加していない（他の認証必須ページ同様、Server Component 側でガード）

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（62 suites / 532 tests）
- [x] `yarn build` が通る（静的ルート89維持）


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_