### PR TITLE
Add: 練習メニュー管理（一覧・作成・編集・削除）を実装

### DIFF
--- a/app/(app)/practice/menus/__tests__/PracticeMenusContent.test.tsx
+++ b/app/(app)/practice/menus/__tests__/PracticeMenusContent.test.tsx
@@ -1,0 +1,543 @@
+const mockOpenProUpgradeModal = jest.fn();
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({
+    open: mockOpenProUpgradeModal,
+    close: jest.fn(),
+  }),
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+jest.mock("@app/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@app/services/v2/practiceMenuService", () => ({
+  createPracticeMenu: jest.fn(),
+  updatePracticeMenu: jest.fn(),
+  deletePracticeMenu: jest.fn(),
+}));
+
+import type { PracticeMenu } from "@app/types/practice";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import {
+  createPracticeMenu,
+  deletePracticeMenu,
+  updatePracticeMenu,
+} from "@app/services/v2/practiceMenuService";
+import PracticeMenusContent from "../_components/PracticeMenusContent";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+const mockCreate = createPracticeMenu as jest.MockedFunction<
+  typeof createPracticeMenu
+>;
+const mockUpdate = updatePracticeMenu as jest.MockedFunction<
+  typeof updatePracticeMenu
+>;
+const mockDelete = deletePracticeMenu as jest.MockedFunction<
+  typeof deletePracticeMenu
+>;
+
+function buildMenu(overrides: Partial<PracticeMenu> = {}): PracticeMenu {
+  return {
+    id: 1,
+    name: "素振り",
+    category: "batting",
+    unit: "count",
+    unit_label: "本",
+    default_value: "200.0",
+    is_favorite: false,
+    sort_order: 1,
+    ...overrides,
+  };
+}
+
+function mockEntitlement({
+  granted = false,
+  isLoading = false,
+}: { granted?: boolean; isLoading?: boolean } = {}) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: granted,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading,
+    hasEntitlement: jest.fn(() => granted),
+  });
+}
+
+async function openCreateForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "メニューを作る" }));
+}
+
+describe("PracticeMenusContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEntitlement();
+  });
+
+  describe("一覧表示", () => {
+    it("カテゴリ別にグルーピングして表示する", () => {
+      render(
+        <PracticeMenusContent
+          initialMenus={[
+            buildMenu({ id: 1, name: "素振り", category: "batting" }),
+            buildMenu({ id: 2, name: "ランニング", category: "training" }),
+            buildMenu({ id: 3, name: "ティー", category: "batting" }),
+          ]}
+        />,
+      );
+
+      const battingGroup = screen.getByRole("region", {
+        name: "バッティング",
+      });
+      expect(within(battingGroup).getByText("素振り")).toBeVisible();
+      expect(within(battingGroup).getByText("ティー")).toBeVisible();
+      expect(within(battingGroup).queryByText("ランニング")).toBeNull();
+
+      const trainingGroup = screen.getByRole("region", {
+        name: "トレーニング",
+      });
+      expect(within(trainingGroup).getByText("ランニング")).toBeVisible();
+    });
+
+    it("カテゴリ見出しは back と同じカテゴリ定義順に並ぶ", () => {
+      render(
+        <PracticeMenusContent
+          initialMenus={[
+            buildMenu({ id: 1, name: "その他練習", category: "other" }),
+            buildMenu({ id: 2, name: "ベンチプレス", category: "strength" }),
+            buildMenu({ id: 3, name: "キャッチボール", category: "pitching" }),
+            buildMenu({ id: 4, name: "素振り", category: "batting" }),
+          ]}
+        />,
+      );
+
+      const groupNames = screen
+        .getAllByRole("region")
+        .map((group) => within(group).getByRole("heading").textContent);
+      expect(groupNames).toEqual(["バッティング", "投手", "筋トレ", "その他"]);
+    });
+
+    it("メニューが無いカテゴリの見出しは表示しない", () => {
+      render(
+        <PracticeMenusContent
+          initialMenus={[buildMenu({ category: "batting" })]}
+        />,
+      );
+
+      expect(screen.getByText("バッティング")).toBeVisible();
+      expect(screen.queryByText("守備")).toBeNull();
+    });
+
+    it("メニューが1件も無いときは空状態を表示する", () => {
+      render(<PracticeMenusContent initialMenus={[]} />);
+
+      expect(screen.getByText("まだ練習メニューがありません")).toBeVisible();
+    });
+
+    it("初期値は decimal 文字列をそのまま出さず数値として表示する", () => {
+      render(
+        <PracticeMenusContent
+          initialMenus={[buildMenu({ default_value: "200.0" })]}
+        />,
+      );
+
+      expect(screen.getByText("回数 ・ 初期値 200本")).toBeVisible();
+      expect(screen.queryByText(/200\.0/)).toBeNull();
+    });
+  });
+
+  describe("作成", () => {
+    it("名前・カテゴリ・計測タイプ・初期値を入力して作成できる", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({
+        ok: true,
+        data: buildMenu({ id: 9, name: "ダッシュ", category: "baserunning" }),
+      });
+      render(<PracticeMenusContent initialMenus={[]} />);
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText(/名前/), "ダッシュ");
+      await user.click(screen.getByRole("button", { name: "走塁" }));
+      await user.click(screen.getByRole("button", { name: "距離" }));
+      await user.type(screen.getByLabelText(/初期値/), "5");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+      expect(mockCreate).toHaveBeenCalledWith({
+        name: "ダッシュ",
+        category: "baserunning",
+        unit: "distance",
+        unit_label: "km",
+        default_value: 5,
+      });
+    });
+
+    it("作成したメニューが一覧に追加される", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({
+        ok: true,
+        data: buildMenu({ id: 9, name: "ティー", category: "batting" }),
+      });
+      render(<PracticeMenusContent initialMenus={[]} />);
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText(/名前/), "ティー");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      expect(await screen.findByText("ティー")).toBeVisible();
+      expect(screen.queryByText("まだ練習メニューがありません")).toBeNull();
+    });
+
+    it("名前が未入力ならバリデーションエラーを出して送信しない", async () => {
+      const user = userEvent.setup();
+      render(<PracticeMenusContent initialMenus={[]} />);
+
+      await openCreateForm(user);
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      expect(
+        await screen.findByText("メニュー名を入力してください"),
+      ).toBeInTheDocument();
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("初期値が未入力なら default_value は null で送る", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({ ok: true, data: buildMenu({ id: 9 }) });
+      render(<PracticeMenusContent initialMenus={[]} />);
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText(/名前/), "アップ");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+      expect(mockCreate.mock.calls[0][0].default_value).toBeNull();
+    });
+  });
+
+  describe("計測タイプと unit_label の連動", () => {
+    it("「筋トレ」を選ぶと計測タイプが重さ×回数へ切り替わる", async () => {
+      const user = userEvent.setup();
+      render(<PracticeMenusContent initialMenus={[]} />);
+
+      await openCreateForm(user);
+      expect(screen.getByRole("button", { name: "回数" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+
+      await user.click(screen.getByRole("button", { name: "筋トレ" }));
+
+      expect(screen.getByRole("button", { name: "重さ×回数" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(screen.getByRole("button", { name: "回数" })).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
+
+    it("「筋トレ」以外へ切り替えると重さ×回数は回数へ戻る", async () => {
+      const user = userEvent.setup();
+      render(<PracticeMenusContent initialMenus={[]} />);
+
+      await openCreateForm(user);
+      await user.click(screen.getByRole("button", { name: "筋トレ" }));
+      await user.click(screen.getByRole("button", { name: "守備" }));
+
+      expect(screen.getByRole("button", { name: "回数" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    it("「筋トレ」を選んでも明示的に選んだ計測タイプは保持される", async () => {
+      const user = userEvent.setup();
+      render(<PracticeMenusContent initialMenus={[]} />);
+
+      await openCreateForm(user);
+      await user.click(screen.getByRole("button", { name: "時間" }));
+      await user.click(screen.getByRole("button", { name: "投手" }));
+
+      expect(screen.getByRole("button", { name: "時間" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    it.each([
+      ["回数", "本"],
+      ["時間", "分"],
+      ["距離", "km"],
+      ["重さ×回数", "回"],
+    ])(
+      "計測タイプ「%s」を選ぶと unit_label は %s で自動送信される",
+      async (unitLabel, expectedLabel) => {
+        const user = userEvent.setup();
+        mockCreate.mockResolvedValue({ ok: true, data: buildMenu({ id: 9 }) });
+        render(<PracticeMenusContent initialMenus={[]} />);
+
+        await openCreateForm(user);
+        await user.type(screen.getByLabelText(/名前/), "メニュー");
+        await user.click(screen.getByRole("button", { name: unitLabel }));
+        await user.click(screen.getByRole("button", { name: "保存" }));
+
+        await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+        expect(mockCreate.mock.calls[0][0].unit_label).toBe(expectedLabel);
+      },
+    );
+
+    it("unit_label を直接入力させる欄は存在しない", async () => {
+      const user = userEvent.setup();
+      render(<PracticeMenusContent initialMenus={[]} />);
+
+      await openCreateForm(user);
+
+      expect(screen.queryByLabelText(/単位/)).toBeNull();
+      expect(screen.queryByLabelText(/ラベル/)).toBeNull();
+    });
+  });
+
+  describe("編集", () => {
+    it("行をタップすると既存の値が入ったフォームが開き、更新できる", async () => {
+      const user = userEvent.setup();
+      const menu = buildMenu({ id: 4, name: "素振り" });
+      mockUpdate.mockResolvedValue({
+        ok: true,
+        data: { ...menu, name: "連続素振り" },
+      });
+      render(<PracticeMenusContent initialMenus={[menu]} />);
+
+      await user.click(screen.getByRole("button", { name: "素振りを編集" }));
+
+      expect(
+        screen.getByRole("dialog", { name: "メニューを編集" }),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText(/名前/)).toHaveValue("素振り");
+      expect(screen.getByLabelText(/初期値/)).toHaveValue(200);
+
+      await user.clear(screen.getByLabelText(/名前/));
+      await user.type(screen.getByLabelText(/名前/), "連続素振り");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      expect(mockUpdate).toHaveBeenCalledWith(
+        4,
+        expect.objectContaining({ name: "連続素振り" }),
+      );
+      expect(await screen.findByText("連続素振り")).toBeVisible();
+    });
+
+    it("編集時は無料枠の上限に達していてもフォームを開ける", async () => {
+      const user = userEvent.setup();
+      render(
+        <PracticeMenusContent
+          initialMenus={[
+            buildMenu({ id: 1, name: "素振り" }),
+            buildMenu({ id: 2, name: "ティー" }),
+            buildMenu({ id: 3, name: "ランニング" }),
+          ]}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "素振りを編集" }));
+
+      expect(
+        screen.getByRole("dialog", { name: "メニューを編集" }),
+      ).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("削除", () => {
+    it("確認を経てから削除する", async () => {
+      const user = userEvent.setup();
+      mockDelete.mockResolvedValue({
+        ok: true,
+        data: { message: "削除しました" },
+      });
+      render(
+        <PracticeMenusContent
+          initialMenus={[buildMenu({ id: 7, name: "ティー" })]}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "ティーを削除" }));
+
+      expect(
+        screen.getByText("「ティー」を削除しますか？"),
+      ).toBeInTheDocument();
+      expect(mockDelete).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole("button", { name: "削除" }));
+
+      await waitFor(() => expect(mockDelete).toHaveBeenCalledWith(7));
+      await waitFor(() => expect(screen.queryByText("ティー")).toBeNull());
+    });
+
+    it("確認をキャンセルすると削除しない", async () => {
+      const user = userEvent.setup();
+      render(
+        <PracticeMenusContent
+          initialMenus={[buildMenu({ id: 7, name: "ティー" })]}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "ティーを削除" }));
+      await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+      expect(mockDelete).not.toHaveBeenCalled();
+      expect(screen.getByText("ティー")).toBeVisible();
+    });
+
+    it("削除確認では練習ログが残ることを伝える", async () => {
+      const user = userEvent.setup();
+      render(
+        <PracticeMenusContent
+          initialMenus={[buildMenu({ id: 7, name: "ティー" })]}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "ティーを削除" }));
+
+      expect(
+        screen.getByText(
+          "これまでに記録した練習ログは削除されず、そのまま残ります。",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("無料枠の上限", () => {
+    const threeMenus = [
+      buildMenu({ id: 1, name: "素振り" }),
+      buildMenu({ id: 2, name: "ティー" }),
+      buildMenu({ id: 3, name: "ランニング" }),
+    ];
+
+    it("無料ユーザーが4件目を作ろうとするとフォームではなくペイウォールが出る", async () => {
+      const user = userEvent.setup();
+      render(<PracticeMenusContent initialMenus={threeMenus} />);
+
+      await openCreateForm(user);
+
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "unlimited_practice_menus",
+      });
+      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("上限に達すると Pro 限定ではなく件数上限として案内する", () => {
+      render(<PracticeMenusContent initialMenus={threeMenus} />);
+
+      expect(
+        screen.getByText("無料プランで登録できる練習メニューは3件までです"),
+      ).toBeVisible();
+      expect(
+        screen.getByText(
+          "Pro プランなら4つ目以降の練習メニューも自由に登録・編集できます。",
+        ),
+      ).toBeVisible();
+    });
+
+    it("上限未満なら案内を出さずフォームを開ける", async () => {
+      const user = userEvent.setup();
+      render(<PracticeMenusContent initialMenus={threeMenus.slice(0, 2)} />);
+
+      expect(
+        screen.queryByText("無料プランで登録できる練習メニューは3件までです"),
+      ).toBeNull();
+
+      await openCreateForm(user);
+
+      expect(
+        screen.getByRole("dialog", { name: "メニューを作る" }),
+      ).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+
+    it("Pro ユーザーは4件目以降も作成フォームを開ける", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ granted: true });
+      render(<PracticeMenusContent initialMenus={threeMenus} />);
+
+      expect(
+        screen.queryByText("無料プランで登録できる練習メニューは3件までです"),
+      ).toBeNull();
+
+      await openCreateForm(user);
+
+      expect(
+        screen.getByRole("dialog", { name: "メニューを作る" }),
+      ).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+
+    it("Pro 判定が未確定の間は上限の案内を出さない", () => {
+      mockEntitlement({ isLoading: true });
+      render(<PracticeMenusContent initialMenus={threeMenus} />);
+
+      expect(
+        screen.queryByText("無料プランで登録できる練習メニューは3件までです"),
+      ).toBeNull();
+    });
+  });
+
+  describe("サーバー側の 403", () => {
+    it("作成が 403 で拒否されたら件数上限の文言とペイウォールを出す", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({
+        ok: false,
+        reason: "forbidden",
+        errors: ["Forbidden"],
+      });
+      render(<PracticeMenusContent initialMenus={[]} />);
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText(/名前/), "ダッシュ");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      expect(
+        await screen.findByText(
+          "無料プランで登録できる練習メニューは3件までです。Pro プランなら4つ目以降の練習メニューも自由に登録・編集できます。",
+        ),
+      ).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "unlimited_practice_menus",
+      });
+    });
+
+    it("作成が 422 で失敗したらサーバーのエラーメッセージを出す", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({
+        ok: false,
+        reason: "error",
+        errors: ["名前はすでに使われています"],
+      });
+      render(<PracticeMenusContent initialMenus={[]} />);
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText(/名前/), "素振り");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      expect(
+        await screen.findByText("名前はすでに使われています"),
+      ).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/(app)/practice/menus/_components/PracticeMenuFormModal.tsx
+++ b/app/(app)/practice/menus/_components/PracticeMenuFormModal.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import type {
+  PracticeCategory,
+  PracticeMenu,
+  PracticeMenuInput,
+  PracticeUnit,
+} from "@app/types/practice";
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import { useState } from "react";
+import {
+  PRACTICE_CATEGORIES,
+  PRACTICE_UNITS,
+  parseDecimal,
+} from "@app/constants/practice";
+import { NAME_REQUIRED_ERROR } from "./practiceMenuCopy";
+
+interface PracticeMenuFormModalProps {
+  /** 編集対象。null なら新規作成。 */
+  menu: PracticeMenu | null;
+  isSaving: boolean;
+  /** 保存に失敗したときにフォーム内へ出すサーバー由来のメッセージ。 */
+  serverErrors: string[];
+  onClose: () => void;
+  onSubmit: (input: PracticeMenuInput) => void;
+}
+
+/** 未知の unit が来ても落とさないよう、既定（回数）へフォールバックする。 */
+function unitMetaFor(unit: PracticeUnit) {
+  return PRACTICE_UNITS.find((item) => item.key === unit) ?? PRACTICE_UNITS[0];
+}
+
+/**
+ * 練習メニューの作成・編集フォーム。
+ *
+ * このコンポーネントは入力値の保持と必須チェックだけを担い、
+ * API 呼び出し・上限判定は呼び出し元（Container）に委ねる。
+ * 開くたびに呼び出し元が key を変えて再マウントするため、
+ * 初期値の同期に useEffect を使わずに済ませている。
+ */
+export default function PracticeMenuFormModal({
+  menu,
+  isSaving,
+  serverErrors,
+  onClose,
+  onSubmit,
+}: PracticeMenuFormModalProps) {
+  const [name, setName] = useState(menu?.name ?? "");
+  const [category, setCategory] = useState<PracticeCategory>(
+    menu?.category ?? "batting",
+  );
+  const [unit, setUnit] = useState<PracticeUnit>(menu?.unit ?? "count");
+  const [defaultValue, setDefaultValue] = useState(() => {
+    const parsed = parseDecimal(menu?.default_value);
+    return parsed === null ? "" : String(parsed);
+  });
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  const unitMeta = unitMetaFor(unit);
+
+  const handleCategoryChange = (next: PracticeCategory) => {
+    setCategory(next);
+    // 筋トレは重さ×回数を既定にする。逆に筋トレ以外へ移したときは重さ×回数を引きずらせない。
+    if (next === "strength") {
+      setUnit("weight_reps");
+    } else if (unit === "weight_reps") {
+      setUnit("count");
+    }
+  };
+
+  const handleSubmit = () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setNameError(NAME_REQUIRED_ERROR);
+      return;
+    }
+    setNameError(null);
+
+    onSubmit({
+      name: trimmedName,
+      category,
+      unit,
+      // 表示ラベルは計測タイプから自動で決める（回数=本、時間=分 など）。ユーザーには入力させない。
+      unit_label: unitMeta.defaultLabel,
+      default_value: defaultValue === "" ? null : Number(defaultValue),
+    });
+  };
+
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      placement="center"
+      scrollBehavior="inside"
+      className="buzz-dark"
+    >
+      <ModalContent>
+        <ModalHeader className="text-white">
+          {menu ? "メニューを編集" : "メニューを作る"}
+        </ModalHeader>
+        <ModalBody className="gap-4">
+          <Input
+            type="text"
+            variant="bordered"
+            label="名前"
+            labelPlacement="outside"
+            isRequired
+            placeholder="例: 素振り、ティー、ランニング"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            isInvalid={nameError !== null}
+            errorMessage={nameError}
+          />
+
+          <div>
+            <p className="mb-1.5 text-sm text-white">
+              カテゴリ<span className="ml-1 text-danger">*</span>
+            </p>
+            <div
+              className="flex flex-wrap gap-2"
+              role="group"
+              aria-label="カテゴリ"
+            >
+              {PRACTICE_CATEGORIES.map((item) => {
+                const isActive = item.key === category;
+                return (
+                  <button
+                    key={item.key}
+                    type="button"
+                    aria-pressed={isActive}
+                    onClick={() => handleCategoryChange(item.key)}
+                    className={`rounded-full px-3.5 py-2 text-xs font-bold transition-colors ${
+                      isActive
+                        ? "bg-[#d08000] text-white"
+                        : "bg-sub text-zinc-400 hover:text-white"
+                    }`}
+                  >
+                    {item.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-1.5 text-sm text-white">
+              計測<span className="ml-1 text-danger">*</span>
+            </p>
+            <div
+              className="flex overflow-hidden rounded-lg border-1 border-zinc-600"
+              role="group"
+              aria-label="計測"
+            >
+              {PRACTICE_UNITS.map((item) => {
+                const isActive = item.key === unit;
+                return (
+                  <button
+                    key={item.key}
+                    type="button"
+                    aria-pressed={isActive}
+                    onClick={() => setUnit(item.key)}
+                    className={`flex-1 py-2.5 text-sm font-bold transition-colors ${
+                      isActive
+                        ? "bg-[#d08000] text-white"
+                        : "bg-sub text-zinc-400"
+                    }`}
+                  >
+                    {item.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <Input
+            type="number"
+            variant="bordered"
+            label="初期値（任意）"
+            labelPlacement="outside"
+            placeholder={`例: ${unitMeta.placeholderValue}`}
+            value={defaultValue}
+            onChange={(event) => setDefaultValue(event.target.value)}
+            endContent={
+              <span className="text-sm text-zinc-400">
+                {unitMeta.defaultLabel}
+              </span>
+            }
+            description="記録するときに初期表示される量です。毎回変更できます。"
+          />
+
+          {serverErrors.length > 0 ? (
+            <ul role="alert" className="space-y-1 text-sm text-danger">
+              {serverErrors.map((message) => (
+                <li key={message}>{message}</li>
+              ))}
+            </ul>
+          ) : null}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="flat" onPress={onClose} isDisabled={isSaving}>
+            キャンセル
+          </Button>
+          <Button
+            color="primary"
+            onPress={handleSubmit}
+            isDisabled={isSaving}
+            isLoading={isSaving}
+            className="font-bold"
+          >
+            保存
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/app/(app)/practice/menus/_components/PracticeMenuList.tsx
+++ b/app/(app)/practice/menus/_components/PracticeMenuList.tsx
@@ -1,0 +1,103 @@
+import type { PracticeMenu } from "@app/types/practice";
+import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
+import {
+  PRACTICE_CATEGORIES,
+  PRACTICE_CATEGORY_ICONS,
+  parseDecimal,
+  unitLabel,
+} from "@app/constants/practice";
+import { EMPTY_MESSAGE } from "./practiceMenuCopy";
+
+interface PracticeMenuListProps {
+  menus: PracticeMenu[];
+  onEdit: (menu: PracticeMenu) => void;
+  onDelete: (menu: PracticeMenu) => void;
+}
+
+/**
+ * メニュー行に出す補足。「回数 ・ 初期値 200本」のように計測タイプと初期値を並べる。
+ * default_value は back から文字列 decimal（"200.0"）で来るため、数値化してから表示する。
+ */
+function menuSummary(menu: PracticeMenu): string {
+  const defaultValue = parseDecimal(menu.default_value);
+  const label = unitLabel(menu.unit);
+  if (defaultValue === null) return label;
+  return `${label} ・ 初期値 ${defaultValue}${menu.unit_label ?? ""}`;
+}
+
+/**
+ * 練習メニューをカテゴリ別にグルーピングして並べる表示コンポーネント。
+ * 並び順は PRACTICE_CATEGORIES（back の CATEGORIES と同順）に従い、
+ * メニューが1件も無いカテゴリは見出しごと出さない。
+ */
+export default function PracticeMenuList({
+  menus,
+  onEdit,
+  onDelete,
+}: PracticeMenuListProps) {
+  if (menus.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-zinc-400">{EMPTY_MESSAGE}</p>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {PRACTICE_CATEGORIES.map((category) => {
+        const inCategory = menus.filter(
+          (menu) => menu.category === category.key,
+        );
+        if (inCategory.length === 0) return null;
+        const CategoryIcon = PRACTICE_CATEGORY_ICONS[category.key];
+
+        return (
+          <section
+            key={category.key}
+            aria-labelledby={`practice-menu-group-${category.key}`}
+          >
+            <h3
+              id={`practice-menu-group-${category.key}`}
+              className="flex items-center gap-1.5 text-sm font-bold text-zinc-400"
+            >
+              <CategoryIcon
+                className="h-4 w-4 shrink-0 text-[#d08000]"
+                aria-hidden
+              />
+              {category.label}
+            </h3>
+            <ul className="mt-2 space-y-2">
+              {inCategory.map((menu) => (
+                <li
+                  key={menu.id}
+                  className="flex items-center gap-3 rounded-[10px] bg-sub px-3.5 py-3"
+                >
+                  <button
+                    type="button"
+                    onClick={() => onEdit(menu)}
+                    aria-label={`${menu.name}を編集`}
+                    className="flex-1 text-left"
+                  >
+                    <span className="block text-sm font-bold text-white">
+                      {menu.name}
+                    </span>
+                    <span className="mt-0.5 block text-xs text-zinc-400">
+                      {menuSummary(menu)}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onDelete(menu)}
+                    aria-label={`${menu.name}を削除`}
+                    className="shrink-0 rounded-full p-1 text-zinc-400 transition-colors hover:text-danger"
+                  >
+                    <TrashIcon className="h-5 w-5" aria-hidden />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(app)/practice/menus/_components/PracticeMenusContent.tsx
+++ b/app/(app)/practice/menus/_components/PracticeMenusContent.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import type { PracticeMenu, PracticeMenuInput } from "@app/types/practice";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
+import { PRACTICE_MENU_FREE_LIMIT } from "@app/constants/practice";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import {
+  createPracticeMenu,
+  deletePracticeMenu,
+  updatePracticeMenu,
+} from "@app/services/v2/practiceMenuService";
+import {
+  DELETE_KEEPS_LOGS_NOTICE,
+  FREE_LIMIT_DESCRIPTION,
+  FREE_LIMIT_SERVER_ERROR,
+  FREE_LIMIT_TITLE,
+} from "./practiceMenuCopy";
+import PracticeMenuFormModal from "./PracticeMenuFormModal";
+import PracticeMenuList from "./PracticeMenuList";
+
+interface PracticeMenusContentProps {
+  initialMenus: PracticeMenu[];
+}
+
+/** フォームを開くたびに増やし、key の付け替えで入力状態を初期化するための識別子。 */
+interface FormTarget {
+  menu: PracticeMenu | null;
+  token: number;
+}
+
+/**
+ * 練習メニュー画面の Container。
+ * 一覧の状態保持・Server Action 呼び出し・無料枠の判定を担い、表示は子コンポーネントへ委ねる。
+ */
+export default function PracticeMenusContent({
+  initialMenus,
+}: PracticeMenusContentProps) {
+  const [menus, setMenus] = useState<PracticeMenu[]>(initialMenus);
+  const [form, setForm] = useState<FormTarget | null>(null);
+  const [formErrors, setFormErrors] = useState<string[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<PracticeMenu | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const { hasEntitlement, isLoading: isEntitlementLoading } = useEntitlement();
+  const { open: openProUpgradeModal } = useProUpgradeModal();
+
+  const hasUnlimited = hasEntitlement("unlimited_practice_menus");
+  // 判定が確定するまでは上限扱いにしない。未確定のまま塞ぐと Pro 加入者に上限を誤って告知してしまう。
+  const isAtFreeLimit =
+    !isEntitlementLoading &&
+    !hasUnlimited &&
+    menus.length >= PRACTICE_MENU_FREE_LIMIT;
+
+  const openForm = (menu: PracticeMenu | null) => {
+    setFormErrors([]);
+    setForm({ menu, token: Date.now() + menus.length });
+  };
+
+  const handleAdd = () => {
+    if (isAtFreeLimit) {
+      openProUpgradeModal({ trigger: "unlimited_practice_menus" });
+      return;
+    }
+    openForm(null);
+  };
+
+  const handleSubmit = async (input: PracticeMenuInput) => {
+    const editing = form?.menu ?? null;
+    setIsSaving(true);
+    setFormErrors([]);
+
+    const result = editing
+      ? await updatePracticeMenu(editing.id, input)
+      : await createPracticeMenu(input);
+    setIsSaving(false);
+
+    if (result.ok) {
+      setMenus((prev) =>
+        editing
+          ? prev.map((item) => (item.id === editing.id ? result.data : item))
+          : [...prev, result.data],
+      );
+      setForm(null);
+      toast.success(
+        editing ? "練習メニューを更新しました" : "練習メニューを作成しました",
+      );
+      return;
+    }
+
+    // 作成時の 403 は Pro 限定機能ではなく無料枠の超過を意味する。
+    // 別端末での追加などでクライアント側の件数判定とずれた場合にここへ入る。
+    if (!editing && result.reason === "forbidden") {
+      setFormErrors([FREE_LIMIT_SERVER_ERROR]);
+      openProUpgradeModal({ trigger: "unlimited_practice_menus" });
+      return;
+    }
+    setFormErrors(result.errors);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    const result = await deletePracticeMenu(deleteTarget.id);
+    setIsDeleting(false);
+
+    if (!result.ok) {
+      toast.error(result.errors[0]);
+      return;
+    }
+    setMenus((prev) => prev.filter((item) => item.id !== deleteTarget.id));
+    setDeleteTarget(null);
+    toast.success("練習メニューを削除しました");
+  };
+
+  return (
+    <>
+      <h2 className="text-2xl font-bold">練習メニュー</h2>
+      <p className="mt-2 text-sm text-zinc-300">
+        練習の記録に使うメニューを登録します。カテゴリと計測タイプを決めておくと、記録するときに量をそのまま入力できます。
+      </p>
+
+      <div className="my-6">
+        <PracticeMenuList
+          menus={menus}
+          onEdit={openForm}
+          onDelete={setDeleteTarget}
+        />
+      </div>
+
+      {isAtFreeLimit ? (
+        <ProUpsellCard
+          feature="unlimited_practice_menus"
+          title={FREE_LIMIT_TITLE}
+          description={FREE_LIMIT_DESCRIPTION}
+          ctaLabel="Pro プランを見る"
+          className="mb-4"
+        />
+      ) : null}
+
+      <Button
+        color="primary"
+        fullWidth
+        radius="sm"
+        className="font-bold"
+        startContent={<PlusIcon className="h-5 w-5" aria-hidden />}
+        isDisabled={isEntitlementLoading}
+        onPress={handleAdd}
+      >
+        メニューを作る
+      </Button>
+
+      {form ? (
+        <PracticeMenuFormModal
+          key={form.token}
+          menu={form.menu}
+          isSaving={isSaving}
+          serverErrors={formErrors}
+          onClose={() => setForm(null)}
+          onSubmit={handleSubmit}
+        />
+      ) : null}
+
+      <Modal
+        isOpen={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        placement="center"
+        className="buzz-dark"
+      >
+        <ModalContent>
+          <ModalHeader className="text-white">メニューの削除</ModalHeader>
+          <ModalBody>
+            <p className="text-sm text-white">
+              「{deleteTarget?.name}」を削除しますか？
+            </p>
+            <p className="text-xs text-zinc-400">{DELETE_KEEPS_LOGS_NOTICE}</p>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="flat"
+              onPress={() => setDeleteTarget(null)}
+              isDisabled={isDeleting}
+            >
+              キャンセル
+            </Button>
+            <Button
+              color="danger"
+              onPress={handleDelete}
+              isDisabled={isDeleting}
+              isLoading={isDeleting}
+            >
+              削除
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/app/(app)/practice/menus/_components/practiceMenuCopy.ts
+++ b/app/(app)/practice/menus/_components/practiceMenuCopy.ts
@@ -1,0 +1,27 @@
+import { PRACTICE_MENU_FREE_LIMIT } from "@app/constants/practice";
+
+/**
+ * 練習メニュー画面の文言。
+ * 無料枠の上限は back の 403 と同じ意味（Pro 限定機能ではなく「件数の上限超過」）で伝えるため、
+ * 上限にまつわる文言は件数を明示した表現に統一して1箇所で持つ。
+ */
+
+/** 無料枠を使い切ったユーザーに出す見出し。 */
+export const FREE_LIMIT_TITLE = `無料プランで登録できる練習メニューは${PRACTICE_MENU_FREE_LIMIT}件までです`;
+
+/** 上限解放後に何ができるかの説明。 */
+export const FREE_LIMIT_DESCRIPTION = `Pro プランなら${PRACTICE_MENU_FREE_LIMIT + 1}つ目以降の練習メニューも自由に登録・編集できます。`;
+
+/**
+ * 作成 API が 403 を返したときにフォーム上へ出すエラー。
+ * クライアント側の件数判定をすり抜けた（別端末で作成した等）ケースで表示する。
+ */
+export const FREE_LIMIT_SERVER_ERROR = `${FREE_LIMIT_TITLE}。${FREE_LIMIT_DESCRIPTION}`;
+
+export const EMPTY_MESSAGE = "まだ練習メニューがありません";
+
+export const NAME_REQUIRED_ERROR = "メニュー名を入力してください";
+
+/** 削除は archived による論理削除で、記録済みの練習ログは消えないことを伝える。 */
+export const DELETE_KEEPS_LOGS_NOTICE =
+  "これまでに記録した練習ログは削除されず、そのまま残ります。";

--- a/app/(app)/practice/menus/page.tsx
+++ b/app/(app)/practice/menus/page.tsx
@@ -1,0 +1,38 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getPracticeMenus } from "@app/services/v2/practiceMenuService";
+import PracticeMenusContent from "./_components/PracticeMenusContent";
+
+export const metadata = {
+  title: "練習メニュー",
+};
+
+export default async function PracticeMenusPage() {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const result = await getPracticeMenus();
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            {result.status === "ok" ? (
+              <PracticeMenusContent initialMenus={result.data} />
+            ) : (
+              // 取得失敗を空配列に丸めると「メニュー未登録」と誤表示し、重複作成を招く。
+              <p className="py-8 text-center text-sm text-zinc-400">
+                練習メニューを取得できませんでした。時間を置いて再度お試しください。
+              </p>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/components/header/HeaderRight.tsx
+++ b/app/components/header/HeaderRight.tsx
@@ -9,6 +9,7 @@ import {
 } from "@heroui/react";
 import Link from "next/link";
 import HeaderLoginAndSignUp from "@app/components/auth/HeaderLoginAndSignUp";
+import { BallIcon } from "@app/components/icon/BallIcon";
 import { CalendarIcon } from "@app/components/icon/CalendarIcon";
 import { MailIcon } from "@app/components/icon/MailIcon";
 import { MenuIcon } from "@app/components/icon/MenuIcon";
@@ -53,6 +54,16 @@ export default function HeaderRight() {
                   }
                 >
                   野球ノート
+                </DropdownItem>
+                <DropdownItem
+                  key="practice-menus"
+                  as={Link}
+                  href="/practice/menus"
+                  startContent={
+                    <BallIcon fill="currentColor" width="18" height="18" />
+                  }
+                >
+                  練習メニュー
                 </DropdownItem>
                 <DropdownItem
                   key="seasons"

--- a/app/components/header/__tests__/HeaderRight.test.tsx
+++ b/app/components/header/__tests__/HeaderRight.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import HeaderRight from "../HeaderRight";
+
+jest.mock("@app/components/auth/HeaderLoginAndSignUp", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@app/components/notification/NotificationBadge", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@app/components/user/UserSearch", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockIsLoggedIn = jest.fn<boolean | undefined, []>();
+jest.mock("@app/contexts/useAuthContext", () => ({
+  useAuthContext: () => ({ isLoggedIn: mockIsLoggedIn() }),
+}));
+
+async function openMenu() {
+  render(<HeaderRight />);
+  await userEvent.click(screen.getByRole("button", { name: "メニュー" }));
+}
+
+describe("HeaderRight のメニュー", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsLoggedIn.mockReturnValue(true);
+  });
+
+  // 導線が無いと機能そのものに到達できないため、リンク先まで固定する
+  it("練習メニューへの導線を持つ", async () => {
+    await openMenu();
+
+    expect(
+      screen.getByRole("menuitem", { name: /練習メニュー/ }),
+    ).toHaveAttribute("href", "/practice/menus");
+  });
+
+  it("野球ノートとシーズン管理の導線を維持する", async () => {
+    await openMenu();
+
+    expect(
+      screen.getByRole("menuitem", { name: /野球ノート/ }),
+    ).toHaveAttribute("href", "/note");
+    expect(
+      screen.getByRole("menuitem", { name: /シーズン管理/ }),
+    ).toHaveAttribute("href", "/seasons");
+  });
+
+  it("未ログインではメニューを出さない", () => {
+    mockIsLoggedIn.mockReturnValue(false);
+
+    render(<HeaderRight />);
+
+    expect(
+      screen.queryByRole("button", { name: "メニュー" }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#468

## 概要

**Pro LP の機能比較表には既に「練習メニュー 無料3件/Pro無制限」を掲載しているのに、front では課金しても該当機能が使えない状態**でした。mobile の `app/(practice-menu)/list.tsx` / `form.tsx` 相当を実装します。

## 変更内容

- `app/(app)/practice/menus/page.tsx` — Server Component。認証チェック → 一覧取得 → 委譲
- `_components/PracticeMenusContent.tsx` — Container。一覧 state / Server Action 呼び出し / 無料枠判定 / 削除確認
- `_components/PracticeMenuList.tsx` — Presentational。カテゴリ別グルーピング・空状態
- `_components/PracticeMenuFormModal.tsx` — 作成/編集フォーム
- `_components/practiceMenuCopy.ts` — 文言を一元管理（件数は `PRACTICE_MENU_FREE_LIMIT` から算出）
- **`HeaderRight.tsx` にヘッダーメニューの導線を追加**（下記参照）

型・定数・サービス・Pro UI は #467 でマージ済みのものをそのまま利用し、**新規作成していません**。

## 導線を追加しました

実装者からの報告で「`/practice/menus` はどこからもリンクされていない」ことが判明したため、**到達できない機能になるのを避けて**ヘッダーメニュー（野球ノート・シーズン管理と並ぶ位置）に導線を追加しました。リンク先まで固定するテストも入れ、**導線の削除とリンク先の改変の両方が検出されること**を確認済みです。

## 筋トレ連動の正確な挙動（mobile 準拠）

mobile の `CategoryPicker.onChange` は**カテゴリ変更時のみ**発火し、以下の3挙動を持ちます。そのまま実装し、3本のテストで固定しています。

1. 筋トレを選んだ時点で既存の計測タイプを**無条件で上書き**（→ `weight_reps`）
2. 筋トレ以外へ移した際に `weight_reps` が残っていれば `count` へ戻す
3. その後ユーザーが計測タイプを手動変更するのは自由（カテゴリを触らない限り上書きされない）

`unit_label` は計測タイプから自動決定し、ユーザーには入力させません（`count`→本 / `minutes`→分 / `distance`→km / `weight_reps`→回）。

## ペイウォールは「無料枠超過」の文脈にしています

back の 403 は「Pro 限定機能」ではなく**無料枠超過**を意味するため、文言をその文脈に合わせました。

- 見出し「無料プランで登録できる練習メニューは3件までです」
- 説明「Pro プランなら4つ目以降の練習メニューも自由に登録・編集できます。」

**クライアント判定とサーバ 403 の両方を実装**しています（片方に頼り切らない）。403 の限定文言は create のときだけ適用し、更新の 403 は上限と無関係なのでサーバのメッセージをそのまま表示します。

**Pro 判定が未確定（`isLoading`）の間は上限扱いにしません**（Pro 加入者に誤って上限を告知しないため）。この間だけ作成ボタンを無効化しています。

## 削除確認では「記録は消えない」ことを伝えています

```
メニューの削除
「素振り」を削除しますか？
これまでに記録した練習ログは削除されず、そのまま残ります。
```

実装は archived による論理削除ですが、「archived」「論理削除」という実装語は使わず**ユーザーにとっての意味に翻訳**しています。削除を躊躇する主因は「今までの積み上げが消えるのでは」という不安であり、それを解消しないと機能が使われなくなるためです。

## 確認手順

1. ヘッダーメニューから「練習メニュー」を開く
2. 空状態「まだ練習メニューがありません」が出ること
3. メニューを作成し、カテゴリ別にグルーピングされること
4. カテゴリで「筋トレ」を選ぶと計測タイプが「重さ×回数」に切り替わること
5. 無料アカウントで4件目を作ろうとするとペイウォールが出ること
6. 削除時に確認が出て、「練習ログは残る」旨が表示されること

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る（error 0 / warning 0）
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（**116 suites / 1219 tests**。新規 2 suites / 32 tests）
- [ ] `yarn build` — CI の Build Check で検証（`/practice/menus` は `cookies()` を読むため動的1件の増加。**既存ルートの分類が変わっていないこと**を確認してください）
- [x] ミューテーションテスト **27 設計 / 27 KILLED / 0 SURVIVED**

<details>
<summary>ミューテーションテスト詳細</summary>

隔離複製で実施（無改変ベースライン通過を事前確認済み。作業ツリーは未改変）。

無料上限 3→4 / 上限判定の off-by-one / entitlement 判定の反転 / 追加時の上限チェック削除 / 上限案内カードの表示条件反転 / 403 ハンドリング削除 / 403 でペイウォールを開かない / 403 文言を汎用 Pro 文言に / 削除確認をスキップ / Pro 判定未確定でも上限扱い / 編集を作成 API に投げる / 筋トレ連動の除去 / 連動カテゴリの取り違え / 筋トレ以外へ戻す分岐の除去 / `unit_label` を送らない / `unit_label` に unit キーを送る / 対応表の取り違え2件 / 名前必須バリデーション除去 / グルーピング順の逆転 / 空カテゴリの見出しを出す / 空状態表示の削除 / `parseDecimal` を通さない / API パス改変 / API メソッド改変 — 全 KILLED。

**導線について追加で2件検証**: リンク先を `/practice` に改変 → KILLED、導線の DropdownItem ごと削除 → KILLED。

</details>

## レビューで確認いただきたい点

- **一覧の再取得を `router.refresh()` ではなく local state 更新にしています**（既存 `SeasonsList` と同方式）。back は「お気に入り先頭 → sort_order 昇順」で返しますが、作成直後は末尾追加なのでカテゴリ内の順序がサーバ順とズレる可能性があります。リロードで整合するため許容範囲と判断しました
- **`is_favorite` / `sort_order` はフォームに出していません**（issue の項目になく mobile のフォームにもないため、作成時は back の既定値に任せています）
- **削除失敗はトースト、保存失敗はフォーム内表示**と出し分けています（保存はフォームが開いたままなので文脈内に出す方が直せるという判断）

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_