### PR TITLE
Add: 初回オンボーディング（Web版ウォークスルー）を実装

### DIFF
--- a/app/(app)/onboarding/_components/OnboardingSlide.tsx
+++ b/app/(app)/onboarding/_components/OnboardingSlide.tsx
@@ -1,0 +1,22 @@
+import type { OnboardingStep } from "@app/constants/onboarding";
+import OnboardingIllustrationView from "./illustrations";
+
+interface Props {
+  step: OnboardingStep;
+}
+
+export default function OnboardingSlide({ step }: Props) {
+  return (
+    <div className="flex max-w-[420px] flex-col items-center text-center">
+      <div className="flex h-44 w-44 items-center justify-center sm:h-56 sm:w-56">
+        <OnboardingIllustrationView name={step.illustration} />
+      </div>
+      <h2 className="mt-10 text-xl font-bold leading-8 text-white sm:text-2xl">
+        {step.title}
+      </h2>
+      <p className="mt-3 text-sm leading-6 text-zic-400 sm:text-base">
+        {step.copy}
+      </p>
+    </div>
+  );
+}

--- a/app/(app)/onboarding/_components/OnboardingWalkthrough.tsx
+++ b/app/(app)/onboarding/_components/OnboardingWalkthrough.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { ONBOARDING_STEPS } from "@app/constants/onboarding";
+import OnboardingSlide from "./OnboardingSlide";
+import PageIndicator from "./PageIndicator";
+
+// このピクセル未満の横移動はタップ・縦スクロールの巻き添えとみなして無視する
+const SWIPE_THRESHOLD_PX = 48;
+
+const LAST_STEP_INDEX = ONBOARDING_STEPS.length - 1;
+
+interface Props {
+  /** スキップと「はじめる」の両方から呼ばれる。どちらも完了として扱う。 */
+  onFinish: () => void;
+}
+
+export default function OnboardingWalkthrough({ onFinish }: Props) {
+  const [stepIndex, setStepIndex] = useState(0);
+  const touchStartXRef = useRef<number | null>(null);
+
+  const isLastStep = stepIndex === LAST_STEP_INDEX;
+
+  // 全画面表示なので、どこにフォーカスがあっても左右キーで送れるよう window で拾う
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "ArrowRight") {
+        setStepIndex((prev) => Math.min(prev + 1, LAST_STEP_INDEX));
+      } else if (event.key === "ArrowLeft") {
+        setStepIndex((prev) => Math.max(prev - 1, 0));
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  const handleTouchStart = (event: React.TouchEvent) => {
+    touchStartXRef.current = event.changedTouches[0]?.clientX ?? null;
+  };
+
+  const handleTouchEnd = (event: React.TouchEvent) => {
+    const startX = touchStartXRef.current;
+    touchStartXRef.current = null;
+    if (startX === null) return;
+
+    const deltaX = (event.changedTouches[0]?.clientX ?? startX) - startX;
+    if (Math.abs(deltaX) < SWIPE_THRESHOLD_PX) return;
+
+    setStepIndex((prev) =>
+      deltaX < 0 ? Math.min(prev + 1, LAST_STEP_INDEX) : Math.max(prev - 1, 0),
+    );
+  };
+
+  return (
+    <section
+      aria-label="BUZZ BASE の使い方"
+      className="buzz-dark fixed inset-0 z-100 flex flex-col bg-main text-white"
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      <div className="flex h-14 shrink-0 items-center justify-between px-4">
+        {stepIndex > 0 ? (
+          <button
+            type="button"
+            onClick={() => setStepIndex((prev) => Math.max(prev - 1, 0))}
+            className="rounded-full px-2 py-1 text-sm font-semibold text-zic-400"
+          >
+            戻る
+          </button>
+        ) : (
+          <span />
+        )}
+        <button
+          type="button"
+          onClick={onFinish}
+          className="rounded-full px-2 py-1 text-sm font-semibold text-zic-400"
+        >
+          スキップ
+        </button>
+      </div>
+
+      <div className="flex flex-1 items-center justify-center overflow-y-auto px-8">
+        <OnboardingSlide step={ONBOARDING_STEPS[stepIndex]} />
+      </div>
+
+      <div className="flex shrink-0 flex-col gap-y-6 px-6 pb-10 pt-4">
+        <PageIndicator
+          count={ONBOARDING_STEPS.length}
+          activeIndex={stepIndex}
+        />
+        {isLastStep ? (
+          <button
+            type="button"
+            onClick={onFinish}
+            className="mx-auto block w-full max-w-[420px] rounded-full bg-[#d08000] py-3 text-base font-bold text-white"
+          >
+            はじめる
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() =>
+              setStepIndex((prev) => Math.min(prev + 1, LAST_STEP_INDEX))
+            }
+            className="mx-auto block w-full max-w-[420px] rounded-full bg-[#d08000] py-3 text-base font-bold text-white"
+          >
+            次へ
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/(app)/onboarding/_components/OnboardingWalkthroughGate.tsx
+++ b/app/(app)/onboarding/_components/OnboardingWalkthroughGate.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useRef } from "react";
+import { useOnboardingWalkthrough } from "@app/hooks/onboarding/useOnboardingWalkthrough";
+import { resolveNextPath } from "../_utils/nextPath";
+import OnboardingWalkthrough from "./OnboardingWalkthrough";
+
+export default function OnboardingWalkthroughGate() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { isCompleted, complete } = useOnboardingWalkthrough();
+  const hasLeftRef = useRef(false);
+
+  const nextPath = resolveNextPath(searchParams.get("next"));
+
+  const leave = useCallback(() => {
+    if (hasLeftRef.current) return;
+    hasLeftRef.current = true;
+    router.replace(nextPath);
+  }, [router, nextPath]);
+
+  // 完了済みのユーザーがこの URL を再訪しても空白のまま留まらせない
+  useEffect(() => {
+    if (isCompleted === true) leave();
+  }, [isCompleted, leave]);
+
+  const finish = () => {
+    complete();
+    leave();
+  };
+
+  if (isCompleted !== false) return null;
+
+  return <OnboardingWalkthrough onFinish={finish} />;
+}

--- a/app/(app)/onboarding/_components/PageIndicator.tsx
+++ b/app/(app)/onboarding/_components/PageIndicator.tsx
@@ -1,0 +1,36 @@
+interface Props {
+  count: number;
+  activeIndex: number;
+}
+
+/**
+ * ウォークスルーの現在位置を示すドット。
+ * 現在地はドットの見た目だけでなく aria-current でも公開する。
+ */
+export default function PageIndicator({ count, activeIndex }: Props) {
+  return (
+    <ol
+      aria-label="ウォークスルーの進捗"
+      className="flex items-center justify-center gap-x-2"
+    >
+      {Array.from({ length: count }, (_, index) => {
+        const isActive = index === activeIndex;
+        return (
+          <li
+            key={index}
+            aria-current={isActive ? "step" : undefined}
+            className="flex items-center"
+          >
+            <span className="sr-only">{`${index + 1}ページ目`}</span>
+            <span
+              aria-hidden="true"
+              className={`h-2 rounded-full transition-all ${
+                isActive ? "w-6 bg-[#d08000]" : "w-2 bg-sub"
+              }`}
+            />
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/app/(app)/onboarding/_components/__tests__/OnboardingWalkthrough.test.tsx
+++ b/app/(app)/onboarding/_components/__tests__/OnboardingWalkthrough.test.tsx
@@ -1,0 +1,168 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import OnboardingWalkthrough from "../OnboardingWalkthrough";
+
+const STEP_TITLES = [
+  "打者も投手も、入力するだけで自動計算",
+  "チームメイトとランキングで競う",
+  "成長を1枚のグラフで",
+];
+
+const STEP_COPIES = [
+  "もう自分で電卓を叩かなくていい。打率・OPS から防御率・奪三振まで、打撃も投球も29指標を自動で算出します。",
+  "友達と打率を競い合おう。グループ内ランキングでモチベーションが続きます。",
+  "成績の推移をグラフで振り返り。自分の成長が一目でわかります。",
+];
+
+const renderWalkthrough = () => {
+  const onFinish = jest.fn();
+  render(<OnboardingWalkthrough onFinish={onFinish} />);
+  return { onFinish, user: userEvent.setup() };
+};
+
+const activeStepIndex = () =>
+  screen
+    .getAllByRole("listitem")
+    .findIndex((item) => item.getAttribute("aria-current") === "step");
+
+const swipe = (fromX: number, toX: number) => {
+  const region = screen.getByRole("region", { name: "BUZZ BASE の使い方" });
+  fireEvent.touchStart(region, { changedTouches: [{ clientX: fromX }] });
+  fireEvent.touchEnd(region, { changedTouches: [{ clientX: toX }] });
+};
+
+describe("OnboardingWalkthrough", () => {
+  it("1ステップ目のタイトルと説明を表示する", () => {
+    renderWalkthrough();
+
+    expect(screen.getByText(STEP_TITLES[0])).toBeInTheDocument();
+    expect(screen.getByText(STEP_COPIES[0])).toBeInTheDocument();
+    expect(screen.queryByText(STEP_TITLES[1])).not.toBeInTheDocument();
+  });
+
+  it("「次へ」で3ステップを順番に表示する", async () => {
+    const { user } = renderWalkthrough();
+
+    await user.click(screen.getByRole("button", { name: "次へ" }));
+    expect(screen.getByText(STEP_TITLES[1])).toBeInTheDocument();
+    expect(screen.getByText(STEP_COPIES[1])).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "次へ" }));
+    expect(screen.getByText(STEP_TITLES[2])).toBeInTheDocument();
+    expect(screen.getByText(STEP_COPIES[2])).toBeInTheDocument();
+  });
+
+  it("「戻る」で前のステップに戻る", async () => {
+    const { user } = renderWalkthrough();
+
+    await user.click(screen.getByRole("button", { name: "次へ" }));
+    await user.click(screen.getByRole("button", { name: "戻る" }));
+
+    expect(screen.getByText(STEP_TITLES[0])).toBeInTheDocument();
+  });
+
+  it("1ステップ目には「戻る」がない", async () => {
+    const { user } = renderWalkthrough();
+
+    expect(screen.queryByRole("button", { name: "戻る" })).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "次へ" }));
+    expect(screen.getByRole("button", { name: "戻る" })).toBeInTheDocument();
+  });
+
+  it("キーボードの左右でステップを移動できる", async () => {
+    const { user } = renderWalkthrough();
+
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByText(STEP_TITLES[1])).toBeInTheDocument();
+
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByText(STEP_TITLES[2])).toBeInTheDocument();
+
+    await user.keyboard("{ArrowLeft}");
+    expect(screen.getByText(STEP_TITLES[1])).toBeInTheDocument();
+  });
+
+  it("最初のステップで左キーを押しても最初のまま", async () => {
+    const { user } = renderWalkthrough();
+
+    await user.keyboard("{ArrowLeft}");
+
+    expect(screen.getByText(STEP_TITLES[0])).toBeInTheDocument();
+    expect(activeStepIndex()).toBe(0);
+  });
+
+  it("最後のステップで右キーを押しても最後のまま", async () => {
+    const { user } = renderWalkthrough();
+
+    await user.keyboard("{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}");
+
+    expect(screen.getByText(STEP_TITLES[2])).toBeInTheDocument();
+    expect(activeStepIndex()).toBe(2);
+  });
+
+  it("PageIndicator が現在のステップを示す", async () => {
+    const { user } = renderWalkthrough();
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    expect(activeStepIndex()).toBe(0);
+
+    await user.click(screen.getByRole("button", { name: "次へ" }));
+    expect(activeStepIndex()).toBe(1);
+
+    await user.click(screen.getByRole("button", { name: "次へ" }));
+    expect(activeStepIndex()).toBe(2);
+  });
+
+  it("最後のステップでは「次へ」ではなく「はじめる」を出す", async () => {
+    const { user, onFinish } = renderWalkthrough();
+
+    await user.click(screen.getByRole("button", { name: "次へ" }));
+    await user.click(screen.getByRole("button", { name: "次へ" }));
+
+    expect(screen.queryByRole("button", { name: "次へ" })).toBeNull();
+    await user.click(screen.getByRole("button", { name: "はじめる" }));
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+
+  it("どのステップからでもスキップできる", async () => {
+    const { user, onFinish } = renderWalkthrough();
+
+    expect(
+      screen.getByRole("button", { name: "スキップ" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "次へ" }));
+    await user.click(screen.getByRole("button", { name: "スキップ" }));
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+
+  it("左スワイプで次、右スワイプで前のステップに移動する", () => {
+    renderWalkthrough();
+
+    swipe(200, 40);
+    expect(screen.getByText(STEP_TITLES[1])).toBeInTheDocument();
+
+    swipe(40, 200);
+    expect(screen.getByText(STEP_TITLES[0])).toBeInTheDocument();
+  });
+
+  it("わずかな横移動ではステップを動かさない", () => {
+    renderWalkthrough();
+
+    swipe(200, 190);
+
+    expect(screen.getByText(STEP_TITLES[0])).toBeInTheDocument();
+  });
+
+  it("アンマウント後はキー操作を拾わない", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<OnboardingWalkthrough onFinish={jest.fn()} />);
+
+    unmount();
+
+    await expect(user.keyboard("{ArrowRight}")).resolves.not.toThrow();
+  });
+});

--- a/app/(app)/onboarding/_components/__tests__/OnboardingWalkthroughGate.test.tsx
+++ b/app/(app)/onboarding/_components/__tests__/OnboardingWalkthroughGate.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderToStaticMarkup } from "react-dom/server";
+import { WALKTHROUGH_COMPLETED_STORAGE_KEY } from "@app/constants/onboarding";
+import OnboardingWalkthroughGate from "../OnboardingWalkthroughGate";
+
+const mockReplace = jest.fn();
+let mockQueryString = "";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => new URLSearchParams(mockQueryString),
+}));
+
+const FIRST_STEP_TITLE = "打者も投手も、入力するだけで自動計算";
+const LAST_STEP_TITLE = "成長を1枚のグラフで";
+
+const advanceToLastStep = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole("button", { name: "次へ" }));
+  await user.click(screen.getByRole("button", { name: "次へ" }));
+};
+
+describe("OnboardingWalkthroughGate", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockReplace.mockClear();
+    mockQueryString = "";
+    jest.restoreAllMocks();
+  });
+
+  it("初回訪問ではウォークスルーを表示する", () => {
+    render(<OnboardingWalkthroughGate />);
+
+    expect(screen.getByText(FIRST_STEP_TITLE)).toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("「はじめる」まで進むと次回訪問では表示されない", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<OnboardingWalkthroughGate />);
+
+    await advanceToLastStep(user);
+    expect(screen.getByText(LAST_STEP_TITLE)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "はじめる" }));
+
+    unmount();
+    mockReplace.mockClear();
+    render(<OnboardingWalkthroughGate />);
+
+    expect(screen.queryByText(FIRST_STEP_TITLE)).not.toBeInTheDocument();
+    expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("スキップしても次回訪問では表示されない", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<OnboardingWalkthroughGate />);
+
+    await user.click(screen.getByRole("button", { name: "スキップ" }));
+
+    unmount();
+    render(<OnboardingWalkthroughGate />);
+
+    expect(screen.queryByText(FIRST_STEP_TITLE)).not.toBeInTheDocument();
+  });
+
+  it("完了すると next で指定されたパスへ遷移する", async () => {
+    mockQueryString = `next=${encodeURIComponent("/mypage/buzz_user")}`;
+    const user = userEvent.setup();
+    render(<OnboardingWalkthroughGate />);
+
+    await user.click(screen.getByRole("button", { name: "スキップ" }));
+
+    expect(mockReplace).toHaveBeenCalledWith("/mypage/buzz_user");
+  });
+
+  it("next が未指定ならダッシュボードへ遷移する", async () => {
+    const user = userEvent.setup();
+    render(<OnboardingWalkthroughGate />);
+
+    await user.click(screen.getByRole("button", { name: "スキップ" }));
+
+    expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("外部サイトを指す next は無視してダッシュボードへ遷移する", async () => {
+    mockQueryString = `next=${encodeURIComponent("//evil.example.com")}`;
+    const user = userEvent.setup();
+    render(<OnboardingWalkthroughGate />);
+
+    await user.click(screen.getByRole("button", { name: "スキップ" }));
+
+    expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("完了フラグが保存済みなら最初から表示せず遷移する", () => {
+    localStorage.setItem(WALKTHROUGH_COMPLETED_STORAGE_KEY, "1");
+
+    render(<OnboardingWalkthroughGate />);
+
+    expect(screen.queryByText(FIRST_STEP_TITLE)).not.toBeInTheDocument();
+    expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("SSR 時点では描画されない（読み込み確定前のちらつき防止）", () => {
+    const html = renderToStaticMarkup(<OnboardingWalkthroughGate />);
+
+    expect(html).toBe("");
+  });
+
+  it("localStorage が例外を投げてもクラッシュしない", () => {
+    jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+
+    expect(() => render(<OnboardingWalkthroughGate />)).not.toThrow();
+    expect(screen.queryByText(FIRST_STEP_TITLE)).not.toBeInTheDocument();
+    expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("保存に失敗しても完了操作で遷移する", async () => {
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    const user = userEvent.setup();
+    render(<OnboardingWalkthroughGate />);
+
+    await user.click(screen.getByRole("button", { name: "スキップ" }));
+
+    expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("遷移は一度きりで、完了操作の直後に重ねて呼ばれない", async () => {
+    const user = userEvent.setup();
+    render(<OnboardingWalkthroughGate />);
+
+    await advanceToLastStep(user);
+    await user.click(screen.getByRole("button", { name: "はじめる" }));
+
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/(app)/onboarding/_components/illustrations/AutoCalcIllustration.tsx
+++ b/app/(app)/onboarding/_components/illustrations/AutoCalcIllustration.tsx
@@ -1,0 +1,104 @@
+const KEYPAD_ROWS = [0, 1, 2];
+const KEYPAD_COLUMNS = [0, 1, 2];
+
+/**
+ * 「打席入力 → 自動計算」を表すイラスト。電卓本体と、算出された主要指標バッジを描く。
+ * 画像素材確定後に差し替え可能な仮ビジュアル。
+ */
+export default function AutoCalcIllustration() {
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      fill="none"
+      aria-hidden="true"
+      className="h-full w-full"
+    >
+      <rect x="34" y="22" width="92" height="156" rx="14" fill="#27272a" />
+      <rect
+        x="34"
+        y="22"
+        width="92"
+        height="156"
+        rx="14"
+        stroke="#424242"
+        strokeWidth="2"
+      />
+      <rect x="46" y="36" width="68" height="30" rx="6" fill="#1f1f22" />
+      <text
+        x="108"
+        y="58"
+        fill="#d08000"
+        fontSize="18"
+        fontWeight="bold"
+        textAnchor="end"
+      >
+        .333
+      </text>
+      {KEYPAD_ROWS.map((row) =>
+        KEYPAD_COLUMNS.map((col) => (
+          <rect
+            key={`${row}-${col}`}
+            x={46 + col * 24}
+            y={80 + row * 24}
+            width="18"
+            height="18"
+            rx="5"
+            fill="#424242"
+          />
+        )),
+      )}
+      <g>
+        <circle cx="150" cy="70" r="22" fill="#d08000" />
+        <text
+          x="150"
+          y="66"
+          fill="#2E2E2E"
+          fontSize="11"
+          fontWeight="bold"
+          textAnchor="middle"
+        >
+          OPS
+        </text>
+        <text
+          x="150"
+          y="80"
+          fill="#2E2E2E"
+          fontSize="12"
+          fontWeight="bold"
+          textAnchor="middle"
+        >
+          .900
+        </text>
+      </g>
+      <g>
+        <circle
+          cx="158"
+          cy="128"
+          r="20"
+          fill="#27272a"
+          stroke="#d08000"
+          strokeWidth="2"
+        />
+        <text x="158" y="124" fill="#A1A1AA" fontSize="9" textAnchor="middle">
+          防御率
+        </text>
+        <text
+          x="158"
+          y="138"
+          fill="#F4F4F4"
+          fontSize="12"
+          fontWeight="bold"
+          textAnchor="middle"
+        >
+          2.50
+        </text>
+      </g>
+      <path
+        d="M128 96 L142 84"
+        stroke="#d08000"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/app/(app)/onboarding/_components/illustrations/GrowthIllustration.tsx
+++ b/app/(app)/onboarding/_components/illustrations/GrowthIllustration.tsx
@@ -1,0 +1,55 @@
+const POINTS = "40,150 72,128 104,138 136,96 168,58";
+const GRID_LINE_Y = [60, 100, 140];
+
+/**
+ * 「成長を1枚のグラフで」を表すイラスト。上昇する成績推移の折れ線グラフを描く。
+ * 画像素材確定後に差し替え可能な仮ビジュアル。
+ */
+export default function GrowthIllustration() {
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      fill="none"
+      aria-hidden="true"
+      className="h-full w-full"
+    >
+      <line x1="36" y1="34" x2="36" y2="166" stroke="#424242" strokeWidth="2" />
+      <line
+        x1="36"
+        y1="166"
+        x2="176"
+        y2="166"
+        stroke="#424242"
+        strokeWidth="2"
+      />
+      {GRID_LINE_Y.map((y) => (
+        <line
+          key={y}
+          x1="36"
+          y1={y}
+          x2="176"
+          y2={y}
+          stroke="#27272a"
+          strokeWidth="1"
+        />
+      ))}
+      <path
+        d="M40 150 L72 128 L104 138 L136 96 L168 58 L168 166 L40 166 Z"
+        fill="#d08000"
+        fillOpacity="0.15"
+      />
+      <polyline
+        points={POINTS}
+        fill="none"
+        stroke="#d08000"
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {POINTS.split(" ").map((point) => {
+        const [x, y] = point.split(",").map(Number);
+        return <circle key={point} cx={x} cy={y} r="5" fill="#d08000" />;
+      })}
+    </svg>
+  );
+}

--- a/app/(app)/onboarding/_components/illustrations/RankingIllustration.tsx
+++ b/app/(app)/onboarding/_components/illustrations/RankingIllustration.tsx
@@ -1,0 +1,68 @@
+const ROWS = [
+  { rank: 1, width: 120, fill: "#d08000", textFill: "#2E2E2E" },
+  { rank: 2, width: 96, fill: "#424242", textFill: "#F4F4F4" },
+  { rank: 3, width: 72, fill: "#424242", textFill: "#F4F4F4" },
+];
+
+/**
+ * 「チームメイトとランキングで競う」を表すイラスト。順位バーと先頭の王冠を描く。
+ * 画像素材確定後に差し替え可能な仮ビジュアル。
+ */
+export default function RankingIllustration() {
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      fill="none"
+      aria-hidden="true"
+      className="h-full w-full"
+    >
+      <path
+        d="M84 28 L92 42 L100 26 L108 42 L116 28 L113 54 L87 54 Z"
+        fill="#d08000"
+      />
+      {ROWS.map((row, index) => {
+        const y = 70 + index * 36;
+        return (
+          <g key={row.rank}>
+            <circle
+              cx="34"
+              cy={y + 11}
+              r="13"
+              fill="#27272a"
+              stroke="#424242"
+              strokeWidth="2"
+            />
+            <text
+              x="34"
+              y={y + 15}
+              fill="#F4F4F4"
+              fontSize="13"
+              fontWeight="bold"
+              textAnchor="middle"
+            >
+              {row.rank}
+            </text>
+            <rect
+              x="54"
+              y={y}
+              width={row.width}
+              height="22"
+              rx="11"
+              fill={row.fill}
+            />
+            <text
+              x={54 + row.width - 12}
+              y={y + 16}
+              fill={row.textFill}
+              fontSize="12"
+              fontWeight="bold"
+              textAnchor="end"
+            >
+              {(0.38 - index * 0.02).toFixed(3).replace(/^0/, "")}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/app/(app)/onboarding/_components/illustrations/index.tsx
+++ b/app/(app)/onboarding/_components/illustrations/index.tsx
@@ -1,0 +1,24 @@
+import type { OnboardingIllustration } from "@app/constants/onboarding";
+import type { ComponentType } from "react";
+import AutoCalcIllustration from "./AutoCalcIllustration";
+import GrowthIllustration from "./GrowthIllustration";
+import RankingIllustration from "./RankingIllustration";
+
+const ILLUSTRATIONS: Record<OnboardingIllustration, ComponentType> = {
+  autoCalc: AutoCalcIllustration,
+  ranking: RankingIllustration,
+  growth: GrowthIllustration,
+};
+
+interface Props {
+  name: OnboardingIllustration;
+}
+
+/**
+ * ステップ名から対応するイラストを描画する。
+ * 外部リクエストを増やさないため、画像ではなくインライン SVG で持つ。
+ */
+export default function OnboardingIllustrationView({ name }: Props) {
+  const Illustration = ILLUSTRATIONS[name];
+  return <Illustration />;
+}

--- a/app/(app)/onboarding/_utils/__tests__/nextPath.test.ts
+++ b/app/(app)/onboarding/_utils/__tests__/nextPath.test.ts
@@ -1,0 +1,24 @@
+import { resolveNextPath } from "../nextPath";
+
+describe("resolveNextPath", () => {
+  it("サイト内の絶対パスはそのまま採用する", () => {
+    expect(resolveNextPath("/mypage/buzz_user")).toBe("/mypage/buzz_user");
+    expect(resolveNextPath("/dashboard?tab=batting")).toBe(
+      "/dashboard?tab=batting",
+    );
+  });
+
+  it("未指定ならダッシュボードに倒す", () => {
+    expect(resolveNextPath(null)).toBe("/dashboard");
+    expect(resolveNextPath(undefined)).toBe("/dashboard");
+    expect(resolveNextPath("")).toBe("/dashboard");
+  });
+
+  it("外部サイトに飛ばしうる値は採用しない", () => {
+    expect(resolveNextPath("//evil.example.com")).toBe("/dashboard");
+    expect(resolveNextPath("/\\evil.example.com")).toBe("/dashboard");
+    expect(resolveNextPath("https://evil.example.com")).toBe("/dashboard");
+    expect(resolveNextPath("javascript:alert(1)")).toBe("/dashboard");
+    expect(resolveNextPath("mypage/buzz_user")).toBe("/dashboard");
+  });
+});

--- a/app/(app)/onboarding/_utils/nextPath.ts
+++ b/app/(app)/onboarding/_utils/nextPath.ts
@@ -1,0 +1,16 @@
+/** ウォークスルー完了後の遷移先が指定されていないときの既定。 */
+export const DEFAULT_NEXT_PATH = "/dashboard";
+
+/**
+ * クエリで渡された遷移先を、自サイト内の絶対パスに限って採用する。
+ * `//evil.com` や `https://evil.com` を弾かないとオープンリダイレクトになるため、
+ * 先頭が `/` かつ 2 文字目がパス区切りでないものだけを通す。
+ *
+ * @param raw クエリから取得した生の値
+ * @returns 遷移先パス。妥当でなければ既定値。
+ */
+export function resolveNextPath(raw: string | null | undefined): string {
+  if (!raw || !raw.startsWith("/")) return DEFAULT_NEXT_PATH;
+  if (raw.startsWith("//") || raw.startsWith("/\\")) return DEFAULT_NEXT_PATH;
+  return raw;
+}

--- a/app/(app)/onboarding/page.tsx
+++ b/app/(app)/onboarding/page.tsx
@@ -1,0 +1,19 @@
+import { type Metadata } from "next";
+import { Suspense } from "react";
+import OnboardingWalkthroughGate from "./_components/OnboardingWalkthroughGate";
+
+export const metadata: Metadata = {
+  title: "はじめかた",
+  description: "BUZZ BASE でできることを3ステップで紹介します。",
+  robots: {
+    index: false,
+  },
+};
+
+export default function OnboardingPage() {
+  return (
+    <Suspense fallback={null}>
+      <OnboardingWalkthroughGate />
+    </Suspense>
+  );
+}

--- a/app/(app)/register-username/page.tsx
+++ b/app/(app)/register-username/page.tsx
@@ -82,7 +82,11 @@ export default function RegisterUserName() {
       const userData = await getUserData();
       if (userData && userData.user_id) {
         setIsLoggedIn(true);
-        router.push(`/mypage/${userData.user_id}`);
+        // 必須項目の登録を終えてからウォークスルーを挟む。
+        // 途中で挟むとフォーム離脱を招くため、順序は入れ替えない。
+        router.push(
+          `/onboarding?next=${encodeURIComponent(`/mypage/${userData.user_id}`)}`,
+        );
       }
     } catch (error: unknown) {
       if (error instanceof AxiosError && error.response?.data?.errors) {

--- a/app/constants/onboarding.ts
+++ b/app/constants/onboarding.ts
@@ -11,3 +11,34 @@ export const GROUP_TAB_BADGE_SEEN_STORAGE_KEY = `${ONBOARDING_STORAGE_PREFIX}gro
 
 /** ダッシュボードのグループ招待カードをユーザーが閉じたか。 */
 export const INVITE_CARD_DISMISSED_STORAGE_KEY = `${ONBOARDING_STORAGE_PREFIX}inviteCardDismissed`;
+
+/** 初回ウォークスルー（3ステップのスライド）を見終えたか。 */
+export const WALKTHROUGH_COMPLETED_STORAGE_KEY = `${ONBOARDING_STORAGE_PREFIX}walkthroughCompleted`;
+
+export type OnboardingIllustration = "autoCalc" | "ranking" | "growth";
+
+export interface OnboardingStep {
+  illustration: OnboardingIllustration;
+  title: string;
+  copy: string;
+}
+
+// 業界平均に合わせ3ステップを上限とする（5以上は離脱増）。順序が表示順。
+// モバイルアプリの初回起動ウォークスルーと文言・順序を揃えている。
+export const ONBOARDING_STEPS: readonly OnboardingStep[] = [
+  {
+    illustration: "autoCalc",
+    title: "打者も投手も、入力するだけで自動計算",
+    copy: "もう自分で電卓を叩かなくていい。打率・OPS から防御率・奪三振まで、打撃も投球も29指標を自動で算出します。",
+  },
+  {
+    illustration: "ranking",
+    title: "チームメイトとランキングで競う",
+    copy: "友達と打率を競い合おう。グループ内ランキングでモチベーションが続きます。",
+  },
+  {
+    illustration: "growth",
+    title: "成長を1枚のグラフで",
+    copy: "成績の推移をグラフで振り返り。自分の成長が一目でわかります。",
+  },
+] as const;

--- a/app/hooks/onboarding/__tests__/useOnboardingFlag.test.tsx
+++ b/app/hooks/onboarding/__tests__/useOnboardingFlag.test.tsx
@@ -5,6 +5,7 @@ import {
   GROUP_JOIN_TOOLTIP_SHOWN_STORAGE_KEY,
   GROUP_TAB_BADGE_SEEN_STORAGE_KEY,
   INVITE_CARD_DISMISSED_STORAGE_KEY,
+  WALKTHROUGH_COMPLETED_STORAGE_KEY,
 } from "@app/constants/onboarding";
 import { useOnboardingFlag } from "../useOnboardingFlag";
 
@@ -109,12 +110,16 @@ describe("オンボーディングの永続化キー", () => {
     expect(INVITE_CARD_DISMISSED_STORAGE_KEY).toBe(
       "buzzbase.onboarding.inviteCardDismissed",
     );
+    expect(WALKTHROUGH_COMPLETED_STORAGE_KEY).toBe(
+      "buzzbase.onboarding.walkthroughCompleted",
+    );
     expect(
       new Set([
         GROUP_JOIN_TOOLTIP_SHOWN_STORAGE_KEY,
         GROUP_TAB_BADGE_SEEN_STORAGE_KEY,
         INVITE_CARD_DISMISSED_STORAGE_KEY,
+        WALKTHROUGH_COMPLETED_STORAGE_KEY,
       ]).size,
-    ).toBe(3);
+    ).toBe(4);
   });
 });

--- a/app/hooks/onboarding/useOnboardingWalkthrough.ts
+++ b/app/hooks/onboarding/useOnboardingWalkthrough.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { WALKTHROUGH_COMPLETED_STORAGE_KEY } from "@app/constants/onboarding";
+import { useOnboardingFlag } from "./useOnboardingFlag";
+
+/**
+ * 初回ウォークスルーの完了状態を保持するフック。
+ * 完了状態の保存先はこのフックと useOnboardingFlag に閉じており、
+ * サーバー保持へ移行する際もここだけを差し替えればよい。
+ *
+ * @returns isCompleted 完了判定。確定まで null（確定前は何も描画しない）。
+ * @returns complete 完了として永続化する。スキップも完了として扱う。
+ */
+export function useOnboardingWalkthrough() {
+  const { isMarked, mark } = useOnboardingFlag(
+    WALKTHROUGH_COMPLETED_STORAGE_KEY,
+  );
+
+  return { isCompleted: isMarked, complete: mark };
+}


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#497

## 概要

mobile はインストール後に3ステップのスライドを表示しますが、front にはサインアップ直後のプロダクト内ウォークスルーがありませんでした。mobile と同じ3ステップを Web に移植します。

## 完了状態の保存先について（issue の「要検討」への回答）

issue が「先に決める」としていた論点について、**`localStorage` 方式を採用しました**（back の `users.onboarding_completed_at` 追加は行いません）。

- **既知の制約**: mobile で完了済みのユーザーが Web で再度ウォークスルーを見ます。これは方針として許容しています
- **将来の移行に備えた設計**: 完了状態の読み書きは `useOnboardingWalkthrough` フック**1箇所だけ**を通ります。back 方式へ移行する際はこのフックの中身を差し替えるだけで済みます

## 既存実装への相乗り

#413 でマージ済みの `useOnboardingFlag` / `onboardingStorage` にそのまま乗せています。**新しい localStorage アクセス経路は作っていません。**

- キーは既存と同じ接頭辞で `buzzbase.onboarding.walkthroughCompleted`
- `isMarked === null`（未確定）の間は何も描画しないちらつき防止規約に従っています
- 既存のキー契約テスト（衝突なしの検証）に新キーを追加しています

## 変更内容

- `ONBOARDING_STEPS` — mobile の3ステップを**タイトル・本文・順序ともそのまま**移植
- イラスト3点 — mobile の `react-native-svg` を Web のインライン SVG へ 1:1 移植。`viewBox` でレスポンシブ化し、装飾要素なので `aria-hidden="true"`。**外部リクエストはゼロ**
- 専用ルート `/onboarding` を新設（Server Component、`robots: { index: false }`）
- スライド UI — キーボード左右・タッチスワイプ（閾値48px）・PageIndicator・スキップ / 戻る / 次へ / はじめる
- `register-username` の登録成功後に `/onboarding?next=…` を挟む

## 表示タイミング: `register-username` の登録完了**後**

issue では「サインアップ完了後 or `register-username` 後」で決めきっていませんでした。**登録完了後**を選んでいます。

サインアップ直後（＝ユーザー名未登録）に挟むと、必須フォームの手前に3枚のスライドが入り**登録完了率を落とす**ためです。必須項目を終えてから価値説明を出す方が離脱が少ないと判断しました。

`register-username` は元々 `/mypage/[user_id]` へ遷移していたため、`next` クエリで**元の着地点を保っています**（未指定時は `/dashboard`）。

## セキュリティ: オープンリダイレクト対策

`next` クエリをそのまま遷移先に使うとオープンリダイレクトになるため、`resolveNextPath` で**自サイト内の絶対パスのみ**を許可しています。`//evil.com` / `https://evil.com` / `/\evil.com` は既定値にフォールバックします。ミューテーション M18（検証の撤廃）で検出できることも確認済みです。

## 静的ルートへの影響を避けた設計

**親レイアウトには一切手を入れていません。** 専用ルートを新設し、全画面は `fixed inset-0` のオーバーレイでナビ/フッタを覆う方式です。`(app)/layout.tsx` に `cookies()` を足すと配下105ルートが動的化する事故が過去にあったため、それを避けています。`useSearchParams` は `<Suspense>` で包んで静的プリレンダを維持しています。

## 確認が必要な点（レビューでご判断ください）

1. **`/onboarding` に認証ガードを付けていません。** 表示内容は静的なマーケティングコピーのみでユーザーデータを含まず、未ログインで直接訪問しても「はじめる」→ `/dashboard` → `proxy.ts` が `/` へリダイレクトします。`proxy.ts` の matcher に追加すべきかご判断ください（**追加すると当該ルートが動的化します**）
2. **`next` クエリの要否。** 「常に `/dashboard` へ着地」でよければ、クエリと `nextPath.ts` ごと削除してより単純にできます
3. **sitemap**: `next-sitemap.config.js` に除外リストがなく、`register-username` 同様 `/onboarding` も載ります。ページ側の `robots.index = false` は付けていますが、除外を追加する方がよければ対応します
4. **`ONBOARDING_STEPS` の置き場所**: 既存の `app/constants/onboarding.ts`（localStorage キー定義）に相乗りさせました。mobile の同名ファイルと対応が取れる一方、キー定義とコンテンツ定義が同居します

## localStorage 例外時の挙動

既存の `readOnboardingFlag` の「例外時は `true`（表示済み扱い）」をそのまま採用しました。

mobile は SecureStore 失敗時に fail-open（表示）ですが、それは**アプリ起動時のリダイレクトガード**だからです。Web 版の `/onboarding` は「一度だけ明示的に踏む導線」であり毎ページのガードではないため、永続化できない環境で `false` に倒すとその URL に戻るたび必ずスライドに入ります。`true` に倒しても失うのは初回説明1回だけで、ユーザーを閉じ込めません。

## 確認手順

1. 新規サインアップ → ユーザー名登録 → ウォークスルーが表示されること
2. 「次へ」「戻る」「キーボード左右」「スワイプ」で3ステップを移動できること
3. 「スキップ」で抜けられ、**次回以降表示されない**こと
4. 「はじめる」で元の着地点（`/mypage/[user_id]`）へ遷移すること
5. `/onboarding?next=//evil.com` で外部に飛ばず `/dashboard` に着地すること

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る（警告0）
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（**99 suites / 1048 tests**。+3 suites / +27 tests）
- [ ] `yarn build` — CI の Build Check で検証（`/onboarding` が静的 `○` であることを確認してください）
- [x] ミューテーションテスト **19 設計 / 19 KILLED / 0 SURVIVED**

<details>
<summary>ミューテーションテスト詳細</summary>

別ディレクトリの複製で実施（無改変で全通過を事前確認済み。作業ツリーは未改変）。

完了フラグの読み取り反転 / `mark` で永続化しない / 例外時に `false` へ倒す / ちらつき防止ガード除去 / 完了済みでも遷移しない / スキップで保存しない / ステップ順序入替 / 文言改変（タイトル・本文）/ キーボード操作の無効化（両方・左のみ）/ 境界（最初で左・最後で右）/ 最終ステップで「はじめる」を出さない / `aria-current` を出さない / PageIndicator の位置ずれ / **遷移先検証の撤廃（オープンリダイレクト）** / スワイプ閾値の無効化 — 全19件 KILLED。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_