### PR TITLE
Add: グループ導線のオンボーディング（ツールチップ / 未参加バッジ / 招待カード）

### DIFF
--- a/app/(app)/dashboard/_components/DashboardContent.tsx
+++ b/app/(app)/dashboard/_components/DashboardContent.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import { adSlots } from "@app/components/ad/adConfig";
 import AdInFeed from "@app/components/ad/AdInFeed";
 import { getFilteredBattingStats, getFilteredPitchingStats } from "../actions";
+import DashboardWelcome from "./DashboardWelcome";
 import GroupRankings from "./GroupRankings";
 import RecentGameResults from "./RecentGameResults";
 import RecordGameButton from "./RecordGameButton";
@@ -55,6 +56,8 @@ export default function DashboardContent({
 
   return (
     <div className="flex flex-col gap-6">
+      <DashboardWelcome data={data} />
+
       <RecordGameButton />
 
       <StatsOverview

--- a/app/(app)/dashboard/_components/DashboardWelcome.tsx
+++ b/app/(app)/dashboard/_components/DashboardWelcome.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import type { DashboardData } from "../actions";
+import Link from "next/link";
+import { useInviteCardDismissal } from "@app/hooks/onboarding/useInviteCardDismissal";
+import RecordGameButton from "./RecordGameButton";
+import WelcomeCard from "./WelcomeCard";
+
+interface DashboardWelcomeProps {
+  data: DashboardData | null;
+}
+
+const RECORD_ACTION = <RecordGameButton label="最初の試合を記録する" />;
+
+const INVITE_ACTION = (
+  <Link
+    href="/groups/new"
+    className="flex items-center justify-center w-full rounded-full bg-[#d08000] px-5 py-2.5 text-base font-bold text-white"
+  >
+    友達を招待する
+  </Link>
+);
+
+/**
+ * オンボーディングの進み具合に応じてウェルカムカードを出し分ける。
+ * 未記録 → 記録カード、記録済みかつグループ未所属 → 招待カード、どちらも済んでいれば何も出さない。
+ * 2枚が同時に出ることはない。
+ */
+export default function DashboardWelcome({ data }: DashboardWelcomeProps) {
+  const { isDismissed, dismiss } = useInviteCardDismissal();
+
+  // 取得に失敗したときは進み具合を判定できないため、どちらの導線も出さない
+  if (!data) return null;
+
+  const hasRecord =
+    data.recent_game_results.length > 0 ||
+    data.batting_stats?.aggregate != null ||
+    data.pitching_stats?.aggregate != null;
+
+  if (!hasRecord) {
+    return <WelcomeCard variant="record" action={RECORD_ACTION} />;
+  }
+
+  const inGroup = data.group_rankings.length > 0;
+  // isDismissed が確定するまで（null）は描画しない。SSR 後に一瞬出て消えるのを防ぐ。
+  if (inGroup || isDismissed !== false) return null;
+
+  return (
+    <WelcomeCard variant="invite" action={INVITE_ACTION} onDismiss={dismiss} />
+  );
+}

--- a/app/(app)/dashboard/_components/RecordGameButton.tsx
+++ b/app/(app)/dashboard/_components/RecordGameButton.tsx
@@ -11,7 +11,13 @@ import {
 } from "@app/constants/gameRecord";
 import { createGameResult } from "@app/services/gameResultsService";
 
-export default function RecordGameButton() {
+interface RecordGameButtonProps {
+  label?: string;
+}
+
+export default function RecordGameButton({
+  label = "試合を記録する",
+}: RecordGameButtonProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
 
@@ -43,7 +49,7 @@ export default function RecordGameButton() {
         isDisabled={isSubmitting}
         className="font-bold text-base"
       >
-        試合を記録する
+        {label}
       </Button>
     </>
   );

--- a/app/(app)/dashboard/_components/WelcomeCard.tsx
+++ b/app/(app)/dashboard/_components/WelcomeCard.tsx
@@ -1,0 +1,113 @@
+import type { ReactNode } from "react";
+
+type WelcomeCardVariant = "record" | "invite";
+
+interface WelcomeCardProps {
+  variant: WelcomeCardVariant;
+  /** CTA。記録は Server Action 起点、招待は遷移リンクと起動方法が異なるため呼び出し側が渡す。 */
+  action: ReactNode;
+  /** 渡した場合のみ閉じるボタンを出す。 */
+  onDismiss?: () => void;
+}
+
+const CONTENT: Record<
+  WelcomeCardVariant,
+  { title: string; description: string }
+> = {
+  record: {
+    title: "BUZZ BASEへようこそ",
+    description:
+      "試合を記録するだけで、打率・OPS から防御率まで自動で計算。打者も投手もまとめて成績を管理できます。",
+  },
+  invite: {
+    title: "チームメイトと競い合おう",
+    description: "グループを作って、打率ランキングで仲間と競おう。",
+  },
+};
+
+function SampleStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex-1 flex flex-col items-center rounded-lg bg-bg_sub py-2.5">
+      <span className="text-lg font-bold text-[#d08000]">{value}</span>
+      <span className="mt-0.5 text-[11px] text-zinc-400">{label}</span>
+    </div>
+  );
+}
+
+function SampleRankRow({ rank, value }: { rank: number; value: string }) {
+  return (
+    <div className="flex items-center py-1.5">
+      <span className="flex items-center justify-center w-[22px] h-[22px] mr-2.5 rounded-full bg-zinc-700 text-xs font-bold text-white">
+        {rank}
+      </span>
+      <span className="flex-1 h-2 mr-2.5 rounded bg-zinc-700" />
+      <span className="text-[13px] font-bold text-[#d08000]">{value}</span>
+    </div>
+  );
+}
+
+const SAMPLE_NOTE = (
+  <p className="mt-2 text-right text-[10px] text-zinc-500">※サンプル</p>
+);
+
+const STATS_PREVIEW = (
+  <div className="mt-4 rounded-[10px] bg-[#1f1f22] p-3.5">
+    <p className="mb-2.5 text-xs text-zinc-500">記録するとこう計算されます</p>
+    <p className="mb-1.5 text-[11px] font-semibold text-zinc-400">打撃成績</p>
+    <div className="flex gap-x-2.5">
+      <SampleStat label="打率" value=".333" />
+      <SampleStat label="OPS" value=".900" />
+      <SampleStat label="本塁打" value="5" />
+    </div>
+    <p className="mt-3 mb-1.5 text-[11px] font-semibold text-zinc-400">
+      投手成績
+    </p>
+    <div className="flex gap-x-2.5">
+      <SampleStat label="防御率" value="2.50" />
+      <SampleStat label="奪三振" value="42" />
+      <SampleStat label="勝利" value="6" />
+    </div>
+    {SAMPLE_NOTE}
+  </div>
+);
+
+const RANKING_PREVIEW = (
+  <div className="mt-4 rounded-[10px] bg-[#1f1f22] p-3.5">
+    <p className="mb-2.5 text-xs text-zinc-500">グループ内ランキング</p>
+    <SampleRankRow rank={1} value=".380" />
+    <SampleRankRow rank={2} value=".355" />
+    <SampleRankRow rank={3} value=".340" />
+    {SAMPLE_NOTE}
+  </div>
+);
+
+/**
+ * オンボーディングの次の一歩を促すカード。
+ * record は「まだ試合を記録していない人」、invite は「記録済みだがグループ未所属の人」向け。
+ */
+export default function WelcomeCard({
+  variant,
+  action,
+  onDismiss,
+}: WelcomeCardProps) {
+  const { title, description } = CONTENT[variant];
+
+  return (
+    <section className="relative rounded-xl border border-sub bg-bg_sub p-5">
+      {onDismiss ? (
+        <button
+          type="button"
+          aria-label="このカードを閉じる"
+          onClick={onDismiss}
+          className="absolute top-3 right-3 p-1 text-zinc-500 text-sm leading-none"
+        >
+          <span aria-hidden="true">✕</span>
+        </button>
+      ) : null}
+      <h3 className="pr-6 text-lg font-bold text-white">{title}</h3>
+      <p className="mt-1.5 text-sm leading-5 text-zinc-400">{description}</p>
+      {variant === "record" ? STATS_PREVIEW : RANKING_PREVIEW}
+      <div className="mt-5">{action}</div>
+    </section>
+  );
+}

--- a/app/(app)/dashboard/_components/__tests__/DashboardWelcome.test.tsx
+++ b/app/(app)/dashboard/_components/__tests__/DashboardWelcome.test.tsx
@@ -1,0 +1,221 @@
+import type { DashboardData } from "../../actions";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderToStaticMarkup } from "react-dom/server";
+import { INVITE_CARD_DISMISSED_STORAGE_KEY } from "@app/constants/onboarding";
+import DashboardWelcome from "../DashboardWelcome";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const RECORD_TITLE = "BUZZ BASEへようこそ";
+const INVITE_TITLE = "チームメイトと競い合おう";
+
+const emptyData: DashboardData = {
+  recent_game_results: [],
+  batting_stats: { aggregate: null, calculated: null },
+  pitching_stats: { aggregate: null, calculated: null },
+  group_rankings: [],
+  available_years: [],
+};
+
+const buildData = (overrides: Partial<DashboardData>): DashboardData => ({
+  ...emptyData,
+  ...overrides,
+});
+
+const gameResult = {
+  id: 1,
+  date: "2026-04-01",
+  opponent_team_name: "対戦チーム",
+  my_team_score: 3,
+  opponent_team_score: 1,
+  match_type: "公式戦",
+  batting_average: null,
+  pitching_result: null,
+};
+
+const groupRanking = {
+  group_id: 1,
+  group_name: "チームA",
+  group_icon: null,
+  total_members: 5,
+  batting_rankings: [],
+  pitching_rankings: [],
+};
+
+const recordedData = buildData({ recent_game_results: [gameResult] });
+
+describe("DashboardWelcome", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  describe("段階的オンボーディング", () => {
+    it("未記録なら記録カードだけを出す", () => {
+      render(<DashboardWelcome data={emptyData} />);
+
+      expect(screen.getByText(RECORD_TITLE)).toBeInTheDocument();
+      expect(screen.queryByText(INVITE_TITLE)).not.toBeInTheDocument();
+    });
+
+    it("記録済みでグループ未所属なら招待カードだけを出す", () => {
+      render(<DashboardWelcome data={recordedData} />);
+
+      expect(screen.getByText(INVITE_TITLE)).toBeInTheDocument();
+      expect(screen.queryByText(RECORD_TITLE)).not.toBeInTheDocument();
+    });
+
+    it("記録済みでグループ所属済みならどちらも出さない", () => {
+      render(
+        <DashboardWelcome
+          data={buildData({
+            recent_game_results: [gameResult],
+            group_rankings: [groupRanking],
+          })}
+        />,
+      );
+
+      expect(screen.queryByText(RECORD_TITLE)).not.toBeInTheDocument();
+      expect(screen.queryByText(INVITE_TITLE)).not.toBeInTheDocument();
+    });
+
+    it("試合一覧が空でも打撃成績があれば記録済みとして扱う", () => {
+      render(
+        <DashboardWelcome
+          data={buildData({
+            batting_stats: {
+              aggregate: { ...emptyData.batting_stats.aggregate },
+              calculated: null,
+            } as DashboardData["batting_stats"],
+          })}
+        />,
+      );
+
+      expect(screen.getByText(INVITE_TITLE)).toBeInTheDocument();
+    });
+
+    it("試合一覧が空でも投手成績があれば記録済みとして扱う", () => {
+      render(
+        <DashboardWelcome
+          data={buildData({
+            pitching_stats: {
+              aggregate: { ...emptyData.pitching_stats.aggregate },
+              calculated: null,
+            } as DashboardData["pitching_stats"],
+          })}
+        />,
+      );
+
+      expect(screen.getByText(INVITE_TITLE)).toBeInTheDocument();
+    });
+
+    it("グループ未所属でもデータ取得に失敗していれば何も出さない", () => {
+      render(<DashboardWelcome data={null} />);
+
+      expect(screen.queryByText(RECORD_TITLE)).not.toBeInTheDocument();
+      expect(screen.queryByText(INVITE_TITLE)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("招待カードの表示内容", () => {
+    it("ランキングプレビューとグループ作成への導線を持つ", () => {
+      render(<DashboardWelcome data={recordedData} />);
+
+      expect(screen.getByText("グループ内ランキング")).toBeInTheDocument();
+      expect(screen.getByText(".380")).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "友達を招待する" }),
+      ).toHaveAttribute("href", "/groups/new");
+    });
+
+    it("記録カードは成績プレビューと記録開始ボタンを持つ", () => {
+      render(<DashboardWelcome data={emptyData} />);
+
+      expect(
+        screen.getByText("記録するとこう計算されます"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "最初の試合を記録する" }),
+      ).toBeInTheDocument();
+    });
+
+    it("記録カードには閉じるボタンがない", () => {
+      render(<DashboardWelcome data={emptyData} />);
+
+      expect(
+        screen.queryByRole("button", { name: "このカードを閉じる" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("招待カードの dismiss", () => {
+    it("× で閉じるとその場で消え、再訪問しても出ない", async () => {
+      const user = userEvent.setup();
+      const { unmount } = render(<DashboardWelcome data={recordedData} />);
+
+      await user.click(
+        screen.getByRole("button", { name: "このカードを閉じる" }),
+      );
+      expect(screen.queryByText(INVITE_TITLE)).not.toBeInTheDocument();
+
+      unmount();
+      render(<DashboardWelcome data={recordedData} />);
+
+      expect(screen.queryByText(INVITE_TITLE)).not.toBeInTheDocument();
+    });
+
+    it("dismiss 済みフラグが保存されていれば最初から出ない", () => {
+      localStorage.setItem(INVITE_CARD_DISMISSED_STORAGE_KEY, "1");
+
+      render(<DashboardWelcome data={recordedData} />);
+
+      expect(screen.queryByText(INVITE_TITLE)).not.toBeInTheDocument();
+    });
+
+    it("dismiss しても記録カードの表示条件には影響しない", () => {
+      localStorage.setItem(INVITE_CARD_DISMISSED_STORAGE_KEY, "1");
+
+      render(<DashboardWelcome data={emptyData} />);
+
+      expect(screen.getByText(RECORD_TITLE)).toBeInTheDocument();
+    });
+  });
+
+  describe("ちらつき防止と localStorage 障害", () => {
+    it("SSR 時点では招待カードを描画しない", () => {
+      const html = renderToStaticMarkup(
+        <DashboardWelcome data={recordedData} />,
+      );
+
+      expect(html).not.toContain(INVITE_TITLE);
+    });
+
+    it("localStorage が例外を投げても招待カードは出さずクラッシュしない", () => {
+      jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
+
+      expect(() =>
+        render(<DashboardWelcome data={recordedData} />),
+      ).not.toThrow();
+      expect(screen.queryByText(INVITE_TITLE)).not.toBeInTheDocument();
+    });
+
+    it("保存に失敗しても閉じた直後は非表示のままになる", async () => {
+      const user = userEvent.setup();
+      jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+
+      render(<DashboardWelcome data={recordedData} />);
+      await user.click(
+        screen.getByRole("button", { name: "このカードを閉じる" }),
+      );
+
+      expect(screen.queryByText(INVITE_TITLE)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/app/(app)/groups/_components/GroupJoinTooltip.tsx
+++ b/app/(app)/groups/_components/GroupJoinTooltip.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useGroupJoinTooltip } from "@app/hooks/onboarding/useGroupJoinTooltip";
+
+/**
+ * グループ未参加のユーザーに、招待コードでの参加を初回訪問時だけ案内する。
+ * localStorage 依存のためクライアントコンポーネント。
+ */
+export default function GroupJoinTooltip() {
+  const { hasShown, markShown } = useGroupJoinTooltip();
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  // 表示した時点で「案内済み」を永続化する。閉じずに離脱しても次回訪問では出さない。
+  useEffect(() => {
+    if (hasShown === false) markShown();
+  }, [hasShown, markShown]);
+
+  if (hasShown !== false || isDismissed) return null;
+
+  return (
+    <div className="flex items-center gap-x-2 mt-4 px-4 py-2.5 rounded-lg border border-[#d08000] bg-[#3a2e1a]">
+      <p className="flex-1 text-sm leading-5 text-white">
+        チームメイトから招待コードをもらって参加しよう
+      </p>
+      <button
+        type="button"
+        aria-label="ヒントを閉じる"
+        onClick={() => setIsDismissed(true)}
+        className="shrink-0 p-1 text-zinc-400 text-sm leading-none"
+      >
+        <span aria-hidden="true">✕</span>
+      </button>
+    </div>
+  );
+}

--- a/app/(app)/groups/_components/__tests__/GroupJoinTooltip.test.tsx
+++ b/app/(app)/groups/_components/__tests__/GroupJoinTooltip.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderToStaticMarkup } from "react-dom/server";
+import { GROUP_JOIN_TOOLTIP_SHOWN_STORAGE_KEY } from "@app/constants/onboarding";
+import GroupJoinTooltip from "../GroupJoinTooltip";
+
+const TOOLTIP_TEXT = "チームメイトから招待コードをもらって参加しよう";
+
+describe("GroupJoinTooltip", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it("初回訪問ではツールチップが表示される", () => {
+    render(<GroupJoinTooltip />);
+
+    expect(screen.getByText(TOOLTIP_TEXT)).toBeInTheDocument();
+  });
+
+  it("2回目の訪問では表示されない", () => {
+    const { unmount } = render(<GroupJoinTooltip />);
+    expect(screen.getByText(TOOLTIP_TEXT)).toBeInTheDocument();
+    unmount();
+
+    render(<GroupJoinTooltip />);
+
+    expect(screen.queryByText(TOOLTIP_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("閉じるとその場で消え、再訪問しても表示されない", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<GroupJoinTooltip />);
+
+    await user.click(screen.getByRole("button", { name: "ヒントを閉じる" }));
+    expect(screen.queryByText(TOOLTIP_TEXT)).not.toBeInTheDocument();
+
+    unmount();
+    render(<GroupJoinTooltip />);
+
+    expect(screen.queryByText(TOOLTIP_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("表示済みフラグが保存されている状態では最初から表示されない", () => {
+    localStorage.setItem(GROUP_JOIN_TOOLTIP_SHOWN_STORAGE_KEY, "1");
+
+    render(<GroupJoinTooltip />);
+
+    expect(screen.queryByText(TOOLTIP_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("SSR 時点では描画されない（localStorage 読み込み前のちらつき防止）", () => {
+    const html = renderToStaticMarkup(<GroupJoinTooltip />);
+
+    expect(html).not.toContain(TOOLTIP_TEXT);
+  });
+
+  it("localStorage が例外を投げてもクラッシュせず表示もしない", () => {
+    jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+
+    expect(() => render(<GroupJoinTooltip />)).not.toThrow();
+    expect(screen.queryByText(TOOLTIP_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("保存に失敗しても初回表示は行われる", () => {
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+
+    render(<GroupJoinTooltip />);
+
+    expect(screen.getByText(TOOLTIP_TEXT)).toBeInTheDocument();
+  });
+});

--- a/app/(app)/groups/page.tsx
+++ b/app/(app)/groups/page.tsx
@@ -10,6 +10,7 @@ import { PlusIcon } from "@app/components/icon/PlusIcon";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import { getGroups } from "@app/services/groupService";
 import { getCurrentUserId } from "@app/services/userService";
+import GroupJoinTooltip from "./_components/GroupJoinTooltip";
 
 export default function Group() {
   const [groups, setGroups] = useState<GroupsData[]>([]);
@@ -82,6 +83,7 @@ export default function Group() {
                   </Button>
                 </Link>
               </div>
+              <GroupJoinTooltip />
               <Divider className="mt-8" />
               <div className="mt-7">
                 <h2 className="text-2xl font-bold">グループ</h2>

--- a/app/components/header/NavigationMenu.tsx
+++ b/app/components/header/NavigationMenu.tsx
@@ -5,13 +5,18 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import HeaderUserMenu from "@app/components/header/HeaderUserMenu";
 import { useAuthContext } from "@app/contexts/useAuthContext";
+import { useGroupNavBadge } from "@app/hooks/onboarding/useGroupNavBadge";
 import { showAuthRequiredToast } from "@app/utils/showAuthRequiredToast";
 import NavigationItems from "./NavigationItems";
+
+const GROUPS_HREF = "/groups";
 
 export default function NavigationMenu() {
   const pathName = usePathname();
   const { isLoggedIn } = useAuthContext();
   const navigationItems = NavigationItems();
+  const { showBadge: showGroupBadge, markSeen: markGroupBadgeSeen } =
+    useGroupNavBadge();
 
   const handleAuthRequiredClick = () => {
     if (!isLoggedIn) {
@@ -57,32 +62,51 @@ export default function NavigationMenu() {
             />
           </Link>
           <ul className="flex items-center justify-around max-w-[720px] mx-auto lg:grid-cols-1 lg:ml-0 lg:h-full lg:items-start lg:gap-y-5 lg:flex-col lg:justify-start">
-            {navigationItems.map((item, index) => (
-              <li key={index}>
-                <Link
-                  href={item.href}
-                  onClick={
-                    item.authRequired ? handleAuthRequiredClick : undefined
-                  }
-                  className={`flex items-center min-w-[50px] flex-col gap-y-1 px-0 bg-transparent overflow-visible text-[10px] font-medium ${
-                    isActive(pathName, item.href)
-                      ? `text-yellow-500`
-                      : `text-white`
-                  } lg:flex-row lg:text-base lg:w-fit lg:font-bold lg:gap-x-5 [&>svg]:lg:w-6 [&>svg]:lg:h-6 [&>svg]:lg:mr-4`}
-                >
-                  <item.icon
-                    fill={isActive(pathName, item.href) ? `#e08e0a` : `#F4F4F4`}
-                    filled={
-                      isActive(pathName, item.href) ? `#e08e0a` : `#F4F4F4`
+            {navigationItems.map((item, index) => {
+              const isGroupsItem = item.href === GROUPS_HREF;
+
+              return (
+                <li key={index}>
+                  <Link
+                    href={item.href}
+                    onClick={
+                      isGroupsItem
+                        ? markGroupBadgeSeen
+                        : item.authRequired
+                          ? handleAuthRequiredClick
+                          : undefined
                     }
-                    height="22"
-                    width="22"
-                    label=""
-                  />
-                  {item.label}
-                </Link>
-              </li>
-            ))}
+                    className={`flex items-center min-w-[50px] flex-col gap-y-1 px-0 bg-transparent overflow-visible text-[10px] font-medium ${
+                      isActive(pathName, item.href)
+                        ? `text-yellow-500`
+                        : `text-white`
+                    } lg:flex-row lg:text-base lg:w-fit lg:font-bold lg:gap-x-5 [&_svg]:lg:w-6 [&_svg]:lg:h-6 [&_svg]:lg:mr-4`}
+                  >
+                    <span className="relative inline-flex">
+                      <item.icon
+                        fill={
+                          isActive(pathName, item.href) ? `#e08e0a` : `#F4F4F4`
+                        }
+                        filled={
+                          isActive(pathName, item.href) ? `#e08e0a` : `#F4F4F4`
+                        }
+                        height="22"
+                        width="22"
+                        label=""
+                      />
+                      {isGroupsItem && showGroupBadge ? (
+                        <span
+                          role="status"
+                          aria-label="グループ未参加"
+                          className="absolute top-0 right-0 block w-2 h-2 rounded-full bg-red-500 lg:right-3"
+                        />
+                      ) : null}
+                    </span>
+                    {item.label}
+                  </Link>
+                </li>
+              );
+            })}
             <li>
               <HeaderUserMenu />
             </li>

--- a/app/components/header/__tests__/NavigationMenu.test.tsx
+++ b/app/components/header/__tests__/NavigationMenu.test.tsx
@@ -1,0 +1,148 @@
+import type { GroupsData } from "@app/interface";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SWRConfig } from "swr";
+import { GROUP_TAB_BADGE_SEEN_STORAGE_KEY } from "@app/constants/onboarding";
+import NavigationMenu from "../NavigationMenu";
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/dashboard",
+}));
+
+jest.mock("@app/components/header/HeaderUserMenu", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockIsLoggedIn = jest.fn<boolean | undefined, []>();
+jest.mock("@app/contexts/useAuthContext", () => ({
+  useAuthContext: () => ({ isLoggedIn: mockIsLoggedIn() }),
+}));
+
+const mockUserId = jest.fn<number | null, []>();
+jest.mock("@app/contexts/userContext", () => ({
+  useUser: () => ({
+    state: { userId: { id: mockUserId(), team_id: null, user_id: "" } },
+  }),
+}));
+
+const mockFetcher = jest.fn();
+jest.mock("@app/hooks/swrFetcher", () => ({
+  fetcher: (url: string) => mockFetcher(url),
+}));
+
+const BADGE_LABEL = "グループ未参加";
+
+const buildGroup = (id: number): GroupsData => ({
+  id,
+  name: `グループ${id}`,
+  icon: { url: "/icon.png" },
+});
+
+// SWR のキャッシュをテストごとに隔離する
+const renderMenu = () =>
+  render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <NavigationMenu />
+    </SWRConfig>,
+  );
+
+const findBadge = () => screen.findByRole("status", { name: BADGE_LABEL });
+const queryBadge = () => screen.queryByRole("status", { name: BADGE_LABEL });
+
+describe("NavigationMenu のグループ未参加バッジ", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    mockIsLoggedIn.mockReturnValue(true);
+    mockUserId.mockReturnValue(1);
+    mockFetcher.mockResolvedValue([]);
+  });
+
+  it("グループ未参加のユーザーにはバッジを出す", async () => {
+    renderMenu();
+
+    expect(await findBadge()).toBeInTheDocument();
+  });
+
+  it("グループ参加済みのユーザーにはバッジを出さない", async () => {
+    mockFetcher.mockResolvedValue([buildGroup(1)]);
+
+    renderMenu();
+
+    await waitFor(() => expect(mockFetcher).toHaveBeenCalled());
+    expect(queryBadge()).not.toBeInTheDocument();
+  });
+
+  it("グループ一覧の取得が確定するまではバッジを出さない", () => {
+    mockFetcher.mockReturnValue(new Promise(() => {}));
+
+    renderMenu();
+
+    expect(queryBadge()).not.toBeInTheDocument();
+  });
+
+  it("未ログインならバッジを出さず、グループ一覧も取得しない", async () => {
+    mockIsLoggedIn.mockReturnValue(false);
+
+    renderMenu();
+
+    await waitFor(() => expect(queryBadge()).not.toBeInTheDocument());
+    expect(mockFetcher).not.toHaveBeenCalled();
+  });
+
+  it("グループを開くとバッジが消え、再訪問しても出ない", async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderMenu();
+    await findBadge();
+
+    await user.click(screen.getByRole("link", { name: /グループ/ }));
+    await waitFor(() => expect(queryBadge()).not.toBeInTheDocument());
+
+    unmount();
+    renderMenu();
+
+    await waitFor(() => expect(queryBadge()).not.toBeInTheDocument());
+  });
+
+  it("閲覧済みが保存されていればバッジを出さず、グループ一覧も取得しない", async () => {
+    localStorage.setItem(GROUP_TAB_BADGE_SEEN_STORAGE_KEY, "1");
+
+    renderMenu();
+
+    await waitFor(() => expect(queryBadge()).not.toBeInTheDocument());
+    expect(mockFetcher).not.toHaveBeenCalled();
+  });
+
+  it("SSR 時点ではバッジを描画しない（localStorage 読み込み前のちらつき防止）", () => {
+    const html = renderToStaticMarkup(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <NavigationMenu />
+      </SWRConfig>,
+    );
+
+    expect(html).not.toContain(BADGE_LABEL);
+  });
+
+  it("localStorage が例外を投げてもクラッシュせずバッジも出さない", async () => {
+    jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+
+    expect(() => renderMenu()).not.toThrow();
+    await waitFor(() => expect(queryBadge()).not.toBeInTheDocument());
+    expect(mockFetcher).not.toHaveBeenCalled();
+  });
+
+  it("グループ以外のナビゲーションを踏んでもバッジは消えない", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+    await findBadge();
+
+    await user.click(screen.getByRole("link", { name: "成績" }));
+
+    expect(await findBadge()).toBeInTheDocument();
+  });
+});

--- a/app/constants/onboarding.ts
+++ b/app/constants/onboarding.ts
@@ -1,0 +1,13 @@
+// グループ導線オンボーディングの表示状態を保持する localStorage キー。
+// 記録フロー（gameResultId など接頭辞なしのキー）と衝突させないため、
+// この機能のキーはすべて同じ接頭辞配下にまとめる。
+const ONBOARDING_STORAGE_PREFIX = "buzzbase.onboarding.";
+
+/** グループ一覧の「招待コードで参加」ツールチップを表示済みか。 */
+export const GROUP_JOIN_TOOLTIP_SHOWN_STORAGE_KEY = `${ONBOARDING_STORAGE_PREFIX}groupJoinTooltipShown`;
+
+/** グローバルナビのグループ未参加バッジを閲覧済みか。 */
+export const GROUP_TAB_BADGE_SEEN_STORAGE_KEY = `${ONBOARDING_STORAGE_PREFIX}groupTabBadgeSeen`;
+
+/** ダッシュボードのグループ招待カードをユーザーが閉じたか。 */
+export const INVITE_CARD_DISMISSED_STORAGE_KEY = `${ONBOARDING_STORAGE_PREFIX}inviteCardDismissed`;

--- a/app/hooks/onboarding/__tests__/useOnboardingFlag.test.tsx
+++ b/app/hooks/onboarding/__tests__/useOnboardingFlag.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  GROUP_JOIN_TOOLTIP_SHOWN_STORAGE_KEY,
+  GROUP_TAB_BADGE_SEEN_STORAGE_KEY,
+  INVITE_CARD_DISMISSED_STORAGE_KEY,
+} from "@app/constants/onboarding";
+import { useOnboardingFlag } from "../useOnboardingFlag";
+
+const KEY = "buzzbase.onboarding.test";
+
+function Probe() {
+  const { isMarked, mark, markForNextVisit } = useOnboardingFlag(KEY);
+
+  return (
+    <div>
+      <p>状態: {isMarked === null ? "未確定" : String(isMarked)}</p>
+      <button type="button" onClick={mark}>
+        今すぐ消す
+      </button>
+      <button type="button" onClick={markForNextVisit}>
+        次回から消す
+      </button>
+    </div>
+  );
+}
+
+const state = () => screen.getByText(/^状態:/).textContent;
+
+describe("useOnboardingFlag", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it("SSR では未確定を返す", () => {
+    const html = renderToStaticMarkup(<Probe />);
+
+    expect(html).toContain("未確定");
+  });
+
+  it("マウント後は未設定のフラグを false として確定する", () => {
+    render(<Probe />);
+
+    expect(state()).toBe("状態: false");
+  });
+
+  it("mark で即座に true になり、次のマウントでも true のまま", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<Probe />);
+
+    await user.click(screen.getByRole("button", { name: "今すぐ消す" }));
+    expect(state()).toBe("状態: true");
+
+    unmount();
+    render(<Probe />);
+
+    expect(state()).toBe("状態: true");
+  });
+
+  it("markForNextVisit は表示中の状態を変えず、次のマウントで true になる", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<Probe />);
+
+    await user.click(screen.getByRole("button", { name: "次回から消す" }));
+    expect(state()).toBe("状態: false");
+
+    unmount();
+    render(<Probe />);
+
+    expect(state()).toBe("状態: true");
+  });
+
+  it("読み込みが例外になったら true（＝もう出さない）に倒す", () => {
+    jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+
+    render(<Probe />);
+
+    expect(state()).toBe("状態: true");
+  });
+
+  it("保存が例外になっても落ちず、その場の状態は保たれる", async () => {
+    const user = userEvent.setup();
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+
+    render(<Probe />);
+
+    await expect(
+      user.click(screen.getByRole("button", { name: "今すぐ消す" })),
+    ).resolves.not.toThrow();
+    expect(state()).toBe("状態: true");
+  });
+});
+
+describe("オンボーディングの永続化キー", () => {
+  // 変更すると既存ユーザーに導線が再表示されるため、キー名は固定の契約として扱う
+  it("機能ごとに衝突しない固定のキー名を持つ", () => {
+    expect(GROUP_JOIN_TOOLTIP_SHOWN_STORAGE_KEY).toBe(
+      "buzzbase.onboarding.groupJoinTooltipShown",
+    );
+    expect(GROUP_TAB_BADGE_SEEN_STORAGE_KEY).toBe(
+      "buzzbase.onboarding.groupTabBadgeSeen",
+    );
+    expect(INVITE_CARD_DISMISSED_STORAGE_KEY).toBe(
+      "buzzbase.onboarding.inviteCardDismissed",
+    );
+    expect(
+      new Set([
+        GROUP_JOIN_TOOLTIP_SHOWN_STORAGE_KEY,
+        GROUP_TAB_BADGE_SEEN_STORAGE_KEY,
+        INVITE_CARD_DISMISSED_STORAGE_KEY,
+      ]).size,
+    ).toBe(3);
+  });
+});

--- a/app/hooks/onboarding/useGroupJoinTooltip.ts
+++ b/app/hooks/onboarding/useGroupJoinTooltip.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { GROUP_JOIN_TOOLTIP_SHOWN_STORAGE_KEY } from "@app/constants/onboarding";
+import { useOnboardingFlag } from "./useOnboardingFlag";
+
+/**
+ * グループ一覧の「招待コードで参加」ツールチップを初回訪問の1回だけ出すためのフック。
+ *
+ * @returns hasShown 表示済み判定。確定まで null。
+ * @returns markShown 表示済みとして永続化する。今表示しているツールチップは消さず、
+ *   次回訪問以降だけ抑止する。
+ */
+export function useGroupJoinTooltip() {
+  const { isMarked, markForNextVisit } = useOnboardingFlag(
+    GROUP_JOIN_TOOLTIP_SHOWN_STORAGE_KEY,
+  );
+
+  return { hasShown: isMarked, markShown: markForNextVisit };
+}

--- a/app/hooks/onboarding/useGroupNavBadge.ts
+++ b/app/hooks/onboarding/useGroupNavBadge.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import type { GroupsData } from "@app/interface";
+import useSWR from "swr";
+import { useAuthContext } from "@app/contexts/useAuthContext";
+import { useUser } from "@app/contexts/userContext";
+import { fetcher } from "@app/hooks/swrFetcher";
+import { useGroupTabBadge } from "./useGroupTabBadge";
+
+/**
+ * グローバルナビのグループ未参加バッジの表示可否を決める。
+ *
+ * 一度閲覧したユーザーには二度と出さないため、閲覧済みが確定している間は
+ * グループ一覧の取得自体を行わない（全ページに常設されるナビからの余計な通信を避ける）。
+ *
+ * @returns showBadge ログイン済み・所属0件が確定・未閲覧のときだけ true。
+ * @returns markSeen グループへ遷移したときに閲覧済みとして確定させる。
+ */
+export function useGroupNavBadge() {
+  const { isLoggedIn } = useAuthContext();
+  const { state } = useUser();
+  const { seen, markSeen } = useGroupTabBadge();
+
+  const userId = state.userId.id;
+  const shouldCheckMembership =
+    isLoggedIn === true && seen === false && userId !== null;
+
+  const { data: groups } = useSWR<GroupsData[]>(
+    shouldCheckMembership ? `/api/v1/groups/?userId=${userId}` : null,
+    fetcher,
+  );
+
+  // 取得が確定するまでは未参加と断定できないので光らせない
+  const showBadge =
+    shouldCheckMembership && Array.isArray(groups) && groups.length === 0;
+
+  return { showBadge, markSeen };
+}

--- a/app/hooks/onboarding/useGroupTabBadge.ts
+++ b/app/hooks/onboarding/useGroupTabBadge.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { GROUP_TAB_BADGE_SEEN_STORAGE_KEY } from "@app/constants/onboarding";
+import { useOnboardingFlag } from "./useOnboardingFlag";
+
+/**
+ * グローバルナビのグループ未参加バッジ（赤ポチ）の閲覧状態を保持するフック。
+ * 一度グループを開いたらバッジは恒久的に消える。
+ *
+ * @returns seen 閲覧済み判定。確定まで null。
+ * @returns markSeen 閲覧済みにして即座にバッジを消し、永続化する。
+ */
+export function useGroupTabBadge() {
+  const { isMarked, mark } = useOnboardingFlag(
+    GROUP_TAB_BADGE_SEEN_STORAGE_KEY,
+  );
+
+  return { seen: isMarked, markSeen: mark };
+}

--- a/app/hooks/onboarding/useInviteCardDismissal.ts
+++ b/app/hooks/onboarding/useInviteCardDismissal.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { INVITE_CARD_DISMISSED_STORAGE_KEY } from "@app/constants/onboarding";
+import { useOnboardingFlag } from "./useOnboardingFlag";
+
+/**
+ * ダッシュボードのグループ招待カードの dismiss 状態を保持するフック。
+ * 一度閉じたら恒久的に表示しない。
+ *
+ * @returns isDismissed 非表示判定。確定まで null。
+ * @returns dismiss 閉じて永続化する。
+ */
+export function useInviteCardDismissal() {
+  const { isMarked, mark } = useOnboardingFlag(
+    INVITE_CARD_DISMISSED_STORAGE_KEY,
+  );
+
+  return { isDismissed: isMarked, dismiss: mark };
+}

--- a/app/hooks/onboarding/useOnboardingFlag.ts
+++ b/app/hooks/onboarding/useOnboardingFlag.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  readOnboardingFlag,
+  writeOnboardingFlag,
+} from "@app/utils/onboardingStorage";
+
+export interface OnboardingFlag {
+  /**
+   * フラグが立っているか。読み込みが確定するまでは null。
+   * 呼び出し側は null の間なにも描画しないことで、SSR 直後の一瞬の表示を防ぐ。
+   */
+  isMarked: boolean | null;
+  /** 今すぐ非表示にして永続化する（ユーザーが閉じた・導線を踏んだとき）。 */
+  mark: () => void;
+  /** 表示中の導線はそのままに、次回以降だけ抑止する（初回だけ出す導線用）。 */
+  markForNextVisit: () => void;
+}
+
+/**
+ * localStorage に持つ「一度きりの導線を出し終えたか」フラグを読み書きする。
+ *
+ * localStorage は SSR では読めないため、初期値は null（未確定）とし、
+ * マウント後に一度だけ読む。この useEffect は localStorage 読み込み専用で、
+ * 他の state から導出できる値の同期には使わない。
+ *
+ * @param key 対象のフラグキー
+ */
+export function useOnboardingFlag(key: string): OnboardingFlag {
+  const [isMarked, setIsMarked] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setIsMarked(readOnboardingFlag(key));
+  }, [key]);
+
+  const mark = useCallback(() => {
+    setIsMarked(true);
+    writeOnboardingFlag(key);
+  }, [key]);
+
+  const markForNextVisit = useCallback(() => {
+    writeOnboardingFlag(key);
+  }, [key]);
+
+  return { isMarked, mark, markForNextVisit };
+}

--- a/app/utils/onboardingStorage.ts
+++ b/app/utils/onboardingStorage.ts
@@ -1,0 +1,34 @@
+// フラグは「立っているかどうか」しか持たないため、値は固定文字列で十分。
+const FLAG_ENABLED_VALUE = "1";
+
+/**
+ * オンボーディング導線の表示済みフラグを読む。
+ *
+ * @param key 対象のフラグキー
+ * @returns フラグが立っていれば true（＝もう出さない）。
+ *   プライベートブラウジングなど localStorage を参照できない環境では true に倒す。
+ *   永続化できない環境で「閉じても毎回出てくる導線」を出し続ける方が害が大きいため。
+ */
+export function readOnboardingFlag(key: string): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    return window.localStorage.getItem(key) === FLAG_ENABLED_VALUE;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * オンボーディング導線を表示済みとして永続化する。
+ * 容量超過などで保存できなくても表示制御そのものは継続させたいので握りつぶす。
+ *
+ * @param key 対象のフラグキー
+ */
+export function writeOnboardingFlag(key: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, FLAG_ENABLED_VALUE);
+  } catch {
+    // 保存できなくても現在の表示状態は呼び出し側が保持する
+  }
+}


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#490

## 概要

mobile がグループ参加率向上のために持っている3つの導線が front に未実装でした。mobile の SecureStore 相当を localStorage で実装し、3導線を追加します。

## 変更内容

- `app/utils/onboardingStorage.ts` / `app/hooks/onboarding/useOnboardingFlag.ts` — localStorage ベースの永続フラグを共通化
- `useGroupJoinTooltip` / `useGroupTabBadge` / `useInviteCardDismissal` — 3導線それぞれのフック
- `app/(app)/groups/_components/GroupJoinTooltip.tsx` — グループ一覧に初回のみ「招待コードで参加」を表示
- `app/components/header/NavigationMenu.tsx` — グループ未参加バッジ（一度開いたら消える）
- `app/(app)/dashboard/_components/WelcomeCard.tsx` / `DashboardWelcome.tsx` — record / invite バリアントを、未記録 → 記録済み未所属 → 完了 の段階で出し分け
- `app/constants/onboarding.ts` — localStorage キーを1箇所に集約（`buzzbase.onboarding.` 接頭辞で既存の記録フローのキーと衝突させない）

## 設計上のポイント

**ちらつき防止**: localStorage は SSR で読めないため、素朴に実装すると「一瞬バッジが出て消える」が起きます。読み込みが完了するまでは何も描画しません。

**localStorage の例外**: プライベートブラウジングや容量超過でアクセスが失敗してもクラッシュしないよう try/catch で包んでいます。

## 確認手順

1. localStorage を空にしてグループ一覧を開く → ツールチップが表示される。再訪問では出ない
2. グループ未参加の状態でグローバルナビにバッジが出る → 一度グループを開くと消え、再訪問でも出ない
3. ダッシュボードで段階的オンボーディングを確認（未記録 → 記録済み未所属 → 完了）
4. 招待カードを × で閉じる → 再訪問でも出ない
5. ページ読み込み時にバッジ・カードが一瞬出て消える挙動がないことを確認

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る（エラー・警告 0）
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（**85 suites / 829 tests**）
- [ ] `yarn build` — CI の Build Check で検証（ルート表がベースライン 静的87 / 動的41〜43 から動いていないことを確認してください）

## レビュー時に確認してほしい点

- ちらつき防止のガード（読み込み完了前は非表示）が、逆に「読み込みが終わらない場合に永久に出ない」状態を作っていないか
- 段階的オンボーディングの出し分けで、複数のカード／バッジが同時に出て画面が騒がしくなっていないか
- localStorage キーの接頭辞が既存キーと衝突していないか

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_