### PR TITLE
Add: PostHog コンバージョン計測を導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,14 @@ yarn dev    # http://localhost:4100
 
 ## 環境変数
 
-| 変数名                         | 説明                        | 開発環境デフォルト             |
-| ------------------------------ | --------------------------- | ------------------------------ |
-| `RAILS_API_URL`                | バックエンドAPI URL         | `http://back:3000`（Docker内） |
-| `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | Google OAuth クライアントID | —                              |
-| `SENTRY_DSN`                   | Sentry DSN                  | —                              |
-| `ADSENSE_ENABLED`              | AdSense有効化               | `false`                        |
+| 変数名                         | 説明                                                     | 開発環境デフォルト             |
+| ------------------------------ | -------------------------------------------------------- | ------------------------------ |
+| `RAILS_API_URL`                | バックエンドAPI URL                                      | `http://back:3000`（Docker内） |
+| `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | Google OAuth クライアントID                              | —                              |
+| `SENTRY_DSN`                   | Sentry DSN                                               | —                              |
+| `ADSENSE_ENABLED`              | AdSense有効化                                            | `false`                        |
+| `NEXT_PUBLIC_POSTHOG_KEY`      | PostHogプロジェクトAPIキー（未設定なら計測は完全に無効） | —                              |
+| `NEXT_PUBLIC_POSTHOG_HOST`     | PostHogのAPIホスト                                       | `https://us.i.posthog.com`     |
 
 ## テスト
 

--- a/app/(app)/game-result/pitching/__tests__/page.test.tsx
+++ b/app/(app)/game-result/pitching/__tests__/page.test.tsx
@@ -1,0 +1,50 @@
+import { render } from "@testing-library/react";
+import PitchingRecord from "../page";
+
+const mockCapture = jest.fn();
+jest.mock("@app/utils/posthog", () => ({
+  capture: (...args: unknown[]) => mockCapture(...args),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => "/game-result/pitching",
+}));
+
+jest.mock("@app/contexts/useAuthContext", () => ({
+  useAuthContext: () => ({ isLoggedIn: true, loading: false }),
+}));
+
+jest.mock("@app/components/header/HeaderResult", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@app/services/pitchingResultsService", () => ({
+  checkExistingPitchingResult: () => Promise.resolve(null),
+  createPitchingResult: () => Promise.resolve({}),
+  updatePitchingResult: () => Promise.resolve({}),
+}));
+
+jest.mock("@app/services/gameResultsService", () => ({
+  updatePitchingResultId: () => Promise.resolve({}),
+}));
+
+jest.mock("@app/services/userService", () => ({
+  getCurrentUserId: () => Promise.resolve(1),
+}));
+
+describe("投手成績入力ページの計測", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("投手成績ステップの表示を game record step viewed で送る", () => {
+    render(<PitchingRecord />);
+
+    expect(mockCapture).toHaveBeenCalledWith("game record step viewed", {
+      step: 3,
+    });
+  });
+});

--- a/app/(app)/game-result/pitching/page.tsx
+++ b/app/(app)/game-result/pitching/page.tsx
@@ -22,6 +22,7 @@ import {
   updatePitchingResult,
 } from "@app/services/pitchingResultsService";
 import { getCurrentUserId } from "@app/services/userService";
+import { trackGameRecordStepViewed } from "@app/utils/analytics";
 
 const winOrLoss = [
   { id: -1, value: "-" },
@@ -129,6 +130,10 @@ export default function PitchingRecord() {
       console.error("Error fetching existing pitting result:", error);
     }
   };
+
+  useEffect(() => {
+    trackGameRecordStepViewed(3);
+  }, []);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/app/(app)/game-result/plate-appearances/__tests__/page.test.tsx
+++ b/app/(app)/game-result/plate-appearances/__tests__/page.test.tsx
@@ -24,11 +24,26 @@ jest.mock("@app/services/pitchingResultsService", () => ({
   getCurrentPitchingResult: () => Promise.resolve([]),
 }));
 
