### PR TITLE
Add: 練習ドメインの型・定数・APIサービス層を整備

### DIFF
--- a/app/constants/__tests__/practice.test.ts
+++ b/app/constants/__tests__/practice.test.ts
@@ -1,0 +1,246 @@
+import { MENU_SET_FREE_LIMIT } from "../menuSet";
+import {
+  CONDITION_MOODS,
+  INJURY_PARTS,
+  PRACTICE_CATEGORIES,
+  PRACTICE_CATEGORY_ICONS,
+  PRACTICE_MENU_FREE_LIMIT,
+  PRACTICE_UNITS,
+  SHADOW_SWING_ICON,
+  categoryLabel,
+  formatPracticeValue,
+  formatTotalAmount,
+  formatVolume,
+  isWeightReps,
+  parseDecimal,
+  practiceIconForLog,
+  unitLabel,
+} from "../practice";
+
+describe("練習ドメインの定数（back との一致を固定する）", () => {
+  it("カテゴリは back の PracticeMenu::CATEGORIES と同じ8種を同順で持つ", () => {
+    expect(PRACTICE_CATEGORIES.map((item) => item.key)).toEqual([
+      "batting",
+      "pitching",
+      "defense",
+      "baserunning",
+      "training",
+      "strength",
+      "care",
+      "other",
+    ]);
+  });
+
+  it("単位は back の PracticeMenu::UNITS と同じ4種を同順で持つ", () => {
+    expect(PRACTICE_UNITS.map((item) => item.key)).toEqual([
+      "count",
+      "minutes",
+      "distance",
+      "weight_reps",
+    ]);
+  });
+
+  it("カテゴリ全種にアイコンが定義されている", () => {
+    PRACTICE_CATEGORIES.forEach((item) => {
+      expect(PRACTICE_CATEGORY_ICONS[item.key]).toBeDefined();
+    });
+    expect(Object.keys(PRACTICE_CATEGORY_ICONS)).toHaveLength(8);
+  });
+
+  it("気分の選択肢は3種", () => {
+    expect(CONDITION_MOODS).toEqual(["好調", "普通", "不調"]);
+  });
+
+  it("怪我部位のプリセットは8種", () => {
+    expect(INJURY_PARTS).toEqual([
+      "肩",
+      "肘",
+      "手首",
+      "腰",
+      "股関節",
+      "膝",
+      "足首",
+      "その他",
+    ]);
+  });
+
+  it("無料プランの上限は back の PlanLimits と一致する", () => {
+    expect(PRACTICE_MENU_FREE_LIMIT).toBe(3);
+    expect(MENU_SET_FREE_LIMIT).toBe(2);
+  });
+
+  it("カテゴリ・単位のラベルを引ける", () => {
+    expect(categoryLabel("strength")).toBe("筋トレ");
+    expect(unitLabel("weight_reps")).toBe("重さ×回数");
+  });
+
+  it("重さ×回数のメニューだけ weight_reps と判定する", () => {
+    expect(isWeightReps("weight_reps")).toBe(true);
+    expect(isWeightReps("count")).toBe(false);
+    expect(isWeightReps("minutes")).toBe(false);
+    expect(isWeightReps("distance")).toBe(false);
+  });
+});
+
+describe("parseDecimal", () => {
+  it("back が文字列で返す decimal を数値に変換する", () => {
+    expect(parseDecimal("200.0")).toBe(200);
+    expect(parseDecimal("7.5")).toBe(7.5);
+    expect(parseDecimal(0)).toBe(0);
+    expect(parseDecimal(-1.5)).toBe(-1.5);
+  });
+
+  it("未入力・数値化できない値は null にして 0 と区別する", () => {
+    expect(parseDecimal(null)).toBeNull();
+    expect(parseDecimal(undefined)).toBeNull();
+    expect(parseDecimal("")).toBeNull();
+    expect(parseDecimal("abc")).toBeNull();
+  });
+});
+
+describe("formatPracticeValue", () => {
+  it("重さがある記録は「60kg × 10回」形式にする", () => {
+    expect(
+      formatPracticeValue({ amount: 10, weight: 60, unit_label: "回" }),
+    ).toBe("60kg × 10回");
+  });
+
+  it("back が文字列で返す decimal でも小数の余りを出さない", () => {
+    expect(
+      formatPracticeValue({ amount: "10.0", weight: "60.0", unit_label: "回" }),
+    ).toBe("60kg × 10回");
+  });
+
+  it("重さがある記録の回数の単位は unit_label に依らず「回」で固定する", () => {
+    expect(
+      formatPracticeValue({ amount: 8, weight: 70, unit_label: "セット" }),
+    ).toBe("70kg × 8回");
+  });
+
+  it("重さがあり回数が未入力なら 0回として表示する", () => {
+    expect(
+      formatPracticeValue({ amount: null, weight: 60, unit_label: "回" }),
+    ).toBe("60kg × 0回");
+  });
+
+  it("重さが 0 でも重さありとして扱う", () => {
+    expect(
+      formatPracticeValue({ amount: 10, weight: 0, unit_label: "回" }),
+    ).toBe("0kg × 10回");
+  });
+
+  it("重さが無い記録は単位ラベルを付けて返す", () => {
+    expect(
+      formatPracticeValue({ amount: 200, weight: null, unit_label: "本" }),
+    ).toBe("200本");
+  });
+
+  it("量が 0 でも空文字にはしない", () => {
+    expect(
+      formatPracticeValue({ amount: 0, weight: null, unit_label: "本" }),
+    ).toBe("0本");
+  });
+
+  it("単位ラベルが無ければ数値だけ返す", () => {
+    expect(
+      formatPracticeValue({ amount: 30, weight: null, unit_label: null }),
+    ).toBe("30");
+  });
+
+  it("量も重さも無い記録は空文字にする", () => {
+    expect(
+      formatPracticeValue({ amount: null, weight: null, unit_label: "本" }),
+    ).toBe("");
+  });
+});
+
+describe("formatTotalAmount", () => {
+  it("3桁区切りで単位ラベルを付ける", () => {
+    expect(formatTotalAmount(12400, "本")).toBe("12,400本");
+  });
+
+  it("3桁区切りの境目", () => {
+    expect(formatTotalAmount(999, "本")).toBe("999本");
+    expect(formatTotalAmount(1000, "本")).toBe("1,000本");
+  });
+
+  it("0 と負値も区切って返す", () => {
+    expect(formatTotalAmount(0, "本")).toBe("0本");
+    expect(formatTotalAmount(-1234, "本")).toBe("-1,234本");
+  });
+
+  it("小数は小数第3位まで残す", () => {
+    expect(formatTotalAmount(1234.5, "km")).toBe("1,234.5km");
+    expect(formatTotalAmount(1234.5678, "km")).toBe("1,234.568km");
+  });
+
+  it("巨大値も区切って返す", () => {
+    expect(formatTotalAmount(123456789, "本")).toBe("123,456,789本");
+  });
+
+  it("単位ラベルが無ければ数値だけ返す", () => {
+    expect(formatTotalAmount(500, null)).toBe("500");
+  });
+
+  it("未入力は 0 として扱う", () => {
+    expect(formatTotalAmount(null, "本")).toBe("0本");
+    expect(formatTotalAmount(undefined, "本")).toBe("0本");
+  });
+});
+
+describe("formatVolume", () => {
+  it("1000kg 未満は kg 表記のまま", () => {
+    expect(formatVolume(0)).toBe("0kg");
+    expect(formatVolume(640)).toBe("640kg");
+    expect(formatVolume(999)).toBe("999kg");
+    expect(formatVolume(999.9)).toBe("999.9kg");
+  });
+
+  it("1000kg ちょうどから t 表記に切り替わる", () => {
+    expect(formatVolume(999.999)).toBe("999.999kg");
+    expect(formatVolume(1000)).toBe("1t");
+  });
+
+  it("t 表記は小数第1位まで（四捨五入）", () => {
+    expect(formatVolume(1049)).toBe("1t");
+    expect(formatVolume(1050)).toBe("1.1t");
+    expect(formatVolume(8200)).toBe("8.2t");
+    expect(formatVolume(8250)).toBe("8.3t");
+  });
+
+  it("巨大値は t 表記のまま3桁区切りにする", () => {
+    expect(formatVolume(1234567)).toBe("1,234.6t");
+  });
+
+  it("負値は t に切り替えず kg 表記のまま", () => {
+    expect(formatVolume(-500)).toBe("-500kg");
+    expect(formatVolume(-1000)).toBe("-1,000kg");
+  });
+
+  it("back が文字列で返す decimal も扱える", () => {
+    expect(formatVolume("1200.0")).toBe("1.2t");
+  });
+
+  it("未入力は 0kg として扱う", () => {
+    expect(formatVolume(null)).toBe("0kg");
+  });
+});
+
+describe("practiceIconForLog", () => {
+  it("素振りのログはカテゴリに依らず専用アイコンにする", () => {
+    expect(practiceIconForLog("shadow_swing", "care")).toBe(SHADOW_SWING_ICON);
+    expect(SHADOW_SWING_ICON).not.toBe(PRACTICE_CATEGORY_ICONS.batting);
+  });
+
+  it("手入力のログはカテゴリのアイコンを使う", () => {
+    expect(practiceIconForLog("manual", "strength")).toBe(
+      PRACTICE_CATEGORY_ICONS.strength,
+    );
+  });
+
+  it("カテゴリ不明（メニュー削除済み）は「その他」にフォールバックする", () => {
+    expect(practiceIconForLog("manual", undefined)).toBe(
+      PRACTICE_CATEGORY_ICONS.other,
+    );
+  });
+});

