### PR TITLE
Add: 通知一覧に未読表示・相対時刻・削除を追加

### DIFF
--- a/app/components/notification/NotificationEventIcon.tsx
+++ b/app/components/notification/NotificationEventIcon.tsx
@@ -1,0 +1,36 @@
+import CheckCircleIcon from "@heroicons/react/24/outline/CheckCircleIcon";
+import MegaphoneIcon from "@heroicons/react/24/outline/MegaphoneIcon";
+import UserGroupIcon from "@heroicons/react/24/outline/UserGroupIcon";
+import UserPlusIcon from "@heroicons/react/24/outline/UserPlusIcon";
+
+// アイコンと通知種別の対応はモバイルアプリの通知一覧と揃えている
+const EVENT_ICONS = {
+  followed: { Icon: UserPlusIcon, label: "フォロー" },
+  follow_request: { Icon: UserPlusIcon, label: "フォローリクエスト" },
+  follow_request_accepted: {
+    Icon: CheckCircleIcon,
+    label: "フォローリクエスト承認",
+  },
+  group_invitation: { Icon: UserGroupIcon, label: "グループ招待" },
+  management_notice: { Icon: MegaphoneIcon, label: "運営からのお知らせ" },
+} as const;
+
+interface NotificationEventIconProps {
+  eventType: string;
+  className?: string;
+}
+
+/**
+ * 通知種別ごとのアイコンを描画する。
+ * 未知の種別ではアイコンを出さない（文言だけで意味が通るため）。
+ */
+export default function NotificationEventIcon({
+  eventType,
+  className = "w-3.5 h-3.5 text-zinc-400",
+}: NotificationEventIconProps) {
+  const entry = EVENT_ICONS[eventType as keyof typeof EVENT_ICONS];
+  if (!entry) return null;
+
+  const { Icon, label } = entry;
+  return <Icon role="img" aria-label={label} className={className} />;
+}

