### PR TITLE
Add: Checkout 完了後の Pro 反映待ちと加入状態の再同期ボタンを追加

### DIFF
--- a/app/(app)/account/subscription/__tests__/page.test.tsx
+++ b/app/(app)/account/subscription/__tests__/page.test.tsx
@@ -39,6 +39,7 @@ import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   DEFAULT_PRO_STATUS,
+  type Platform,
   type ProStatus,
   type ProSubscription,
   type SubscriptionStatus,
@@ -1167,5 +1168,161 @@ describe("取得失敗", () => {
     expect(
       screen.getByRole("link", { name: "ログインし直す" }),
     ).toHaveAttribute("href", "/signin");
+  });
+});
+
+describe("加入状態の再同期", () => {
+  const syncSection = () =>
+    screen.getByRole("region", { name: "加入状態の再同期" });
+
+  const clickSync = () =>
+    userEvent.click(screen.getByRole("button", { name: "状態を再同期" }));
+
+  // 「Webhook がまだ届かず無料プランと表示されている」状態からの復旧手段なので、
+  // 加入していない状態でも必ず出す。
+  it.each<SubscriptionStatus>([
+    "free",
+    "trial",
+    "active",
+    "cancelled",
+    "billing_issue",
+    "expired",
+    "pending",
+  ])("status=%s でも再同期ボタンを出す", async (status) => {
+    await renderPage({ status });
+
+    expect(
+      within(syncSection()).getByRole("button", { name: "状態を再同期" }),
+    ).toBeInTheDocument();
+  });
+
+  // back の同期はストア課金・Web 課金のどちらも RevenueCat の subscriber から
+  // 再構築するため、媒体で出し分けない。
+  it.each<Platform>(["web", "ios", "android"])(
+    "platform=%s でも再同期ボタンを出す",
+    async (platform) => {
+      await renderPage({ status: "active", pro_active: true, platform });
+
+      expect(
+        screen.getByRole("button", { name: "状態を再同期" }),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it("加入媒体が不明でも再同期ボタンを出す", async () => {
+    await renderPage({ status: "active", pro_active: true, platform: null });
+
+    expect(
+      screen.getByRole("button", { name: "状態を再同期" }),
+    ).toBeInTheDocument();
+  });
+
+  it("押すまでは同期 API を叩かない", async () => {
+    await renderPage({ status: "free" });
+
+    expect(mockSyncProStatus).not.toHaveBeenCalled();
+  });
+
+  it("押すと同期 API を呼び、成功を伝えて状態を再取得する", async () => {
+    await renderPage({ status: "free" });
+
+    await clickSync();
+
+    expect(mockSyncProStatus).toHaveBeenCalledTimes(1);
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "最新の加入状態を取得しました。",
+    );
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("同期の結果は Server Component から取り直す（クライアント側で状態を組み立てない）", async () => {
+    await renderPage({ status: "free" });
+
+    await clickSync();
+
+    await screen.findByRole("status");
+    expect(mockSyncProStatus.mock.invocationCallOrder[0]).toBeLessThan(
+      mockRefresh.mock.invocationCallOrder[0],
+    );
+  });
+
+  // 同期の失敗は「契約が変わった」ではなく「今の契約を確認できなかった」。
+  // 課金中のユーザーを不安にさせないため、契約が無事であることを併せて伝える。
+  it("同期に失敗したときは再取得せず、契約が変わっていないことを伝える", async () => {
+    mockSyncProStatus.mockResolvedValue(null);
+    await renderPage({ status: "active", pro_active: true });
+
+    await clickSync();
+
+    const message = await screen.findByRole("status");
+    expect(message).toHaveTextContent("加入状態を取得できませんでした");
+    expect(message).toHaveTextContent("ご契約の内容は変わっていません");
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it("失敗のあとに再度押すと前回の失敗表示を残さない", async () => {
+    mockSyncProStatus.mockResolvedValueOnce(null);
+    await renderPage({ status: "free" });
+
+    await clickSync();
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "加入状態を取得できませんでした",
+    );
+
+    await clickSync();
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "最新の加入状態を取得しました。",
+    );
+    expect(
+      screen.queryByText(/加入状態を取得できませんでした/),
+    ).not.toBeInTheDocument();
+  });
+
+  describe("同期中", () => {
+    async function startPendingSync() {
+      let settle: (result: ProStatus | null) => void = () => {};
+      mockSyncProStatus.mockReturnValue(
+        new Promise<ProStatus | null>((resolve) => {
+          settle = resolve;
+        }),
+      );
+      await clickSync();
+      await screen.findByRole("button", { name: "同期中…" });
+      return async () => {
+        await act(async () => {
+          settle(DEFAULT_PRO_STATUS);
+        });
+      };
+    }
+
+    it("同期中はボタンを無効化して二重送信させない", async () => {
+      await renderPage({ status: "free" });
+      const finish = await startPendingSync();
+
+      const button = screen.getByRole("button", { name: "同期中…" });
+      expect(button).toBeDisabled();
+      await userEvent.click(button);
+      expect(mockSyncProStatus).toHaveBeenCalledTimes(1);
+
+      await finish();
+    });
+
+    // 前回の失敗表示を残したまま再同期すると、成功したのに失敗したように見える。
+    it("同期中は前回の結果表示を消す", async () => {
+      mockSyncProStatus.mockResolvedValueOnce(null);
+      await renderPage({ status: "free" });
+
+      await clickSync();
+      expect(await screen.findByRole("status")).toHaveTextContent(
+        "加入状態を取得できませんでした",
+      );
+
+      const finish = await startPendingSync();
+
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+      await finish();
+    });
   });
 });

--- a/app/(app)/account/subscription/_components/SubscriptionOverview.tsx
+++ b/app/(app)/account/subscription/_components/SubscriptionOverview.tsx
@@ -4,11 +4,12 @@ import BillingIssueGuide from "./BillingIssueGuide";
 import CancelGuide from "./CancelGuide";
 import PlanChangeGuide from "./PlanChangeGuide";
 import SubscriptionStatusCard from "./SubscriptionStatusCard";
+import SyncProStatus from "./SyncProStatus";
 
 const JOINABLE_STATUSES: SubscriptionStatus[] = ["free", "expired"];
 
 /**
- * 加入状態カード・加入 CTA・支払い更新案内・プラン変更・解約案内をまとめた本体表示。
+ * 加入状態カード・再同期・加入 CTA・支払い更新案内・プラン変更・解約案内をまとめた本体表示。
  */
 export default function SubscriptionOverview({
   subscription,
@@ -18,6 +19,7 @@ export default function SubscriptionOverview({
   return (
     <div className="flex flex-col gap-4">
       <SubscriptionStatusCard subscription={subscription} />
+      <SyncProStatus />
       <BillingIssueGuide subscription={subscription} />
       <PlanChangeGuide subscription={subscription} />
       {JOINABLE_STATUSES.includes(subscription.status) ? (

--- a/app/(app)/account/subscription/_components/SyncProStatus.tsx
+++ b/app/(app)/account/subscription/_components/SyncProStatus.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { syncProStatus } from "@app/(app)/pro/actions";
+
+type SyncResultState = "idle" | "synced" | "failed";
+
+const RESULT_MESSAGES: Record<Exclude<SyncResultState, "idle">, string> = {
+  synced: "最新の加入状態を取得しました。",
+  failed:
+    "加入状態を取得できませんでした。時間をおいて再度お試しください。ご契約の内容は変わっていません。",
+};
+
+/**
+ * 決済プロバイダ側の状態を取り込み直し、この画面の表示を最新化するボタン。
+ *
+ * webhook の取りこぼし・遅延で表示が実際の契約とずれたときの復旧手段として、
+ * 加入媒体を問わず提供する。back の同期 API は ios / android / web いずれの加入も
+ * RevenueCat の subscriber から再構築するため、Stripe 加入者にとっても no-op ではない。
+ */
+export default function SyncProStatus() {
+  const router = useRouter();
+  const [result, setResult] = useState<SyncResultState>("idle");
+  const [isSyncing, startTransition] = useTransition();
+
+  const handleSync = () => {
+    setResult("idle");
+    startTransition(async () => {
+      const synced = await syncProStatus();
+      if (synced === null) {
+        setResult("failed");
+        return;
+      }
+      setResult("synced");
+      // 同期後の状態は Server Component 側で描画しているので、再取得させる。
+      router.refresh();
+    });
+  };
+
+  return (
+    <section aria-label="加入状態の再同期" className="rounded-xl bg-sub p-4">
+      <p className="text-sm leading-5 text-zic-300">
+        ご加入直後や決済内容の変更直後は、表示への反映に時間がかかる場合があります。実際のご契約と表示が異なるときは再同期してください。
+      </p>
+      <button
+        type="button"
+        onClick={handleSync}
+        disabled={isSyncing}
+        className="mt-3 rounded-lg border border-[#d08000] px-4 py-2 text-sm font-bold text-[#d08000] transition-opacity hover:opacity-80 disabled:opacity-50"
+      >
+        {isSyncing ? "同期中…" : "状態を再同期"}
+      </button>
+      {result === "idle" ? null : (
+        <p
+          role="status"
+          className={`mt-3 rounded-lg p-3 text-sm leading-5 text-white ${
+            result === "failed" ? "bg-[#7f1d1d]" : "bg-[#065f46]"
+          }`}
+        >
+          {RESULT_MESSAGES[result]}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/app/(app)/pro/__tests__/actions.test.ts
+++ b/app/(app)/pro/__tests__/actions.test.ts
@@ -18,7 +18,12 @@ jest.mock("../../../featureFlags/actions", () => ({
   getFeatureFlags: (keys: string[]) => mockGetFeatureFlags(keys),
 }));
 
-import { getProStatus, getProStatusResult, startProCheckout } from "../actions";
+import {
+  getProStatus,
+  getProStatusResult,
+  startProCheckout,
+  syncProStatus,
+} from "../actions";
 
 function setupAuthCookies() {
   mockGet.mockImplementation((key: string) => {
@@ -316,5 +321,80 @@ describe("startProCheckout", () => {
         body: expect.stringContaining("http://localhost:8100/pro/success"),
       }),
     );
+  });
+});
+
+describe("syncProStatus", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("未認証 cookie のときは fetch せずに null を返す", async () => {
+    mockGet.mockReturnValue(undefined);
+
+    await expect(syncProStatus()).resolves.toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("同期後の Pro 状態を返す", async () => {
+    setupAuthCookies();
+    const proStatus = {
+      subscription: { status: "active", pro_active: true },
+      entitlements: ["no_ads"],
+    };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => proStatus,
+    });
+
+    await expect(syncProStatus()).resolves.toEqual(proStatus);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://back:3000/api/v1/pro/sync",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("失敗したら null を返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+    });
+
+    await expect(syncProStatus()).resolves.toBeNull();
+  });
+
+  it("fetch が throw したら null を返す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("network"));
+
+    await expect(syncProStatus()).resolves.toBeNull();
+  });
+
+  // back が RevenueCat REST を同期的に叩くため、上限が無いと再同期ボタンが永久に戻らない。
+  it("タイムアウト用の AbortSignal を渡す", async () => {
+    setupAuthCookies();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ subscription: {}, entitlements: [] }),
+    });
+
+    await syncProStatus();
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/app/(app)/pro/actions.ts
+++ b/app/(app)/pro/actions.ts
@@ -13,6 +13,9 @@ import { getFeatureFlags } from "../../featureFlags/actions";
 // Rails 側が詰まったときにレンダーや Server Action を無期限に待たせないための上限。
 const PRO_API_TIMEOUT_MS = 5000;
 
+// 同期 API は back が RevenueCat REST（サーバー側 5 秒上限）を挟むぶん往復が長い。
+const PRO_SYNC_API_TIMEOUT_MS = 10000;
+
 async function getAuthHeaders(): Promise<Record<string, string> | null> {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get("access-token")?.value;
@@ -196,6 +199,11 @@ export async function startProCheckout(args: {
  * 決済側で契約内容が変わったのに webhook がローカルの expires_at / plan_type を
  * 更新しない操作（プラン変更など）のあとは、これを呼ばないと古い期限が残り
  * Pro が早期失効する。
+ *
+ * back は RevenueCat の subscriber を唯一の入力としてローカルの Subscription を
+ * 上書きする（entitlement が無ければ free / expired に確定させる）。Stripe Checkout
+ * 直後は RevenueCat がまだ加入を取り込んでいないため、反映待ちの手段としてこれを
+ * ポーリングしてはいけない。反映待ちは読み取り専用の getProStatusResult() で行うこと。
  */
 export async function syncProStatus(): Promise<ProStatus | null> {
   try {
@@ -203,9 +211,11 @@ export async function syncProStatus(): Promise<ProStatus | null> {
     if (!headers) return null;
 
     // POST はそもそも Next.js のフェッチキャッシュ対象外。cache: "no-store" は不要。
+    // back が RevenueCat REST を同期的に叩くぶん status API より遅く、上限も長めに取る。
     const response = await fetch(`${RAILS_API_URL}/api/v1/pro/sync`, {
       method: "POST",
       headers,
+      signal: AbortSignal.timeout(PRO_SYNC_API_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/app/(app)/pro/success/__tests__/page.test.tsx
+++ b/app/(app)/pro/success/__tests__/page.test.tsx
@@ -1,0 +1,333 @@
+const mockReplace = jest.fn();
+const mockGetProStatusResult = jest.fn();
+let searchParams = new URLSearchParams();
+
+// 本物の useRouter は参照が安定しており、再レンダーだけではポーリング用の effect は
+// 貼り直されない。毎回新しいオブジェクトを返すと実装より緩い前提でテストしてしまう。
+const mockRouter = { replace: mockReplace };
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+  useSearchParams: () => searchParams,
+}));
+
+jest.mock("@app/(app)/pro/actions", () => ({
+  getProStatusResult: () => mockGetProStatusResult(),
+}));
+
+import { act, render, screen } from "@testing-library/react";
+import { DEFAULT_PRO_STATUS, type ProStatus } from "@app/types/pro";
+import ProSuccessPage, { metadata } from "../page";
+
+const POLL_INTERVAL_MS = 2000;
+const MAX_ATTEMPTS = 10;
+
+function buildStatus(pro_active: boolean): ProStatus {
+  return {
+    ...DEFAULT_PRO_STATUS,
+    subscription: { ...DEFAULT_PRO_STATUS.subscription, pro_active },
+  };
+}
+
+const okResult = (pro_active: boolean) => ({
+  status: "ok" as const,
+  proStatus: buildStatus(pro_active),
+});
+
+function renderWithSession(sessionId: string | null = "cs_test_123") {
+  searchParams = new URLSearchParams(
+    sessionId === null ? "" : `session_id=${sessionId}`,
+  );
+  return render(<ProSuccessPage />);
+}
+
+// ポーリングの待機を進める。setTimeout を跨いで await を挟むため act で包む。
+async function advanceOnePoll() {
+  await act(async () => {
+    jest.advanceTimersByTime(POLL_INTERVAL_MS);
+  });
+}
+
+// 最初の 1 回はマウント直後に走るので、待機で進めるのは残り回数ぶん。
+async function exhaustPolling() {
+  for (let i = 0; i < MAX_ATTEMPTS; i += 1) {
+    await advanceOnePoll();
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  mockGetProStatusResult.mockResolvedValue(okResult(false));
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe("メタデータ", () => {
+  it("加入内容を含むため検索エンジンに登録させない", () => {
+    expect(metadata.robots).toEqual({ index: false });
+  });
+});
+
+describe("Checkout からの復帰", () => {
+  it("反映を待っていることを伝える", async () => {
+    renderWithSession();
+
+    expect(
+      await screen.findByText(
+        "決済の反映を確認しています。そのままお待ちください。",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("すでに Pro なら待たずにサブスクリプション管理へ送る", async () => {
+    mockGetProStatusResult.mockResolvedValue(okResult(true));
+    renderWithSession();
+
+    await act(async () => {});
+
+    expect(mockGetProStatusResult).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith("/account/subscription");
+  });
+
+  it("反映されるまで再取得を続け、反映されたらサブスクリプション管理へ送る", async () => {
+    mockGetProStatusResult
+      .mockResolvedValueOnce(okResult(false))
+      .mockResolvedValueOnce(okResult(false))
+      .mockResolvedValue(okResult(true));
+    renderWithSession();
+
+    await act(async () => {});
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    await advanceOnePoll();
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    await advanceOnePoll();
+
+    expect(mockGetProStatusResult).toHaveBeenCalledTimes(3);
+    expect(mockReplace).toHaveBeenCalledWith("/account/subscription");
+    expect(
+      screen.getByText("Pro 機能が使えるようになりました"),
+    ).toBeInTheDocument();
+  });
+
+  it("反映後はそれ以上ポーリングしない", async () => {
+    mockGetProStatusResult
+      .mockResolvedValueOnce(okResult(false))
+      .mockResolvedValue(okResult(true));
+    renderWithSession();
+
+    await act(async () => {});
+    await advanceOnePoll();
+    expect(mockGetProStatusResult).toHaveBeenCalledTimes(2);
+
+    await advanceOnePoll();
+    await advanceOnePoll();
+
+    expect(mockGetProStatusResult).toHaveBeenCalledTimes(2);
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+  });
+
+  // 間隔を詰めると反映待ちの利用者が増えたぶんだけ Rails への負荷が跳ねる。
+  it("間隔が経つまでは再取得しない", async () => {
+    renderWithSession();
+
+    await act(async () => {});
+    expect(mockGetProStatusResult).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(POLL_INTERVAL_MS - 1);
+    });
+    expect(mockGetProStatusResult).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(mockGetProStatusResult).toHaveBeenCalledTimes(2);
+  });
+
+  // Webhook が落ちた場合にタブを開いている限り叩き続けないための上限。
+  it("上限回数で打ち切り、それ以上は再取得しない", async () => {
+    renderWithSession();
+
+    await exhaustPolling();
+    expect(mockGetProStatusResult).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+
+    await advanceOnePoll();
+    await advanceOnePoll();
+
+    expect(mockGetProStatusResult).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+  });
+
+  it("打ち切ったら反映待ちであることと手動の確認導線を出す", async () => {
+    renderWithSession();
+
+    await exhaustPolling();
+
+    expect(
+      screen.getByText(
+        "反映に時間がかかっています。決済は完了していますので、時間をおいて加入状態をご確認ください。",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "加入状態を確認する" }),
+    ).toHaveAttribute("href", "/account/subscription");
+    expect(
+      screen.getByRole("link", { name: "ダッシュボードへ" }),
+    ).toHaveAttribute("href", "/dashboard");
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  // 決済は Stripe 側で成立済み。打ち切りを「失敗した」と受け取らせてはいけない。
+  it("打ち切りの案内で決済が失敗したとは言わない", async () => {
+    renderWithSession();
+
+    await exhaustPolling();
+
+    expect(screen.queryByText(/決済に失敗/)).not.toBeInTheDocument();
+    expect(screen.getByText(/決済は完了しています/)).toBeInTheDocument();
+  });
+
+  // 反映を待たずに他画面へ移った利用者のぶんまで Rails を叩き続けないようにする。
+  it("画面を離れたら再取得を止める", async () => {
+    const view = renderWithSession();
+
+    await act(async () => {});
+    expect(mockGetProStatusResult).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+    await advanceOnePoll();
+    await advanceOnePoll();
+
+    expect(mockGetProStatusResult).toHaveBeenCalledTimes(1);
+  });
+
+  // 離脱後に応答が返ってきても、利用者が見ている別画面から勝手に遷移させない。
+  it("画面を離れたあとに応答が返ってきても遷移しない", async () => {
+    let settle: (result: ReturnType<typeof okResult>) => void = () => {};
+    mockGetProStatusResult.mockReturnValue(
+      new Promise<ReturnType<typeof okResult>>((resolve) => {
+        settle = resolve;
+      }),
+    );
+    const view = renderWithSession();
+
+    view.unmount();
+    await act(async () => {
+      settle(okResult(true));
+    });
+
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("待機中も表示を読み上げさせる", async () => {
+    renderWithSession();
+
+    await act(async () => {});
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "決済の反映を確認しています。そのままお待ちください。",
+    );
+  });
+});
+
+describe("直接アクセス", () => {
+  it("session_id が無ければポーリングせず案内だけ出す", async () => {
+    renderWithSession(null);
+
+    await act(async () => {});
+    await advanceOnePoll();
+
+    expect(mockGetProStatusResult).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(
+        "反映には数分かかる場合があります。マイページから加入状態をご確認ください。",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "加入状態を確認する" }),
+    ).toHaveAttribute("href", "/account/subscription");
+  });
+});
+
+describe("状態を取得できないとき", () => {
+  it("トークン失効なら再試行せず再ログインへ誘導する", async () => {
+    mockGetProStatusResult.mockResolvedValue({ status: "unauthorized" });
+    renderWithSession();
+
+    await act(async () => {});
+
+    expect(screen.getByRole("link", { name: "ログインする" })).toHaveAttribute(
+      "href",
+      "/signin",
+    );
+    expect(
+      screen.getByText(/ログインの有効期限が切れているため/),
+    ).toBeInTheDocument();
+
+    await advanceOnePoll();
+    expect(mockGetProStatusResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("トークン失効でも決済が完了していることを伝える", async () => {
+    mockGetProStatusResult.mockResolvedValue({ status: "unauthorized" });
+    renderWithSession();
+
+    await act(async () => {});
+
+    expect(screen.getByText(/決済は完了しています/)).toBeInTheDocument();
+  });
+
+  // API 障害は一過性のことが多いので、1 回で諦めず上限まで再試行する。
+  it("API 障害でも上限まで再試行し、途中で復帰したら遷移する", async () => {
+    mockGetProStatusResult
+      .mockResolvedValueOnce({ status: "error" })
+      .mockResolvedValueOnce({ status: "error" })
+      .mockResolvedValue(okResult(true));
+    renderWithSession();
+
+    await act(async () => {});
+    await advanceOnePoll();
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    await advanceOnePoll();
+
+    expect(mockReplace).toHaveBeenCalledWith("/account/subscription");
+  });
+
+  it("最後まで API 障害なら反映待ちではなく確認できなかったことを伝える", async () => {
+    mockGetProStatusResult.mockResolvedValue({ status: "error" });
+    renderWithSession();
+
+    await exhaustPolling();
+
+    expect(
+      screen.getByText(
+        "加入状態を確認できませんでした。決済は完了していますので、時間をおいて加入状態をご確認ください。",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "加入状態を確認する" }),
+    ).toHaveAttribute("href", "/account/subscription");
+  });
+
+  // 途中で復旧したなら通信は問題ないので、通信エラーとして案内してはいけない。
+  it("途中の API 障害から復旧して打ち切ったときは反映待ちとして案内する", async () => {
+    mockGetProStatusResult
+      .mockResolvedValueOnce({ status: "error" })
+      .mockResolvedValue(okResult(false));
+    renderWithSession();
+
+    await exhaustPolling();
+
+    expect(
+      screen.getByText(
+        "反映に時間がかかっています。決済は完了していますので、時間をおいて加入状態をご確認ください。",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/(app)/pro/success/_components/ProActivationWaiter.tsx
+++ b/app/(app)/pro/success/_components/ProActivationWaiter.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { getProStatusResult } from "@app/(app)/pro/actions";
+
+// Stripe Checkout 完了から Webhook がローカルの Subscription を更新するまでの待ち時間。
+// 上限を設けないと Webhook が落ちた場合にタブを開いている限り叩き続けるため、
+// 「体感で待てる長さ」と「Webhook の通常到達時間」の妥協点として 2 秒 × 10 回とする。
+const POLL_INTERVAL_MS = 2000;
+const MAX_ATTEMPTS = 10;
+
+const SUBSCRIPTION_PATH = "/account/subscription";
+
+type WaitState = "idle" | "polling" | "activated" | "timeout" | "unauthorized";
+
+const CARD_LINK_CLASS =
+  "inline-block rounded-lg bg-[#d08000] px-6 py-3 font-bold text-white transition hover:bg-[#b66c00]";
+const CARD_SUBLINK_CLASS =
+  "inline-block rounded-lg border border-gray-600 px-6 py-3 font-bold text-gray-200 transition hover:bg-[#2E2E2E]";
+
+// 打ち切り時の文言。どちらも決済自体は成立しているので、失敗と受け取られない書き方に揃える。
+const TIMEOUT_MESSAGES = {
+  pending:
+    "反映に時間がかかっています。決済は完了していますので、時間をおいて加入状態をご確認ください。",
+  error:
+    "加入状態を確認できませんでした。決済は完了していますので、時間をおいて加入状態をご確認ください。",
+} as const;
+
+/**
+ * Checkout からの復帰直後に Pro 反映を待ち、反映され次第サブスクリプション管理画面へ送る。
+ *
+ * ポーリングは読み取り専用の getProStatusResult() だけで行い、syncProStatus() は呼ばない。
+ * back の同期 API は RevenueCat の subscriber を唯一の入力とするため、RevenueCat が
+ * Stripe の加入をまだ取り込んでいないこの時間帯に叩くと entitlement 無しと判定され、
+ * ローカルの status を free / expired へ確定させてしまう。
+ */
+export default function ProActivationWaiter() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  // Checkout 経由でのみ session_id が付く。直接開かれたときに待たせても反映される
+  // 決済が存在しないため、その場合はポーリングせず案内だけ出す。
+  const hasCheckoutSession = Boolean(searchParams.get("session_id"));
+
+  const [state, setState] = useState<WaitState>(
+    hasCheckoutSession ? "polling" : "idle",
+  );
+  // 打ち切り時に「まだ反映されていない」のか「状態を確認できなかった」のかを区別するために持つ。
+  // 途中で復旧したなら通信は問題ないので、最後の試行の結果だけを反映させる。
+  const [lastAttemptFailed, setLastAttemptFailed] = useState(false);
+
+  useEffect(() => {
+    if (!hasCheckoutSession) return;
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const poll = async (attempt: number) => {
+      const result = await getProStatusResult();
+      if (cancelled) return;
+
+      if (result.status === "unauthorized") {
+        setState("unauthorized");
+        return;
+      }
+      setLastAttemptFailed(result.status === "error");
+
+      if (result.status === "ok" && result.proStatus.subscription.pro_active) {
+        setState("activated");
+        // 戻る操作でこの待機画面へ戻さない。決済は完了済みで再度待つ意味がない。
+        router.replace(SUBSCRIPTION_PATH);
+        return;
+      }
+      if (attempt >= MAX_ATTEMPTS) {
+        setState("timeout");
+        return;
+      }
+
+      timer = setTimeout(() => void poll(attempt + 1), POLL_INTERVAL_MS);
+    };
+
+    void poll(1);
+
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) clearTimeout(timer);
+    };
+  }, [hasCheckoutSession, router]);
+
+  if (state === "activated") {
+    return (
+      <>
+        <h1 className="mb-4 text-2xl font-bold text-white md:text-3xl">
+          Pro 機能が使えるようになりました
+        </h1>
+        <p className="mb-8 text-sm leading-relaxed text-gray-200" role="status">
+          加入状態の画面へ移動します。
+        </p>
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+          <Link href={SUBSCRIPTION_PATH} className={CARD_LINK_CLASS}>
+            加入状態を確認する
+          </Link>
+        </div>
+      </>
+    );
+  }
+
+  if (state === "unauthorized") {
+    return (
+      <>
+        <h1 className="mb-4 text-2xl font-bold text-white md:text-3xl">
+          Pro 加入手続きを受け付けました
+        </h1>
+        <p className="mb-8 text-sm leading-relaxed text-gray-200" role="status">
+          ログインの有効期限が切れているため、加入状態を確認できませんでした。決済は完了しています。再度ログインしてご確認ください。
+        </p>
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+          <Link href="/signin" className={CARD_LINK_CLASS}>
+            ログインする
+          </Link>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <p className="mb-3 inline-block rounded-full bg-[#d08000]/20 px-4 py-1 text-xs font-bold uppercase tracking-wider text-[#d08000]">
+        ありがとうございます
+      </p>
+      <h1 className="mb-4 text-2xl font-bold text-white md:text-3xl">
+        Pro 加入手続きを受け付けました
+      </h1>
+
+      {/* 打ち切りまで文言が入れ替わるので、live region 自体は状態をまたいで同じ要素に保つ。 */}
+      <div role="status" aria-live="polite">
+        {state === "polling" ? (
+          <p className="mb-8 text-sm leading-relaxed text-gray-200">
+            決済の反映を確認しています。そのままお待ちください。
+          </p>
+        ) : (
+          <>
+            <p className="mb-2 text-sm leading-relaxed text-gray-200">
+              決済の確定後、自動的に Pro 機能がご利用いただけるようになります。
+            </p>
+            <p className="mb-8 text-xs text-gray-400">
+              {state === "timeout"
+                ? TIMEOUT_MESSAGES[lastAttemptFailed ? "error" : "pending"]
+                : "反映には数分かかる場合があります。マイページから加入状態をご確認ください。"}
+            </p>
+          </>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+        <Link href={SUBSCRIPTION_PATH} className={CARD_LINK_CLASS}>
+          加入状態を確認する
+        </Link>
+        <Link href="/dashboard" className={CARD_SUBLINK_CLASS}>
+          ダッシュボードへ
+        </Link>
+      </div>
+    </>
+  );
+}

--- a/app/(app)/pro/success/page.tsx
+++ b/app/(app)/pro/success/page.tsx
@@ -1,41 +1,43 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { Suspense } from "react";
+import ProActivationWaiter from "./_components/ProActivationWaiter";
 
 export const metadata: Metadata = {
   title: "Pro 加入手続きを受け付けました — BUZZ BASE",
   robots: { index: false },
 };
 
+// ハイドレーション前に描画される静的な骨組み。ProActivationWaiter が useSearchParams() を
+// 使うため Suspense 境界が必須で、ここを省くとルート全体が dynamic に落ちる。
+const WAITER_FALLBACK = (
+  <>
+    <h1 className="mb-4 text-2xl font-bold text-white md:text-3xl">
+      Pro 加入手続きを受け付けました
+    </h1>
+    <p className="mb-8 text-sm leading-relaxed text-gray-200">
+      決済の確定後、自動的に Pro 機能がご利用いただけるようになります。
+    </p>
+    <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+      <Link
+        href="/account/subscription"
+        className="inline-block rounded-lg bg-[#d08000] px-6 py-3 font-bold text-white transition hover:bg-[#b66c00]"
+      >
+        加入状態を確認する
+      </Link>
+    </div>
+  </>
+);
+
+// session_id は page の searchParams ではなくクライアント側で読む。
+// searchParams を受け取るとこのルートが dynamic になり、静的プリレンダリングを失う。
 export default function ProSuccessPage() {
   return (
     <main className="flex min-h-screen items-center justify-center bg-[#2E2E2E] px-6 py-16">
       <div className="mx-auto max-w-xl rounded-2xl border border-gray-700 bg-[#424242] p-8 text-center shadow-xl">
-        <p className="mb-3 inline-block rounded-full bg-[#d08000]/20 px-4 py-1 text-xs font-bold uppercase tracking-wider text-[#d08000]">
-          ありがとうございます
-        </p>
-        <h1 className="mb-4 text-2xl font-bold text-white md:text-3xl">
-          Pro 加入手続きを受け付けました
-        </h1>
-        <p className="mb-2 text-sm leading-relaxed text-gray-200">
-          決済の確定後、自動的に Pro 機能がご利用いただけるようになります。
-        </p>
-        <p className="mb-8 text-xs text-gray-400">
-          反映には数分かかる場合があります。マイページから加入状態をご確認ください。
-        </p>
-        <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
-          <Link
-            href="/account/subscription"
-            className="inline-block rounded-lg bg-[#d08000] px-6 py-3 font-bold text-white transition hover:bg-[#b66c00]"
-          >
-            加入状態を確認する
-          </Link>
-          <Link
-            href="/dashboard"
-            className="inline-block rounded-lg border border-gray-600 px-6 py-3 font-bold text-gray-200 transition hover:bg-[#2E2E2E]"
-          >
-            ダッシュボードへ
-          </Link>
-        </div>
+        <Suspense fallback={WAITER_FALLBACK}>
+          <ProActivationWaiter />
+        </Suspense>
       </div>
     </main>
   );


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#461

## `POST /api/v1/pro/sync` の挙動調査（最重要）

**結論: no-op ではなく「RevenueCat から状態を再構築する」。ただし特定の時間帯だけ状態を壊す。**

- `RevenueCat::PlanCatalog::STORE_TO_PLATFORM` に `'STRIPE' => 'web'` があり、spec にも store `stripe` → `platform: 'web'` の期待値がある。**Web 加入も RevenueCat 経由で表現される設計**
- `App::Stripe::EventDispatcher::HANDLERS` は `checkout.session.completed` のみで、そのハンドラは ID しか書かない。**status の唯一の書き手は RevenueCat 系**

**壊れる条件**（`SubscriberSync#apply_no_entitlement`）:

```ruby
new_status = subscription.has_used_trial || subscription.product_id.present? ? 'expired' : 'free'
```

RevenueCat に entitlement が無いときに `product_id` が入っていると **`expired` に確定**し `pro_active?` が false になる。これは Stripe 固有ではなく全媒体共通だが、**Checkout 直後は RevenueCat が Stripe の加入をまだ取り込んでいない窓があり、sync が `free`/`expired` を確定させて直後の `INITIAL_PURCHASE` webhook と競合しうる**。

### 設計判断

| 画面 | 方針 |
| --- | --- |
| `/pro/success`（反映待ち） | **`syncProStatus()` を呼ばない**。読み取り専用の `getProStatusResult()` のみでポーリング |
| `/account/subscription`（再同期ボタン） | **platform で出し分けず全媒体に表示**（RevenueCat が全媒体の状態ソースであり、リスクも媒体非依存） |

この制約は `syncProStatus()` と `ProActivationWaiter` の TSDoc に恒久的に残した。

## 変更内容

- `pro/success/page.tsx` — `searchParams` を受け取らず `<Suspense>` 越しに `ProActivationWaiter` を描画する静的シェルに
- `ProActivationWaiter.tsx`（新規）— `useSearchParams()` で `session_id` を読みポーリング。`pro_active` で `/account/subscription` へ
- `SyncProStatus.tsx`（新規）— 「状態を再同期」ボタン
- `pro/actions.ts` — `syncProStatus()` に `AbortSignal.timeout(10s)` と呼び出し可否の TSDoc

## ポーリング仕様

- 間隔 2000ms / 最大10回（初回は即実行、最長約18秒）
- `pro_active` が既に true なら**1回目で即遷移**
- 打ち切り時: 「反映に時間がかかっています。決済は完了していますので〜」＋手動導線
- `unauthorized`: 即中断（再試行しても無意味）。「決済は完了しています」と明示して `/signin` へ
- `error`: 一過性とみなし上限まで再試行
- `session_id` なし（直接アクセス）: ポーリングせず従来の静的案内のみ
- アンマウント時: `clearTimeout` + `cancelled` フラグで停止

## ビルド突合

```
STATIC=87  DYNAMIC=43   （ベースライン・変更後とも同一、差分なし）
├ ○ /pro/success        ← static のまま維持
```

## ミューテーション検出力（17/17 KILLED）

初回4件生存（cleanup の `clearTimeout` / `cancelled` ガード / 再実行時の結果リセット / ポーリング間隔）→ テスト追加後すべて検出。

副産物として、モックの `useRouter` が毎レンダー新オブジェクトを返していたため effect が貼り直され**実装より緩い前提でテストしていた**ことが判明。本物は参照が安定するのでモックも安定化させた。

## レビューで見てほしい点

1. **再同期ボタンを platform で出し分けなかった判断** — 「Stripe 加入者にとって RevenueCat が状態ソースである」という前提が実運用（RevenueCat の Stripe 連携が有効か）と合っているか確認してほしい。**もし連携が入っていないなら `SubscriberSync` は Web 加入者を必ず `expired` に落とすことになり、この機能どころか既存の `ChangeWebPlan` の sync 呼び出しも危険になる**
2. ポーリング上限 2s × 10回（約18秒）の妥当性。Stripe → RevenueCat → 自前 webhook の実測到達時間が分かれば調整したい
3. `unauthorized` 時に `/signin` へ誘導している点（`page.tsx` の未認証リダイレクトは `/signup?auth_required=true` で使い分けが分かれている）

## チェックリスト

- [x] `yarn typecheck` / `yarn lint` / `yarn format:check` が通る
- [x] `yarn test` が通る（82 suites / 832 tests）
- [x] `yarn build` が通る（static 87 維持・ルート表差分なし）


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_