--- a/app/constants/menuSet.ts
+++ b/app/constants/menuSet.ts
@@ -1,0 +1,2 @@
+// back/app/models/concerns/plan_limits.rb の MENU_SET_FREE_LIMIT と一致させる。
+export const MENU_SET_FREE_LIMIT = 2;

--- a/app/constants/practice.ts
+++ b/app/constants/practice.ts
@@ -1,0 +1,183 @@
+import type {
+  DecimalValue,
+  PracticeCategory,
+  PracticeLogSource,
+  PracticeUnit,
+} from "@app/types/practice";
+import type { ComponentType, SVGProps } from "react";
+import ArrowTrendingUpIcon from "@heroicons/react/24/outline/ArrowTrendingUpIcon";
+import BoltIcon from "@heroicons/react/24/outline/BoltIcon";
+import EllipsisHorizontalCircleIcon from "@heroicons/react/24/outline/EllipsisHorizontalCircleIcon";
+import FireIcon from "@heroicons/react/24/outline/FireIcon";
+import HandRaisedIcon from "@heroicons/react/24/outline/HandRaisedIcon";
+import HeartIcon from "@heroicons/react/24/outline/HeartIcon";
+import ScaleIcon from "@heroicons/react/24/outline/ScaleIcon";
+import ShieldCheckIcon from "@heroicons/react/24/outline/ShieldCheckIcon";
+import SolidBoltIcon from "@heroicons/react/24/solid/BoltIcon";
+
+// back/app/models/concerns/plan_limits.rb の PRACTICE_MENU_FREE_LIMIT と一致させる。
+export const PRACTICE_MENU_FREE_LIMIT = 3;
+
+/**
+ * 数値の整形は実行環境のロケールに依存させない。
+ * Server Component / Server Action は Vercel のロケール未定なコンテナで動くため、
+ * 既定ロケールに任せると桁区切りが環境ごとにぶれる（"12,400" / "12.400"）。
+ */
+const NUMBER_LOCALE = "ja-JP";
+
+/** カテゴリの表示ラベル。key は back の PracticeMenu::CATEGORIES と完全一致させる。 */
+export const PRACTICE_CATEGORIES: ReadonlyArray<{
+  key: PracticeCategory;
+  label: string;
+}> = [
+  { key: "batting", label: "バッティング" },
+  { key: "pitching", label: "投手" },
+  { key: "defense", label: "守備" },
+  { key: "baserunning", label: "走塁" },
+  { key: "training", label: "トレーニング" },
+  { key: "strength", label: "筋トレ" },
+  { key: "care", label: "ケア" },
+  { key: "other", label: "その他" },
+];
+
+/**
+ * 単位マスタ。key は back の PracticeMenu::UNITS と完全一致させる。
+ * defaultLabel はメニュー作成時に unit_label 未入力だった場合の既定表記、
+ * placeholderValue は量の入力欄に出す例示値。
+ */
+export const PRACTICE_UNITS: ReadonlyArray<{
+  key: PracticeUnit;
+  label: string;
+  defaultLabel: string;
+  placeholderValue: string;
+}> = [
+  { key: "count", label: "回数", defaultLabel: "本", placeholderValue: "200" },
+  { key: "minutes", label: "時間", defaultLabel: "分", placeholderValue: "30" },
+  { key: "distance", label: "距離", defaultLabel: "km", placeholderValue: "5" },
+  {
+    key: "weight_reps",
+    label: "重さ×回数",
+    defaultLabel: "回",
+    placeholderValue: "10",
+  },
+];
+
+/** カテゴリごとのアイコン。一覧・詳細でメニューの種類を見分けやすくする。 */
+export const PRACTICE_CATEGORY_ICONS: Readonly<
+  Record<PracticeCategory, ComponentType<SVGProps<SVGSVGElement>>>
+> = {
+  batting: BoltIcon,
+  pitching: HandRaisedIcon,
+  defense: ShieldCheckIcon,
+  baserunning: ArrowTrendingUpIcon,
+  training: FireIcon,
+  strength: ScaleIcon,
+  care: HeartIcon,
+  other: EllipsisHorizontalCircleIcon,
+};
+
+/** 気分の選択肢。back は自由文字列カラムのため、選択肢は front / mobile 側で揃える。 */
+export const CONDITION_MOODS: ReadonlyArray<string> = ["好調", "普通", "不調"];
+
+/** 故障箇所のプリセット。back は jsonb の自由文字列のため、入力補助としてのみ使う。 */
+export const INJURY_PARTS: ReadonlyArray<string> = [
+  "肩",
+  "肘",
+  "手首",
+  "腰",
+  "股関節",
+  "膝",
+  "足首",
+  "その他",
+];
+
+/** カテゴリの表示ラベルを返す。未知の値はそのまま返して情報を落とさない。 */
+export const categoryLabel = (category: PracticeCategory): string =>
+  PRACTICE_CATEGORIES.find((item) => item.key === category)?.label ?? category;
+
+/** 単位の表示ラベルを返す。未知の値はそのまま返して情報を落とさない。 */
+export const unitLabel = (unit: PracticeUnit): string =>
+  PRACTICE_UNITS.find((item) => item.key === unit)?.label ?? unit;
+
+/** 筋トレ（重さ×回数）の計測かどうか。 */
+export const isWeightReps = (unit: PracticeUnit): boolean =>
+  unit === "weight_reps";
+
+/**
+ * back が文字列で返す decimal 値を数値へ変換する。
+ * 数値化できない値（null / 空文字 / 非数）は null を返し、
+ * 表示側が「未入力」と「0」を取り違えないようにする。
+ */
+export const parseDecimal = (
+  value: DecimalValue | null | undefined,
+): number | null => {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+/**
+ * 練習量1件を表示用に整形する。
+ * 重さがある記録（筋トレ）は「60kg × 10回」、それ以外は「200本」のように返す。
+ * 量も重さも無い記録は空文字を返す。
+ *
+ * 重さがある場合の回数の単位は、unit_label に依らず「回」で固定する（mobile と表示を揃えるため）。
+ */
+export const formatPracticeValue = (log: {
+  amount: DecimalValue | null;
+  weight: DecimalValue | null;
+  unit_label: string | null;
+}): string => {
+  const amount = parseDecimal(log.amount);
+  const weight = parseDecimal(log.weight);
+  const reps = amount === null ? "" : String(amount);
+
+  if (weight !== null) return `${weight}kg × ${reps || "0"}回`;
+  if (amount === null) return "";
+  return `${reps}${log.unit_label ?? ""}`;
+};
+
+/**
+ * 積み上げの量を「12,400本」のように整形する。
+ * 単位ラベルが無いメニューは数値のみを返す。
+ */
+export const formatTotalAmount = (
+  amount: DecimalValue | null | undefined,
+  unitLabelText: string | null,
+): string =>
+  `${(parseDecimal(amount) ?? 0).toLocaleString(NUMBER_LOCALE)}${unitLabelText ?? ""}`;
+
+/**
+ * 総挙上重量を「8.2t」「640kg」のように整形する。
+ * 1000kg 以上は t 表記（小数第1位まで）、それ未満は kg 表記にする。
+ */
+export const formatVolume = (kg: DecimalValue | null | undefined): string => {
+  const value = parseDecimal(kg) ?? 0;
+  if (value >= 1000) {
+    return `${(value / 1000).toLocaleString(NUMBER_LOCALE, {
+      maximumFractionDigits: 1,
+    })}t`;
+  }
+  return `${value.toLocaleString(NUMBER_LOCALE)}kg`;
+};
+
+/**
+ * 素振り自動ログのアイコン。
+ * バッティングと同系のモチーフを塗りつぶしで使い分け、手入力の記録と見分けられるようにする。
+ */
+export const SHADOW_SWING_ICON: ComponentType<SVGProps<SVGSVGElement>> =
+  SolidBoltIcon;
+
+/**
+ * 練習ログのアイコンを決める。素振りは専用アイコン、それ以外はメニューのカテゴリで振り分ける。
+ * category が不明（メニュー削除済みなど）の場合は「その他」のアイコンにフォールバックする。
+ */
+export const practiceIconForLog = (
+  source: PracticeLogSource,
+  category: PracticeCategory | undefined,
+): ComponentType<SVGProps<SVGSVGElement>> => {
+  if (source === "shadow_swing") return SHADOW_SWING_ICON;
+  return category
+    ? PRACTICE_CATEGORY_ICONS[category]
+    : PRACTICE_CATEGORY_ICONS.other;
+};

--- a/app/services/v2/__tests__/practiceServices.test.ts
+++ b/app/services/v2/__tests__/practiceServices.test.ts
@@ -1,0 +1,538 @@
+const mockGet = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(() => Promise.resolve({ get: mockGet })),
+}));
+
+jest.mock("@app/constants/api", () => ({
+  RAILS_API_URL: "http://back:3000",
+}));
+
+jest.mock("../../../../lib/sentry-helpers", () => ({
+  captureServerActionError: jest.fn(),
+}));
+
+import {
+  createMenuSet,
+  deleteMenuSet,
+  getMenuSet,
+  getMenuSets,
+  updateMenuSet,
+} from "../menuSetService";
+import {
+  createPracticeLog,
+  deletePracticeLog,
+  getPracticeLogs,
+} from "../practiceLogService";
+import {
+  createPracticeMenu,
+  deletePracticeMenu,
+  getPracticeMenus,
+  updatePracticeMenu,
+} from "../practiceMenuService";
+import {
+  deletePracticeSession,
+  getPracticeSession,
+  getPracticeSessionByDate,
+  getPracticeSessions,
+  upsertPracticeSession,
+} from "../practiceSessionService";
+import {
+  getMenuSummaries,
+  getMenuTrend,
+  getPracticeOverview,
+} from "../practiceSummaryService";
+
+function setupAuthCookies() {
+  mockGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: "test-uid" },
+    };
+    return values[key];
+  });
+}
+
+function mockResponse(status: number, body: unknown) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+function requestedUrl(callIndex = 0): string {
+  return (global.fetch as jest.Mock).mock.calls[callIndex][0] as string;
+}
+
+function requestedInit(callIndex = 0): RequestInit {
+  return (global.fetch as jest.Mock).mock.calls[callIndex][1] as RequestInit;
+}
+
+const practiceMenu = {
+  id: 1,
+  name: "素振り",
+  category: "batting",
+  unit: "count",
+  unit_label: "本",
+  default_value: "200.0",
+  is_favorite: true,
+  sort_order: 0,
+};
+
+describe("練習ドメインの v2 Server Actions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    setupAuthCookies();
+  });
+
+  describe("認証ヘッダー", () => {
+    it("3トークンを付けて no-store で叩く", async () => {
+      mockResponse(200, []);
+      await getPracticeMenus();
+
+      expect(requestedInit()).toEqual(
+        expect.objectContaining({
+          cache: "no-store",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            "access-token": "test-access-token",
+            client: "test-client",
+            uid: "test-uid",
+          }),
+        }),
+      );
+    });
+
+    it("Cookie が欠けていればリクエストせず error を返す", async () => {
+      mockGet.mockReturnValue(undefined);
+
+      const result = await getPracticeMenus();
+
+      expect(result).toEqual({ status: "error" });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("Cookie が欠けている更新系はリクエストせず失敗を返す", async () => {
+      mockGet.mockReturnValue(undefined);
+
+      const result = await createPracticeMenu({
+        name: "ティー",
+        category: "batting",
+        unit: "count",
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        reason: "error",
+        errors: ["ログインが必要です"],
+      });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getPracticeMenus", () => {
+    it("メニュー一覧を取得する", async () => {
+      mockResponse(200, [practiceMenu]);
+
+      const result = await getPracticeMenus();
+
+      expect(result).toEqual({ status: "ok", data: [practiceMenu] });
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/practice_menus");
+    });
+
+    it("0件は error ではなく空配列の ok として返す", async () => {
+      mockResponse(200, []);
+
+      expect(await getPracticeMenus()).toEqual({ status: "ok", data: [] });
+    });
+
+    it("500 は error を返す", async () => {
+      mockResponse(500, { errors: ["失敗"] });
+
+      expect(await getPracticeMenus()).toEqual({ status: "error" });
+    });
+
+    it("通信例外は error を返す", async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("network"));
+
+      expect(await getPracticeMenus()).toEqual({ status: "error" });
+    });
+  });
+
+  describe("createPracticeMenu", () => {
+    it("practice_menu でラップして POST する", async () => {
+      mockResponse(201, practiceMenu);
+
+      const result = await createPracticeMenu({
+        name: "ティー",
+        category: "batting",
+        unit: "count",
+        unit_label: "球",
+        default_value: 150,
+      });
+
+      expect(result).toEqual({ ok: true, data: practiceMenu });
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/practice_menus");
+      expect(requestedInit().method).toBe("POST");
+      expect(JSON.parse(requestedInit().body as string)).toEqual({
+        practice_menu: {
+          name: "ティー",
+          category: "batting",
+          unit: "count",
+          unit_label: "球",
+          default_value: 150,
+        },
+      });
+    });
+
+    it("上限超過の 403 は forbidden として返し、バリデーションエラーと区別する", async () => {
+      mockResponse(403, {
+        error: "Pro プランで練習メニューを無制限に登録できます",
+      });
+
+      expect(
+        await createPracticeMenu({
+          name: "4つ目",
+          category: "other",
+          unit: "count",
+        }),
+      ).toEqual({
+        ok: false,
+        reason: "forbidden",
+        errors: ["Pro プランで練習メニューを無制限に登録できます"],
+      });
+    });
+
+    it("422 は error としてバリデーションメッセージを返す", async () => {
+      mockResponse(422, { errors: ["名前を入力してください"] });
+
+      expect(
+        await createPracticeMenu({
+          name: "",
+          category: "other",
+          unit: "count",
+        }),
+      ).toEqual({
+        ok: false,
+        reason: "error",
+        errors: ["名前を入力してください"],
+      });
+    });
+
+    it("エラー本文が無ければ既定のメッセージを返す", async () => {
+      mockResponse(500, null);
+
+      expect(
+        await createPracticeMenu({
+          name: "x",
+          category: "other",
+          unit: "count",
+        }),
+      ).toEqual({
+        ok: false,
+        reason: "error",
+        errors: ["練習メニューの作成に失敗しました"],
+      });
+    });
+  });
+
+  describe("updatePracticeMenu / deletePracticeMenu", () => {
+    it("PATCH で更新する", async () => {
+      mockResponse(200, practiceMenu);
+
+      await updatePracticeMenu(7, { is_favorite: false });
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/practice_menus/7");
+      expect(requestedInit().method).toBe("PATCH");
+      expect(JSON.parse(requestedInit().body as string)).toEqual({
+        practice_menu: { is_favorite: false },
+      });
+    });
+
+    it("DELETE は本文なしで叩く", async () => {
+      mockResponse(200, { message: "削除しました" });
+
+      const result = await deletePracticeMenu(7);
+
+      expect(result).toEqual({ ok: true, data: { message: "削除しました" } });
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/practice_menus/7");
+      expect(requestedInit().method).toBe("DELETE");
+      expect(requestedInit().body).toBeUndefined();
+    });
+  });
+
+  describe("getPracticeLogs", () => {
+    it("期間指定なしはクエリを付けない", async () => {
+      mockResponse(200, []);
+
+      await getPracticeLogs();
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/practice_logs");
+    });
+
+    it("from / to を back のパラメータ名で送る", async () => {
+      mockResponse(200, []);
+
+      await getPracticeLogs({ from: "2026-08-01", to: "2026-08-31" });
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/practice_logs?from=2026-08-01&to=2026-08-31",
+      );
+    });
+
+    it("片方だけの指定でも欠けたキーは送らない", async () => {
+      mockResponse(200, []);
+
+      await getPracticeLogs({ from: "2026-08-01" });
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/practice_logs?from=2026-08-01",
+      );
+    });
+  });
+
+  describe("createPracticeLog / deletePracticeLog", () => {
+    it("practice_log でラップして POST する", async () => {
+      mockResponse(201, { id: 1 });
+
+      await createPracticeLog({
+        practice_menu_id: 3,
+        logged_on: "2026-08-03",
+        amount: 200,
+        memo: "外角重点",
+      });
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/practice_logs");
+      expect(JSON.parse(requestedInit().body as string)).toEqual({
+        practice_log: {
+          practice_menu_id: 3,
+          logged_on: "2026-08-03",
+          amount: 200,
+          memo: "外角重点",
+        },
+      });
+    });
+
+    it("削除は DELETE /api/v2/practice_logs/:id", async () => {
+      mockResponse(200, { message: "削除しました" });
+
+      await deletePracticeLog(9);
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/practice_logs/9");
+      expect(requestedInit().method).toBe("DELETE");
+    });
+  });
+
+  describe("練習セッション", () => {
+    it("一覧は from / to / improvement_theme_id を送る", async () => {
+      mockResponse(200, []);
+
+      await getPracticeSessions({
+        from: "2026-08-01",
+        to: "2026-08-31",
+        improvement_theme_id: 5,
+      });
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/practice_sessions?from=2026-08-01&to=2026-08-31&improvement_theme_id=5",
+      );
+    });
+
+    it("単一取得は id をパスに付ける", async () => {
+      mockResponse(200, { id: 4 });
+
+      await getPracticeSession(4);
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/practice_sessions/4",
+      );
+    });
+
+    it("他ユーザーのセッション（404）は error を返す", async () => {
+      mockResponse(404, {});
+
+      expect(await getPracticeSession(4)).toEqual({ status: "error" });
+    });
+
+    it("日付指定は by_date に date クエリで問い合わせる", async () => {
+      mockResponse(200, { id: 4 });
+
+      await getPracticeSessionByDate("2026-08-03");
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/practice_sessions/by_date?date=2026-08-03",
+      );
+    });
+
+    it("記録の無い日は null を ok として返す（取得失敗と区別する）", async () => {
+      mockResponse(200, null);
+
+      expect(await getPracticeSessionByDate("2026-08-03")).toEqual({
+        status: "ok",
+        data: null,
+      });
+    });
+
+    it("保存は practice_session でラップして POST する", async () => {
+      mockResponse(201, { id: 4 });
+
+      await upsertPracticeSession({
+        logged_on: "2026-08-03",
+        memo: "今日の振り返り",
+        items: [{ practice_menu_id: 1, amount: 200 }],
+      });
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/practice_sessions");
+      expect(requestedInit().method).toBe("POST");
+      expect(JSON.parse(requestedInit().body as string)).toEqual({
+        practice_session: {
+          logged_on: "2026-08-03",
+          memo: "今日の振り返り",
+          items: [{ practice_menu_id: 1, amount: 200 }],
+        },
+      });
+    });
+
+    it("無料ユーザーのコンディション保存（403）は forbidden として返す", async () => {
+      mockResponse(403, { error: "コンディション記録は Pro プラン限定です" });
+
+      expect(
+        await upsertPracticeSession({
+          logged_on: "2026-08-03",
+          items: [],
+          condition: { fatigue_level: 3 },
+        }),
+      ).toEqual({
+        ok: false,
+        reason: "forbidden",
+        errors: ["コンディション記録は Pro プラン限定です"],
+      });
+    });
+
+    it("削除は DELETE /api/v2/practice_sessions/:id", async () => {
+      mockResponse(200, { message: "削除しました" });
+
+      await deletePracticeSession(4);
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/practice_sessions/4",
+      );
+      expect(requestedInit().method).toBe("DELETE");
+    });
+  });
+
+  describe("練習サマリー", () => {
+    it("メニュー別サマリーを取得する", async () => {
+      mockResponse(200, []);
+
+      await getMenuSummaries();
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/practice_menu_summaries",
+      );
+    });
+
+    it("全体 KPI を取得する", async () => {
+      const overview = {
+        total_practice_days: 2,
+        this_month_practice_days: 1,
+        total_swing_count: 50,
+        total_volume: 600,
+        total_menus: 2,
+      };
+      mockResponse(200, overview);
+
+      expect(await getPracticeOverview()).toEqual({
+        status: "ok",
+        data: overview,
+      });
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/practice_overview");
+    });
+
+    it("メニュー推移はメニュー id をパスに付ける", async () => {
+      mockResponse(200, { menu: { id: 3 } });
+
+      await getMenuTrend(3);
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/practice_menu_trends/3",
+      );
+    });
+
+    it("無料ユーザーのメニュー推移（403）は forbidden を返す", async () => {
+      mockResponse(403, {
+        error: "メニュー推移の詳細表示は Pro プラン限定です",
+      });
+
+      expect(await getMenuTrend(3)).toEqual({ status: "forbidden" });
+    });
+  });
+
+  describe("メニューセット", () => {
+    it("一覧を取得する", async () => {
+      mockResponse(200, []);
+
+      await getMenuSets();
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/menu_sets");
+    });
+
+    it("単一取得は id をパスに付ける", async () => {
+      mockResponse(200, { id: 2 });
+
+      await getMenuSet(2);
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/menu_sets/2");
+    });
+
+    it("menu_set でラップして POST する", async () => {
+      mockResponse(201, { id: 2 });
+
+      await createMenuSet({
+        name: "オフ日ルーティン",
+        items: [{ practice_menu_id: 1, target_value: 200 }],
+      });
+
+      expect(requestedInit().method).toBe("POST");
+      expect(JSON.parse(requestedInit().body as string)).toEqual({
+        menu_set: {
+          name: "オフ日ルーティン",
+          items: [{ practice_menu_id: 1, target_value: 200 }],
+        },
+      });
+    });
+
+    it("上限超過の 403 は forbidden として返す", async () => {
+      mockResponse(403, {
+        error: "Pro プランでメニューセットを無制限に登録できます",
+      });
+
+      expect(await createMenuSet({ name: "3つ目" })).toEqual({
+        ok: false,
+        reason: "forbidden",
+        errors: ["Pro プランでメニューセットを無制限に登録できます"],
+      });
+    });
+
+    it("更新は PATCH /api/v2/menu_sets/:id", async () => {
+      mockResponse(200, { id: 2 });
+
+      await updateMenuSet(2, { name: "新" });
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/menu_sets/2");
+      expect(requestedInit().method).toBe("PATCH");
+    });
+
+    it("削除は DELETE /api/v2/menu_sets/:id", async () => {
+      mockResponse(200, { message: "削除しました" });
+
+      await deleteMenuSet(2);
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/menu_sets/2");
+      expect(requestedInit().method).toBe("DELETE");
+    });
+  });
+});