+const mockCapture = jest.fn();
+jest.mock("@app/utils/posthog", () => ({
+  capture: (...args: unknown[]) => mockCapture(...args),
+}));
+
 describe("打席一覧ページ", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
     mockGetPlateAppearancesByGame.mockResolvedValue([]);
+  });
+
+  it("打席入力ステップの表示を game record step viewed で送る", () => {
+    localStorage.setItem(GAME_RESULT_ID_STORAGE_KEY, "42");
+
+    render(<PlateAppearanceListPage />);
+
+    expect(mockCapture).toHaveBeenCalledWith("game record step viewed", {
+      step: 2,
+    });
   });
 
   it("記録中の試合を見失ったときは試合一覧へ逃がす", async () => {

--- a/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/PlateAppearanceWizard.tsx
@@ -11,16 +11,24 @@ import type {
   SwingType,
 } from "@app/interface/plateAppearanceV2";
 import { Button } from "@heroui/react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { NextArrowIcon } from "@app/components/icon/NextArrowIcon";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import {
   createPlateAppearanceV2,
   updatePlateAppearanceV2,
 } from "@app/services/v2/plateAppearanceService";
+import {
+  trackPlateAppearanceCanceled,
+  trackPlateAppearanceCompleted,
+} from "@app/utils/analytics";
 import { roundHitLocation, type Point } from "@app/utils/groundZoneDetector";
 import { DetailDataForm } from "./detail/DetailDataForm";
-import { EMPTY_DETAIL, type DetailState } from "./detail/detailState";
+import {
+  EMPTY_DETAIL,
+  hasDetailInput,
+  type DetailState,
+} from "./detail/detailState";
 import { GroundTapField } from "./GroundTapField";
 import { HitTypeModal } from "./HitTypeModal";
 import { OutTypeModal } from "./OutTypeModal";
@@ -113,6 +121,19 @@ export function PlateAppearanceWizard({
 
   const setDetail = (patch: Partial<DetailState>) =>
     setDetailState((prev) => ({ ...prev, ...patch }));
+
+  // 保存せずに画面を離れた場合だけ途中離脱として計測するためのフラグ。
+  // クリーンアップで最新値を読む必要があるため ref で持つ。
+  const isCompletedRef = useRef(false);
+
+  useEffect(() => {
+    return () => {
+      // 中断ボタン・ブラウザバック・親画面の遷移を区別せず「完了しなかった」で計測する。
+      if (!isCompletedRef.current) {
+        trackPlateAppearanceCanceled({ is_edit: isEdit });
+      }
+    };
+  }, [isEdit]);
 
   // 編集モードはタブで自由に切り替えるため、結果選択での自動遷移はしない。
   const goToScore = () => {
@@ -214,6 +235,12 @@ export function PlateAppearanceWizard({
         ? await updatePlateAppearanceV2(editingPlateAppearance.id, input)
         : await createPlateAppearanceV2(input);
     if (result.ok) {
+      isCompletedRef.current = true;
+      trackPlateAppearanceCompleted({
+        is_edit: isEdit,
+        has_pitcher: detail.pitcherId !== null,
+        has_detail: hasDetailInput(detail),
+      });
       // onCompleted が遷移しなかった場合でもボタンが永続 disabled にならないよう先に解除する。
       setIsSubmitting(false);
       onCompleted();

--- a/app/(app)/game-result/plate-appearances/_components/__tests__/PlateAppearanceWizard.test.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/__tests__/PlateAppearanceWizard.test.tsx
@@ -102,6 +102,30 @@ describe("打席記録ウィザードの計測", () => {
     );
   });
 
+  it("対戦投手だけ入力されていても has_detail は true で送る", async () => {
+    const user = userEvent.setup();
+    render(
+      <PlateAppearanceWizard
+        gameResultId={1}
+        batterBoxNumber={1}
+        onCompleted={jest.fn()}
+        editingPlateAppearance={buildEditingPlateAppearance({
+          pitcher: { id: 9, name: "投手" } as PlateAppearanceV2["pitcher"],
+        })}
+      />,
+    );
+
+    await user.click(screen.getByText("この打席を更新"));
+
+    await waitFor(() =>
+      expect(mockCapture).toHaveBeenCalledWith("plate appearance completed", {
+        is_edit: true,
+        has_pitcher: true,
+        has_detail: true,
+      }),
+    );
+  });
+
   it("保存せず画面を離れると plate appearance canceled を送る", () => {
     const { unmount } = render(
       <PlateAppearanceWizard

--- a/app/(app)/game-result/plate-appearances/_components/__tests__/PlateAppearanceWizard.test.tsx
+++ b/app/(app)/game-result/plate-appearances/_components/__tests__/PlateAppearanceWizard.test.tsx
@@ -1,0 +1,141 @@
+import type { PlateAppearanceV2 } from "@app/interface/plateAppearanceV2";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PlateAppearanceWizard } from "../PlateAppearanceWizard";
+
+const mockCapture = jest.fn();
+jest.mock("@app/utils/posthog", () => ({
+  capture: (...args: unknown[]) => mockCapture(...args),
+}));
+
+const mockCreate = jest.fn();
+const mockUpdate = jest.fn();
+jest.mock("@app/services/v2/plateAppearanceService", () => ({
+  createPlateAppearanceV2: (...args: unknown[]) => mockCreate(...args),
+  updatePlateAppearanceV2: (...args: unknown[]) => mockUpdate(...args),
+}));
+
+const buildEditingPlateAppearance = (
+  overrides: Partial<PlateAppearanceV2> = {},
+): PlateAppearanceV2 =>
+  ({
+    id: 7,
+    game_result_id: 1,
+    batter_box_number: 1,
+    plate_result_id: 1,
+    hit_direction_id: null,
+    hit_location_x: null,
+    hit_location_y: null,
+    out_type: null,
+    hit_type: null,
+    swing_type: null,
+    rbi: 0,
+    run_scored: 0,
+    stolen_bases: 0,
+    caught_stealing: 0,
+    final_balls: null,
+    final_strikes: null,
+    final_outs: null,
+    first_pitch_swing: null,
+    runners_state: null,
+    inning: null,
+    self_analysis_memo: null,
+    contact_quality: null,
+    timing: null,
+    pitch_type: null,
+    pitcher: null,
+    appearance_situation: null,
+    ...overrides,
+  }) as PlateAppearanceV2;
+
+describe("打席記録ウィザードの計測", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreate.mockResolvedValue({ ok: true });
+    mockUpdate.mockResolvedValue({ ok: true });
+  });
+
+  it("打席を保存すると plate appearance completed を送る", async () => {
+    const user = userEvent.setup();
+    const onCompleted = jest.fn();
+    render(
+      <PlateAppearanceWizard
+        gameResultId={1}
+        batterBoxNumber={1}
+        onCompleted={onCompleted}
+        editingPlateAppearance={buildEditingPlateAppearance()}
+      />,
+    );
+
+    await user.click(screen.getByText("この打席を更新"));
+
+    await waitFor(() => expect(onCompleted).toHaveBeenCalled());
+    expect(mockCapture).toHaveBeenCalledWith("plate appearance completed", {
+      is_edit: true,
+      has_pitcher: false,
+      has_detail: false,
+    });
+  });
+
+  it("詳細と対戦投手が入力済みなら has_pitcher / has_detail を true で送る", async () => {
+    const user = userEvent.setup();
+    render(
+      <PlateAppearanceWizard
+        gameResultId={1}
+        batterBoxNumber={1}
+        onCompleted={jest.fn()}
+        editingPlateAppearance={buildEditingPlateAppearance({
+          inning: 3,
+          pitcher: { id: 9, name: "投手" } as PlateAppearanceV2["pitcher"],
+        })}
+      />,
+    );
+
+    await user.click(screen.getByText("この打席を更新"));
+
+    await waitFor(() =>
+      expect(mockCapture).toHaveBeenCalledWith("plate appearance completed", {
+        is_edit: true,
+        has_pitcher: true,
+        has_detail: true,
+      }),
+    );
+  });
+
+  it("保存せず画面を離れると plate appearance canceled を送る", () => {
+    const { unmount } = render(
+      <PlateAppearanceWizard
+        gameResultId={1}
+        batterBoxNumber={1}
+        onCompleted={jest.fn()}
+      />,
+    );
+
+    unmount();
+
+    expect(mockCapture).toHaveBeenCalledWith("plate appearance canceled", {
+      is_edit: false,
+    });
+  });
+
+  it("保存して離れたときは途中離脱として計測しない", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(
+      <PlateAppearanceWizard
+        gameResultId={1}
+        batterBoxNumber={1}
+        onCompleted={jest.fn()}
+        editingPlateAppearance={buildEditingPlateAppearance()}
+      />,
+    );
+
+    await user.click(screen.getByText("この打席を更新"));
+    await waitFor(() => expect(mockCapture).toHaveBeenCalled());
+    unmount();
+
+    expect(mockCapture).not.toHaveBeenCalledWith(
+      "plate appearance canceled",
+      expect.anything(),
+    );
+  });
+});

--- a/app/(app)/game-result/plate-appearances/_components/detail/detailState.ts
+++ b/app/(app)/game-result/plate-appearances/_components/detail/detailState.ts
@@ -16,6 +16,24 @@ export interface DetailState {
   appearanceSituationId: number | null;
 }
 
+/**
+ * 任意項目である打席詳細が 1 つでも入力されているか。
+ * 詳細入力の利用率を計測するために使う（メモは空文字を未入力として扱う）。
+ */
+export const hasDetailInput = (detail: DetailState): boolean =>
+  detail.finalBalls !== null ||
+  detail.finalStrikes !== null ||
+  detail.finalOuts !== null ||
+  detail.firstPitchSwing !== null ||
+  detail.runnersState !== null ||
+  detail.inning !== null ||
+  detail.contactQualityId !== null ||
+  detail.timingId !== null ||
+  detail.pitchTypeId !== null ||
+  detail.pitcherId !== null ||
+  detail.appearanceSituationId !== null ||
+  (detail.selfAnalysisMemo !== null && detail.selfAnalysisMemo !== "");
+
 export const EMPTY_DETAIL: DetailState = {
   finalBalls: null,
   finalStrikes: null,

--- a/app/(app)/game-result/plate-appearances/page.tsx
+++ b/app/(app)/game-result/plate-appearances/page.tsx
@@ -13,6 +13,7 @@ import {
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import { getCurrentPitchingResult } from "@app/services/pitchingResultsService";
 import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
+import { trackGameRecordStepViewed } from "@app/utils/analytics";
 import { AddPlateAppearanceCard } from "./_components/AddPlateAppearanceCard";
 import { PlateAppearanceCard } from "./_components/PlateAppearanceCard";
 
@@ -39,6 +40,10 @@ export default function PlateAppearanceListPage() {
   const [isEditMode, setIsEditMode] = useState(false);
   const [hasPitching, setHasPitching] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    trackGameRecordStepViewed(2);
+  }, []);
 
   useEffect(() => {
     const saved = localStorage.getItem("gameResultId");

--- a/app/(app)/game-result/record/__tests__/page.test.tsx
+++ b/app/(app)/game-result/record/__tests__/page.test.tsx
@@ -1,0 +1,78 @@
+import { render } from "@testing-library/react";
+import GameRecord from "../page";
+
+const mockCapture = jest.fn();
+jest.mock("@app/utils/posthog", () => ({
+  capture: (...args: unknown[]) => mockCapture(...args),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => "/game-result/record",
+}));
+
+jest.mock("@app/contexts/useAuthContext", () => ({
+  useAuthContext: () => ({ isLoggedIn: true, loading: false }),
+}));
+
+jest.mock("@app/components/header/HeaderResult", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@app/services/gameResultsService", () => ({
+  createGameResult: () => Promise.resolve({ id: 1 }),
+  updateGameResult: () => Promise.resolve({}),
+}));
+
+jest.mock("@app/services/matchResultsService", () => ({
+  checkExistingMatchResults: () => Promise.resolve(null),
+  createMatchResults: () => Promise.resolve({ id: 1 }),
+  getMatchResultFormDefaults: () => Promise.resolve(null),
+  updateMatchResult: () => Promise.resolve({}),
+}));
+
+jest.mock("@app/services/positionService", () => ({
+  getPositions: () => Promise.resolve([]),
+}));
+
+jest.mock("@app/services/seasonsService", () => ({
+  createSeason: () => Promise.resolve({}),
+  getSeasons: () => Promise.resolve([]),
+}));
+
+jest.mock("@app/services/teamsService", () => ({
+  createOrUpdateTeam: () => Promise.resolve({}),
+  getTeams: () => Promise.resolve([]),
+}));
+
+jest.mock("@app/services/tournamentsService", () => ({
+  createTournament: () => Promise.resolve({}),
+  getTournaments: () => Promise.resolve([]),
+  updateTournament: () => Promise.resolve({}),
+}));
+
+jest.mock("@app/services/userService", () => ({
+  getCurrentUserId: () => Promise.resolve(1),
+  getUserData: () => Promise.resolve({ positions: [], team_id: null }),
+}));
+
+jest.mock("@app/services/v2/stadiumService", () => ({
+  createStadium: () => Promise.resolve({}),
+  searchStadiums: () => Promise.resolve({ stadiums: [] }),
+}));
+
+describe("試合結果入力ページの計測", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("試合情報ステップの表示を game record step viewed で送る", () => {
+    render(<GameRecord />);
+
+    expect(mockCapture).toHaveBeenCalledWith("game record step viewed", {
+      step: 1,
+    });
+  });
+});

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -51,6 +51,7 @@ import {
 } from "@app/services/tournamentsService";
 import { getCurrentUserId, getUserData } from "@app/services/userService";
 import { createStadium, searchStadiums } from "@app/services/v2/stadiumService";
+import { trackGameRecordStepViewed } from "@app/utils/analytics";
 import PatternSelector from "./_components/PatternSelector";
 import ScoreStepper from "./_components/ScoreStepper";
 
@@ -149,6 +150,9 @@ export default function GameRecord() {
   const pathname = usePathname();
   const router = useRouter();
   useRequireAuth();
+  useEffect(() => {
+    trackGameRecordStepViewed(1);
+  }, []);
   // 球場サジェスト検索のデバウンスタイマーと、最新リクエスト判定用のシーケンス番号。
   const stadiumSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const stadiumRequestId = useRef(0);

--- a/app/(app)/game-result/summary/__tests__/page.test.tsx
+++ b/app/(app)/game-result/summary/__tests__/page.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GAME_RESULT_ID_STORAGE_KEY } from "@app/constants/gameRecord";
+import ResultsSummary from "../page";
+
+const mockCapture = jest.fn();
+jest.mock("@app/utils/posthog", () => ({
+  capture: (...args: unknown[]) => mockCapture(...args),
+}));
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => "/game-result/summary",
+}));
+
+jest.mock("@app/components/header/SummaryHeader", () => ({
+  __esModule: true,
+  default: ({
+    onSummaryResult,
+    text,
+  }: {
+    onSummaryResult: () => void;
+    text: string;
+  }) => (
+    <button type="button" onClick={onSummaryResult}>
+      {text}
+    </button>
+  ),
+}));
+
+jest.mock("@app/components/share/ResultShareComponent", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@app/components/ad/AdInFeed", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockGetCurrentPitchingResult = jest.fn();
+jest.mock("@app/services/pitchingResultsService", () => ({
+  getCurrentPitchingResult: () => mockGetCurrentPitchingResult(),
+}));
+
+jest.mock("@app/services/matchResultsService", () => ({
+  getCurrentMatchResult: () =>
+    Promise.resolve([
+      {
+        id: 1,
+        game_result_id: 1,
+        user_id: 1,
+        match_type: "open",
+        appearance_type: "pinch_hitter",
+        date_and_time: "2026-04-01",
+        batting_order: "1",
+        defensive_position: "1",
+        my_team_id: 1,
+        opponent_team_id: 2,
+        my_team_score: 3,
+        opponent_team_score: 1,
+        tournament_id: null,
+        memo: "",
+      },
+    ]),
+}));
+
+jest.mock("@app/services/battingAveragesService", () => ({
+  getCurrentBattingAverage: () => Promise.resolve([]),
+}));
+
+jest.mock("@app/services/plateAppearanceService", () => ({
+  getCurrentPlateAppearance: () => Promise.resolve([]),
+}));
+
+jest.mock("@app/services/v2/plateAppearanceService", () => ({
+  getPlateAppearancesByGame: () => Promise.resolve([]),
+}));
+
+jest.mock("@app/services/userService", () => ({
+  getCurrentUserId: () => Promise.resolve(1),
+  getCurrentUsersUserId: () => Promise.resolve("buzz-user"),
+}));
+
+jest.mock("@app/services/teamsService", () => ({
+  getTeamName: () => Promise.resolve("チーム"),
+}));
+
+jest.mock("@app/services/tournamentsService", () => ({
+  getTournamentName: () => Promise.resolve("大会"),
+}));
+
+jest.mock("@app/services/positionService", () => ({
+  getPositionName: () => Promise.resolve("投手"),
+}));
+
+describe("試合結果まとめページの計測", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem(GAME_RESULT_ID_STORAGE_KEY, "42");
+    mockGetCurrentPitchingResult.mockResolvedValue([]);
+  });
+
+  it("まとめ画面の表示を game record step viewed で送る", () => {
+    render(<ResultsSummary />);
+
+    expect(mockCapture).toHaveBeenCalledWith("game record step viewed", {
+      step: "summary",
+    });
+  });
+
+  it("記録を完了すると game record completed を試合の内容付きで送る", async () => {
+    const user = userEvent.setup();
+    mockGetCurrentPitchingResult.mockResolvedValue([{ id: 3 }]);
+    render(<ResultsSummary />);
+    await screen.findAllByText("チーム");
+
+    await user.click(screen.getByText("試合一覧へ"));
+
+    await waitFor(() =>
+      expect(mockCapture).toHaveBeenCalledWith("game record completed", {
+        match_type: "open",
+        appearance_type: "pinch_hitter",
+        has_pitching: true,
+      }),
+    );
+    expect(mockPush).toHaveBeenCalledWith("/game-result/lists");
+  });
+
+  it("投手成績が無ければ has_pitching は false で送る", async () => {
+    const user = userEvent.setup();
+    render(<ResultsSummary />);
+    await screen.findAllByText("チーム");
+
+    await user.click(screen.getByText("試合一覧へ"));
+
+    await waitFor(() =>
+      expect(mockCapture).toHaveBeenCalledWith("game record completed", {
+        match_type: "open",
+        appearance_type: "pinch_hitter",
+        has_pitching: false,
+      }),
+    );
+  });
+});