--- a/app/components/notification/NotificationFollowed.tsx
+++ b/app/components/notification/NotificationFollowed.tsx
@@ -14,11 +14,7 @@ export default function NotificationFollowed({
   onRead,
 }: NotificationFollowedProps) {
   return (
-    <div
-      className={`grid grid-cols-[28px_1fr] gap-x-3 ${
-        notice.read_at ? "opacity-30" : ""
-      }`}
-    >
+    <div className="grid grid-cols-[28px_1fr] gap-x-3">
       <Link
         href={`/mypage/${notice.actor_user_id}`}
         onClick={() => onRead(notice.id)}

--- a/app/components/notification/NotificationGroup.tsx
+++ b/app/components/notification/NotificationGroup.tsx
@@ -22,11 +22,24 @@ import { deleteNotification } from "@app/services/notificationsService";
 
 interface NotificationGroupProps {
   notice: Notifications;
+  onChanged?: () => void;
 }
 
-export default function NotificationGroup({ notice }: NotificationGroupProps) {
+const INVITATION_STATUS_LABELS: Record<string, string> = {
+  accepted: "参加済み",
+  declined: "辞退済み",
+};
+
+export default function NotificationGroup({
+  notice,
+  onChanged,
+}: NotificationGroupProps) {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const router = useRouter();
+
+  // 承認・辞退できるのは招待が保留中のときだけ。それ以外は結果を履歴として表示する
+  const isPending = notice.group_invitation === "pending";
+  const statusLabel = INVITATION_STATUS_LABELS[notice.group_invitation];
 
   const handleAcceptGroupInvitation = async (groupId: number, id: number) => {
     try {
@@ -45,7 +58,7 @@ export default function NotificationGroup({ notice }: NotificationGroupProps) {
       await declinedGroupInvitation(groupId);
       await deleteNotification(id);
       onClose();
-      window.location.reload();
+      onChanged?.();
     } catch (error) {
       Sentry.captureException(error, {
         tags: { source: "notification-group", action: "declineInvitation" },
@@ -86,61 +99,68 @@ export default function NotificationGroup({ notice }: NotificationGroupProps) {
             </span>
             グループへ招待されました
           </p>
-          <div className="flex justify-start gap-x-5 w-full mt-2">
-            <Button
-              size="sm"
-              color="primary"
-              onPress={() =>
-                handleAcceptGroupInvitation(
-                  notice.event_id,
-                  notice.id as number,
-                )
-              }
-            >
-              参加する
-            </Button>
-            <Button size="sm" color="danger" onPress={() => handleOpen()}>
-              拒否する
-            </Button>
-            <Modal
-              size="lg"
-              isOpen={isOpen}
-              onClose={onClose}
-              placement="center"
-              className="w-11/12"
-            >
-              <ModalContent>
-                {(onClose) => (
-                  <>
-                    <ModalHeader className="flex gap-1 text-base text-white pb-0">
-                      本当に 「{notice.group_name}」
-                      への招待を拒否してもよろしいですか？
-                    </ModalHeader>
-                    <ModalFooter>
-                      <Button
-                        variant="light"
-                        onPress={onClose}
-                        className="text-white"
-                      >
-                        キャンセル
-                      </Button>
-                      <Button
-                        color="danger"
-                        onPress={() =>
-                          handleDeclinedGroupInvitation(
-                            notice.event_id,
-                            notice.id as number,
-                          )
-                        }
-                      >
-                        拒否する
-                      </Button>
-                    </ModalFooter>
-                  </>
-                )}
-              </ModalContent>
-            </Modal>
-          </div>
+          {statusLabel ? (
+            <span className="mt-1 px-2 py-0.5 rounded-full border-1 border-zinc-500 text-zinc-300 text-xxs font-bold">
+              {statusLabel}
+            </span>
+          ) : null}
+          {isPending ? (
+            <div className="flex justify-start gap-x-5 w-full mt-2">
+              <Button
+                size="sm"
+                color="primary"
+                onPress={() =>
+                  handleAcceptGroupInvitation(
+                    notice.event_id,
+                    notice.id as number,
+                  )
+                }
+              >
+                参加する
+              </Button>
+              <Button size="sm" color="danger" onPress={() => handleOpen()}>
+                拒否する
+              </Button>
+              <Modal
+                size="lg"
+                isOpen={isOpen}
+                onClose={onClose}
+                placement="center"
+                className="w-11/12"
+              >
+                <ModalContent>
+                  {(onClose) => (
+                    <>
+                      <ModalHeader className="flex gap-1 text-base text-white pb-0">
+                        本当に 「{notice.group_name}」
+                        への招待を拒否してもよろしいですか？
+                      </ModalHeader>
+                      <ModalFooter>
+                        <Button
+                          variant="light"
+                          onPress={onClose}
+                          className="text-white"
+                        >
+                          キャンセル
+                        </Button>
+                        <Button
+                          color="danger"
+                          onPress={() =>
+                            handleDeclinedGroupInvitation(
+                              notice.event_id,
+                              notice.id as number,
+                            )
+                          }
+                        >
+                          拒否する
+                        </Button>
+                      </ModalFooter>
+                    </>
+                  )}
+                </ModalContent>
+              </Modal>
+            </div>
+          ) : null}
         </div>
       </div>
     </>

--- a/app/components/notification/NotificationItem.tsx
+++ b/app/components/notification/NotificationItem.tsx
@@ -3,13 +3,23 @@ import type { Notifications } from "@app/interface";
 import { Divider, Spinner } from "@heroui/react";
 import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
+import { toast } from "sonner";
 import NotificationFollowed from "@app/components/notification/NotificationFollowed";
 import NotificationFollowRequest from "@app/components/notification/NotificationFollowRequest";
 import NotificationGroup from "@app/components/notification/NotificationGroup";
 import NotificationManagementNotice from "@app/components/notification/NotificationManagementNotice";
+import NotificationRow from "@app/components/notification/NotificationRow";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import { useNotifications } from "@app/hooks/notification/getNotifications";
-import { readNotification } from "@app/services/notificationsService";
+import {
+  deleteNotification,
+  readNotification,
+} from "@app/services/notificationsService";
+
+const withoutNotification = (
+  current: Notifications[] | undefined,
+  id: number,
+) => (current ?? []).filter((notice) => notice.id !== id);
 
 export default function NotificationItem() {
   const { notifications, isError, isLoading, mutate } = useNotifications();
@@ -53,17 +63,38 @@ export default function NotificationItem() {
     }
   };
 
+  const handleDelete = async (id: number) => {
+    try {
+      // 楽観的に行を消し、削除が失敗したら rollbackOnError で元の一覧に戻す
+      await mutate(
+        async (current: Notifications[] | undefined) => {
+          await deleteNotification(id);
+          return withoutNotification(current, id);
+        },
+        {
+          optimisticData: (current: Notifications[] | undefined) =>
+            withoutNotification(current, id),
+          rollbackOnError: true,
+          populateCache: true,
+          revalidate: true,
+        },
+      );
+    } catch (error) {
+      Sentry.captureException(error, {
+        tags: { source: "notification-item", action: "delete" },
+      });
+      toast.error("通知の削除に失敗しました");
+    }
+  };
+
   const renderNotification = (notice: Notifications) => {
     if (notice.event_type === "management_notice") {
       return (
         <NotificationManagementNotice notice={notice} onRead={() => mutate()} />
       );
     }
-    if (
-      notice.event_type === "group_invitation" &&
-      notice.group_invitation === "pending"
-    ) {
-      return <NotificationGroup notice={notice} />;
+    if (notice.event_type === "group_invitation") {
+      return <NotificationGroup notice={notice} onChanged={() => mutate()} />;
     }
     if (notice.event_type === "follow_request") {
       return <NotificationFollowRequest notice={notice} />;
@@ -86,7 +117,9 @@ export default function NotificationItem() {
             if (!content) return null;
             return (
               <div key={notice.id}>
-                {content}
+                <NotificationRow notice={notice} onDelete={handleDelete}>
+                  {content}
+                </NotificationRow>
                 <Divider className="mt-3" />
               </div>
             );

--- a/app/components/notification/NotificationManagementNotice.tsx
+++ b/app/components/notification/NotificationManagementNotice.tsx
@@ -22,11 +22,7 @@ export default function NotificationManagementNotice({
   };
 
   return (
-    <div
-      className={`grid grid-cols-[28px_1fr] gap-x-3 ${
-        notice.read_at ? "opacity-30" : ""
-      }`}
-    >
+    <div className="grid grid-cols-[28px_1fr] gap-x-3">
       <div className="flex items-center justify-center min-w-[28px] max-w-[28px] min-h-[28px] max-h-[28px] rounded-full bg-yellow-500">
         <svg
           className="w-4 h-4 text-white"

--- a/app/components/notification/NotificationRow.tsx
+++ b/app/components/notification/NotificationRow.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import type { Notifications } from "@app/interface";
+import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  useDisclosure,
+} from "@heroui/react";
+import { useState, type ReactNode } from "react";
+import NotificationEventIcon from "@app/components/notification/NotificationEventIcon";
+import { formatNotificationTime } from "@app/utils/notificationTime";
+
+interface NotificationRowProps {
+  notice: Notifications;
+  onDelete?: (id: number) => Promise<void>;
+  children: ReactNode;
+}
+
+/**
+ * 通知1件分の共通の外枠。未読表示・イベントアイコン・相対時刻・削除操作を担い、
+ * 通知種別ごとの本文は children として受け取る。
+ */
+export default function NotificationRow({
+  notice,
+  onDelete,
+  children,
+}: NotificationRowProps) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const isUnread = !notice.read_at;
+  // 運営からのお知らせは id が "mn_1" のような文字列で、削除エンドポイントの対象外
+  const deletableId = typeof notice.id === "number" ? notice.id : null;
+  const canDelete = onDelete !== undefined && deletableId !== null;
+
+  const handleConfirmDelete = async () => {
+    if (!onDelete || deletableId === null || isDeleting) return;
+    setIsDeleting(true);
+    try {
+      await onDelete(deletableId);
+    } finally {
+      setIsDeleting(false);
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className={`grid grid-cols-[1fr_auto] gap-x-2 border-l-2 pl-3 py-1 rounded-r-md ${
+        isUnread
+          ? "border-primary bg-primary/10"
+          : "border-transparent opacity-60"
+      }`}
+    >
+      <div className="min-w-0">
+        {children}
+        <div className="flex items-center gap-x-1 mt-1">
+          <NotificationEventIcon eventType={notice.event_type} />
+          <time dateTime={notice.created_at} className="text-xs text-zinc-400">
+            {formatNotificationTime(notice.created_at)}
+          </time>
+        </div>
+      </div>
+      <div className="flex items-start gap-x-1 shrink-0">
+        {isUnread ? (
+          // 色だけに頼らず「未読」の文言とドットの両方で区別する
+          <span className="flex items-center gap-x-1 h-6 px-2 rounded-full border-1 border-primary text-primary text-xxs font-bold">
+            <span
+              aria-hidden="true"
+              className="block w-1.5 h-1.5 rounded-full bg-primary"
+            />
+            未読
+          </span>
+        ) : null}
+        {canDelete ? (
+          <>
+            <Button
+              isIconOnly
+              size="sm"
+              variant="light"
+              radius="full"
+              aria-label="通知を削除"
+              className="min-w-6 w-6 h-6 text-zinc-400"
+              onPress={onOpen}
+            >
+              <TrashIcon aria-hidden="true" className="w-4 h-4" />
+            </Button>
+            <Modal
+              size="sm"
+              isOpen={isOpen}
+              onClose={onClose}
+              placement="center"
+              className="w-11/12"
+            >
+              <ModalContent>
+                <ModalHeader className="text-base text-white pb-0">
+                  この通知を削除しますか？
+                </ModalHeader>
+                <ModalBody className="text-sm text-zinc-400">
+                  削除した通知は元に戻せません。
+                </ModalBody>
+                <ModalFooter>
+                  <Button
+                    variant="light"
+                    className="text-white"
+                    isDisabled={isDeleting}
+                    onPress={onClose}
+                  >
+                    キャンセル
+                  </Button>
+                  <Button
+                    color="danger"
+                    isLoading={isDeleting}
+                    onPress={handleConfirmDelete}
+                  >
+                    削除する
+                  </Button>
+                </ModalFooter>
+              </ModalContent>
+            </Modal>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/app/components/notification/__tests__/NotificationItem.test.tsx
+++ b/app/components/notification/__tests__/NotificationItem.test.tsx
@@ -1,0 +1,274 @@
+import type { Notifications } from "@app/interface";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { toast } from "sonner";
+import { SWRConfig } from "swr";
+import axiosInstance from "@app/utils/axiosInstance";
+import NotificationItem from "../NotificationItem";
+
+jest.mock("@app/utils/axiosInstance", () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock("@app/contexts/userContext", () => ({
+  useUser: () => ({ state: { usersUserId: { user_id: "buzz_user" } } }),
+}));
+
+jest.mock("@app/hooks/auth/useRequireAuth", () => ({
+  __esModule: true,
+  default: () => true,
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@sentry/nextjs", () => ({
+  captureException: jest.fn(),
+}));
+
+const mockGet = axiosInstance.get as jest.Mock;
+const mockDelete = axiosInstance.delete as jest.Mock;
+const mockToastError = toast.error as jest.Mock;
+
+const minutesAgo = (minutes: number) =>
+  new Date(Date.now() - minutes * 60 * 1000).toISOString();
+
+const buildNotification = (
+  overrides: Partial<Notifications> = {},
+): Notifications => ({
+  id: 1,
+  actor_user_id: 100,
+  actor_name: "テスト太郎",
+  event_type: "followed",
+  event_id: 10,
+  read_at: null,
+  created_at: minutesAgo(5),
+  actor_icon: { url: "/icon.png" },
+  group_name: "バズベース",
+  group_invitation: "",
+  ...overrides,
+});
+
+const renderNotifications = (notifications: Notifications[]) => {
+  mockGet.mockImplementation(() => Promise.resolve({ data: notifications }));
+  return render(
+    <SWRConfig
+      value={{
+        provider: () => new Map(),
+        dedupingInterval: 0,
+        shouldRetryOnError: false,
+      }}
+    >
+      <NotificationItem />
+    </SWRConfig>,
+  );
+};
+
+describe("NotificationItem", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDelete.mockResolvedValue({ data: { success: true } });
+  });
+
+  describe("未読表示", () => {
+    it("read_at が null の通知には未読であることを示す", async () => {
+      renderNotifications([buildNotification({ read_at: null })]);
+
+      expect(await screen.findByText("未読")).toBeInTheDocument();
+    });
+
+    it("read_at がある通知には未読表示を出さない", async () => {
+      renderNotifications([
+        buildNotification({ read_at: "2024-03-10T12:00:00+09:00" }),
+      ]);
+
+      await screen.findByText("テスト太郎");
+      expect(screen.queryByText("未読")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("相対時刻", () => {
+    it("作成からの経過時間を表示する", async () => {
+      renderNotifications([buildNotification({ created_at: minutesAgo(5) })]);
+
+      expect(await screen.findByText("5分前")).toBeInTheDocument();
+    });
+  });
+
+  describe("イベント別アイコン", () => {
+    it.each([
+      ["followed", "フォロー"],
+      ["follow_request", "フォローリクエスト"],
+      ["follow_request_accepted", "フォローリクエスト承認"],
+    ])("%s には %s のアイコンを表示する", async (eventType, label) => {
+      renderNotifications([buildNotification({ event_type: eventType })]);
+
+      expect(await screen.findByLabelText(label)).toBeInTheDocument();
+    });
+
+    it("group_invitation にはグループ招待のアイコンを表示する", async () => {
+      renderNotifications([
+        buildNotification({
+          event_type: "group_invitation",
+          group_invitation: "pending",
+        }),
+      ]);
+
+      expect(await screen.findByLabelText("グループ招待")).toBeInTheDocument();
+    });
+
+    it("management_notice には運営からのお知らせのアイコンを表示する", async () => {
+      renderNotifications([
+        buildNotification({
+          id: "mn_1",
+          event_type: "management_notice",
+          title: "メンテナンスのお知らせ",
+          management_notice_id: 1,
+        }),
+      ]);
+
+      expect(
+        await screen.findByLabelText("運営からのお知らせ"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("削除", () => {
+    it("確認してから削除すると通知が消え、一覧を再取得する", async () => {
+      renderNotifications([buildNotification({ id: 1 })]);
+      await screen.findByText("テスト太郎");
+      const initialFetchCount = mockGet.mock.calls.length;
+
+      fireEvent.click(screen.getByRole("button", { name: "通知を削除" }));
+      expect(
+        await screen.findByText("この通知を削除しますか？"),
+      ).toBeInTheDocument();
+      expect(mockDelete).not.toHaveBeenCalled();
+
+      mockGet.mockImplementation(() => Promise.resolve({ data: [] }));
+      fireEvent.click(screen.getByRole("button", { name: "削除する" }));
+
+      await waitFor(() => {
+        expect(mockDelete).toHaveBeenCalledWith("/api/v1/notifications/1");
+      });
+      await waitFor(() => {
+        expect(screen.queryByText("テスト太郎")).not.toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(mockGet.mock.calls.length).toBeGreaterThan(initialFetchCount);
+      });
+    });
+
+    it("確認をキャンセルすると削除しない", async () => {
+      renderNotifications([buildNotification({ id: 1 })]);
+      await screen.findByText("テスト太郎");
+
+      fireEvent.click(screen.getByRole("button", { name: "通知を削除" }));
+      await screen.findByText("この通知を削除しますか？");
+      fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("この通知を削除しますか？"),
+        ).not.toBeInTheDocument();
+      });
+      expect(mockDelete).not.toHaveBeenCalled();
+      expect(screen.getByText("テスト太郎")).toBeInTheDocument();
+    });
+
+    it("削除に失敗したら通知は一覧に残る", async () => {
+      mockDelete.mockRejectedValue(new Error("削除に失敗"));
+      renderNotifications([buildNotification({ id: 1 })]);
+      await screen.findByText("テスト太郎");
+
+      fireEvent.click(screen.getByRole("button", { name: "通知を削除" }));
+      await screen.findByText("この通知を削除しますか？");
+      // 再取得が返ってこない状況でも巻き戻せていることを見るため、以降の取得は保留のままにする
+      mockGet.mockImplementation(() => new Promise(() => {}));
+      fireEvent.click(screen.getByRole("button", { name: "削除する" }));
+
+      await waitFor(() => {
+        expect(mockToastError).toHaveBeenCalledWith("通知の削除に失敗しました");
+      });
+      expect(screen.getByText("テスト太郎")).toBeInTheDocument();
+    });
+
+    it("運営からのお知らせには削除ボタンを出さない", async () => {
+      renderNotifications([
+        buildNotification({
+          id: "mn_1",
+          event_type: "management_notice",
+          title: "メンテナンスのお知らせ",
+          management_notice_id: 1,
+        }),
+      ]);
+
+      await screen.findByText("メンテナンスのお知らせ");
+      expect(
+        screen.queryByRole("button", { name: "通知を削除" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("グループ招待", () => {
+    const groupInvitation = (state: string) =>
+      buildNotification({
+        id: 2,
+        event_type: "group_invitation",
+        group_invitation: state,
+        group_name: "バズベース",
+      });
+
+    it("保留中は参加・拒否のボタンを表示する", async () => {
+      renderNotifications([groupInvitation("pending")]);
+
+      expect(
+        await screen.findByRole("button", { name: "参加する" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "拒否する" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("参加済み")).not.toBeInTheDocument();
+    });
+
+    it("承認済みでも履歴として表示し、状態が分かる", async () => {
+      renderNotifications([groupInvitation("accepted")]);
+
+      expect(await screen.findByText("バズベース")).toBeInTheDocument();
+      expect(screen.getByText("参加済み")).toBeInTheDocument();
+    });
+
+    it("辞退済みでも履歴として表示し、状態が分かる", async () => {
+      renderNotifications([groupInvitation("declined")]);
+
+      expect(await screen.findByText("バズベース")).toBeInTheDocument();
+      expect(screen.getByText("辞退済み")).toBeInTheDocument();
+    });
+
+    it.each(["accepted", "declined"])(
+      "%s では参加・拒否のボタンを出さない",
+      async (state) => {
+        renderNotifications([groupInvitation(state)]);
+
+        await screen.findByText("バズベース");
+        expect(
+          screen.queryByRole("button", { name: "参加する" }),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByRole("button", { name: "拒否する" }),
+        ).not.toBeInTheDocument();
+      },
+    );
+  });
+});

--- a/app/interface/index.ts
+++ b/app/interface/index.ts
@@ -370,8 +370,9 @@ export interface Notifications {
   actor_name: string;
   event_type: string;
   event_id: number;
-  read_at: Date;
-  created_at: Date;
+  // API は ISO8601 文字列で返す。未読は null
+  read_at: string | null;
+  created_at: string;
   actor_icon: {
     url: string;
   };

--- a/app/utils/__tests__/notificationTime.test.ts
+++ b/app/utils/__tests__/notificationTime.test.ts
@@ -1,0 +1,88 @@
+import { formatNotificationTime } from "../notificationTime";
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+const NOW = new Date("2024-03-10T12:00:00+09:00");
+
+/** NOW から ms ミリ秒だけ過去の日時を相対時刻に変換する */
+const agoBy = (ms: number) =>
+  formatNotificationTime(new Date(NOW.getTime() - ms).toISOString(), NOW);
+
+// 日付表示の検証はローカルタイムゾーンに依存する。TZ は jest.config.js で Asia/Tokyo に固定している
+describe("formatNotificationTime", () => {
+  describe("たった今", () => {
+    it("同時刻は「たった今」", () => {
+      expect(agoBy(0)).toBe("たった今");
+    });
+
+    it("59秒前は「たった今」", () => {
+      expect(agoBy(59 * SECOND)).toBe("たった今");
+    });
+
+    it("未来の日時でも「たった今」", () => {
+      expect(agoBy(-10 * MINUTE)).toBe("たった今");
+    });
+  });
+
+  describe("分", () => {
+    it("60秒前は「1分前」", () => {
+      expect(agoBy(60 * SECOND)).toBe("1分前");
+    });
+
+    it("59分59秒前は「59分前」", () => {
+      expect(agoBy(59 * MINUTE + 59 * SECOND)).toBe("59分前");
+    });
+  });
+
+  describe("時間", () => {
+    it("60分前は「1時間前」", () => {
+      expect(agoBy(60 * MINUTE)).toBe("1時間前");
+    });
+
+    it("23時間59分前は「23時間前」", () => {
+      expect(agoBy(23 * HOUR + 59 * MINUTE)).toBe("23時間前");
+    });
+  });
+
+  describe("日", () => {
+    it("24時間前は「1日前」", () => {
+      expect(agoBy(24 * HOUR)).toBe("1日前");
+    });
+
+    it("6日23時間59分前は「6日前」", () => {
+      expect(agoBy(6 * DAY + 23 * HOUR + 59 * MINUTE)).toBe("6日前");
+    });
+  });
+
+  describe("日付表示", () => {
+    it("7日前ちょうどから日付表示に切り替わる", () => {
+      expect(agoBy(7 * DAY)).toBe("2024/03/03");
+    });
+
+    it("月日は2桁ゼロ埋めする", () => {
+      expect(formatNotificationTime("2024-01-05T10:00:00+09:00", NOW)).toBe(
+        "2024/01/05",
+      );
+    });
+
+    it("ローカルタイムゾーンの暦日で表示する", () => {
+      // UTC では 2024/02/29、Asia/Tokyo では 2024/03/01 になる時刻
+      expect(formatNotificationTime("2024-02-29T15:30:00Z", NOW)).toBe(
+        "2024/03/01",
+      );
+    });
+
+    it("タイムゾーンオフセット付きの表記と UTC 表記で同じ結果になる", () => {
+      expect(formatNotificationTime("2024-03-01T00:30:00+09:00", NOW)).toBe(
+        formatNotificationTime("2024-02-29T15:30:00Z", NOW),
+      );
+    });
+  });
+
+  it("日時として解釈できない値は空文字を返す", () => {
+    expect(formatNotificationTime("", NOW)).toBe("");
+  });
+});

--- a/app/utils/notificationTime.ts
+++ b/app/utils/notificationTime.ts
@@ -1,0 +1,35 @@
+const MINUTE_MS = 1000 * 60;
+const HOUR_MS = MINUTE_MS * 60;
+const DAY_MS = HOUR_MS * 24;
+
+/**
+ * 通知の日時を相対時刻の文言に変換する。
+ * しきい値・文言・日付フォーマットはモバイルアプリの通知一覧と一致させている。
+ *
+ * @param value バックエンドが返す ISO8601 文字列（タイムゾーンオフセット付き）または Date
+ * @param now 比較の基準時刻。省略時は呼び出し時点の現在時刻
+ * @returns 「たった今」/「N分前」/「N時間前」/「N日前」/「YYYY/MM/DD」。日時として解釈できない場合は空文字
+ */
+export function formatNotificationTime(
+  value: string | Date,
+  now: Date = new Date(),
+): string {
+  const date =
+    value instanceof Date ? new Date(value.getTime()) : new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+
+  const diffMs = now.getTime() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / MINUTE_MS);
+  const diffHours = Math.floor(diffMs / HOUR_MS);
+  const diffDays = Math.floor(diffMs / DAY_MS);
+
+  if (diffMinutes < 1) return "たった今";
+  if (diffMinutes < 60) return `${diffMinutes}分前`;
+  if (diffHours < 24) return `${diffHours}時間前`;
+  if (diffDays < 7) return `${diffDays}日前`;
+
+  // 7日以上前は閲覧者のローカルタイムゾーンの暦日で表示する（UTC の暦日ではない）
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}/${month}/${day}`;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,7 @@
+// 日時表示のテストを実行環境のタイムゾーンに依存させないため、サービスの主要ユーザーの
+// タイムゾーンに固定する（worker はこの env を引き継いで起動する）
+process.env.TZ = "Asia/Tokyo";
+
 // 環境変数を先に設定（next.config.jsで必要）
 process.env.NEXT_PUBLIC_IMAGE_PROTOCOL = "http";
 process.env.NEXT_PUBLIC_IMAGE_HOSTNAME = "localhost";

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -12,6 +12,9 @@ global.ResizeObserver = class ResizeObserver {
 jest.mock("framer-motion", () => ({
   ...jest.requireActual("framer-motion"),
   AnimatePresence: ({ children }) => children,
+  // HeroUI Modal は LazyMotion の features を動的 import で読み込むが、
+  // jest の CJS 環境では動的 import が失敗するため features ごとバイパスする
+  LazyMotion: ({ children }) => children,
   motion: {
     div: ({ children, ...props }) => <div {...props}>{children}</div>,
     button: ({ children, ...props }) => <button {...props}>{children}</button>,


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#491

## 概要

front の通知一覧は `read_at` を表示に使っておらず、`notificationsService.deleteNotification` が定義済みなのに UI から呼ばれていませんでした。mobile の `NotificationItem` が持つ機能に揃えます。

あわせて、**`group_invitation` が `pending` 以外のとき行ごと消えていたバグ**を修正しています（承認済み・辞退済みの通知が履歴から消えてしまう状態でした）。

## 変更内容

- `read_at` による未読ドットと未読スタイル
- `app/utils/notificationTime.ts` — 相対時刻表示（たった今 / N分前 / N時間前 / N日前 / 日付）
- 削除ボタン（確認ダイアログ付き）と削除後の再取得
- `NotificationEventIcon.tsx` — イベント別アイコンを分離
- `NotificationRow.tsx` — 行レイアウトを共通化
- `group_invitation` が `accepted` / `declined` でも履歴として表示するよう修正（承認 / 辞退の操作ボタンは `pending` のときだけ表示）

## jest の共有設定を変更しています（レビュー確認事項）

全テストに影響する設定を2箇所変更しました。いずれも本 PR の機能を検証するために必要です。

1. **`jest.config.js` に `process.env.TZ = "Asia/Tokyo"`** — 相対時刻・日付表示のテストを実行環境のタイムゾーンに依存させないため。CI とローカルで結果が変わるのを防ぎます
2. **`jest.setup.js` で `LazyMotion` をバイパス** — 削除確認に HeroUI Modal を使っていますが、HeroUI Modal は LazyMotion の features を動的 import で読み込み、jest の CJS 環境では失敗します

## 確認手順

1. 未読（`read_at` が null）の通知に未読ドットが出ること、既読には出ないこと
2. 相対時刻が各しきい値で正しく切り替わること
3. 削除 → 確認ダイアログ → 削除実行 → 一覧が再取得されること
4. 確認ダイアログをキャンセルすると削除されないこと
5. **承認済み・辞退済みのグループ招待が一覧に残ること**（従来は消えていた）。かつ承認 / 辞退ボタンが出ないこと

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る（エラー・警告 0）
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（**83 suites / 822 tests**）
- [ ] `yarn build` — CI の Build Check で検証（ルート表がベースライン 静的87 / 動的41〜43 から動いていないことを確認してください）

## レビュー時に確認してほしい点

- 相対時刻のしきい値と文言が mobile と一致しているか（境界値: 59秒/60秒、59分/60分、23時間/24時間、日付表示への切替）
- 削除失敗時に「消えたように見える」状態が作れないか
- 未読 / 既読の区別が色だけに依存していないか
- タイムゾーンの扱いで日付がずれていないか

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_