--- a/app/services/v2/__tests__/practiceServices.test.ts
+++ b/app/services/v2/__tests__/practiceServices.test.ts
@@ -42,6 +42,7 @@ import {
   getMenuTrend,
   getPracticeOverview,
 } from "../practiceSummaryService";
+import { buildQuery } from "../requests";
 
 function setupAuthCookies() {
   mockGet.mockImplementation((key: string) => {
@@ -290,6 +291,32 @@ describe("練習ドメインの v2 Server Actions", () => {
 
       expect(requestedUrl()).toBe(
         "http://back:3000/api/v2/practice_logs?from=2026-08-01",
+      );
+    });
+
+    it("空文字の絞り込みは送らない（back が空値を条件として解釈しないようにする）", async () => {
+      mockResponse(200, []);
+
+      await getPracticeLogs({ from: "", to: "2026-08-31" });
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/practice_logs?to=2026-08-31",
+      );
+    });
+  });
+
+  describe("buildQuery", () => {
+    it("null / undefined / 空文字のパラメータは送らない", () => {
+      expect(buildQuery({ a: "1", b: null, c: undefined, d: "" })).toBe("?a=1");
+    });
+
+    it("送る値が1つも無ければ空文字を返す（末尾の ? を付けない）", () => {
+      expect(buildQuery({ a: null, b: undefined })).toBe("");
+    });
+
+    it("数値は文字列化して送る", () => {
+      expect(buildQuery({ improvement_theme_id: 5 })).toBe(
+        "?improvement_theme_id=5",
       );
     });
   });

