### PR TITLE
Fix: Pro 加入者(no_ads)に AdSense 広告を表示しないよう修正

### DIFF
--- a/app/(app)/__tests__/layout.test.tsx
+++ b/app/(app)/__tests__/layout.test.tsx
@@ -59,6 +59,20 @@ jest.mock("sonner", () => ({
   },
 }));
 
+jest.mock("@app/components/ad/adConfig", () => ({
+  ADSENSE_CLIENT_ID: "ca-pub-test",
+  isAdsenseEnabled: true,
+  isAdsenseScriptEnabled: true,
+  adSlots: {},
+}));
+
+jest.mock("next/script", () => ({
+  __esModule: true,
+  default: ({ src }: { src: string }) => (
+    <div data-testid="adsense-script" data-src={src} />
+  ),
+}));
+
 import { act, render, screen, type RenderResult } from "@testing-library/react";
 import ProGate from "@app/components/pro/ProGate";
 import { useProStatus } from "@app/hooks/pro/useProStatus";
@@ -237,6 +251,41 @@ describe("AppLayout の ProStatusProvider", () => {
 
     expect(mockGetProStatus).toHaveBeenCalledTimes(1);
     expect(screen.getByText("PRO")).toBeInTheDocument();
+  });
+
+  // AdsenseScript が Provider の外に出ると useProStatus が無料状態にフォールバックし、
+  // Pro 加入者にもスクリプトが読み込まれる状態へ静かに退行する
+  it("no_ads を持つ Pro 加入者には AdSense スクリプトを読み込まない", async () => {
+    setAuthCookies("pro-user@example.com");
+    mockGetProStatus.mockResolvedValue({
+      ...proStatus,
+      entitlements: [...proStatus.entitlements, "no_ads"],
+    });
+
+    await renderLayout();
+
+    expect(screen.queryByTestId("adsense-script")).not.toBeInTheDocument();
+  });
+
+  it("無料ユーザーには AdSense スクリプトを読み込む", async () => {
+    setAuthCookies("free-user@example.com");
+    mockGetProStatus.mockResolvedValue(DEFAULT_PRO_STATUS);
+
+    await renderLayout();
+
+    expect(screen.getByTestId("adsense-script")).toBeInTheDocument();
+  });
+
+  // Server Action の通信自体が失敗しても確定させないと isLoading が永久 true になり、
+  // 無料ユーザーに広告が二度と出ない
+  it("Pro status の取得が reject しても無料状態として確定する", async () => {
+    setAuthCookies("free-user@example.com");
+    mockGetProStatus.mockRejectedValue(new Error("network error"));
+
+    await renderLayout();
+
+    expect(screen.getByText("FREE")).toBeInTheDocument();
+    expect(screen.getByTestId("adsense-script")).toBeInTheDocument();
   });
 
   it("access-token が失効し uid だけ残っている場合は無料状態にする", async () => {

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Toaster } from "sonner";
+import AdsenseScript from "@app/components/ad/AdsenseScript";
 import Footer from "@app/components/footer/Footer";
 import NavigationMenu from "@app/components/header/NavigationMenu";
 import ProStatusBanners from "@app/components/pro/ProStatusBanners";
@@ -22,11 +23,14 @@ export const metadata: Metadata = {
 // 読むと配下 105 ルートすべてが dynamic 扱いになり、コラム記事やツールなど
 // データ取得のない静的ページまでビルド時プリレンダリングを失う。
 export default function AppLayout({ children }: { children: React.ReactNode }) {
+  const isProduction = process.env.NODE_ENV === "production";
+
   return (
     <AuthProvider>
       <UserProvider>
         <Providers>
           <ProStatusProvider>
+            {isProduction ? <AdsenseScript /> : null}
             <SmartAppBanner />
             <ProStatusBanners />
             <GameRecordStorageCleanup />

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -23,14 +23,12 @@ export const metadata: Metadata = {
 // 読むと配下 105 ルートすべてが dynamic 扱いになり、コラム記事やツールなど
 // データ取得のない静的ページまでビルド時プリレンダリングを失う。
 export default function AppLayout({ children }: { children: React.ReactNode }) {
-  const isProduction = process.env.NODE_ENV === "production";
-
   return (
     <AuthProvider>
       <UserProvider>
         <Providers>
           <ProStatusProvider>
-            {isProduction ? <AdsenseScript /> : null}
+            <AdsenseScript />
             <SmartAppBanner />
             <ProStatusBanners />
             <GameRecordStorageCleanup />

--- a/app/components/ad/AdBanner.tsx
+++ b/app/components/ad/AdBanner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { ADSENSE_CLIENT_ID, isAdsenseEnabled } from "./adConfig";
+import { ADSENSE_CLIENT_ID } from "./adConfig";
+import { useAdSlot } from "./useAdSlot";
 
 type Props = {
   slot: string;
@@ -14,28 +14,13 @@ export default function AdBanner({
   format = "auto",
   className = "",
 }: Props) {
-  const adRef = useRef<HTMLModElement>(null);
-  const isAdLoaded = useRef(false);
+  const canRenderAd = useAdSlot(slot);
 
-  useEffect(() => {
-    if (!isAdsenseEnabled || !slot || isAdLoaded.current) return;
-
-    try {
-      ((window as unknown as { adsbygoogle: unknown[] }).adsbygoogle =
-        (window as unknown as { adsbygoogle: unknown[] }).adsbygoogle ||
-        []).push({});
-      isAdLoaded.current = true;
-    } catch {
-      // AdSense script not loaded
-    }
-  }, [slot]);
-
-  if (!isAdsenseEnabled || !slot) return null;
+  if (!canRenderAd) return null;
 
   return (
     <div className={`ad-container my-6 ${className}`}>
       <ins
-        ref={adRef}
         className="adsbygoogle"
         style={{ display: "block" }}
         data-ad-client={ADSENSE_CLIENT_ID}

--- a/app/components/ad/AdInFeed.tsx
+++ b/app/components/ad/AdInFeed.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { ADSENSE_CLIENT_ID, isAdsenseEnabled } from "./adConfig";
+import { ADSENSE_CLIENT_ID } from "./adConfig";
+import { useAdSlot } from "./useAdSlot";
 
 type Props = {
   slot: string;
@@ -10,22 +10,9 @@ type Props = {
 };
 
 export default function AdInFeed({ slot, layoutKey, className = "" }: Props) {
-  const isAdLoaded = useRef(false);
+  const canRenderAd = useAdSlot(slot);
 
-  useEffect(() => {
-    if (!isAdsenseEnabled || !slot || isAdLoaded.current) return;
-
-    try {
-      ((window as unknown as { adsbygoogle: unknown[] }).adsbygoogle =
-        (window as unknown as { adsbygoogle: unknown[] }).adsbygoogle ||
-        []).push({});
-      isAdLoaded.current = true;
-    } catch {
-      // AdSense script not loaded
-    }
-  }, [slot]);
-
-  if (!isAdsenseEnabled || !slot) return null;
+  if (!canRenderAd) return null;
 
   return (
     <div className={`ad-container my-4 ${className}`}>

--- a/app/components/ad/AdsenseScript.tsx
+++ b/app/components/ad/AdsenseScript.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Script from "next/script";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { ADSENSE_CLIENT_ID } from "./adConfig";
+
+/**
+ * AdSense 本体スクリプトを読み込む。no_ads を持つ Pro 加入者には読み込ませない。
+ *
+ * ProStatusProvider 配下でのみ意味を持つため (app)/layout.tsx に置く。
+ * strategy="afterInteractive" はもともとハイドレーション後に読み込むため、
+ * ハイドレーション直後に確定する未認証ユーザーの読み込み開始は実質遅れない。
+ */
+export default function AdsenseScript() {
+  const { hasEntitlement, isLoading } = useEntitlement();
+
+  if (isLoading || hasEntitlement("no_ads")) return null;
+
+  return (
+    <Script
+      async
+      strategy="afterInteractive"
+      src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT_ID}`}
+      crossOrigin="anonymous"
+    />
+  );
+}

--- a/app/components/ad/AdsenseScript.tsx
+++ b/app/components/ad/AdsenseScript.tsx
@@ -2,7 +2,7 @@
 
 import Script from "next/script";
 import { useEntitlement } from "@app/hooks/pro/useEntitlement";
-import { ADSENSE_CLIENT_ID } from "./adConfig";
+import { ADSENSE_CLIENT_ID, isAdsenseScriptEnabled } from "./adConfig";
 
 /**
  * AdSense 本体スクリプトを読み込む。no_ads を持つ Pro 加入者には読み込ませない。
@@ -10,10 +10,14 @@ import { ADSENSE_CLIENT_ID } from "./adConfig";
  * ProStatusProvider 配下でのみ意味を持つため (app)/layout.tsx に置く。
  * strategy="afterInteractive" はもともとハイドレーション後に読み込むため、
  * ハイドレーション直後に確定する未認証ユーザーの読み込み開始は実質遅れない。
+ *
+ * 環境による出し分けもここで完結させる。呼び出し側に置くと、広告枠が 1 つも出ない環境
+ * （NEXT_PUBLIC_ADSENSE_ENABLED 未設定）でスクリプトだけ読み込まれる状態を作りやすい。
  */
 export default function AdsenseScript() {
   const { hasEntitlement, isLoading } = useEntitlement();
 
+  if (!isAdsenseScriptEnabled) return null;
   if (isLoading || hasEntitlement("no_ads")) return null;
 
   return (

--- a/app/components/ad/__tests__/AdBanner.test.tsx
+++ b/app/components/ad/__tests__/AdBanner.test.tsx
@@ -66,6 +66,8 @@ describe("AdBanner", () => {
     const { container } = renderBanner();
 
     expect(container.querySelector("ins.adsbygoogle")).toBeNull();
+    // 枠だけ残ると余白が空きセルとして残る
+    expect(container.querySelector(".ad-container")).toBeNull();
     expect(adRequestCount()).toBe(0);
   });
 

--- a/app/components/ad/__tests__/AdBanner.test.tsx
+++ b/app/components/ad/__tests__/AdBanner.test.tsx
@@ -1,0 +1,131 @@
+jest.mock("../adConfig", () => ({
+  ADSENSE_CLIENT_ID: "ca-pub-test",
+  isAdsenseEnabled: true,
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+import { render } from "@testing-library/react";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import AdBanner from "../AdBanner";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+
+// isAdsenseEnabled はビルド時の環境変数から決まる定数のため、モジュールごとモックして切り替える
+const mutableAdConfig = jest.requireMock("../adConfig") as {
+  isAdsenseEnabled: boolean;
+};
+
+function mockEntitlement({
+  hasNoAds = false,
+  isLoading = false,
+}: { hasNoAds?: boolean; isLoading?: boolean } = {}) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: hasNoAds,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading,
+    hasEntitlement: jest.fn((feature) => feature === "no_ads" && hasNoAds),
+  });
+}
+
+function adRequestCount() {
+  return (window as unknown as { adsbygoogle: unknown[] }).adsbygoogle.length;
+}
+
+function renderBanner() {
+  return render(<AdBanner slot="1234567890" />);
+}
+
+describe("AdBanner", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mutableAdConfig.isAdsenseEnabled = true;
+    (window as unknown as { adsbygoogle: unknown[] }).adsbygoogle = [];
+  });
+
+  it("無料ユーザーには広告枠を描画し、広告をリクエストする", () => {
+    mockEntitlement();
+
+    const { container } = renderBanner();
+
+    expect(container.querySelector("ins.adsbygoogle")).toHaveAttribute(
+      "data-ad-slot",
+      "1234567890",
+    );
+    expect(adRequestCount()).toBe(1);
+  });
+
+  it("no_ads を持つ Pro 加入者には広告枠を描画せず、リクエストもしない", () => {
+    mockEntitlement({ hasNoAds: true });
+
+    const { container } = renderBanner();
+
+    expect(container.querySelector("ins.adsbygoogle")).toBeNull();
+    expect(adRequestCount()).toBe(0);
+  });
+
+  it("Pro 判定が確定するまで広告枠を描画しない", () => {
+    mockEntitlement({ isLoading: true });
+
+    const { container } = renderBanner();
+
+    expect(container.querySelector("ins.adsbygoogle")).toBeNull();
+    expect(adRequestCount()).toBe(0);
+  });
+
+  it("判定中に描画しないまま Pro が確定した場合、広告は一度も描画されない", () => {
+    mockEntitlement({ isLoading: true });
+    const { container, rerender } = renderBanner();
+    expect(container.querySelector("ins.adsbygoogle")).toBeNull();
+
+    mockEntitlement({ hasNoAds: true });
+    rerender(<AdBanner slot="1234567890" />);
+
+    expect(container.querySelector("ins.adsbygoogle")).toBeNull();
+    expect(adRequestCount()).toBe(0);
+  });
+
+  it("判定中に描画しないまま無料が確定した場合、確定後に広告を描画する", () => {
+    mockEntitlement({ isLoading: true });
+    const { container, rerender } = renderBanner();
+
+    mockEntitlement();
+    rerender(<AdBanner slot="1234567890" />);
+
+    expect(container.querySelector("ins.adsbygoogle")).not.toBeNull();
+    expect(adRequestCount()).toBe(1);
+  });
+
+  it("再レンダリングされても広告リクエストは重複しない", () => {
+    mockEntitlement();
+    const { rerender } = renderBanner();
+
+    rerender(<AdBanner slot="1234567890" />);
+
+    expect(adRequestCount()).toBe(1);
+  });
+
+  it("AdSense が無効なら無料ユーザーでも描画しない", () => {
+    mutableAdConfig.isAdsenseEnabled = false;
+    mockEntitlement();
+
+    const { container } = renderBanner();
+
+    expect(container.querySelector("ins.adsbygoogle")).toBeNull();
+    expect(adRequestCount()).toBe(0);
+  });
+
+  it("スロット未設定なら無料ユーザーでも描画しない", () => {
+    mockEntitlement();
+
+    const { container } = render(<AdBanner slot="" />);
+
+    expect(container.querySelector("ins.adsbygoogle")).toBeNull();
+    expect(adRequestCount()).toBe(0);
+  });
+});

--- a/app/components/ad/__tests__/AdInFeed.test.tsx
+++ b/app/components/ad/__tests__/AdInFeed.test.tsx
@@ -66,6 +66,8 @@ describe("AdInFeed", () => {
     const { container } = renderInFeed();
 
     expect(container.querySelector("ins.adsbygoogle")).toBeNull();
+    // 枠だけ残ると余白が空きセルとして残る
+    expect(container.querySelector(".ad-container")).toBeNull();
     expect(adRequestCount()).toBe(0);
   });
 

--- a/app/components/ad/__tests__/AdInFeed.test.tsx
+++ b/app/components/ad/__tests__/AdInFeed.test.tsx
@@ -1,0 +1,99 @@
+jest.mock("../adConfig", () => ({
+  ADSENSE_CLIENT_ID: "ca-pub-test",
+  isAdsenseEnabled: true,
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+import { render } from "@testing-library/react";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import AdInFeed from "../AdInFeed";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+
+// isAdsenseEnabled はビルド時の環境変数から決まる定数のため、モジュールごとモックして切り替える
+const mutableAdConfig = jest.requireMock("../adConfig") as {
+  isAdsenseEnabled: boolean;
+};
+
+function mockEntitlement({
+  hasNoAds = false,
+  isLoading = false,
+}: { hasNoAds?: boolean; isLoading?: boolean } = {}) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: hasNoAds,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading,
+    hasEntitlement: jest.fn((feature) => feature === "no_ads" && hasNoAds),
+  });
+}
+
+function adRequestCount() {
+  return (window as unknown as { adsbygoogle: unknown[] }).adsbygoogle.length;
+}
+
+function renderInFeed() {
+  return render(<AdInFeed slot="9876543210" layoutKey="-fb+5w+4e-db+86" />);
+}
+
+describe("AdInFeed", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mutableAdConfig.isAdsenseEnabled = true;
+    (window as unknown as { adsbygoogle: unknown[] }).adsbygoogle = [];
+  });
+
+  it("無料ユーザーには広告枠を描画し、広告をリクエストする", () => {
+    mockEntitlement();
+
+    const { container } = renderInFeed();
+
+    expect(container.querySelector("ins.adsbygoogle")).toHaveAttribute(
+      "data-ad-slot",
+      "9876543210",
+    );
+    expect(adRequestCount()).toBe(1);
+  });
+
+  it("no_ads を持つ Pro 加入者には広告枠を描画せず、リクエストもしない", () => {
+    mockEntitlement({ hasNoAds: true });
+
+    const { container } = renderInFeed();
+
+    expect(container.querySelector("ins.adsbygoogle")).toBeNull();
+    expect(adRequestCount()).toBe(0);
+  });
+
+  it("Pro 判定が確定するまで広告枠を描画しない", () => {
+    mockEntitlement({ isLoading: true });
+
+    const { container } = renderInFeed();
+
+    expect(container.querySelector("ins.adsbygoogle")).toBeNull();
+    expect(adRequestCount()).toBe(0);
+  });
+
+  it("AdSense が無効なら無料ユーザーでも描画しない", () => {
+    mutableAdConfig.isAdsenseEnabled = false;
+    mockEntitlement();
+
+    const { container } = renderInFeed();
+
+    expect(container.querySelector("ins.adsbygoogle")).toBeNull();
+    expect(adRequestCount()).toBe(0);
+  });
+
+  it("スロット未設定なら無料ユーザーでも描画しない", () => {
+    mockEntitlement();
+
+    const { container } = render(<AdInFeed slot="" />);
+
+    expect(container.querySelector("ins.adsbygoogle")).toBeNull();
+    expect(adRequestCount()).toBe(0);
+  });
+});

--- a/app/components/ad/__tests__/AdsenseScript.test.tsx
+++ b/app/components/ad/__tests__/AdsenseScript.test.tsx
@@ -1,6 +1,7 @@
 jest.mock("../adConfig", () => ({
   ADSENSE_CLIENT_ID: "ca-pub-test",
   isAdsenseEnabled: true,
+  isAdsenseScriptEnabled: true,
 }));
 
 jest.mock("@app/hooks/pro/useEntitlement", () => ({

--- a/app/components/ad/__tests__/AdsenseScript.test.tsx
+++ b/app/components/ad/__tests__/AdsenseScript.test.tsx
@@ -1,0 +1,70 @@
+jest.mock("../adConfig", () => ({
+  ADSENSE_CLIENT_ID: "ca-pub-test",
+  isAdsenseEnabled: true,
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+// next/script は実際には document へ script を差し込むため、読み込み有無だけを観測できる形に置き換える
+jest.mock("next/script", () => ({
+  __esModule: true,
+  default: ({ src }: { src: string }) => (
+    <div data-testid="script" data-src={src} />
+  ),
+}));
+
+import { render, screen } from "@testing-library/react";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import AdsenseScript from "../AdsenseScript";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+
+function mockEntitlement({
+  hasNoAds = false,
+  isLoading = false,
+}: { hasNoAds?: boolean; isLoading?: boolean } = {}) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: hasNoAds,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading,
+    hasEntitlement: jest.fn((feature) => feature === "no_ads" && hasNoAds),
+  });
+}
+
+describe("AdsenseScript", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("無料ユーザーには AdSense スクリプトを読み込む", () => {
+    mockEntitlement();
+
+    render(<AdsenseScript />);
+
+    expect(screen.getByTestId("script")).toHaveAttribute(
+      "data-src",
+      "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-test",
+    );
+  });
+
+  it("no_ads を持つ Pro 加入者にはスクリプト自体を読み込まない", () => {
+    mockEntitlement({ hasNoAds: true });
+
+    render(<AdsenseScript />);
+
+    expect(screen.queryByTestId("script")).not.toBeInTheDocument();
+  });
+
+  it("Pro 判定が確定するまでスクリプトを読み込まない", () => {
+    mockEntitlement({ isLoading: true });
+
+    render(<AdsenseScript />);
+
+    expect(screen.queryByTestId("script")).not.toBeInTheDocument();
+  });
+});

--- a/app/components/ad/__tests__/AdsenseScriptDisabled.test.tsx
+++ b/app/components/ad/__tests__/AdsenseScriptDisabled.test.tsx
@@ -1,0 +1,42 @@
+// 環境フラグは import 時に束縛されるため、無効時の挙動は専用ファイルでモックを固定して検証する
+jest.mock("../adConfig", () => ({
+  ADSENSE_CLIENT_ID: "ca-pub-test",
+  isAdsenseEnabled: false,
+  isAdsenseScriptEnabled: false,
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+jest.mock("next/script", () => ({
+  __esModule: true,
+  default: ({ src }: { src: string }) => (
+    <div data-testid="script" data-src={src} />
+  ),
+}));
+
+import { render, screen } from "@testing-library/react";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import AdsenseScript from "../AdsenseScript";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+
+describe("AdsenseScript（AdSense 無効な環境）", () => {
+  // 広告枠が 1 つも出ない環境でスクリプトだけ読み込まれると、無駄な通信が発生する
+  it("無料ユーザーでもスクリプトを読み込まない", () => {
+    mockUseEntitlement.mockReturnValue({
+      isPro: false,
+      inTrial: false,
+      inGracePeriod: false,
+      isLoading: false,
+      hasEntitlement: jest.fn(() => false),
+    });
+
+    render(<AdsenseScript />);
+
+    expect(screen.queryByTestId("script")).not.toBeInTheDocument();
+  });
+});

--- a/app/components/ad/__tests__/adGating.test.tsx
+++ b/app/components/ad/__tests__/adGating.test.tsx
@@ -1,0 +1,119 @@
+jest.mock("../adConfig", () => ({
+  ADSENSE_CLIENT_ID: "ca-pub-test",
+  isAdsenseEnabled: true,
+}));
+
+jest.mock("@app/(app)/pro/actions", () => ({
+  getProStatus: jest.fn(),
+}));
+
+import { act, render } from "@testing-library/react";
+import { getProStatus } from "@app/(app)/pro/actions";
+import { ProStatusProvider } from "@app/components/pro/ProStatusProvider";
+import { DEFAULT_PRO_STATUS, type ProStatus } from "@app/types/pro";
+import AdBanner from "../AdBanner";
+
+const mockGetProStatus = getProStatus as jest.MockedFunction<
+  typeof getProStatus
+>;
+
+function setAuthCookies() {
+  document.cookie = "access-token=test-access-token";
+  document.cookie = "client=test-client";
+  document.cookie = "uid=user@example.com";
+}
+
+function clearAuthCookies() {
+  for (const name of ["access-token", "client", "uid"]) {
+    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+  }
+}
+
+function makeProStatus(entitlements: ProStatus["entitlements"]): ProStatus {
+  return {
+    subscription: {
+      ...DEFAULT_PRO_STATUS.subscription,
+      status: "active",
+      pro_active: true,
+    },
+    entitlements,
+  };
+}
+
+function renderWithProvider() {
+  const view = render(
+    <ProStatusProvider>
+      <AdBanner slot="1234567890" />
+    </ProStatusProvider>,
+  );
+
+  return {
+    ...view,
+    hasAd: () => view.container.querySelector("ins.adsbygoogle") !== null,
+  };
+}
+
+describe("広告の no_ads ゲート（ProStatusProvider 連携）", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearAuthCookies();
+    (window as unknown as { adsbygoogle: unknown[] }).adsbygoogle = [];
+  });
+
+  it("未認証ユーザーには Server Action を待たずに広告を描画する", async () => {
+    const { hasAd } = renderWithProvider();
+
+    await act(async () => {});
+
+    expect(mockGetProStatus).not.toHaveBeenCalled();
+    expect(hasAd()).toBe(true);
+  });
+
+  it("Pro 加入者には判定確定前も確定後も広告を描画しない", async () => {
+    setAuthCookies();
+    let resolveProStatus!: (status: ProStatus) => void;
+    mockGetProStatus.mockReturnValue(
+      new Promise<ProStatus>((resolve) => {
+        resolveProStatus = resolve;
+      }),
+    );
+
+    const { hasAd } = renderWithProvider();
+
+    expect(hasAd()).toBe(false);
+
+    await act(async () => {
+      resolveProStatus(
+        makeProStatus([...DEFAULT_PRO_STATUS.entitlements, "no_ads"]),
+      );
+    });
+
+    expect(hasAd()).toBe(false);
+    expect(
+      (window as unknown as { adsbygoogle: unknown[] }).adsbygoogle.length,
+    ).toBe(0);
+  });
+
+  it("ログイン中の無料ユーザーには判定確定後に広告を描画する", async () => {
+    setAuthCookies();
+    let resolveProStatus!: (status: ProStatus) => void;
+    mockGetProStatus.mockReturnValue(
+      new Promise<ProStatus>((resolve) => {
+        resolveProStatus = resolve;
+      }),
+    );
+
+    const { hasAd } = renderWithProvider();
+
+    expect(hasAd()).toBe(false);
+
+    await act(async () => {
+      resolveProStatus({
+        ...DEFAULT_PRO_STATUS,
+        subscription: { ...DEFAULT_PRO_STATUS.subscription },
+      });
+    });
+
+    expect(hasAd()).toBe(true);
+  });
+});

--- a/app/components/ad/adConfig.ts
+++ b/app/components/ad/adConfig.ts
@@ -3,6 +3,15 @@ export const ADSENSE_CLIENT_ID = "ca-pub-2173577862865148";
 export const isAdsenseEnabled =
   process.env.NEXT_PUBLIC_ADSENSE_ENABLED === "true";
 
+/**
+ * AdSense 本体スクリプトを読み込んでよい環境か。
+ *
+ * 広告枠と同じ条件に加えて本番のみに絞る。枠が 1 つも出ない環境
+ * （NEXT_PUBLIC_ADSENSE_ENABLED 未設定の preview / stg）でスクリプトだけ読み込まれるのを防ぐ。
+ */
+export const isAdsenseScriptEnabled =
+  isAdsenseEnabled && process.env.NODE_ENV === "production";
+
 export const adSlots = {
   /** 計算ツールページ CTAバナー下 ディスプレイ広告 */
   toolsDisplay: "6569468966",

--- a/app/components/ad/useAdSlot.ts
+++ b/app/components/ad/useAdSlot.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { isAdsenseEnabled } from "./adConfig";
+
+/**
+ * AdSense の広告枠を描画してよいかを判定し、描画するときだけ広告リクエストを push する。
+ *
+ * Pro 判定が確定するまでは描画しない。ProStatusProvider はクライアントで Pro 状態を
+ * 解決するため、確定前は hasEntitlement("no_ads") が無料扱いの false を返す。
+ * そのまま描画すると Pro 加入者に広告が一瞬見えてから消える。
+ * 未認証（大多数の閲覧者）は Server Action を呼ばずに即確定するため、この待機は
+ * ハイドレーション直後の 1 レンダー分しか発生しない。
+ *
+ * @param slot AdSense の広告ユニット ID。空文字なら未設定の枠として描画しない。
+ * @returns 広告枠を描画してよいなら true
+ */
+export function useAdSlot(slot: string): boolean {
+  const { hasEntitlement, isLoading } = useEntitlement();
+  const isAdRequested = useRef(false);
+
+  const canRenderAd =
+    isAdsenseEnabled && !!slot && !isLoading && !hasEntitlement("no_ads");
+
+  useEffect(() => {
+    if (!canRenderAd || isAdRequested.current) return;
+
+    try {
+      ((window as unknown as { adsbygoogle: unknown[] }).adsbygoogle =
+        (window as unknown as { adsbygoogle: unknown[] }).adsbygoogle ||
+        []).push({});
+      isAdRequested.current = true;
+    } catch {
+      // AdSense script not loaded
+    }
+  }, [canRenderAd, slot]);
+
+  return canRenderAd;
+}

--- a/app/components/pro/ProStatusProvider.tsx
+++ b/app/components/pro/ProStatusProvider.tsx
@@ -76,9 +76,16 @@ export function ProStatusProvider({ children }: { children: ReactNode }) {
     const pending =
       identity === ANONYMOUS_IDENTITY ? Promise.resolve(null) : getProStatus();
 
-    void pending.then((next) => {
-      if (active) setResolved({ identity, proStatus: next });
-    });
+    void pending
+      .then((next) => {
+        if (active) setResolved({ identity, proStatus: next });
+      })
+      .catch(() => {
+        // Server Action の通信自体が失敗した場合は無料状態で確定させる。
+        // 未確定のままだと isLoading が永久に true になり、Pro 判定に依存する UI（広告枠など）が
+        // 二度と描画されない
+        if (active) setResolved({ identity, proStatus: null });
+      });
 
     return () => {
       active = false;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,14 +51,10 @@ export default function RootLayout({
       <meta name="application-name" content="BUZZ BASE" />
       <meta name="apple-itunes-app" content="app-id=6761011816" />
       <meta name="google-adsense-account" content="ca-pub-2173577862865148" />
-      {isProduction && (
-        <Script
-          async
-          strategy="afterInteractive"
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2173577862865148"
-          crossOrigin="anonymous"
-        />
-      )}
+      {/* AdSense 本体スクリプトは Pro 判定が要るため (app)/layout.tsx の AdsenseScript が読み込む。
+          読み込み開始がハイドレーション後になる分を、接続だけ先に張って埋める */}
+      <link rel="preconnect" href="https://pagead2.googlesyndication.com" />
+      <link rel="dns-prefetch" href="https://pagead2.googlesyndication.com" />
       {isProduction && gaId && (
         <>
           <Script

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -53,7 +53,12 @@ export default function RootLayout({
       <meta name="google-adsense-account" content="ca-pub-2173577862865148" />
       {/* AdSense 本体スクリプトは Pro 判定が要るため (app)/layout.tsx の AdsenseScript が読み込む。
           読み込み開始がハイドレーション後になる分を、接続だけ先に張って埋める */}
-      <link rel="preconnect" href="https://pagead2.googlesyndication.com" />
+      {/* AdSense 本体は crossOrigin="anonymous" で取得されるため、CORS 無しで張った接続は再利用されない */}
+      <link
+        rel="preconnect"
+        href="https://pagead2.googlesyndication.com"
+        crossOrigin="anonymous"
+      />
       <link rel="dns-prefetch" href="https://pagead2.googlesyndication.com" />
       {isProduction && gaId && (
         <>

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,9 @@ process.env.NEXT_PUBLIC_IMAGE_HOSTNAME = "localhost";
 process.env.NEXT_PUBLIC_IMAGE_PORT = "3000";
 process.env.NEXT_PUBLIC_IMAGE_PATHNAME = "/**";
 process.env.NEXT_PUBLIC_BACKEND_URL = "http://localhost:3000";
+// Server Action を経由するコンポーネント（ProStatusProvider 等）を描画するテストは
+// app/constants/api.ts を読み込む。未設定だとモジュール評価時に throw する
+process.env.RAILS_API_URL = "http://localhost:3000";
 
 const nextJest = require("next/jest");
 


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#452

## 概要

`AdBanner` / `AdInFeed` は `isAdsenseEnabled` とスロット有無しか判定しておらず **`no_ads` entitlement を一切参照していない**ため、Pro 課金者にも広告が表示されていた。広告非表示は Pro の中核的な提供価値の1つで、課金価値の毀損に直結する。

## 変更内容

| ファイル | 要点 |
| --- | --- |
| `app/components/ad/useAdSlot.ts`（新規） | 描画判定と `adsbygoogle.push` を集約。`isAdsenseEnabled && !!slot && !isLoading && !hasEntitlement("no_ads")` |
| `AdBanner.tsx` / `AdInFeed.tsx` | 重複していた effect/ガードを `useAdSlot` へ委譲 |
| `AdsenseScript.tsx`（新規） | AdSense 本体スクリプトを Pro 判定でゲート |
| `app/layout.tsx` | AdSense `<Script>` を削除し `preconnect` / `dns-prefetch` を追加 |
| `app/(app)/layout.tsx` | `ProStatusProvider` 直下に `<AdsenseScript />` |

`AdBanner|AdInFeed` を参照する30ファイル（コラム約50本・tools・dashboard 等、計50箇所）はすべて2コンポーネント経由で、独自の `<ins>` 実装は存在しない。呼び出し側は装飾ラッパー無しの兄弟要素配置なので `null` 返却で空枠は残らない。

## フラッシュ抑止 vs CLS の判断

**フラッシュ抑止を採用**（mobile の `AppBannerAd` / 既存の `ProGate` と同じ挙動）。

- 元々 `<ins>` は高さ0で広告の充填は `push({})`（ハイドレーション後）に依存しており、**レイアウトシフトは変更前から発生していた**。判定待ちが増やす遅延は未認証で1レンダー分（マイクロタスク）で、CLS の悪化は実質ゼロ
- 逆に枠を先出しすると、Pro 加入者に**広告が見えてから消える**（課金価値の毀損が可視化される最悪パターン）
- 高さ予約は、Pro 確定時に枠を畳めば結局シフトが起き、無料ユーザーには「空白→広告」が残るだけで両取りにならないため不採用

## 未認証ユーザー（SEO 流入）への影響

遅延なし。`ProStatusProvider` は cookie 3点が揃わなければ Server Action を呼ばず `Promise.resolve(null)` で確定するため、待ちはハイドレーション直後のマイクロタスク1回。「未認証ユーザーには Server Action を待たずに広告を描画する」テストで `getProStatus` が呼ばれないことも固定している。

## AdSense スクリプトの最適化

Pro には `adsbygoogle.js` 自体を配らないようにした。副作用として無料ユーザー向けにも静的 HTML からタグが消え先行取得が失われるため、root layout の `preconnect` / `dns-prefetch` で補っている（preconnect は TCP/TLS を張るだけで SDK 実行もトラッキングも発生しない）。

ポリシー面: 加入者への広告非表示は正規の運用で、`push({})` は動的挿入ユニットの公式パターン。1枠1 push を ref で保証しリフレッシュは起きない。

## ビルド突合（static 87 維持）

```
baseline: ○ 87 / ƒ 41 (128 ルート)
final   : ○ 87 / ƒ 41 (128 ルート)
route classification diffs: NONE
```

プリレンダー済み `/column/ops` の HTML に `adsbygoogle` 文字列が0件（判定はクライアント）、`preconnect` は入っていることも確認済み。

## ミューテーション検出力（8/8 KILLED）

`no_ads` 判定 / `isLoading` 判定（フラッシュ再現）/ `isAdsenseEnabled` / `slot` / effect のガード / effect 依存 / スクリプト側の2種、すべて検出。

## レビューで見てほしい点

1. **`jest.config.js` への `RAILS_API_URL` 追加** — 広告コンポーネントが `useEntitlement → ProStatusProvider → pro/actions → constants/api` を辿るようになり、既存3スイートがモジュール評価時 throw で落ちた。各テストに `jest.mock` を足すより共通設定で解決する方を選んだ
2. **AdSense スクリプトを root layout から (app) layout へ移した点** — `(admin)` 配下では読み込まれなくなる（広告なし画面なので意図通り）。Auto ads を将来使うなら判断ポイント
3. **preconnect を Pro 含む全ユーザーに出している点** — 無料ユーザーの読み込み遅延の補償を優先した。Pro に一切のドメイン接続もさせたくない方針なら削除可能

## チェックリスト

- [x] `yarn typecheck` / `yarn lint` / `yarn format:check` が通る
- [x] `yarn test` が通る（85 suites / 810 tests）
- [x] `yarn build` が通る（**static 87 維持・ルート分類の差分ゼロ**）


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_