### PR TITLE
Update: シーズン管理のUX細部をmobileと揃える

### DIFF
--- a/app/(app)/game-result/lists/__tests__/GameResultTabs.test.tsx
+++ b/app/(app)/game-result/lists/__tests__/GameResultTabs.test.tsx
@@ -39,6 +39,24 @@ describe("GameResultTabs", () => {
     expect(screen.getByText("試合結果を記録する")).toBeInTheDocument();
   });
 
+  it("シーズン管理画面への導線が表示される", () => {
+    render(<GameResultTabs userId={1} adSlot="slot" adLayoutKey="key" />);
+
+    const link = screen.getByRole("link", { name: /シーズンを管理/ });
+    expect(link).toHaveAttribute("href", "/seasons");
+  });
+
+  it("一覧タブに切り替えてもシーズン管理への導線は残る", async () => {
+    const user = userEvent.setup();
+    render(<GameResultTabs userId={1} adSlot="slot" adLayoutKey="key" />);
+
+    await user.click(screen.getByText("一覧"));
+
+    expect(
+      screen.getByRole("link", { name: /シーズンを管理/ }),
+    ).toHaveAttribute("href", "/seasons");
+  });
+
   it("初期表示はサマリータブ", () => {
     render(<GameResultTabs userId={1} adSlot="slot" adLayoutKey="key" />);
 

--- a/app/(app)/game-result/lists/_components/GameResultTabs.tsx
+++ b/app/(app)/game-result/lists/_components/GameResultTabs.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { PlusIcon } from "@app/components/icon/PlusIcon";
+import SeasonManageLink from "@app/components/season/SeasonManageLink";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import MatchResultList from "@app/components/user/MatchResultList";
 import {
@@ -78,11 +79,15 @@ export function GameResultTabs({
         ))}
       </div>
 
+      <div className="mt-4 flex justify-end">
+        <SeasonManageLink />
+      </div>
+
       <button
         type="button"
         onClick={handleNewRecord}
         disabled={isSubmitting}
-        className="mt-5 flex w-full items-center justify-center gap-2 rounded-lg bg-[#d08000] py-3 font-bold text-white disabled:opacity-60"
+        className="mt-2 flex w-full items-center justify-center gap-2 rounded-lg bg-[#d08000] py-3 font-bold text-white disabled:opacity-60"
       >
         <PlusIcon width="20" height="20" fill="#FFFFFF" />
         試合結果を記録する

--- a/app/(app)/game-result/record/_components/SeasonField.tsx
+++ b/app/(app)/game-result/record/_components/SeasonField.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import type { SeasonData } from "@app/interface";
+import { Autocomplete, AutocompleteItem } from "@heroui/react";
+import SeasonManageLink from "@app/components/season/SeasonManageLink";
+
+interface SeasonFieldProps {
+  seasons: SeasonData[];
+  selectedSeason: number | null;
+  onInputChange: (value: string) => void;
+  onSelectionChange: (value: React.Key | null) => void;
+}
+
+/**
+ * 試合結果登録のシーズン入力欄。
+ *
+ * 候補が 0 件だとシーズン機能の存在に気付けないため、そのときは
+ * シーズン管理画面への導線を作成の入口として明示する。
+ */
+export default function SeasonField({
+  seasons,
+  selectedSeason,
+  onInputChange,
+  onSelectionChange,
+}: SeasonFieldProps) {
+  return (
+    <div>
+      <Autocomplete
+        allowsCustomValue
+        label="シーズン"
+        variant="bordered"
+        placeholder="シーズン名を入力"
+        labelPlacement="outside-left"
+        className="[&>div]:justify-between [&>div&>label]:whitespace-nowrap"
+        size="md"
+        onInputChange={onInputChange}
+        onSelectionChange={onSelectionChange}
+        selectedKey={selectedSeason !== null ? selectedSeason.toString() : null}
+      >
+        {seasons.map((season) => (
+          <AutocompleteItem key={season.id}>{season.name}</AutocompleteItem>
+        ))}
+      </Autocomplete>
+      <div className="mt-2 flex justify-end">
+        {seasons.length === 0 ? (
+          <SeasonManageLink label="シーズンがありません。シーズンを登録する" />
+        ) : (
+          <SeasonManageLink />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/game-result/record/_components/__tests__/SeasonField.test.tsx
+++ b/app/(app)/game-result/record/_components/__tests__/SeasonField.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import SeasonField from "../SeasonField";
+
+const noop = () => {};
+
+describe("SeasonField", () => {
+  it("シーズンがあるときは管理画面への導線を表示する", () => {
+    render(
+      <SeasonField
+        seasons={[{ id: 1, name: "2024年春季" }]}
+        selectedSeason={null}
+        onInputChange={noop}
+        onSelectionChange={noop}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: /シーズンを管理/ });
+    expect(link).toHaveAttribute("href", "/seasons");
+  });
+
+  it("シーズンが0件のときは登録を促す文言で導線を表示する", () => {
+    render(
+      <SeasonField
+        seasons={[]}
+        selectedSeason={null}
+        onInputChange={noop}
+        onSelectionChange={noop}
+      />,
+    );
+
+    const link = screen.getByRole("link", {
+      name: /シーズンがありません。シーズンを登録する/,
+    });
+    expect(link).toHaveAttribute("href", "/seasons");
+  });
+
+  it("シーズン入力欄を描画する", () => {
+    render(
+      <SeasonField
+        seasons={[]}
+        selectedSeason={null}
+        onInputChange={noop}
+        onSelectionChange={noop}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("シーズン名を入力")).toBeInTheDocument();
+  });
+});

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -53,6 +53,7 @@ import { getCurrentUserId, getUserData } from "@app/services/userService";
 import { createStadium, searchStadiums } from "@app/services/v2/stadiumService";
 import PatternSelector from "./_components/PatternSelector";
 import ScoreStepper from "./_components/ScoreStepper";
+import SeasonField from "./_components/SeasonField";
 
 // 打順の選択肢。代打・代走・途中出場・未出場のケースで「なし」を選べるよう先頭に追加。
 // 「なし」は id=""（空文字）として、state（matchBattingOrder）と Select の selectedKeys を一致させる。
@@ -835,26 +836,12 @@ export default function GameRecord() {
                   ))}
                 </Autocomplete>
                 <Divider className="my-4" />
-                <Autocomplete
-                  allowsCustomValue
-                  label="シーズン"
-                  variant="bordered"
-                  placeholder="シーズン名を入力"
-                  labelPlacement="outside-left"
-                  className="[&>div]:justify-between [&>div&>label]:whitespace-nowrap"
-                  size="md"
+                <SeasonField
+                  seasons={seasonsData}
+                  selectedSeason={selectedSeason}
                   onInputChange={handleSeasonInputChange}
                   onSelectionChange={handleSeasonSelectionChange}
-                  selectedKey={
-                    selectedSeason !== null ? selectedSeason.toString() : null
-                  }
-                >
-                  {seasonsData.map((data) => (
-                    <AutocompleteItem key={data.id}>
-                      {data.name}
-                    </AutocompleteItem>
-                  ))}
-                </Autocomplete>
+                />
                 <Divider className="my-4" />
                 <Input
                   isRequired

--- a/app/(app)/seasons/__tests__/SeasonsContent.test.tsx
+++ b/app/(app)/seasons/__tests__/SeasonsContent.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import SeasonsContent from "../_components/SeasonsContent";
+
+jest.mock("../_components/SeasonsList", () => {
+  return function SeasonsList() {
+    return <div data-testid="seasons-list" />;
+  };
+});
+
+describe("SeasonsContent", () => {
+  it("「シーズン管理とは」の説明を開閉操作なしで表示する", () => {
+    render(<SeasonsContent initialSeasons={[]} />);
+
+    expect(screen.getByText("シーズン管理とは")).toBeVisible();
+    expect(
+      screen.getByText(/試合記録を期間（シーズン）ごとにまとめる機能です/),
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        /試合結果の登録時にシーズンを選択すると、成績や試合一覧をシーズンごとに絞り込めます/,
+      ),
+    ).toBeVisible();
+  });
+
+  it("説明を開くためのトリガーは存在しない", () => {
+    render(<SeasonsContent initialSeasons={[]} />);
+
+    expect(
+      screen.queryByRole("button", { name: "シーズンについて" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("活用例を一覧で表示する", () => {
+    render(<SeasonsContent initialSeasons={[]} />);
+
+    expect(screen.getByText("活用例")).toBeVisible();
+    expect(
+      screen.getByText("「新チーム」「旧チーム」で世代ごとに分ける"),
+    ).toBeVisible();
+  });
+});

--- a/app/(app)/seasons/_components/SeasonsContent.tsx
+++ b/app/(app)/seasons/_components/SeasonsContent.tsx
@@ -1,27 +1,5 @@
-"use client";
-
 import type { SeasonData } from "@app/interface";
-import { Popover, PopoverContent, PopoverTrigger } from "@heroui/react";
 import SeasonsList from "./SeasonsList";
-
-function InfoIcon() {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="12" cy="12" r="10" />
-      <path d="M12 16v-4" />
-      <path d="M12 8h.01" />
-    </svg>
-  );
-}
 
 type SeasonsContentProps = {
   initialSeasons: SeasonData[];
@@ -32,37 +10,23 @@ export default function SeasonsContent({
 }: SeasonsContentProps) {
   return (
     <>
-      <div className="flex items-center gap-x-2">
-        <h2 className="text-2xl font-bold">シーズン管理</h2>
-        <Popover placement="bottom-start">
-          <PopoverTrigger>
-            <button
-              className="text-zinc-400 hover:text-zinc-200 transition-colors"
-              aria-label="シーズンについて"
-            >
-              <InfoIcon />
-            </button>
-          </PopoverTrigger>
-          <PopoverContent className="max-w-xs p-4">
-            <div className="space-y-2 text-sm">
-              <p className="font-bold text-base">シーズンとは？</p>
-              <p className="text-zinc-300">
-                チームや期間ごとに試合をグループ分けするための機能です。
-              </p>
-              <p className="font-bold mt-3">活用例</p>
-              <ul className="list-disc pl-4 text-zinc-300 space-y-1">
-                <li>「2024年春季」「2024年秋季」など期間で分ける</li>
-                <li>「〇〇高校」「〇〇大学」などチーム移籍時に分ける</li>
-                <li>「新チーム」「旧チーム」で世代ごとに分ける</li>
-              </ul>
-              <p className="font-bold mt-3">使い方</p>
-              <p className="text-zinc-300">
-                試合結果の登録時にシーズンを選択すると、成績や試合一覧をシーズンごとに絞り込めます。
-              </p>
-            </div>
-          </PopoverContent>
-        </Popover>
-      </div>
+      <h2 className="text-2xl font-bold">シーズン管理</h2>
+      <section className="mt-4 rounded-xl bg-bg_sub p-4">
+        <h3 className="text-base font-bold">シーズン管理とは</h3>
+        <p className="mt-1.5 text-sm text-zinc-300">
+          試合記録を期間（シーズン）ごとにまとめる機能です。学年・年度・大会単位でシーズンを分けておくと、成績をその期間ごとに集計・比較でき、成長の振り返りに役立ちます。
+        </p>
+        <h4 className="mt-3 text-sm font-bold">活用例</h4>
+        <ul className="mt-1.5 list-disc space-y-1 pl-4 text-sm text-zinc-300">
+          <li>「2024年春季」「2024年秋季」など期間で分ける</li>
+          <li>「〇〇高校」「〇〇大学」などチーム移籍時に分ける</li>
+          <li>「新チーム」「旧チーム」で世代ごとに分ける</li>
+        </ul>
+        <h4 className="mt-3 text-sm font-bold">使い方</h4>
+        <p className="mt-1.5 text-sm text-zinc-300">
+          試合結果の登録時にシーズンを選択すると、成績や試合一覧をシーズンごとに絞り込めます。
+        </p>
+      </section>
       <div className="my-6">
         <SeasonsList initialSeasons={initialSeasons} />
       </div>

--- a/app/components/season/SeasonManageLink.tsx
+++ b/app/components/season/SeasonManageLink.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { CalendarIcon } from "@app/components/icon/CalendarIcon";
+import { DetailLinkArrowIcon } from "@app/components/icon/DetailLinkArrowIcon";
+
+interface SeasonManageLinkProps {
+  /** 導線の文言。空状態など文脈に応じて差し替える。 */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * シーズン管理画面（/seasons）への導線。
+ *
+ * mobile は Android で `Alert.prompt` が使えずシーズンを作成できないため、
+ * Web がその唯一の作成手段になっている。シーズンを扱う画面から必ず辿れるようにする。
+ */
+export default function SeasonManageLink({
+  label = "シーズンを管理",
+  className = "",
+}: SeasonManageLinkProps) {
+  return (
+    <Link
+      href="/seasons"
+      className={`inline-flex items-center gap-x-1.5 text-xs font-semibold text-primary ${className}`}
+    >
+      <CalendarIcon fill="currentColor" width="15" height="15" />
+      {label}
+      <DetailLinkArrowIcon stroke="currentColor" width="14" height="14" />
+    </Link>
+  );
+}

--- a/app/components/season/__tests__/SeasonManageLink.test.tsx
+++ b/app/components/season/__tests__/SeasonManageLink.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import SeasonManageLink from "../SeasonManageLink";
+
+describe("SeasonManageLink", () => {
+  it("既定では「シーズンを管理」としてシーズン管理画面へリンクする", () => {
+    render(<SeasonManageLink />);
+
+    const link = screen.getByRole("link", { name: /シーズンを管理/ });
+    expect(link).toHaveAttribute("href", "/seasons");
+  });
+
+  it("文言を差し替えても遷移先はシーズン管理画面のまま", () => {
+    render(
+      <SeasonManageLink label="シーズンがありません。シーズンを登録する" />,
+    );
+
+    const link = screen.getByRole("link", {
+      name: /シーズンがありません。シーズンを登録する/,
+    });
+    expect(link).toHaveAttribute("href", "/seasons");
+    expect(
+      screen.queryByRole("link", { name: /^シーズンを管理$/ }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/services/__tests__/seasonsService.test.ts
+++ b/app/services/__tests__/seasonsService.test.ts
@@ -1,0 +1,37 @@
+const mockAxiosPatch = jest.fn();
+const mockAxiosPut = jest.fn();
+
+jest.mock("@app/utils/axiosInstance", () => ({
+  __esModule: true,
+  default: {
+    patch: (...args: unknown[]) => mockAxiosPatch(...args),
+    put: (...args: unknown[]) => mockAxiosPut(...args),
+  },
+}));
+
+import { updateSeason } from "../seasonsService";
+
+describe("シーズン更新", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAxiosPatch.mockResolvedValue({ data: { id: 3, name: "2024年秋季" } });
+  });
+
+  it("PATCH でシーズン名を更新する", async () => {
+    const result = await updateSeason(3, "2024年秋季");
+
+    expect(mockAxiosPatch).toHaveBeenCalledWith("/api/v1/seasons/3", {
+      season: { name: "2024年秋季" },
+    });
+    expect(mockAxiosPut).not.toHaveBeenCalled();
+    expect(result).toEqual({ id: 3, name: "2024年秋季" });
+  });
+
+  it("APIがエラーを返した場合はそのままスローする", async () => {
+    mockAxiosPatch.mockRejectedValueOnce(new Error("Request failed"));
+
+    await expect(updateSeason(3, "2024年秋季")).rejects.toThrow(
+      "Request failed",
+    );
+  });
+});

--- a/app/services/seasonsService.tsx
+++ b/app/services/seasonsService.tsx
@@ -24,7 +24,7 @@ export const createSeason = async (name: string) => {
 
 export const updateSeason = async (id: number, name: string) => {
   try {
-    const response = await axiosInstance.put(`/api/v1/seasons/${id}`, {
+    const response = await axiosInstance.patch(`/api/v1/seasons/${id}`, {
       season: { name },
     });
     return response.data as SeasonData;


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#498

## 概要

mobile は `Alert.prompt` 依存で **Android ではシーズンを作成できず**、「Webからシーズンを作成してください」と案内しています。つまり front が Android ユーザーの唯一の作成手段であるため、導線を増やし、説明を見つけやすくします。

## 変更内容

- `app/components/season/SeasonManageLink.tsx`（新規）— `/seasons` への共通導線（Server Component、`label` で文言差し替え可）
- 試合一覧（`GameResultTabs`）の記録ボタン上に導線を追加。タブ外に置いたのでサマリー/一覧の両タブで表示されます（mobile と同じ位置）
- `SeasonField.tsx`（新規）— 試合結果登録画面のシーズン入力欄を抽出。**0件時は「シーズンがありません。シーズンを登録する」**、1件以上は「シーズンを管理」
- `seasonsService.updateSeason` を `PUT` → `PATCH` に統一
- `/seasons` の「シーズン管理とは」を Popover から**常時表示カード**に変更

## `PUT` → `PATCH` の安全性確認

back の `config/routes.rb:150` は `resources :seasons, only: %i[index create update destroy]` で、`only:` に `update` が含まれています。Rails は `update` に対して **`PATCH` と `PUT` の両方**を生成するため、`PATCH` は既に受け付けられます。404 になる懸念はありません。

## 「シーズン管理とは」を常時表示にした理由

issue では「検討」となっていた点です。**常時表示カード**を選びました。

1. front は Android ユーザーにとって唯一の作成手段で、mobile から案内されて来る**初見ユーザー**が主な流入です。Popover は「ⓘ を押す」という追加操作を要求し、機能の存在意義に気づかないまま離脱しえます
2. mobile が常時表示なので端末を跨いだ体験が揃います（issue の趣旨そのもの）
3. シーズンが 0〜数件のページで縦の情報量が少なく、常時表示でも一覧を圧迫しません。むしろ**空状態のときに最も説明が必要**です
4. 副次効果として Popover（HeroUI のクライアント依存）が消え、`SeasonsContent` を **Server Component 化**できました（規約の「Server Component 優先」に合致）

内容は front の既存コピー（活用例・使い方）を維持し、見出しとリード文だけ mobile に揃えています。

## issue との差異（報告）

issue の「**目標作成画面**から `/seasons` への導線追加」は、**front に目標（goal）機能自体が存在しない**ためそのままでは移植できません。front でシーズンを選ぶ唯一の画面である**試合結果登録画面**を等価な導線先として選び、mobile の目標作成画面と同じ「シーズンがありません。シーズンを登録する」という空状態文言を移植しました。

## 確認手順

1. 試合一覧を開き、サマリー/一覧の**両タブ**で「シーズンを管理」が表示され `/seasons` に遷移すること
2. 試合結果登録画面で、シーズンが0件のとき「シーズンがありません。シーズンを登録する」が出ること
3. `/seasons` で「シーズン管理とは」が**押さずに**表示されていること
4. シーズンを編集して保存できること（`PATCH` に変更したため）

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る（エラー0 / 警告0）
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（**100 suites / 1033 tests**）
- [ ] `yarn build` — CI の Build Check で検証
- [x] ミューテーションテスト **12 設計 / 12 KILLED / 0 SURVIVED**

<details>
<summary>ミューテーションテスト詳細</summary>

別ディレクトリの複製で実施（無改変でテストが通ることを事前確認済み。作業ツリーは未改変）。

| # | 次元 | 内容 |
| --- | --- | --- |
| M1 | リンク先改変 | `/seasons` → `/season` |
| M2 | HTTPメソッド改変 | `patch` → `put` |
| M3 | HTTPパス改変 | `/api/v1/seasons/:id` → `/api/v1/season/:id` |
| M4 | 導線削除 | 試合一覧の導線を削除 |
| M5 | 導線削除 | 試合結果登録の導線を削除 |
| M6 | 表示条件反転 | `seasons.length === 0` → `> 0` |
| M7 | 文言改変 | 既定ラベルを変更 |
| M8 | 説明文改変 | 見出しを変更 |
| M9 | 説明文削除 | 「使い方」段落を削除 |
| M10 | 表示条件反転 | 常時表示 → 開閉トリガーに戻す |
| M11 | 説明文削除 | 「活用例」見出しを削除 |
| M12 | 文言改変 | 空状態文言を変更 |

</details>

## 補足

issue にも記載のとおり、**mobile 側に Modal ベースのシーズン作成 UI を実装する issue（Android 対応）が別途必要**です。本 PR は front 側の導線改善のみです。

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_