--- a/app/services/v2/menuSetService.ts
+++ b/app/services/v2/menuSetService.ts
@@ -1,0 +1,65 @@
+"use server";
+
+import type { MenuSet, MenuSetInput } from "@app/types/menuSet";
+import {
+  type DeletedResponse,
+  type FetchResult,
+  type MutationResult,
+  fetchV2,
+  mutateV2,
+} from "./requests";
+
+const BASE_PATH = "/api/v2/menu_sets";
+
+/** メニューセット一覧を取得する（GET /api/v2/menu_sets）。sort_order 昇順で返る。 */
+export async function getMenuSets(): Promise<FetchResult<MenuSet[]>> {
+  return fetchV2<MenuSet[]>(BASE_PATH, "getMenuSets");
+}
+
+/** メニューセットを1件取得する（GET /api/v2/menu_sets/:id）。他ユーザーのセットは 404。 */
+export async function getMenuSet(id: number): Promise<FetchResult<MenuSet>> {
+  return fetchV2<MenuSet>(`${BASE_PATH}/${id}`, "getMenuSet");
+}
+
+/**
+ * メニューセットを新規作成する（POST /api/v2/menu_sets）。
+ * 無料プランは MENU_SET_FREE_LIMIT 件を超えると 403 になる。
+ * items に他ユーザーのメニューを混ぜても back 側で除外される（エラーにはならない）。
+ */
+export async function createMenuSet(
+  input: MenuSetInput,
+): Promise<MutationResult<MenuSet>> {
+  return mutateV2<MenuSet>(BASE_PATH, {
+    method: "POST",
+    body: { menu_set: input },
+    action: "createMenuSet",
+    fallbackMessage: "メニューセットの作成に失敗しました",
+  });
+}
+
+/**
+ * メニューセットを更新する（PATCH /api/v2/menu_sets/:id）。
+ * items を渡すとセット内メニューを全置換する。省略すると既存のまま維持される。
+ */
+export async function updateMenuSet(
+  id: number,
+  input: MenuSetInput,
+): Promise<MutationResult<MenuSet>> {
+  return mutateV2<MenuSet>(`${BASE_PATH}/${id}`, {
+    method: "PATCH",
+    body: { menu_set: input },
+    action: "updateMenuSet",
+    fallbackMessage: "メニューセットの更新に失敗しました",
+  });
+}
+
+/** メニューセットを削除する（DELETE /api/v2/menu_sets/:id）。 */
+export async function deleteMenuSet(
+  id: number,
+): Promise<MutationResult<DeletedResponse>> {
+  return mutateV2<DeletedResponse>(`${BASE_PATH}/${id}`, {
+    method: "DELETE",
+    action: "deleteMenuSet",
+    fallbackMessage: "メニューセットの削除に失敗しました",
+  });
+}