--- a/app/(app)/game-result/summary/page.tsx
+++ b/app/(app)/game-result/summary/page.tsx
@@ -28,6 +28,10 @@ import {
 } from "@app/services/userService";
 import { getPlateAppearancesByGame } from "@app/services/v2/plateAppearanceService";
 import {
+  trackGameRecordCompleted,
+  trackGameRecordStepViewed,
+} from "@app/utils/analytics";
+import {
   getBattingResultColor,
   HIT_RESULT_COLOR,
   SACRIFICE_RESULT_COLOR,
@@ -102,6 +106,10 @@ export default function ResultsSummary() {
     setMatchResult(updateMatchResults);
     setIsDetailDataFetched(true);
   };
+
+  useEffect(() => {
+    trackGameRecordStepViewed("summary");
+  }, []);
 
   useEffect(() => {
     // ローカルストレージからid取得
@@ -214,6 +222,12 @@ export default function ResultsSummary() {
 
   const _handleShare = () => {};
   const handleResultComplete = () => {
+    const match = matchResult[0];
+    trackGameRecordCompleted({
+      match_type: match?.match_type ?? null,
+      appearance_type: match?.appearance_type ?? "starter",
+      has_pitching: pitchingResult.length > 0,
+    });
     clearGameRecordStorage();
     router.push("/game-result/lists");
   };

--- a/app/(app)/groups/join/__tests__/page.test.tsx
+++ b/app/(app)/groups/join/__tests__/page.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import GroupJoinPage from "../page";
+
+const mockCapture = jest.fn();
+jest.mock("@app/utils/posthog", () => ({
+  capture: (...args: unknown[]) => mockCapture(...args),
+}));
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => "/groups/join",
+}));
+
+jest.mock("@app/contexts/useAuthContext", () => ({
+  useAuthContext: () => ({ isLoggedIn: true, loading: false }),
+}));
+
+jest.mock("@app/components/header/Header", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockGetInviteLinkInfo = jest.fn();
+const mockAcceptInviteLink = jest.fn();
+jest.mock("@app/services/groupInviteLinksService", () => ({
+  getInviteLinkInfo: (...args: unknown[]) => mockGetInviteLinkInfo(...args),
+  acceptInviteLink: (...args: unknown[]) => mockAcceptInviteLink(...args),
+}));
+
+const joinWithCode = async () => {
+  const user = userEvent.setup();
+  render(<GroupJoinPage />);
+  await user.type(screen.getByPlaceholderText("例: ABC12DEF"), "abc12def");
+  await user.click(screen.getByText("確認する"));
+  await screen.findByText("テストグループ");
+  await user.click(screen.getByText("グループに参加"));
+};
+
+describe("グループ参加ページの計測", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetInviteLinkInfo.mockResolvedValue({
+      group: { id: 5, name: "テストグループ", icon: null, member_count: 3 },
+      inviter: { name: "招待者", image: { url: null } },
+    });
+    mockAcceptInviteLink.mockResolvedValue({ group_id: 5 });
+  });
+
+  it("招待コードで参加すると group joined を送る", async () => {
+    await joinWithCode();
+
+    await waitFor(() =>
+      expect(mockCapture).toHaveBeenCalledWith("group joined", {
+        group_id: 5,
+      }),
+    );
+  });
+
+  it("参加に失敗したときは計測しない", async () => {
+    mockAcceptInviteLink.mockRejectedValue(new Error("failed"));
+
+    await joinWithCode();
+
+    await waitFor(() => expect(mockAcceptInviteLink).toHaveBeenCalled());
+    expect(mockCapture).not.toHaveBeenCalledWith(
+      "group joined",
+      expect.anything(),
+    );
+  });
+});

--- a/app/(app)/groups/join/page.tsx
+++ b/app/(app)/groups/join/page.tsx
@@ -11,6 +11,7 @@ import {
   acceptInviteLink,
   getInviteLinkInfo,
 } from "@app/services/groupInviteLinksService";
+import { trackGroupJoined } from "@app/utils/analytics";
 
 export default function GroupJoinPage() {
   const router = useRouter();
@@ -43,6 +44,7 @@ export default function GroupJoinPage() {
     setIsAccepting(true);
     try {
       const result = await acceptInviteLink(trimmedCode);
+      trackGroupJoined(result.group_id);
       router.push(`/groups/${result.group_id}`);
     } catch (error) {
       console.error("グループへの参加に失敗しました", error);

--- a/app/(app)/groups/new/__tests__/page.test.tsx
+++ b/app/(app)/groups/new/__tests__/page.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import GroupNew from "../page";
+
+const mockCapture = jest.fn();
+jest.mock("@app/utils/posthog", () => ({
+  capture: (...args: unknown[]) => mockCapture(...args),
+}));
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => "/groups/new",
+}));
+
+jest.mock("@app/contexts/useAuthContext", () => ({
+  useAuthContext: () => ({ isLoggedIn: true, loading: false }),
+}));
+
+jest.mock("@app/components/header/HeaderMatchResultSave", () => ({
+  __esModule: true,
+  default: ({
+    onMatchResultNext,
+    text,
+  }: {
+    onMatchResultNext: () => void;
+    text: string;
+  }) => (
+    <button type="button" onClick={onMatchResultNext}>
+      {text}
+    </button>
+  ),
+}));
+
+const mockCreateGroup = jest.fn();
+jest.mock("@app/services/groupService", () => ({
+  createGroup: (...args: unknown[]) => mockCreateGroup(...args),
+}));
+
+jest.mock("@app/services/userService", () => ({
+  getCurrentUserId: () => Promise.resolve(1),
+  getFollowingUser: () =>
+    Promise.resolve([
+      { id: 2, name: "フォロー中ユーザー", user_id: "foo", image: { url: "" } },
+    ]),
+}));
+
+const createGroupWithMember = async () => {
+  const user = userEvent.setup();
+  render(<GroupNew />);
+  await screen.findByText("フォロー中ユーザー");
+  await user.type(screen.getByLabelText("グループ名"), "テストチーム");
+  await user.click(screen.getByRole("checkbox"));
+  await user.click(screen.getByText("作成"));
+};
+
+describe("グループ作成ページの計測", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateGroup.mockResolvedValue({ id: 77 });
+  });
+
+  it("グループを作成すると group created を送る", async () => {
+    await createGroupWithMember();
+
+    await waitFor(() =>
+      expect(mockCapture).toHaveBeenCalledWith("group created", {
+        group_id: 77,
+      }),
+    );
+  });
+
+  it("作成に失敗したときは計測しない", async () => {
+    mockCreateGroup.mockRejectedValue(new Error("failed"));
+
+    await createGroupWithMember();
+
+    await waitFor(() => expect(mockCreateGroup).toHaveBeenCalled());
+    expect(mockCapture).not.toHaveBeenCalled();
+  });
+});

--- a/app/(app)/groups/new/page.tsx
+++ b/app/(app)/groups/new/page.tsx
@@ -9,6 +9,7 @@ import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import { createGroup } from "@app/services/groupService";
 import { getCurrentUserId, getFollowingUser } from "@app/services/userService";
+import { trackGroupCreated } from "@app/utils/analytics";
 
 export default function GroupNew() {
   const [currentUserId, setCurrentUserId] = useState(null);
@@ -129,6 +130,7 @@ export default function GroupNew() {
     });
     try {
       const response = await createGroup(formData);
+      trackGroupCreated(response.id);
       router.push(`/groups/${response.id}/share-invite`);
     } catch {}
   };