--- a/app/services/v2/practiceLogService.ts
+++ b/app/services/v2/practiceLogService.ts
@@ -1,0 +1,57 @@
+"use server";
+
+import type { PracticeLog, PracticeLogInput } from "@app/types/practice";
+import {
+  type DeletedResponse,
+  type FetchResult,
+  type MutationResult,
+  buildQuery,
+  fetchV2,
+  mutateV2,
+} from "./requests";
+
+const BASE_PATH = "/api/v2/practice_logs";
+
+interface GetPracticeLogsParams {
+  /** YYYY-MM-DD。この日以降の記録に絞る。 */
+  from?: string;
+  /** YYYY-MM-DD。この日以前の記録に絞る。 */
+  to?: string;
+}
+
+/**
+ * 練習ログ一覧を取得する（GET /api/v2/practice_logs）。
+ * 期間を指定しなければ全期間を新しい順で返す（量記録の閲覧は無料でも制限なし）。
+ */
+export async function getPracticeLogs(
+  params: GetPracticeLogsParams = {},
+): Promise<FetchResult<PracticeLog[]>> {
+  const query = buildQuery({ from: params.from, to: params.to });
+  return fetchV2<PracticeLog[]>(`${BASE_PATH}${query}`, "getPracticeLogs");
+}
+
+/**
+ * 練習ログを単票で作成する（POST /api/v2/practice_logs）。
+ * back 側でメニュー名・単位ラベルをスナップショットし、当日の日次セッションへ自動で束ねる。
+ */
+export async function createPracticeLog(
+  input: PracticeLogInput,
+): Promise<MutationResult<PracticeLog>> {
+  return mutateV2<PracticeLog>(BASE_PATH, {
+    method: "POST",
+    body: { practice_log: input },
+    action: "createPracticeLog",
+    fallbackMessage: "練習記録の保存に失敗しました",
+  });
+}
+
+/** 練習ログを削除する（DELETE /api/v2/practice_logs/:id）。 */
+export async function deletePracticeLog(
+  id: number,
+): Promise<MutationResult<DeletedResponse>> {
+  return mutateV2<DeletedResponse>(`${BASE_PATH}/${id}`, {
+    method: "DELETE",
+    action: "deletePracticeLog",
+    fallbackMessage: "練習記録の削除に失敗しました",
+  });
+}

--- a/app/services/v2/practiceMenuService.ts
+++ b/app/services/v2/practiceMenuService.ts
@@ -1,0 +1,63 @@
+"use server";
+
+import type { PracticeMenu, PracticeMenuInput } from "@app/types/practice";
+import {
+  type DeletedResponse,
+  type FetchResult,
+  type MutationResult,
+  fetchV2,
+  mutateV2,
+} from "./requests";
+
+const BASE_PATH = "/api/v2/practice_menus";
+
+/**
+ * 練習メニュー一覧を取得する（GET /api/v2/practice_menus）。
+ * back 側で archived を除外し、お気に入り先頭・sort_order 昇順で返る。
+ */
+export async function getPracticeMenus(): Promise<FetchResult<PracticeMenu[]>> {
+  return fetchV2<PracticeMenu[]>(BASE_PATH, "getPracticeMenus");
+}
+
+/**
+ * 練習メニューを新規作成する（POST /api/v2/practice_menus）。
+ * 無料プランは PRACTICE_MENU_FREE_LIMIT 件を超えると 403 になるため、
+ * reason:"forbidden" を Pro 訴求の分岐に使う。
+ */
+export async function createPracticeMenu(
+  input: PracticeMenuInput,
+): Promise<MutationResult<PracticeMenu>> {
+  return mutateV2<PracticeMenu>(BASE_PATH, {
+    method: "POST",
+    body: { practice_menu: input },
+    action: "createPracticeMenu",
+    fallbackMessage: "練習メニューの作成に失敗しました",
+  });
+}
+
+/** 練習メニューを更新する（PATCH /api/v2/practice_menus/:id）。自分のメニューのみ更新可。 */
+export async function updatePracticeMenu(
+  id: number,
+  input: Partial<PracticeMenuInput>,
+): Promise<MutationResult<PracticeMenu>> {
+  return mutateV2<PracticeMenu>(`${BASE_PATH}/${id}`, {
+    method: "PATCH",
+    body: { practice_menu: input },
+    action: "updatePracticeMenu",
+    fallbackMessage: "練習メニューの更新に失敗しました",
+  });
+}
+
+/**
+ * 練習メニューを削除する（DELETE /api/v2/practice_menus/:id）。
+ * back は履歴を残すため archived による論理削除を行う。
+ */
+export async function deletePracticeMenu(
+  id: number,
+): Promise<MutationResult<DeletedResponse>> {
+  return mutateV2<DeletedResponse>(`${BASE_PATH}/${id}`, {
+    method: "DELETE",
+    action: "deletePracticeMenu",
+    fallbackMessage: "練習メニューの削除に失敗しました",
+  });
+}

--- a/app/services/v2/practiceSessionService.ts
+++ b/app/services/v2/practiceSessionService.ts
@@ -1,0 +1,95 @@
+"use server";
+
+import type {
+  PracticeSession,
+  PracticeSessionInput,
+} from "@app/types/practice";
+import {
+  type DeletedResponse,
+  type FetchResult,
+  type MutationResult,
+  buildQuery,
+  fetchV2,
+  mutateV2,
+} from "./requests";
+
+const BASE_PATH = "/api/v2/practice_sessions";
+
+interface GetPracticeSessionsParams {
+  /** YYYY-MM-DD。この日以降のセッションに絞る。 */
+  from?: string;
+  /** YYYY-MM-DD。この日以前のセッションに絞る。 */
+  to?: string;
+  /** 指定した課題テーマに紐づくセッションだけに絞る。 */
+  improvement_theme_id?: number;
+}
+
+/**
+ * 日次セッション一覧を取得する（GET /api/v2/practice_sessions）。
+ * logged_on の新しい順で返り、各セッションにその日のコンディションが含まれる。
+ */
+export async function getPracticeSessions(
+  params: GetPracticeSessionsParams = {},
+): Promise<FetchResult<PracticeSession[]>> {
+  const query = buildQuery({
+    from: params.from,
+    to: params.to,
+    improvement_theme_id: params.improvement_theme_id,
+  });
+  return fetchV2<PracticeSession[]>(
+    `${BASE_PATH}${query}`,
+    "getPracticeSessions",
+  );
+}
+
+/** 日次セッションを1件取得する（GET /api/v2/practice_sessions/:id）。他ユーザーのセッションは 404。 */
+export async function getPracticeSession(
+  id: number,
+): Promise<FetchResult<PracticeSession>> {
+  return fetchV2<PracticeSession>(`${BASE_PATH}/${id}`, "getPracticeSession");
+}
+
+/**
+ * 指定日の日次セッションを取得する（GET /api/v2/practice_sessions/by_date）。
+ * その日の記録がまだ無い場合、back は 200 + null を返すため data は null になりうる。
+ */
+export async function getPracticeSessionByDate(
+  date: string,
+): Promise<FetchResult<PracticeSession | null>> {
+  return fetchV2<PracticeSession | null>(
+    `${BASE_PATH}/by_date${buildQuery({ date })}`,
+    "getPracticeSessionByDate",
+  );
+}
+
+/**
+ * 日次セッションを保存する（POST /api/v2/practice_sessions）。
+ * 同じ logged_on への再送は新規作成ではなく upsert（メニュー項目は差分同期）になる。
+ *
+ * コンディション付きの保存と、2件以上の課題紐付けは Pro 限定のため 403 になりうる。
+ * その場合は更新全体がロールバックされる。
+ */
+export async function upsertPracticeSession(
+  input: PracticeSessionInput,
+): Promise<MutationResult<PracticeSession>> {
+  return mutateV2<PracticeSession>(BASE_PATH, {
+    method: "POST",
+    body: { practice_session: input },
+    action: "upsertPracticeSession",
+    fallbackMessage: "練習記録の保存に失敗しました",
+  });
+}
+
+/**
+ * 日次セッションを削除する（DELETE /api/v2/practice_sessions/:id）。
+ * 配下の練習ログも一緒に削除される。
+ */
+export async function deletePracticeSession(
+  id: number,
+): Promise<MutationResult<DeletedResponse>> {
+  return mutateV2<DeletedResponse>(`${BASE_PATH}/${id}`, {
+    method: "DELETE",
+    action: "deletePracticeSession",
+    fallbackMessage: "練習記録の削除に失敗しました",
+  });
+}

--- a/app/services/v2/practiceSummaryService.ts
+++ b/app/services/v2/practiceSummaryService.ts
@@ -1,0 +1,45 @@
+"use server";
+
+import type {
+  MenuSummary,
+  MenuTrend,
+  PracticeOverview,
+} from "@app/types/practice";
+import { type FetchResult, fetchV2 } from "./requests";
+
+/**
+ * メニュー別の積み上げサマリーを取得する（GET /api/v2/practice_menu_summaries）。
+ * 直近に記録したメニュー順で返る。記録が無ければ空配列（status:"ok"）。
+ */
+export async function getMenuSummaries(): Promise<FetchResult<MenuSummary[]>> {
+  return fetchV2<MenuSummary[]>(
+    "/api/v2/practice_menu_summaries",
+    "getMenuSummaries",
+  );
+}
+
+/** 練習全体の KPI を取得する（GET /api/v2/practice_overview）。 */
+export async function getPracticeOverview(): Promise<
+  FetchResult<PracticeOverview>
+> {
+  return fetchV2<PracticeOverview>(
+    "/api/v2/practice_overview",
+    "getPracticeOverview",
+  );
+}
+
+/**
+ * 単一メニューの推移を取得する（GET /api/v2/practice_menu_trends/:id）。
+ * 推移詳細は Pro 限定（entitlement: practice_menu_trend_detail）のため、
+ * 無料プランでは status:"forbidden" が返る。
+ *
+ * @param menuId practice_menu の id
+ */
+export async function getMenuTrend(
+  menuId: number,
+): Promise<FetchResult<MenuTrend>> {
+  return fetchV2<MenuTrend>(
+    `/api/v2/practice_menu_trends/${menuId}`,
+    "getMenuTrend",
+  );
+}