--- a/app/(app)/mypage/edit/__tests__/page.test.tsx
+++ b/app/(app)/mypage/edit/__tests__/page.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import MypageEdit from "../page";
+
+const mockCapture = jest.fn();
+jest.mock("@app/utils/posthog", () => ({
+  capture: (...args: unknown[]) => mockCapture(...args),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => "/mypage/edit",
+}));
+
+jest.mock("@app/contexts/useAuthContext", () => ({
+  useAuthContext: () => ({ isLoggedIn: true, loading: false }),
+}));
+
+jest.mock("@app/components/header/HeaderSave", () => ({
+  __esModule: true,
+  default: ({ onProfileUpdate }: { onProfileUpdate: () => void }) => (
+    <button type="button" onClick={onProfileUpdate}>
+      保存
+    </button>
+  ),
+}));
+
+const mockUpdateProfile = jest.fn();
+jest.mock("@app/services/userService", () => ({
+  getUserData: () =>
+    Promise.resolve({
+      id: 1,
+      name: "テスト太郎",
+      user_id: "test-user",
+      introduction: "",
+      image: { url: "" },
+      is_private: false,
+      positions: [],
+      team_id: null,
+    }),
+  updateProfile: (...args: unknown[]) => mockUpdateProfile(...args),
+}));
+
+jest.mock("@app/services/positionService", () => ({
+  getPositions: () => Promise.resolve([]),
+  updateUserPositions: () => Promise.resolve({}),
+}));
+
+jest.mock("@app/services/prefectureService", () => ({
+  getPrefectures: () => Promise.resolve([]),
+}));
+
+jest.mock("@app/services/baseballCategoryService", () => ({
+  getBaseballCategory: () => Promise.resolve([]),
+}));
+
+jest.mock("@app/services/teamsService", () => ({
+  getTeams: () => Promise.resolve([]),
+  createOrUpdateTeam: () => Promise.resolve({}),
+  updateTeam: () => Promise.resolve({}),
+}));
+
+jest.mock("@app/services/awardsService", () => ({
+  getUserAwards: () => Promise.resolve([]),
+  createAward: () => Promise.resolve({}),
+  deleteAward: () => Promise.resolve({}),
+  updatePutAward: () => Promise.resolve({}),
+}));
+
+describe("プロフィール編集ページの計測", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdateProfile.mockResolvedValue({});
+  });
+
+  it("プロフィールを保存すると profile updated を送る", async () => {
+    const user = userEvent.setup();
+    render(<MypageEdit />);
+    await screen.findByDisplayValue("テスト太郎");
+
+    await user.click(screen.getByText("保存"));
+
+    await waitFor(() =>
+      expect(mockCapture).toHaveBeenCalledWith("profile updated"),
+    );
+  });
+
+  it("保存に失敗したときは計測しない", async () => {
+    const user = userEvent.setup();
+    mockUpdateProfile.mockRejectedValue(new Error("failed"));
+    render(<MypageEdit />);
+    await screen.findByDisplayValue("テスト太郎");
+
+    await user.click(screen.getByText("保存"));
+
+    await waitFor(() => expect(mockUpdateProfile).toHaveBeenCalled());
+    expect(mockCapture).not.toHaveBeenCalled();
+  });
+});

--- a/app/(app)/mypage/edit/page.tsx
+++ b/app/(app)/mypage/edit/page.tsx
@@ -40,6 +40,7 @@ import {
   updateTeam,
 } from "@app/services/teamsService";
 import { getUserData, updateProfile } from "@app/services/userService";