--- a/app/services/v2/requests.ts
+++ b/app/services/v2/requests.ts
@@ -1,0 +1,131 @@
+import { RAILS_API_URL } from "@app/constants/api";
+import { captureServerActionError } from "../../../lib/sentry-helpers";
+import { getAuthHeaders } from "./authHeaders";
+
+/**
+ * 取得系 Server Action の戻り値。
+ * dashboardStatsService が使う StatsFetchResult と同じ判別可能ユニオンで、
+ * 「Pro 未加入・非公開などで見られない（forbidden）」「取得に失敗した（error）」
+ * 「取得できた（ok / データが空配列でも ok）」を必ず区別する。
+ * 失敗を空データへ丸めると「記録が 0 件」と誤表示してしまうため統合しない。
+ */
+export type FetchResult<T> =
+  | { status: "ok"; data: T }
+  | { status: "forbidden" }
+  | { status: "error" };
+
+/**
+ * 更新系 Server Action の戻り値。
+ * back は上限超過・Pro 限定機能を 403 + `{ error: "..." }` で返すため、
+ * バリデーションエラー（422）と区別できるよう reason を持たせて Paywall へ倒せるようにする。
+ */
+export type MutationResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; reason: "forbidden"; errors: string[] }
+  | { ok: false; reason: "error"; errors: string[] };
+
+/** 削除系エンドポイントの共通レスポンス。 */
+export interface DeletedResponse {
+  message: string;
+}
+
+/**
+ * back のエラーレスポンスをメッセージ配列へ正規化する。
+ * 422 は `{ errors: string[] }`、403 は `{ error: string }` と形が違うため両方を吸収する。
+ */
+export function extractErrors(body: unknown, fallback: string): string[] {
+  if (typeof body === "object" && body !== null) {
+    const { errors, error } = body as { errors?: unknown; error?: unknown };
+    if (Array.isArray(errors) && errors.length > 0) return errors.map(String);
+    if (typeof error === "string" && error !== "") return [error];
+  }
+  return [fallback];
+}
+
+/**
+ * v2 API の GET を叩く。
+ *
+ * @param path `/api/v2/...` から始まるパス（クエリを含めてよい）
+ * @param action Sentry に送るアクション名
+ */
+export async function fetchV2<T>(
+  path: string,
+  action: string,
+): Promise<FetchResult<T>> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return { status: "error" };
+
+    const response = await fetch(`${RAILS_API_URL}${path}`, {
+      headers,
+      cache: "no-store",
+    });
+
+    if (response.status === 403) return { status: "forbidden" };
+    if (!response.ok) return { status: "error" };
+
+    return { status: "ok", data: (await response.json()) as T };
+  } catch (error) {
+    captureServerActionError(error, { action });
+    return { status: "error" };
+  }
+}
+
+interface MutateOptions {
+  method: "POST" | "PATCH" | "DELETE";
+  /** JSON 化して送るリクエストボディ。DELETE のように本文が無い場合は省略する。 */
+  body?: unknown;
+  action: string;
+  /** back がエラー詳細を返さなかったときに表示するメッセージ。 */
+  fallbackMessage: string;
+}
+
+/**
+ * v2 API の更新系（POST / PATCH / DELETE）を叩く。
+ * 403 は reason:"forbidden" として返し、上限超過・Pro 限定の案内へ分岐できるようにする。
+ */
+export async function mutateV2<T>(
+  path: string,
+  { method, body, action, fallbackMessage }: MutateOptions,
+): Promise<MutationResult<T>> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) {
+      return { ok: false, reason: "error", errors: ["ログインが必要です"] };
+    }
+
+    const response = await fetch(`${RAILS_API_URL}${path}`, {
+      method,
+      headers,
+      cache: "no-store",
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    const payload = await response.json().catch(() => null);
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        reason: response.status === 403 ? "forbidden" : "error",
+        errors: extractErrors(payload, fallbackMessage),
+      };
+    }
+    return { ok: true, data: payload as T };
+  } catch (error) {
+    captureServerActionError(error, { action });
+    return { ok: false, reason: "error", errors: [fallbackMessage] };
+  }
+}
+
+/** 未定義・null の値を除いたクエリ文字列（先頭 `?` 付き）を組み立てる。値が無ければ空文字。 */
+export function buildQuery(
+  params: Record<string, string | number | null | undefined>,
+): string {
+  const query = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== null && value !== undefined && value !== "") {
+      query.append(key, String(value));
+    }
+  });
+  const serialized = query.toString();
+  return serialized ? `?${serialized}` : "";
+}

--- a/app/types/menuSet.ts
+++ b/app/types/menuSet.ts
@@ -1,0 +1,37 @@
+/**
+ * メニューセット（再利用できる練習メニューの束）の型定義。
+ * back/app/serializers/v2/menu_set_serializer.rb のレスポンスに対応する。
+ */
+
+/**
+ * セット内のメニュー1件。
+ * name / unit_label は practice_menu から都度引く表示用の値で、
+ * メニューが削除されている場合は null になる。
+ */
+export interface MenuSetItem {
+  practice_menu_id: number;
+  name: string | null;
+  unit_label: string | null;
+  /** back は float カラムのため文字列化されず number で返る。 */
+  target_value: number | null;
+}
+
+export interface MenuSet {
+  id: number;
+  name: string;
+  note: string | null;
+  sort_order: number;
+  items: MenuSetItem[];
+}
+
+/**
+ * メニューセットの作成・更新パラメータ。
+ * items は差分更新ではなく全置換（back が menu_set_items を作り直す）。
+ * 更新時に items を省略するとセット内メニューは変更されない。
+ */
+export interface MenuSetInput {
+  name: string;
+  note?: string | null;
+  sort_order?: number;
+  items?: { practice_menu_id: number; target_value?: number | null }[];
+}

--- a/app/types/practice.ts
+++ b/app/types/practice.ts
@@ -1,0 +1,201 @@
+/**
+ * 練習ドメインの型定義。
+ * back/app/serializers/v2/*（practice_menu / practice_log / practice_session / condition_log）と
+ * back/app/services/practices/*（menu_summary / menu_trend / overall_summary）のレスポンスに対応する。
+ * キー名は back の JSON をそのまま使う（snake_case のまま扱い、変換しない）。
+ */
+
+/**
+ * back の decimal カラムは ActiveModel::Serializer の JSON 化で文字列として返る
+ * （例: amount 200 → "200.0"）。計算・表示の前に必ず数値化が要るため型で明示する。
+ * 集計系（MenuSummary / MenuTrend / PracticeOverview）は Ruby 側で Float 化済みのため素の number。
+ */
+export type DecimalValue = number | string;
+
+/** 練習メニューのカテゴリ。back の PracticeMenu::CATEGORIES と完全一致させる。 */
+export type PracticeCategory =
+  | "batting"
+  | "pitching"
+  | "defense"
+  | "baserunning"
+  | "training"
+  | "strength"
+  | "care"
+  | "other";
+
+/** 練習量の計測単位。back の PracticeMenu::UNITS と完全一致させる。 */
+export type PracticeUnit = "count" | "minutes" | "distance" | "weight_reps";
+
+/** 練習ログの発生源。back の PracticeLog::SOURCES と完全一致させる。 */
+export type PracticeLogSource = "manual" | "shadow_swing";
+
+/** 練習メニューのマスタ（ユーザーごと）。 */
+export interface PracticeMenu {
+  id: number;
+  name: string;
+  category: PracticeCategory;
+  unit: PracticeUnit;
+  unit_label: string | null;
+  default_value: DecimalValue | null;
+  is_favorite: boolean;
+  sort_order: number;
+}
+
+/** 練習量の1件の記録。メニュー削除後も履歴を保てるよう名称・単位をスナップショットして持つ。 */
+export interface PracticeLog {
+  id: number;
+  practice_menu_id: number | null;
+  schedule_id: number | null;
+  logged_on: string;
+  amount: DecimalValue | null;
+  weight: DecimalValue | null;
+  menu_name: string;
+  unit_label: string | null;
+  source: PracticeLogSource;
+  memo: string | null;
+  created_at: string;
+}
+
+/** コンディションに記録する故障箇所。back では jsonb 配列で保持する。 */
+export interface Injury {
+  part: string;
+  memo?: string | null;
+}
+
+/**
+ * その日のコンディション（1日1件）。
+ * 記録・参照ともに Pro 限定（entitlement: detailed_condition_log）。
+ */
+export interface ConditionLog {
+  id: number;
+  logged_on: string;
+  /** 疲労度。back の ConditionLog::LEVEL_RANGE と同じく 1〜4。 */
+  fatigue_level: number | null;
+  /** 体の状態。back の ConditionLog::LEVEL_RANGE と同じく 1〜4。 */
+  physical_level: number | null;
+  sleep_hours: DecimalValue | null;
+  mood: string | null;
+  memo: string | null;
+  injuries: Injury[];
+}
+
+/** 日次の練習セッション。1日（logged_on）の量ログとコンディションを束ねる。 */
+export interface PracticeSession {
+  id: number;
+  logged_on: string;
+  memo: string | null;
+  improvement_theme_ids: number[];
+  practice_logs: PracticeLog[];
+  condition: ConditionLog | null;
+  created_at: string;
+}
+
+/** メニュー別の積み上げサマリー。total_volume は重さ×回数のメニューのみ値を持つ。 */
+export interface MenuSummary {
+  practice_menu_id: number | null;
+  menu_name: string;
+  unit: PracticeUnit;
+  unit_label: string | null;
+  total_amount: number;
+  total_volume: number | null;
+  this_month_amount: number;
+  this_month_volume: number | null;
+  days_count: number;
+  last_logged_on: string | null;
+}
+
+/** 推移グラフの1バケット（年 / 月 / 日のいずれか）。 */
+export interface MenuTrendBucket {
+  /** 年は "2026"、月は "2026-08"、日は "2026-08-03" 形式。 */
+  period: string;
+  total_amount: number;
+  total_volume: number;
+  days_count: number;
+}
+
+/**
+ * 単一メニューの推移（年別・月別・日別）。
+ * by_day は back 側で直近 60 件に制限される。
+ */
+export interface MenuTrend {
+  menu: {
+    id: number;
+    name: string;
+    unit: PracticeUnit;
+    unit_label: string | null;
+    is_weight_reps: boolean;
+  };
+  by_year: MenuTrendBucket[];
+  by_month: MenuTrendBucket[];
+  by_day: MenuTrendBucket[];
+}
+
+/** 練習全体の積み上げ KPI。 */
+export interface PracticeOverview {
+  total_practice_days: number;
+  this_month_practice_days: number;
+  total_swing_count: number;
+  total_volume: number;
+  total_menus: number;
+}
+
+/** 練習メニューの作成・更新パラメータ（back の practice_menu_params に対応）。 */
+export interface PracticeMenuInput {
+  name: string;
+  category: PracticeCategory;
+  unit: PracticeUnit;
+  unit_label?: string | null;
+  default_value?: number | null;
+  is_favorite?: boolean;
+  sort_order?: number;
+}
+
+/** 練習ログ単票の作成パラメータ（back の practice_log_params に対応）。 */
+export interface PracticeLogInput {
+  practice_menu_id: number;
+  schedule_id?: number | null;
+  logged_on: string;
+  amount?: number | null;
+  weight?: number | null;
+  memo?: string | null;
+}
+
+/** セッション保存時の1メニュー項目。practice_menu_id をキーに差分同期される。 */
+export interface PracticeSessionItemInput {
+  practice_menu_id: number;
+  amount?: number | null;
+  weight?: number | null;
+  memo?: string | null;
+}
+
+/** コンディション単体の入力値。 */
+export interface ConditionLogInput {
+  logged_on: string;
+  fatigue_level?: number | null;
+  physical_level?: number | null;
+  sleep_hours?: number | null;
+  mood?: string | null;
+  memo?: string | null;
+  injuries?: Injury[];
+}
+
+/** セッション内のコンディションは logged_on をセッションの日付から決めるため省く。 */
+export type ConditionInput = Omit<ConditionLogInput, "logged_on">;
+
+/**
+ * 日次セッションの upsert パラメータ（back の session_params に対応）。
+ * 同じ logged_on への再送は同一セッションの更新になる。
+ */
+export interface PracticeSessionInput {
+  logged_on: string;
+  memo?: string | null;
+  improvement_theme_ids?: number[];
+  items: PracticeSessionItemInput[];
+  condition?: ConditionInput | null;
+}
+
+/** 練習記録画面へ事前選択メニュー（目標量つき）を渡すためのパラメータ項目。 */
+export interface PresetMenu {
+  practice_menu_id: number;
+  target_value: number | null;
+}


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#467

## 概要

front には練習ドメインの実装が一切存在しませんでした（画面・ルート・Server Action・サービス層・型のすべてがゼロ）。**練習系 issue #468〜#473 すべての前提となる基盤レイヤー**を整備します。画面は作らず、型・定数・サービス層のみです。

## 変更内容

- `app/types/practice.ts` / `app/types/menuSet.ts` — 練習ドメインの型
- `app/constants/practice.ts` — カテゴリ8種・単位マスタ・アイコン・整形関数・気分/怪我部位・`PRACTICE_MENU_FREE_LIMIT`
- `app/constants/menuSet.ts` — `MENU_SET_FREE_LIMIT`
- `app/services/v2/requests.ts` — `FetchResult<T>`(ok/forbidden/error) / `MutationResult<T>` / `fetchV2` / `mutateV2` / `buildQuery` / `extractErrors`
- `app/services/v2/` に practiceMenu / practiceSession / practiceLog / practiceSummary / menuSet の各 Server Actions

## back との突き合わせ結果

**無料枠は issue の記載どおりでした**（`PRACTICE_MENU_FREE_LIMIT = 3` / `MENU_SET_FREE_LIMIT = 2`）。

enum は back と完全一致させ、テストで固定しています:
- カテゴリ8種: `batting / pitching / defense / baserunning / training / strength / care / other`
- 単位4種: `count / minutes / distance / weight_reps`
- ログ発生源: `manual / shadow_swing`
- コンディションのレベル: `1..4`

**`mood` と怪我部位は back では enum ではありません**（前者は自由文字列カラム、後者は jsonb の自由文字列）。選択肢は front/mobile 側の定義なので mobile と同じ内容（気分3種 / 部位8種）にしています。

**エラー形式が 403 と 422 で異なります**（403 は `{error: "..."}` の単数、422 は `{errors: [...]}` の複数）。両方を吸収する `extractErrors` を実装しました。

## 整形関数の仕様（mobile と一致・テストで固定）

- `formatPracticeValue`: weight があれば `60kg × 10回`（回数の単位は `unit_label` に依らず「回」固定＝mobile 準拠）／amount のみなら `200本`
- `formatTotalAmount`: `12,400本`。小数は第3位まで
- `formatVolume`: **1000kg ちょうどから t 表記**（`999.999` → `999.999kg`、`1000` → `1t`）。t は小数第1位で四捨五入（`1049`→`1t`、`1050`→`1.1t`）。負値は t に切り替えません

**mobile との意図的な差分が2点あります**: ①ロケールを `ja-JP` に固定（Server Action の実行環境ロケールに依存させないため）②`parseDecimal` で数値化できない値を `null` にし、「未入力」と「0」を区別

## ⚠️ 後続 issue（#468〜#473）の実装者への申し送り

1. **decimal は文字列で返ります。** `practice_log.amount` / `weight`、`practice_menu.default_value`、`condition_log.sleep_hours` は `"200.0"` のような文字列です。必ず `parseDecimal()` を通してください（型を `DecimalValue` にしてあるので、そのまま算術すると型エラーになります＝事故防止）。一方 `MenuSummary` / `MenuTrend` / `PracticeOverview` は Ruby 側で Float 化済みなので素の number です
2. **403 の意味がエンドポイントごとに違います。** `practice_menu_trends` は「Pro 限定機能」、`practice_menus`/`menu_sets` の POST は「無料枠超過」、`practice_sessions` の POST は「コンディション or 複数課題が Pro 限定」。`forbidden` を受けたら Paywall へ倒す前に文脈で出し分けてください
3. **セッション POST の 403 は更新全体がロールバックされます**（メモやメニュー項目も保存されない）。楽観的 UI を組むなら失敗時に完全に巻き戻してください
4. **`by_date` は 200 + `null`** を返します。`{status:"ok", data:null}` は「その日はまだ記録なし」であって取得失敗ではありません
5. **セッション POST は upsert です。** 同じ `logged_on` への再送は差分同期になり、`items` から外したメニューのログは削除されます（＝画面側で常に全項目を送る必要があります）。素振り自動ログ（`source: shadow_swing`）は同期対象外なので消えません
6. **`menu_set` の `items` は全置換です。** 更新時に省略すれば維持されますが、渡すと丸ごと差し替わります。他人の `practice_menu_id` はエラーにならず**黙って除外**されます
7. **メニュー削除は archived の論理削除です。** 一覧から消えるだけでログの `menu_name` / `unit_label` はスナップショットが残ります。削除済みメニューのログは `practice_menu_id: null` になりうるので、カテゴリ不明のフォールバック（`practiceIconForLog`）を使ってください
8. 追加のサービスは `fetchV2` / `mutateV2` を使えば認証ヘッダー・`no-store`・403 判別・Sentry 送出が揃います。**`ActionResult`（`authHeaders.ts`）は 403 を区別できないので練習系では使わないでください**

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る（0 errors / 0 warnings）
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（**115 suites / 1187 tests**。新規 2 suites / 76 tests）
- [ ] `yarn build` — CI の Build Check で検証
- [x] ミューテーションテスト **25 設計 / 25 KILLED / 0 SURVIVED**

<details>
<summary>ミューテーションテスト詳細</summary>

隔離ディレクトリで実施（無改変ベースライン通過を事前確認済み）。

境界ずらし（`>=`→`>`）/ 単位取り違え（t↔kg）/ 丸め桁変更 / 換算係数 / enum 改名 / プリセット増減 / 上限 3→4・2→3 / API パス・HTTP メソッド改変 / ラップキー改変 / 403 と error の取り違え（取得系・更新系）/ クエリ空値ガード除去 など。

**初回に2件が SURVIVED**（`by_date` パス / `buildQuery` の空値除去）→ テストを追加して KILL 済み。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_