+import { trackProfileUpdated } from "@app/utils/analytics";
 
 type Position = {
   userId: string;
@@ -296,6 +297,7 @@ export default function ProfileEdit() {
     setErrors([]);
     try {
       await updateProfile(formData);
+      trackProfileUpdated();
       setSave(true);
       // ポジション保存
       await updateUserPositions({

--- a/app/(app)/signin/_components/SignUpCompletionTracker.tsx
+++ b/app/(app)/signin/_components/SignUpCompletionTracker.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { trackEvent } from "@app/lib/analytics";
+import { trackSignUpCompleted } from "@app/utils/analytics";
 
 type Props = {
   triggered: boolean;
@@ -18,6 +19,7 @@ export default function SignUpCompletionTracker({ triggered }: Props) {
     if (!triggered || hasFired.current) return;
     hasFired.current = true;
     trackEvent("sign_up", { method: "email" });
+    trackSignUpCompleted("email");
   }, [triggered]);
   return null;
 }

--- a/app/(app)/stats/_components/StatsContainer.tsx
+++ b/app/(app)/stats/_components/StatsContainer.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@app/components/filter/filterTypes";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import FilterBar from "@app/components/filter/FilterBar";
+import { trackFilterChanges } from "@app/components/filter/trackFilterChange";
 import { buildRecentYearOptions } from "@app/components/filter/yearOptions";
 import { getBattingStats, getPitchingStats } from "../actions";
 import BattingStatsTable from "./BattingStatsTable";
@@ -84,6 +85,11 @@ export default function StatsContainer({
       active = false;
     };
   }, [tab, period, tableFilters]);
+
+  const handleTableFiltersChange = (next: FilterValues) => {
+    trackFilterChanges(tableFilters, next);
+    setTableFilters(next);
+  };
 
   const handlePeriodChange = (next: StatsPeriod) => {
     setPeriod(next);
@@ -174,7 +180,7 @@ export default function StatsContainer({
         <div className="mb-3">
           <FilterBar
             values={tableFilters}
-            onChange={setTableFilters}
+            onChange={handleTableFiltersChange}
             resetTo={PERIODIC_DEFAULT_FILTERS}
             options={{
               years: yearOptions,

--- a/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
+++ b/app/(app)/stats/_components/analysis/AnalysisContainer.tsx
@@ -4,12 +4,14 @@ import type { ProFeature } from "@app/types/pro";
 import { useEffect, useRef, useState, useTransition } from "react";
 import FilterBar from "@app/components/filter/FilterBar";
 import { MATCH_TYPE_OPTIONS } from "@app/components/filter/matchTypeOptions";
+import { trackFilterChanges } from "@app/components/filter/trackFilterChange";
 import { buildRecentYearOptions } from "@app/components/filter/yearOptions";
 import { ProUpsellOverlay } from "@app/components/pro/ProUpsellOverlay";
 import { SampleDataLabel } from "@app/components/pro/SampleDataLabel";
 import { useProGatedFeatures } from "@app/hooks/pro/useProGatedFeatures";
 import { useProGatedResource } from "@app/hooks/pro/useProGatedResource";
 import { useSeasonTrendGranularity } from "@app/hooks/pro/useSeasonTrendGranularity";
+import { trackBattingTrendGranularityChanged } from "@app/utils/analytics";
 import {
   type AnalysisFilters as Filters,
   type AnalysisInitialData,
@@ -216,11 +218,21 @@ export function AnalysisContainer({
     };
   }, [filters, granularity, resolveTrend, startTrendTransition]);
 
+  const handleFiltersChange = (next: Filters) => {
+    trackFilterChanges(filters, next);
+    setFilters(next);
+  };
+
+  const handleGranularityChange = (next: BattingTrendGranularity) => {
+    trackBattingTrendGranularityChanged(next);
+    requestGranularity(next);
+  };
+
   return (
     <div className="flex flex-col gap-y-5">
       <FilterBar
         values={filters}
-        onChange={setFilters}
+        onChange={handleFiltersChange}
         options={{
           years: yearOptions,
           months: monthOptions,
@@ -245,7 +257,7 @@ export function AnalysisContainer({
           <BattingTrendChart
             points={battingTrend.points}
             granularity={granularity}
-            onGranularityChange={requestGranularity}
+            onGranularityChange={handleGranularityChange}
           />
         </div>
         <SprayChart

--- a/app/components/analytics/PostHogInit.tsx
+++ b/app/components/analytics/PostHogInit.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect } from "react";
+import { initPostHog } from "@app/utils/posthog";
+
+/**
+ * PostHog をハイドレーション後に 1 度だけ初期化する計装専用コンポーネント。
+ * DOM を持たないため、描画やレイアウトには一切影響しない。
+ */
+export default function PostHogInit() {
+  useEffect(() => {
+    initPostHog();
+  }, []);
+  return null;
+}

--- a/app/components/auth/GoogleLoginButton.tsx
+++ b/app/components/auth/GoogleLoginButton.tsx
@@ -10,6 +10,8 @@ import { useAuthContext } from "@app/contexts/useAuthContext";
 import { trackEvent } from "@app/lib/analytics";
 import { googleSignIn } from "@app/services/authService";
 import { getUserData } from "@app/services/userService";
+import { trackSignUpCompleted, trackUserLoggedIn } from "@app/utils/analytics";
+import { identifyUser } from "@app/utils/posthog";
 
 interface GoogleLoginButtonProps {
   mode?: "signin" | "signup";
@@ -47,14 +49,17 @@ export default function GoogleLoginButton({
 
       if (response.data.requires_username) {
         trackEvent("sign_up", { method: "google" });
+        trackSignUpCompleted("google");
         navigateAfterAuth("/register-username");
         setIsLoggedIn(true);
       } else {
         // requires_username=false はバックエンドが既存ユーザーと判断したことを意味する。
         // getUserData() が user_id を返さない一時的失敗があっても sign_up ではなく login として記録する。
         trackEvent("login", { method: "google" });
+        trackUserLoggedIn("google");
         const userData = await getUserData();
         if (userData && userData.user_id) {
+          identifyUser(userData.id);
           navigateAfterAuth(`/mypage/${userData.user_id}`);
         } else {
           navigateAfterAuth("/register-username");

--- a/app/components/auth/Logout.tsx
+++ b/app/components/auth/Logout.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { startTransition } from "react";
 import { useAuthContext } from "@app/contexts/useAuthContext";
 import { signOut } from "@app/services/authService";
+import { resetUser } from "@app/utils/posthog";
 
 export default function Logout() {
   const router = useRouter();
@@ -12,6 +13,7 @@ export default function Logout() {
   const handleLogout = async () => {
     try {
       await signOut();
+      resetUser();
       setIsLoggedIn(false);
       // 認証 cookie 削除後も Server Component のレンダー結果はログイン中のまま
       // 残るため、明示的に作り直す。

--- a/app/components/auth/SignIn.tsx
+++ b/app/components/auth/SignIn.tsx
@@ -14,6 +14,8 @@ import { useAuthContext } from "@app/contexts/useAuthContext";
 import { trackEvent } from "@app/lib/analytics";
 import { signIn } from "@app/services/authService";
 import { getUserData } from "@app/services/userService";
+import { trackUserLoggedIn } from "@app/utils/analytics";
+import { identifyUser } from "@app/utils/posthog";
 
 export default function SignIn() {
   const [email, setEmail] = useState("");
@@ -56,8 +58,10 @@ export default function SignIn() {
       await signIn({ email, password });
       setIsLoggedIn(true);
       trackEvent("login", { method: "email" });
+      trackUserLoggedIn("email");
       const userData = await getUserData();
       if (userData && userData.user_id) {
+        identifyUser(userData.id);
         setIsLoggedIn(true);
         navigateAfterAuth(`/mypage/${userData.user_id}`);
       } else {

--- a/app/components/button/FollowButton.tsx
+++ b/app/components/button/FollowButton.tsx
@@ -5,6 +5,7 @@ import { Button } from "@heroui/react";
 import { useState } from "react";
 import { useAuthContext } from "@app/contexts/useAuthContext";
 import { userFollow, userUnFollow } from "@app/services/userService";
+import { trackUserFollowed } from "@app/utils/analytics";
 
 export default function FollowButton({
   userId,
@@ -25,6 +26,7 @@ export default function FollowButton({
       setFollowStatus("none");
     } else {
       const response = await userFollow(userId);
+      trackUserFollowed(userId);
       setFollowStatus(response?.follow_status ?? "following");
     }
   };

--- a/app/components/button/__tests__/FollowButton.test.tsx
+++ b/app/components/button/__tests__/FollowButton.test.tsx
@@ -14,6 +14,11 @@ jest.mock("@app/services/userService", () => ({
   userUnFollow: jest.fn(),
 }));
 
+const mockCapture = jest.fn();
+jest.mock("@app/utils/posthog", () => ({
+  capture: (...args: unknown[]) => mockCapture(...args),
+}));
+
 describe("FollowButton", () => {
   const mockSetErrorsWithTimeout = jest.fn();
   const mockUseAuthContext = useAuthContext as jest.Mock;
@@ -66,6 +71,33 @@ describe("FollowButton", () => {
       expect(mockUserFollow).toHaveBeenCalledWith(1);
       expect(screen.getByText("フォロー中")).toBeInTheDocument();
     });
+  });
+
+  it("フォローすると user followed を送る", async () => {
+    const user = userEvent.setup();
+    mockUserFollow.mockResolvedValue({ follow_status: "following" });
+
+    render(<FollowButton {...defaultProps} userId={42} />);
+
+    await user.click(screen.getByText("フォローする"));
+
+    await waitFor(() =>
+      expect(mockCapture).toHaveBeenCalledWith("user followed", {
+        followed_user_id: 42,
+      }),
+    );
+  });
+
+  it("フォロー解除では user followed を送らない", async () => {
+    const user = userEvent.setup();
+    mockUserUnFollow.mockResolvedValue({});
+
+    render(<FollowButton {...defaultProps} initialFollowStatus="following" />);
+
+    await user.click(screen.getByText("フォロー中"));
+
+    await waitFor(() => expect(mockUserUnFollow).toHaveBeenCalled());
+    expect(mockCapture).not.toHaveBeenCalled();
   });
 
   it("非公開アカウントへのフォローでリクエスト済みになる", async () => {

--- a/app/components/filter/__tests__/trackFilterChange.test.ts
+++ b/app/components/filter/__tests__/trackFilterChange.test.ts
@@ -1,0 +1,46 @@
+import { trackFilterChanges } from "../trackFilterChange";
+
+const mockCapture = jest.fn();
+jest.mock("@app/utils/posthog", () => ({
+  capture: (...args: unknown[]) => mockCapture(...args),
+}));
+
+describe("trackFilterChanges", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("変更されたキーだけ stats filter changed を送る", () => {
+    trackFilterChanges({ year: "2025" }, { year: "2026" });
+
+    expect(mockCapture).toHaveBeenCalledTimes(1);
+    expect(mockCapture).toHaveBeenCalledWith("stats filter changed", {
+      filter_key: "year",
+      filter_value: "2026",
+    });
+  });
+
+  it("絞り込みの解除は値 null で送る", () => {
+    trackFilterChanges({ matchType: "regular" }, {});
+
+    expect(mockCapture).toHaveBeenCalledWith("stats filter changed", {
+      filter_key: "matchType",
+      filter_value: null,
+    });
+  });
+
+  it("複数のキーが変わればその分だけ送る", () => {
+    trackFilterChanges(
+      {},
+      { seasonId: "3", tournamentId: "9", startMonth: "2026-04" },
+    );
+
+    expect(mockCapture).toHaveBeenCalledTimes(3);
+  });
+
+  it("値が変わっていなければ送らない", () => {
+    trackFilterChanges({ year: "2026" }, { year: "2026" });
+
+    expect(mockCapture).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/filter/filterTypes.ts
+++ b/app/components/filter/filterTypes.ts
@@ -29,7 +29,7 @@ export interface FilterValues {
  */
 export const ALL_FILTER_KEY = "__all__";
 
-const FILTER_KEYS = [
+export const FILTER_KEYS = [
   "year",
   "matchType",
   "seasonId",

--- a/app/components/filter/trackFilterChange.ts
+++ b/app/components/filter/trackFilterChange.ts
@@ -1,0 +1,21 @@
+import type { FilterValues } from "./filterTypes";
+import { trackStatsFilterChanged } from "@app/utils/analytics";
+import { FILTER_KEYS } from "./filterTypes";
+
+/**
+ * 絞り込みの変更を計測する。どの絞り込みが使われるかを見るため、
+ * 変更されたキーだけを 1 件ずつ送る（解除は値 null で送る）。
+ */
+export function trackFilterChanges(
+  previous: FilterValues,
+  next: FilterValues,
+): void {
+  for (const key of FILTER_KEYS) {
+    if (previous[key] !== next[key]) {
+      trackStatsFilterChanged({
+        filter_key: key,
+        filter_value: next[key] ?? null,
+      });
+    }
+  }
+}

--- a/app/components/notification/NotificationGroup.tsx
+++ b/app/components/notification/NotificationGroup.tsx
@@ -19,6 +19,7 @@ import {
   declinedGroupInvitation,
 } from "@app/services/groupInvitationsService";
 import { deleteNotification } from "@app/services/notificationsService";
+import { trackGroupJoined } from "@app/utils/analytics";
 
 interface NotificationGroupProps {
   notice: Notifications;
@@ -44,6 +45,7 @@ export default function NotificationGroup({
   const handleAcceptGroupInvitation = async (groupId: number, id: number) => {
     try {
       await acceptGroupInvitation(groupId);
+      trackGroupJoined(groupId);
       await deleteNotification(id);
       router.push(`/groups/${groupId}`);
     } catch (error) {

--- a/app/contexts/__tests__/proUpgradeModalContext.test.tsx
+++ b/app/contexts/__tests__/proUpgradeModalContext.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  ProUpgradeModalProvider,
+  useProUpgradeModal,
+} from "../proUpgradeModalContext";
+
+const mockCapture = jest.fn();
+jest.mock("@app/utils/posthog", () => ({
+  capture: (...args: unknown[]) => mockCapture(...args),
+}));
+
+jest.mock("@app/components/pro/ProUpgradeModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+function OpenButtons() {
+  const { open } = useProUpgradeModal();
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => open({ trigger: "pitch_type_average" })}
+      >
+        機能から開く
+      </button>
+      <button type="button" onClick={() => open()}>
+        CTA から開く
+      </button>
+    </>
+  );
+}
+
+const renderWithProvider = () =>
+  render(
+    <ProUpgradeModalProvider>
+      <OpenButtons />
+    </ProUpgradeModalProvider>,
+  );
+
+describe("Pro 訴求モーダルの計測", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("機能起点で開いたときは pro feature tapped をその機能名で送る", async () => {
+    const user = userEvent.setup();
+    renderWithProvider();
+
+    await user.click(screen.getByText("機能から開く"));
+
+    expect(mockCapture).toHaveBeenCalledWith("pro feature tapped", {
+      feature: "pitch_type_average",
+    });
+  });
+
+  it("機能非依存の CTA から開いたときは general として送る", async () => {
+    const user = userEvent.setup();
+    renderWithProvider();
+
+    await user.click(screen.getByText("CTA から開く"));
+
+    expect(mockCapture).toHaveBeenCalledWith("pro feature tapped", {
+      feature: "general",
+    });
+  });
+});

--- a/app/contexts/proUpgradeModalContext.tsx
+++ b/app/contexts/proUpgradeModalContext.tsx
@@ -5,6 +5,7 @@ import type { ProFeature } from "@app/types/pro";
 import type { ReactNode } from "react";
 import { createContext, useCallback, useContext, useState } from "react";
 import ProUpgradeModal from "@app/components/pro/ProUpgradeModal";
+import { trackProFeatureTapped } from "@app/utils/analytics";
 
 export interface OpenProUpgradeModalOptions {
   /** 表示時に「○○を使うには Pro 加入が必要」のコンテキスト訴求を出すための機能キー。 */
@@ -38,6 +39,9 @@ export function ProUpgradeModalProvider({ children }: { children: ReactNode }) {
   const [openCount, setOpenCount] = useState(0);
 
   const open = useCallback((options?: OpenProUpgradeModalOptions) => {
+    // Pro 訴求はここに集約されているため、どの機能が課金意向のきっかけかを一箇所で計測する。
+    // 機能非依存の CTA（LP など）は trigger を持たないため "general" として区別する。
+    trackProFeatureTapped(options?.trigger ?? "general");
     setTrigger(options?.trigger);
     setDefaultPlan(options?.defaultPlan);
     setOpenCount((prev) => prev + 1);

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { HeroUIProvider } from "@heroui/react";
 import { GoogleOAuthProvider } from "@react-oauth/google";
+import PostHogInit from "@app/components/analytics/PostHogInit";
 import { ProUpgradeModalProvider } from "@app/contexts/proUpgradeModalContext";
 
 if (!process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID) {
@@ -11,6 +12,7 @@ if (!process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID) {
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <HeroUIProvider>
+      <PostHogInit />
       <GoogleOAuthProvider
         clientId={process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || ""}
       >

--- a/app/utils/__tests__/analytics.test.ts
+++ b/app/utils/__tests__/analytics.test.ts
@@ -181,10 +181,34 @@ describe("analytics", () => {
   });
 
   describe("環境変数が未設定のとき", () => {
+    it("計測が無効になる", async () => {
+      const { posthog } = await loadModules();
+
+      expect(posthog.isPostHogEnabled()).toBe(false);
+    });
+
+    it("キーがあれば計測が有効になる", async () => {
+      const { posthog } = await loadModules("phc_test");
+
+      expect(posthog.isPostHogEnabled()).toBe(true);
+    });
+
     it("PostHog を初期化せず、外部通信も発生させない", async () => {
       await loadModules();
 
       expect(mockInit).not.toHaveBeenCalled();
+    });
+
+    it("無効な間に呼ばれた計測は、後から有効化されても送らない", async () => {
+      const { analytics, posthog } = await loadModules();
+
+      analytics.trackGroupJoined(1);
+
+      process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
+      posthog.initPostHog();
+      await flushMicrotasks();
+
+      expect(mockCapture).not.toHaveBeenCalled();
     });
 
     it("計測を呼んでもエラーにならず、イベントも送らない", async () => {

--- a/app/utils/__tests__/analytics.test.ts
+++ b/app/utils/__tests__/analytics.test.ts
@@ -1,0 +1,305 @@
+const mockInit = jest.fn();
+const mockCapture = jest.fn();
+const mockIdentify = jest.fn();
+const mockReset = jest.fn();
+
+jest.mock("posthog-js", () => ({
+  __esModule: true,
+  default: {
+    init: (...args: unknown[]) => mockInit(...args),
+    capture: (...args: unknown[]) => mockCapture(...args),
+    identify: (...args: unknown[]) => mockIdentify(...args),
+    reset: (...args: unknown[]) => mockReset(...args),
+  },
+}));
+
+import type * as AnalyticsNamespace from "@app/utils/analytics";
+import type * as PostHogNamespace from "@app/utils/posthog";
+
+type AnalyticsModule = typeof AnalyticsNamespace;
+type PostHogModule = typeof PostHogNamespace;
+
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
+ * 環境変数を差し替えたうえでモジュールを読み込み直す。
+ * key を渡さない場合はキー未設定の環境（開発 / CI / preview）を再現する。
+ */
+const loadModules = async (
+  key?: string,
+): Promise<{ analytics: AnalyticsModule; posthog: PostHogModule }> => {
+  jest.resetModules();
+  if (key) process.env.NEXT_PUBLIC_POSTHOG_KEY = key;
+  else delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  const posthog: PostHogModule = await import("@app/utils/posthog");
+  const analytics: AnalyticsModule = await import("@app/utils/analytics");
+  posthog.initPostHog();
+  await flushMicrotasks();
+  return { analytics, posthog };
+};
+
+/**
+ * mobile（buzzbase_mobile/utils/analytics.ts）が送っているイベント名とプロパティ。
+ * Web / アプリでファネルを横断集計するため、この表からずれてはならない。
+ */
+const MOBILE_EVENT_CASES: {
+  event: string;
+  properties: Record<string, unknown> | undefined;
+  run: (analytics: AnalyticsModule) => void;
+}[] = [
+  {
+    event: "sign up completed",
+    properties: { login_type: "google" },
+    run: (a) => a.trackSignUpCompleted("google"),
+  },
+  {
+    event: "user logged in",
+    properties: { login_type: "email" },
+    run: (a) => a.trackUserLoggedIn("email"),
+  },
+  {
+    event: "game record step viewed",
+    properties: { step: 2 },
+    run: (a) => a.trackGameRecordStepViewed(2),
+  },
+  {
+    event: "game record step viewed",
+    properties: { step: "summary" },
+    run: (a) => a.trackGameRecordStepViewed("summary"),
+  },
+  {
+    event: "game record completed",
+    properties: {
+      match_type: "regular",
+      appearance_type: "starter",
+      has_pitching: true,
+    },
+    run: (a) =>
+      a.trackGameRecordCompleted({
+        match_type: "regular",
+        appearance_type: "starter",
+        has_pitching: true,
+      }),
+  },
+  {
+    event: "plate appearance completed",
+    properties: { is_edit: false, has_pitcher: true, has_detail: false },
+    run: (a) =>
+      a.trackPlateAppearanceCompleted({
+        is_edit: false,
+        has_pitcher: true,
+        has_detail: false,
+      }),
+  },
+  {
+    event: "plate appearance canceled",
+    properties: { is_edit: true },
+    run: (a) => a.trackPlateAppearanceCanceled({ is_edit: true }),
+  },
+  {
+    event: "group created",
+    properties: { group_id: 12 },
+    run: (a) => a.trackGroupCreated(12),
+  },
+  {
+    event: "group joined",
+    properties: { group_id: 34 },
+    run: (a) => a.trackGroupJoined(34),
+  },
+  {
+    event: "user followed",
+    properties: { followed_user_id: 56 },
+    run: (a) => a.trackUserFollowed(56),
+  },
+  {
+    event: "profile updated",
+    properties: undefined,
+    run: (a) => a.trackProfileUpdated(),
+  },
+  {
+    event: "stats filter changed",
+    properties: { filter_key: "year", filter_value: "2026" },
+    run: (a) =>
+      a.trackStatsFilterChanged({ filter_key: "year", filter_value: "2026" }),
+  },
+  {
+    event: "batting trend granularity changed",
+    properties: { granularity: "season" },
+    run: (a) => a.trackBattingTrendGranularityChanged("season"),
+  },
+  {
+    event: "pro feature tapped",
+    properties: { feature: "hit_direction_average" },
+    run: (a) => a.trackProFeatureTapped("hit_direction_average"),
+  },
+];
+
+describe("analytics", () => {
+  const originalKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    if (originalKey) process.env.NEXT_PUBLIC_POSTHOG_KEY = originalKey;
+    else delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  });
+
+  describe("イベント名（mobile と共通）", () => {
+    it("mobile の utils/analytics.ts と同じイベント名を使う", async () => {
+      const { analytics } = await loadModules("phc_test");
+
+      expect(analytics.ANALYTICS_EVENTS).toEqual({
+        SIGN_UP_COMPLETED: "sign up completed",
+        USER_LOGGED_IN: "user logged in",
+        GAME_RECORD_STEP_VIEWED: "game record step viewed",
+        GAME_RECORD_COMPLETED: "game record completed",
+        PLATE_APPEARANCE_COMPLETED: "plate appearance completed",
+        PLATE_APPEARANCE_CANCELED: "plate appearance canceled",
+        GROUP_CREATED: "group created",
+        GROUP_JOINED: "group joined",
+        USER_FOLLOWED: "user followed",
+        PROFILE_UPDATED: "profile updated",
+        STATS_FILTER_CHANGED: "stats filter changed",
+        BATTING_TREND_GRANULARITY_CHANGED: "batting trend granularity changed",
+        PRO_FEATURE_TAPPED: "pro feature tapped",
+      });
+    });
+
+    it.each(MOBILE_EVENT_CASES)(
+      "$event を mobile と同じプロパティで送る",
+      async ({ event, properties, run }) => {
+        const { analytics } = await loadModules("phc_test");
+
+        run(analytics);
+
+        expect(mockCapture).toHaveBeenCalledTimes(1);
+        expect(mockCapture).toHaveBeenCalledWith(event, properties);
+      },
+    );
+  });
+
+  describe("環境変数が未設定のとき", () => {
+    it("PostHog を初期化せず、外部通信も発生させない", async () => {
+      await loadModules();
+
+      expect(mockInit).not.toHaveBeenCalled();
+    });
+
+    it("計測を呼んでもエラーにならず、イベントも送らない", async () => {
+      const { analytics, posthog } = await loadModules();
+
+      for (const testCase of MOBILE_EVENT_CASES) {
+        expect(() => testCase.run(analytics)).not.toThrow();
+      }
+      expect(() => posthog.identifyUser(1)).not.toThrow();
+      expect(() => posthog.resetUser()).not.toThrow();
+
+      expect(mockCapture).not.toHaveBeenCalled();
+      expect(mockIdentify).not.toHaveBeenCalled();
+      expect(mockReset).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("計測が失敗したとき", () => {
+    it("例外を投げず、呼び出し元の処理を止めない", async () => {
+      const { analytics } = await loadModules("phc_test");
+      mockCapture.mockImplementation(() => {
+        throw new Error("network down");
+      });
+
+      let continued = false;
+      expect(() => {
+        analytics.trackGroupCreated(1);
+        continued = true;
+      }).not.toThrow();
+
+      expect(continued).toBe(true);
+      mockCapture.mockReset();
+    });
+
+    it("identify / reset が失敗しても例外を投げない", async () => {
+      const { posthog } = await loadModules("phc_test");
+      mockIdentify.mockImplementation(() => {
+        throw new Error("boom");
+      });
+      mockReset.mockImplementation(() => {
+        throw new Error("boom");
+      });
+
+      expect(() => posthog.identifyUser(7)).not.toThrow();
+      expect(() => posthog.resetUser()).not.toThrow();
+
+      mockIdentify.mockReset();
+      mockReset.mockReset();
+    });
+  });
+
+  describe("個人情報", () => {
+    const FORBIDDEN_KEY = /mail|password|token|birth|phone|address|^name$/i;
+
+    it("イベントプロパティに個人情報を含めない", async () => {
+      const { analytics } = await loadModules("phc_test");
+
+      for (const testCase of MOBILE_EVENT_CASES) {
+        mockCapture.mockClear();
+        testCase.run(analytics);
+        const [, properties] = mockCapture.mock.calls[0] as [
+          string,
+          Record<string, unknown> | undefined,
+        ];
+        for (const [key, value] of Object.entries(properties ?? {})) {
+          expect(key).not.toMatch(FORBIDDEN_KEY);
+          // オブジェクトを丸ごと載せると意図せず個人情報が混ざるため、スカラーのみ許容する
+          expect(["string", "number", "boolean"]).toContain(
+            value === null ? "string" : typeof value,
+          );
+        }
+      }
+    });
+
+    it("ユーザー識別には不可逆な内部 ID だけを渡す", async () => {
+      const { posthog } = await loadModules("phc_test");
+
+      posthog.identifyUser(42);
+
+      expect(mockIdentify).toHaveBeenCalledWith("42");
+      expect(mockIdentify).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("初期化前のイベント", () => {
+    it("posthog-js のロード完了前に発生したイベントも取りこぼさない", async () => {
+      jest.resetModules();
+      process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
+      const posthog: PostHogModule = await import("@app/utils/posthog");
+      const analytics: AnalyticsModule = await import("@app/utils/analytics");
+
+      analytics.trackGameRecordStepViewed(1);
+      expect(mockCapture).not.toHaveBeenCalled();
+
+      posthog.initPostHog();
+      await flushMicrotasks();
+
+      expect(mockCapture).toHaveBeenCalledWith("game record step viewed", {
+        step: 1,
+      });
+    });
+  });
+
+  describe("初期化", () => {
+    it("PII を収集する自動計測を無効にして初期化する", async () => {
+      await loadModules("phc_test");
+
+      expect(mockInit).toHaveBeenCalledTimes(1);
+      const [apiKey, config] = mockInit.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
+      expect(apiKey).toBe("phc_test");
+      expect(config.autocapture).toBe(false);
+      expect(config.disable_session_recording).toBe(true);
+    });
+  });
+});

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -1,0 +1,88 @@
+import { capture } from "@app/utils/posthog";
+
+/**
+ * PostHog コンバージョンイベント名。
+ *
+ * **mobile（`buzzbase_mobile/utils/analytics.ts`）と同一の文字列で固定する。**
+ * 片方だけ改名すると Web / アプリのファネルが分断され、横断分析ができなくなる。
+ * 命名は object-verb（PostHog 慣例）。
+ */
+export const ANALYTICS_EVENTS = {
+  SIGN_UP_COMPLETED: "sign up completed",
+  USER_LOGGED_IN: "user logged in",
+  GAME_RECORD_STEP_VIEWED: "game record step viewed",
+  GAME_RECORD_COMPLETED: "game record completed",
+  PLATE_APPEARANCE_COMPLETED: "plate appearance completed",
+  PLATE_APPEARANCE_CANCELED: "plate appearance canceled",
+  GROUP_CREATED: "group created",
+  GROUP_JOINED: "group joined",
+  USER_FOLLOWED: "user followed",
+  PROFILE_UPDATED: "profile updated",
+  STATS_FILTER_CHANGED: "stats filter changed",
+  BATTING_TREND_GRANULARITY_CHANGED: "batting trend granularity changed",
+  PRO_FEATURE_TAPPED: "pro feature tapped",
+} as const;
+
+type LoginType = "email" | "google" | "apple";
+
+/** 試合記録フローのステップ。1: 試合情報 / 2: 打席 / 3: 投手成績 / summary: まとめ。 */
+export type GameRecordStep = 1 | 2 | 3 | "summary";
+
+export const trackSignUpCompleted = (loginType: LoginType) =>
+  capture(ANALYTICS_EVENTS.SIGN_UP_COMPLETED, { login_type: loginType });
+
+export const trackUserLoggedIn = (loginType: LoginType) =>
+  capture(ANALYTICS_EVENTS.USER_LOGGED_IN, { login_type: loginType });
+
+export const trackGameRecordStepViewed = (step: GameRecordStep) =>
+  capture(ANALYTICS_EVENTS.GAME_RECORD_STEP_VIEWED, { step });
+
+export const trackGameRecordCompleted = (props: {
+  match_type: string | null;
+  appearance_type: string;
+  has_pitching: boolean;
+}) => capture(ANALYTICS_EVENTS.GAME_RECORD_COMPLETED, props);
+
+export const trackGroupCreated = (groupId: number) =>
+  capture(ANALYTICS_EVENTS.GROUP_CREATED, { group_id: groupId });
+
+export const trackGroupJoined = (groupId: number) =>
+  capture(ANALYTICS_EVENTS.GROUP_JOINED, { group_id: groupId });
+
+export const trackUserFollowed = (followedUserId: number) =>
+  capture(ANALYTICS_EVENTS.USER_FOLLOWED, {
+    followed_user_id: followedUserId,
+  });
+
+export const trackProfileUpdated = () =>
+  capture(ANALYTICS_EVENTS.PROFILE_UPDATED);
+
+/**
+ * 打席記録ウィザードの作成 / 更新完了。`is_edit` で新規・編集を区別する。
+ * `has_pitcher` / `has_detail` は任意の詳細入力がどれだけ使われたかの計測用。
+ */
+export const trackPlateAppearanceCompleted = (props: {
+  is_edit: boolean;
+  has_pitcher: boolean;
+  has_detail: boolean;
+}) => capture(ANALYTICS_EVENTS.PLATE_APPEARANCE_COMPLETED, props);
+
+/** 打席記録ウィザードの途中離脱（完了せずに画面を離れた）。 */
+export const trackPlateAppearanceCanceled = (props: { is_edit: boolean }) =>
+  capture(ANALYTICS_EVENTS.PLATE_APPEARANCE_CANCELED, props);
+
+/** 成績画面のフィルター変更。どの絞り込みが使われるかの計測用。 */
+export const trackStatsFilterChanged = (props: {
+  filter_key: string;
+  filter_value: string | null;
+}) => capture(ANALYTICS_EVENTS.STATS_FILTER_CHANGED, props);
+
+/** 打撃成績推移グラフの粒度切替（試合 / 月 / 年 / シーズン）。 */
+export const trackBattingTrendGranularityChanged = (granularity: string) =>
+  capture(ANALYTICS_EVENTS.BATTING_TREND_GRANULARITY_CHANGED, {
+    granularity,
+  });
+
+/** Pro 訴求（Paywall / Coming Soon）の起動。課金意向シグナルとして計測する。 */
+export const trackProFeatureTapped = (feature: string) =>
+  capture(ANALYTICS_EVENTS.PRO_FEATURE_TAPPED, { feature });

--- a/app/utils/posthog.ts
+++ b/app/utils/posthog.ts
@@ -1,0 +1,121 @@
+import type { PostHog } from "posthog-js";
+
+/**
+ * 計測イベントに載せるプロパティ。
+ * 個人情報（メールアドレス・本名・生年月日・トークン）を載せないため、
+ * 値はスカラーのみに限定してオブジェクトの丸ごと送信を型で防ぐ。
+ */
+export type AnalyticsProperties = Record<
+  string,
+  string | number | boolean | null
+>;
+
+interface QueuedEvent {
+  event: string;
+  properties?: AnalyticsProperties;
+}
+
+const DEFAULT_API_HOST = "https://us.i.posthog.com";
+
+// posthog-js のロード完了前に発生したイベント（画面表示直後の step viewed など）を
+// 落とさないためのバッファ。ロードに失敗し続けてもメモリを食い潰さないよう上限を持つ。
+const MAX_QUEUED_EVENTS = 20;
+
+let client: PostHog | null = null;
+let isLoading = false;
+const queue: QueuedEvent[] = [];
+
+/**
+ * 計測が有効かどうか。
+ * キー未設定の環境（開発 / CI / preview）とサーバー側では常に false になり、
+ * posthog-js のロードもネットワークリクエストも一切発生しない。
+ */
+export function isPostHogEnabled(): boolean {
+  return typeof window !== "undefined" && !!process.env.NEXT_PUBLIC_POSTHOG_KEY;
+}
+
+function flushQueue(instance: PostHog): void {
+  while (queue.length > 0) {
+    const queued = queue.shift();
+    if (!queued) return;
+    try {
+      instance.capture(queued.event, queued.properties);
+    } catch {
+      // 計測層はアプリの動作を壊さない
+    }
+  }
+}
+
+/**
+ * PostHog クライアントを初期化する。ブラウザでのみ動作し、多重呼び出しは無視される。
+ * posthog-js は初回描画に不要なため動的 import で遅延ロードし、描画をブロックしない。
+ */
+export function initPostHog(): void {
+  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!isPostHogEnabled() || !apiKey || client !== null || isLoading) return;
+  isLoading = true;
+  void import("posthog-js")
+    .then(({ default: posthog }) => {
+      posthog.init(apiKey, {
+        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? DEFAULT_API_HOST,
+        defaults: "2025-05-24",
+        // 中高生ユーザーの PII 保護のため、DOM のテキストや入力値を自動収集する
+        // 機能（autocapture / セッションリプレイ）は全て無効にし、
+        // このリポジトリで明示的に定義したイベントだけを送る。
+        autocapture: false,
+        disable_session_recording: true,
+        disable_surveys: true,
+        capture_pageview: "history_change",
+        person_profiles: "identified_only",
+      });
+      client = posthog;
+      flushQueue(posthog);
+    })
+    .catch(() => {
+      // 計測ライブラリのロード失敗でアプリを壊さない
+    })
+    .finally(() => {
+      isLoading = false;
+    });
+}
+
+/**
+ * イベントを 1 件送信する。
+ * 無効時（キー未設定 / サーバー側）は完全な no-op で、失敗しても例外を投げない。
+ */
+export function capture(event: string, properties?: AnalyticsProperties): void {
+  if (!isPostHogEnabled()) return;
+  try {
+    if (client === null) {
+      if (queue.length < MAX_QUEUED_EVENTS) queue.push({ event, properties });
+      return;
+    }
+    client.capture(event, properties);
+  } catch {
+    // 計測の失敗で呼び出し元の処理（保存・画面遷移）を止めない
+  }
+}
+
+/**
+ * ログイン中ユーザーを PostHog に紐付ける。
+ * 名前やメールアドレスは渡さず、mobile と同じ内部 ID のみを識別子に使う
+ * （Web / アプリで同一ユーザーとして集計するため）。
+ */
+export function identifyUser(userId: number): void {
+  if (!isPostHogEnabled()) return;
+  try {
+    client?.identify(String(userId));
+  } catch {
+    // 計測の失敗で呼び出し元の処理を止めない
+  }
+}
+
+/** ログアウト時に識別情報を破棄し、以降を匿名ユーザーとして扱う。 */
+export function resetUser(): void {
+  if (!isPostHogEnabled()) return;
+  try {
+    client?.reset();
+  } catch {
+    // 計測の失敗で呼び出し元の処理を止めない
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "jsonwebtoken": "^9.0.2",
     "next": "^16.2.6",
     "next-sitemap": "^4.2.3",
+    "posthog-js": "^1.409.5",
     "react": "^19.2.6",
     "react-anchor-link-smooth-scroll": "^1.0.12",
     "react-dom": "^19.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2551,6 +2551,26 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
+"@posthog/browser-common@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.3.1.tgz#5c1aa9ba11878c8a4ca566bc3ac4a261701c9c74"
+  integrity sha512-1nhMVY1wnHADTg8tR9yvm+lPAz5ROxznfQlBtLzB2FFo4lp/LU8lk9KyFPsARDkBxCfYachsJfvRjocL1G/AJQ==
+  dependencies:
+    "@posthog/core" "^1.46.0"
+    "@posthog/types" "^1.399.0"
+
+"@posthog/core@^1.46.0", "@posthog/core@^1.46.1":
+  version "1.46.1"
+  resolved "https://registry.npmjs.org/@posthog/core/-/core-1.46.1.tgz#a8cf3a32806eff1fe0b8606ecc680142ca360d3d"
+  integrity sha512-EoCFduRkvrg9E5ylMi4QnZCjlAdRJCq6tJouWfngBVR79XSI4iPvIWYA+CdzokAjk+TfSVBFVJ++4Im3r+T0Dg==
+  dependencies:
+    "@posthog/types" "^1.399.0"
+
+"@posthog/types@^1.399.0":
+  version "1.399.0"
+  resolved "https://registry.npmjs.org/@posthog/types/-/types-1.399.0.tgz#96248f0822fa3a1c38b1882d04a77bf5349c08fe"
+  integrity sha512-/WDwBzqIPko8VJ1B+0rlso2XQEz9+2sqtsY9Tqy3p1GhgTqsFakcz/PmMpAnA321LTEZVRcO6x5hAwABV4yrDw==
+
 "@prisma/instrumentation@7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@prisma/instrumentation/-/instrumentation-7.2.0.tgz#9409a436d8f98e8950c8659aeeba045c4a07e891"
@@ -4695,6 +4715,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
@@ -5677,6 +5702,11 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+core-js@^3.49.0:
+  version "3.49.0"
+  resolved "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz#8b4d520ac034311fa21aa616f017ada0e0dbbddd"
+  integrity sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==
+
 cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -5998,6 +6028,13 @@ dom-accessibility-api@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
   integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
+
+dompurify@^3.3.2:
+  version "3.4.12"
+  resolved "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz#6fa2265e9bbdce882c4ace4107626051b448ffa8"
+  integrity sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 dotenv@^16.3.1:
   version "16.6.1"
@@ -6643,6 +6680,11 @@ fdir@^6.2.0, fdir@^6.5.0:
   version "6.5.0"
   resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
+
+fflate@^0.4.8:
+  version "0.4.9"
+  resolved "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz#b5d1fd9776e4d3cbcd1a83a1f163b984a0972e21"
+  integrity sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==
 
 file-entry-cache@^8.0.0:
   version "8.0.0"
@@ -9444,6 +9486,26 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
+posthog-js@^1.409.5:
+  version "1.409.5"
+  resolved "https://registry.npmjs.org/posthog-js/-/posthog-js-1.409.5.tgz#bae95dec159f6b5785efe0498a9f1e3eeb7e5296"
+  integrity sha512-s1iJz+vq0YAluUD4OwLjUFIJt/9pqiiB6MITvHWIS16a7pqTJqbSLXsd5/8kJcIgfrOSZHe+mdYAXLYcJCS4LQ==
+  dependencies:
+    "@posthog/browser-common" "^0.3.1"
+    "@posthog/core" "^1.46.1"
+    "@posthog/types" "^1.399.0"
+    core-js "^3.49.0"
+    dompurify "^3.3.2"
+    fflate "^0.4.8"
+    preact "^10.29.3"
+    query-selector-shadow-dom "^1.0.1"
+    web-vitals "^5.3.0"
+
+preact@^10.29.3:
+  version "10.29.8"
+  resolved "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz#fc85b82dc2474e245b1430b51781d417361f5fc3"
+  integrity sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
@@ -9510,6 +9572,11 @@ pure-rand@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-7.0.1.tgz#6f53a5a9e3e4a47445822af96821ca509ed37566"
   integrity sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==
+
+query-selector-shadow-dom@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz#1c7b0058eff4881ac44f45d8f84ede32e9a2f349"
+  integrity sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -10959,6 +11026,11 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+web-vitals@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz#a67f57f229fdf68be99eb99d3725946def284ff3"
+  integrity sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#496

## 概要

front には PostHog 依存も計測コードも無く、Web 側のファネル（試合記録ステップ離脱率、打席詳細入力の利用率、グループ参加率）が計測できませんでした。**mobile の `utils/analytics.ts` とイベント名・プロパティを 1:1 で揃えて**導入します。

イベント名が揃っていないと分析が分断されるため、**イベント名は定数化してテストで固定**しています。

## イベント対応表（mobile と完全一致）

| イベント名 | プロパティ | front 設置箇所 |
| --- | --- | --- |
| `sign up completed` | `login_type` | `SignUpCompletionTracker`(email) / `GoogleLoginButton`(google) |
| `user logged in` | `login_type` | `SignIn`(email) / `GoogleLoginButton`(google) |
| `game record step viewed` | `step` (1/2/3/"summary") | 試合記録4画面 |
| `game record completed` | `match_type` / `appearance_type` / `has_pitching` | `summary/page.tsx` |
| `plate appearance completed` | `is_edit` / `has_pitcher` / `has_detail` | `PlateAppearanceWizard` |
| `plate appearance canceled` | `is_edit` | 同上（未完了アンマウント時） |
| `group created` | `group_id` | `groups/new` |
| `group joined` | `group_id` | `groups/join`（招待コード）+ `NotificationGroup`（招待承認） |
| `user followed` | `followed_user_id` | `FollowButton` |
| `profile updated` | — | `mypage/edit` |
| `stats filter changed` | `filter_key` / `filter_value` | `StatsContainer` / `AnalysisContainer` |
| `batting trend granularity changed` | `granularity` | `AnalysisContainer` |
| `pro feature tapped` | `feature` | `proUpgradeModalContext.open()` |

mobile と同様に `identify(String(user.id))` / `reset()` も実装し、**Web とアプリで同一ユーザーとして集計**できます。

## プライバシー設計

- **`NEXT_PUBLIC_POSTHOG_KEY` が未設定なら posthog-js の動的 import 自体が走りません。** ネットワークリクエスト0・`init` も呼ばれず、`capture` / `identify` / `reset` は完全 no-op です（開発・CI・preview で外部通信が発生しません）
- `autocapture: false` / `disable_session_recording: true` / `disable_surveys: true` / `person_profiles: "identified_only"` で **DOM テキスト由来の PII 収集を全て遮断**
- 識別子は内部数値 ID のみ。メールアドレス・本名・生年月日・トークンはプロパティに含めていません
- `capture()` は try/catch で包み、計測の失敗が呼び出し元の処理を止めません

## ⚠️ レビューで必ず確認いただきたい点

### 1. `yarn.lock` を手動マージしています（最重要）

`node_modules` が共有ディレクトリへのシンボリックリンクのため、本体の `package.json` / `yarn.lock` を書き換える `yarn add` を実行できませんでした。代わりに:

1. 別ディレクトリで `yarn add posthog-js` を実行して依存を解決
2. **lock エントリだけを既存の並びを一切動かさずアルファベット順に挿入**（+72行の追記のみ、既存行の変更ゼロ）

**CI は `yarn install --frozen-lockfile` なので、ここが通るかが本 PR の最大の確認ポイントです。** Build Check の結果を必ず確認してください。

なお新規エントリの `resolved` URL は `registry.npmjs.org`（既存行は `registry.yarnpkg.com`）ですが、tarball と integrity は同一です。

### 2. `capture_pageview: "history_change"` により URL が送信されます

`/mypage/{公開ハンドル}` などの URL が PostHog に送られます。公開ハンドルなので PII ではないと判断しましたが、**行動と識別子の紐付けを避けたい場合は無効化してください**。

### 3. `pro feature tapped` の `feature` の値域が mobile と異なります

front は Pro 訴求の唯一の入口である `ProUpgradeModalProvider.open()` に集約したため、値が `ProFeature` キー（`hit_direction_average` 等）になります。mobile は個別カードのタップ位置で送るため `hit_direction` 等です。**値も揃えるなら変換表が必要**です。分析時にこの差を認識できるようご確認ください。

### 4. `stats filter changed` を2箇所に入れています

front は同一画面に成績テーブル用と分析用の2系統のフィルタがあるため両方に入れました。片方に絞る判断もあり得ます。

## その他の補足

- `plate appearance canceled` はアンマウント時発火のため、開発の StrictMode では二重発火し得ます（開発環境はキー未設定で no-op のため実害なしと判断）
- `game record completed` の `appearance_type` は match_result 未取得時 `"starter"` にフォールバック（mobile ストアの既定値と同じ）

## 環境変数

| 変数 | 既定 | 未設定時 |
| --- | --- | --- |
| `NEXT_PUBLIC_POSTHOG_KEY` | — | 計測を完全に無効化（外部通信なし） |
| `NEXT_PUBLIC_POSTHOG_HOST` | `https://us.i.posthog.com` | 既定値を使用 |

README の環境変数表にも追記済みです。

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る（error 0 / warning 0）
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（**106 suites / 1072 tests**。+10 suites / +51 tests）
- [ ] `yarn build` — **CI の Build Check で `--frozen-lockfile` が通るかを必ず確認**
- [x] ミューテーションテスト **23 設計 / 23 KILLED / 0 SURVIVED**

<details>
<summary>ミューテーションテスト詳細</summary>

別ディレクトリの複製で実施（無改変で全通過を事前確認済み。作業ツリーは未改変）。

次元別: イベント名の改名 4 / プロパティキーの改変 4 / 環境変数ガードの除去 2 / try/catch の除去 2 / 計測呼び出しの削除 6 / 個人情報の混入 2 / 計測内容・タイミングの改変 3

**初回ラウンドで3件が SURVIVED**（`isPostHogEnabled` からキー判定を削除 / `capture` の有効判定を削除 / `hasDetailInput` から pitcher 判定を削除）→ テストを4本追加して全て KILLED にしました。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_