### PR TITLE
Add: 練習記録（日次セッション）入力画面を実装

### DIFF
--- a/app/(app)/practice/record/__tests__/PracticeRecordContent.test.tsx
+++ b/app/(app)/practice/record/__tests__/PracticeRecordContent.test.tsx
@@ -1,0 +1,684 @@
+const mockPush = jest.fn();
+const mockOpenProUpgradeModal = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({
+    open: mockOpenProUpgradeModal,
+    close: jest.fn(),
+  }),
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@app/services/v2/practiceSessionService", () => ({
+  getPracticeSessionByDate: jest.fn(),
+  upsertPracticeSession: jest.fn(),
+}));
+
+import type { ImprovementTheme } from "@app/types/improvementTheme";
+import type {
+  PracticeLog,
+  PracticeMenu,
+  PracticeSession,
+  PracticeSessionItemInput,
+} from "@app/types/practice";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import {
+  getPracticeSessionByDate,
+  upsertPracticeSession,
+} from "@app/services/v2/practiceSessionService";
+import PracticeRecordContent from "../_components/PracticeRecordContent";
+import { todayString } from "../_utils/practiceRecordDraft";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+const mockGetByDate = getPracticeSessionByDate as jest.MockedFunction<
+  typeof getPracticeSessionByDate
+>;
+const mockUpsert = upsertPracticeSession as jest.MockedFunction<
+  typeof upsertPracticeSession
+>;
+
+const TODAY = todayString();
+
+/** 基準日から日数をずらした `YYYY-MM-DD` を返す。 */
+function shiftDays(date: string, days: number): string {
+  const shifted = new Date(`${date}T00:00:00+09:00`);
+  shifted.setDate(shifted.getDate() + days);
+  return todayString(shifted);
+}
+
+const YESTERDAY = shiftDays(TODAY, -1);
+const TOMORROW = shiftDays(TODAY, 1);
+
+function buildMenu(overrides: Partial<PracticeMenu> = {}): PracticeMenu {
+  return {
+    id: 1,
+    name: "素振り",
+    category: "batting",
+    unit: "count",
+    unit_label: "本",
+    default_value: "200.0",
+    is_favorite: false,
+    sort_order: 1,
+    ...overrides,
+  };
+}
+
+function buildLog(overrides: Partial<PracticeLog> = {}): PracticeLog {
+  return {
+    id: 1,
+    practice_menu_id: 1,
+    schedule_id: null,
+    logged_on: YESTERDAY,
+    amount: "300.0",
+    weight: null,
+    menu_name: "素振り",
+    unit_label: "本",
+    source: "manual",
+    memo: null,
+    created_at: `${YESTERDAY}T10:00:00+09:00`,
+    ...overrides,
+  };
+}
+
+function buildSession(
+  overrides: Partial<PracticeSession> = {},
+): PracticeSession {
+  return {
+    id: 10,
+    logged_on: YESTERDAY,
+    memo: null,
+    improvement_theme_ids: [],
+    practice_logs: [],
+    condition: null,
+    created_at: `${YESTERDAY}T10:00:00+09:00`,
+    ...overrides,
+  };
+}
+
+function buildTheme(
+  overrides: Partial<ImprovementTheme> = {},
+): ImprovementTheme {
+  return {
+    id: 1,
+    title: "内角の対応",
+    category: null,
+    purpose: null,
+    status: "open",
+    started_on: TODAY,
+    achieved_on: null,
+    sort_order: 1,
+    practice_logs_count: 0,
+    notes_count: 0,
+    active_days: 0,
+    created_at: `${TODAY}T10:00:00+09:00`,
+    ...overrides,
+  };
+}
+
+function mockEntitlement({
+  granted = false,
+  isLoading = false,
+}: { granted?: boolean; isLoading?: boolean } = {}) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: granted,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading,
+    hasEntitlement: jest.fn(() => granted),
+  });
+}
+
+const DEFAULT_MENUS = [
+  buildMenu({ id: 1, name: "素振り", category: "batting" }),
+  buildMenu({
+    id: 2,
+    name: "ベンチプレス",
+    category: "strength",
+    unit: "weight_reps",
+    unit_label: "回",
+    default_value: "10.0",
+  }),
+  buildMenu({
+    id: 3,
+    name: "ランニング",
+    category: "training",
+    unit: "distance",
+    unit_label: "km",
+    default_value: null,
+  }),
+];
+
+function renderContent(
+  overrides: Partial<React.ComponentProps<typeof PracticeRecordContent>> = {},
+) {
+  return render(
+    <PracticeRecordContent
+      today={TODAY}
+      initialDate={TODAY}
+      menus={DEFAULT_MENUS}
+      initialSession={null}
+      initialLoadFailed={false}
+      presetMenus={[]}
+      themes={[]}
+      {...overrides}
+    />,
+  );
+}
+
+/** 日付欄を別日に切り替える。 */
+function changeDate(value: string) {
+  fireEvent.change(screen.getByLabelText("日付"), { target: { value } });
+}
+
+/** 直近の保存リクエストの items を practice_menu_id 昇順で取り出す。 */
+function savedItems(): PracticeSessionItemInput[] {
+  const input = mockUpsert.mock.calls.at(-1)?.[0];
+  return [...(input?.items ?? [])].sort(
+    (a, b) => a.practice_menu_id - b.practice_menu_id,
+  );
+}
+
+describe("PracticeRecordContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEntitlement();
+    mockUpsert.mockResolvedValue({ ok: true, data: buildSession() });
+  });
+
+  describe("日付の切り替え", () => {
+    it("日付を選ぶとその日の既存セッションを読み込んでフォームが差し替わる", async () => {
+      mockGetByDate.mockResolvedValue({
+        status: "ok",
+        data: buildSession({
+          practice_logs: [buildLog({ practice_menu_id: 1, amount: "300.0" })],
+        }),
+      });
+      renderContent();
+
+      expect(
+        screen.getByRole("checkbox", { name: "素振り" }),
+      ).not.toBeChecked();
+
+      changeDate(YESTERDAY);
+
+      await waitFor(() =>
+        expect(mockGetByDate).toHaveBeenCalledWith(YESTERDAY),
+      );
+      expect(
+        await screen.findByRole("checkbox", { name: "素振り" }),
+      ).toBeChecked();
+      expect(screen.getByLabelText("素振りの量")).toHaveValue(300);
+    });
+
+    it("記録が無い日（by_date が null）は空フォームを出しエラーにしない", async () => {
+      mockGetByDate.mockResolvedValue({ status: "ok", data: null });
+      renderContent({
+        initialSession: buildSession({
+          practice_logs: [buildLog({ practice_menu_id: 1 })],
+        }),
+      });
+
+      changeDate(YESTERDAY);
+
+      await waitFor(() => expect(mockGetByDate).toHaveBeenCalled());
+      await waitFor(() =>
+        expect(
+          screen.getByRole("checkbox", { name: "素振り" }),
+        ).not.toBeChecked(),
+      );
+      expect(screen.queryByRole("alert")).toBeNull();
+      expect(
+        screen.getByRole("button", { name: "練習記録のみ保存" }),
+      ).toBeVisible();
+    });
+
+    it("読み込みに失敗した日は空フォームではなくエラーを出す", async () => {
+      mockGetByDate.mockResolvedValue({ status: "error" });
+      renderContent();
+
+      changeDate(YESTERDAY);
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        "この日の練習記録を読み込めませんでした",
+      );
+      expect(screen.queryByRole("checkbox", { name: "素振り" })).toBeNull();
+    });
+
+    it("未来日は選べない", async () => {
+      renderContent();
+
+      expect(screen.getByLabelText("日付")).toHaveAttribute("max", TODAY);
+
+      changeDate(TOMORROW);
+
+      await waitFor(() => expect(mockGetByDate).not.toHaveBeenCalled());
+    });
+  });
+
+  describe("メニューの選択と量の入力", () => {
+    it("選ぶとメニューの初期値（default_value）が入る", async () => {
+      const user = userEvent.setup();
+      renderContent();
+
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+
+      expect(screen.getByLabelText("素振りの量")).toHaveValue(200);
+    });
+
+    it("重さ×回数のメニューは kg と回の2入力になる", async () => {
+      const user = userEvent.setup();
+      renderContent();
+
+      await user.click(screen.getByRole("checkbox", { name: "ベンチプレス" }));
+
+      expect(screen.getByLabelText("ベンチプレスの重さ（kg）")).toBeVisible();
+      expect(screen.getByLabelText("ベンチプレスの回数")).toHaveValue(10);
+      expect(screen.getByText("kg ×")).toBeVisible();
+    });
+
+    it("重さ×回数以外のメニューは量の1入力だけになる", async () => {
+      const user = userEvent.setup();
+      renderContent();
+
+      await user.click(screen.getByRole("checkbox", { name: "ランニング" }));
+
+      expect(screen.getByLabelText("ランニングの量")).toBeVisible();
+      expect(screen.queryByLabelText(/ランニングの重さ/)).toBeNull();
+    });
+
+    it("重さと回数を入力すると weight と amount に分けて送る", async () => {
+      const user = userEvent.setup();
+      renderContent();
+
+      await user.click(screen.getByRole("checkbox", { name: "ベンチプレス" }));
+      await user.type(screen.getByLabelText("ベンチプレスの重さ（kg）"), "60");
+      await user.click(
+        screen.getByRole("button", { name: "練習記録のみ保存" }),
+      );
+
+      await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+      expect(savedItems()).toEqual([
+        { practice_menu_id: 2, amount: 10, weight: 60 },
+      ]);
+    });
+
+    it("メニューを選ばずに保存しようとすると送信しない", async () => {
+      const user = userEvent.setup();
+      renderContent();
+
+      await user.click(
+        screen.getByRole("button", { name: "練習記録のみ保存" }),
+      );
+
+      expect(
+        await screen.findByText(
+          "記録する内容がありません。メニューを選んでください",
+        ),
+      ).toBeVisible();
+      expect(mockUpsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("既存セッションの上書き保存", () => {
+    it("触っていない項目も含めて全項目を送る", async () => {
+      const user = userEvent.setup();
+      renderContent({
+        initialSession: buildSession({
+          practice_logs: [
+            buildLog({ id: 1, practice_menu_id: 1, amount: "300.0" }),
+            buildLog({
+              id: 2,
+              practice_menu_id: 3,
+              amount: "5.0",
+              menu_name: "ランニング",
+            }),
+          ],
+        }),
+      });
+
+      await user.clear(screen.getByLabelText("素振りの量"));
+      await user.type(screen.getByLabelText("素振りの量"), "400");
+      await user.click(
+        screen.getByRole("button", { name: "練習記録の変更を保存" }),
+      );
+
+      await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+      expect(savedItems()).toEqual([
+        { practice_menu_id: 1, amount: 400, weight: null },
+        { practice_menu_id: 3, amount: 5, weight: null },
+      ]);
+    });
+
+    it("一覧に出ないメニューの記録も送り返してログを消さない", async () => {
+      const user = userEvent.setup();
+      renderContent({
+        initialSession: buildSession({
+          practice_logs: [
+            buildLog({ id: 1, practice_menu_id: 1, amount: "300.0" }),
+            buildLog({
+              id: 2,
+              practice_menu_id: 99,
+              amount: "20.0",
+              menu_name: "削除済みメニュー",
+            }),
+          ],
+        }),
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: "練習記録の変更を保存" }),
+      );
+
+      await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+      expect(savedItems()).toEqual([
+        { practice_menu_id: 1, amount: 300, weight: null },
+        { practice_menu_id: 99, amount: 20, weight: null },
+      ]);
+    });
+
+    it("外したメニューは送らない", async () => {
+      const user = userEvent.setup();
+      renderContent({
+        initialSession: buildSession({
+          practice_logs: [
+            buildLog({ id: 1, practice_menu_id: 1 }),
+            buildLog({ id: 2, practice_menu_id: 3, amount: "5.0" }),
+          ],
+        }),
+      });
+
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+      await user.click(
+        screen.getByRole("button", { name: "練習記録の変更を保存" }),
+      );
+
+      await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+      expect(savedItems()).toEqual([
+        { practice_menu_id: 3, amount: 5, weight: null },
+      ]);
+    });
+
+    it("選んだ日付を logged_on として送る", async () => {
+      const user = userEvent.setup();
+      mockGetByDate.mockResolvedValue({ status: "ok", data: null });
+      renderContent();
+
+      changeDate(YESTERDAY);
+      await waitFor(() => expect(mockGetByDate).toHaveBeenCalled());
+
+      await user.click(await screen.findByRole("checkbox", { name: "素振り" }));
+      await user.click(
+        screen.getByRole("button", { name: "練習記録のみ保存" }),
+      );
+
+      await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+      expect(mockUpsert.mock.calls[0][0].logged_on).toBe(YESTERDAY);
+    });
+  });
+
+  describe("プリセットメニュー", () => {
+    const presetMenus = [{ practice_menu_id: 1, target_value: 150 }];
+
+    it("プリセットで指定されたメニューを目標量つきで選択済みにする", () => {
+      renderContent({ presetMenus });
+
+      expect(screen.getByRole("checkbox", { name: "素振り" })).toBeChecked();
+      expect(screen.getByLabelText("素振りの量")).toHaveValue(150);
+    });
+
+    it("日付を変えるとプリセットは無効になる", async () => {
+      mockGetByDate.mockResolvedValue({ status: "ok", data: null });
+      renderContent({ presetMenus });
+
+      changeDate(YESTERDAY);
+
+      await waitFor(() => expect(mockGetByDate).toHaveBeenCalled());
+      await waitFor(() =>
+        expect(
+          screen.getByRole("checkbox", { name: "素振り" }),
+        ).not.toBeChecked(),
+      );
+    });
+  });
+
+  describe("メニューが1件も無いとき", () => {
+    it("空状態とメニュー作成の導線を出す", () => {
+      renderContent({ menus: [] });
+
+      expect(screen.getByText("まだ練習メニューがありません")).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "最初のメニューを作る" }),
+      ).toHaveAttribute("href", "/practice/menus");
+      expect(screen.queryByRole("checkbox")).toBeNull();
+    });
+  });
+
+  describe("取り組む課題の紐付け", () => {
+    it("選んだ課題を紐付けて保存する", async () => {
+      const user = userEvent.setup();
+      renderContent({ themes: [buildTheme({ id: 7, title: "内角の対応" })] });
+
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+      await user.click(screen.getByRole("button", { name: "内角の対応" }));
+      await user.click(
+        screen.getByRole("button", { name: "練習記録のみ保存" }),
+      );
+
+      await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+      expect(mockUpsert.mock.calls[0][0].improvement_theme_ids).toEqual([7]);
+    });
+
+    it("無料プランで2件目を選ぼうとするとペイウォールを出して選択しない", async () => {
+      const user = userEvent.setup();
+      renderContent({
+        themes: [
+          buildTheme({ id: 7, title: "内角の対応" }),
+          buildTheme({ id: 8, title: "初球打ち" }),
+        ],
+      });
+
+      await user.click(screen.getByRole("button", { name: "内角の対応" }));
+      await user.click(screen.getByRole("button", { name: "初球打ち" }));
+
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "multi_improvement_theme_links",
+      });
+      expect(screen.getByRole("button", { name: "初球打ち" })).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
+
+    it("Pro プランなら複数の課題を紐付けられる", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ granted: true });
+      renderContent({
+        themes: [
+          buildTheme({ id: 7, title: "内角の対応" }),
+          buildTheme({ id: 8, title: "初球打ち" }),
+        ],
+      });
+
+      await user.click(screen.getByRole("button", { name: "内角の対応" }));
+      await user.click(screen.getByRole("button", { name: "初球打ち" }));
+
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+      expect(screen.getByRole("button", { name: "初球打ち" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    it("既に複数紐付いている記録は無料プランでもそのまま維持できる", async () => {
+      const user = userEvent.setup();
+      renderContent({
+        themes: [
+          buildTheme({ id: 7, title: "内角の対応" }),
+          buildTheme({ id: 8, title: "初球打ち" }),
+        ],
+        initialSession: buildSession({
+          improvement_theme_ids: [7, 8],
+          practice_logs: [buildLog({ practice_menu_id: 1 })],
+        }),
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: "練習記録の変更を保存" }),
+      );
+
+      await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+      expect(mockUpsert.mock.calls[0][0].improvement_theme_ids).toEqual([7, 8]);
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("野球ノートを書く", () => {
+    it("保存後に日付・セッション ID・課題を引き継いでノート作成画面へ進む", async () => {
+      const user = userEvent.setup();
+      mockUpsert.mockResolvedValue({
+        ok: true,
+        data: buildSession({ id: 42, logged_on: TODAY }),
+      });
+      renderContent({ themes: [buildTheme({ id: 7, title: "内角の対応" })] });
+
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+      await user.click(screen.getByRole("button", { name: "内角の対応" }));
+      await user.click(
+        screen.getByRole("button", { name: "野球ノートを書く" }),
+      );
+
+      await waitFor(() => expect(mockPush).toHaveBeenCalledTimes(1));
+      expect(mockPush).toHaveBeenCalledWith(
+        `/note/new?date=${TODAY}&practiceSessionId=42&improvementThemeIds=7`,
+      );
+    });
+
+    it("課題が未選択ならノートへは引き継がない", async () => {
+      const user = userEvent.setup();
+      mockUpsert.mockResolvedValue({
+        ok: true,
+        data: buildSession({ id: 42, logged_on: TODAY }),
+      });
+      renderContent();
+
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+      await user.click(
+        screen.getByRole("button", { name: "野球ノートを書く" }),
+      );
+
+      await waitFor(() => expect(mockPush).toHaveBeenCalledTimes(1));
+      expect(mockPush).toHaveBeenCalledWith(
+        `/note/new?date=${TODAY}&practiceSessionId=42`,
+      );
+    });
+
+    it("練習記録のみ保存ではノート作成画面へ遷移しない", async () => {
+      const user = userEvent.setup();
+      renderContent();
+
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+      await user.click(
+        screen.getByRole("button", { name: "練習記録のみ保存" }),
+      );
+
+      await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(toast.success).toHaveBeenCalledWith("練習記録を保存しました");
+    });
+  });
+
+  describe("保存の失敗", () => {
+    it("403 のときは保存できたように見せず、課題の上限としてペイウォールを出す", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ granted: true });
+      mockUpsert.mockResolvedValue({
+        ok: false,
+        reason: "forbidden",
+        errors: ["複数の課題への紐付けは Pro プラン限定です"],
+      });
+      renderContent({
+        themes: [
+          buildTheme({ id: 7, title: "内角の対応" }),
+          buildTheme({ id: 8, title: "初球打ち" }),
+        ],
+      });
+
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+      await user.click(screen.getByRole("button", { name: "内角の対応" }));
+      await user.click(screen.getByRole("button", { name: "初球打ち" }));
+      await user.click(
+        screen.getByRole("button", { name: "野球ノートを書く" }),
+      );
+
+      expect(
+        await screen.findByText("複数の課題への紐付けは Pro プラン限定です"),
+      ).toBeVisible();
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(toast.success).not.toHaveBeenCalled();
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "multi_improvement_theme_links",
+      });
+    });
+
+    it("課題を複数送っていない 403 ではペイウォールを出さずサーバーの文言を出す", async () => {
+      const user = userEvent.setup();
+      mockUpsert.mockResolvedValue({
+        ok: false,
+        reason: "forbidden",
+        errors: ["コンディション記録は Pro プラン限定です"],
+      });
+      renderContent();
+
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+      await user.click(
+        screen.getByRole("button", { name: "野球ノートを書く" }),
+      );
+
+      expect(
+        await screen.findByText("コンディション記録は Pro プラン限定です"),
+      ).toBeVisible();
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("保存に失敗したらエラーを出して遷移も成功表示もしない", async () => {
+      const user = userEvent.setup();
+      mockUpsert.mockResolvedValue({
+        ok: false,
+        reason: "error",
+        errors: ["練習記録の保存に失敗しました"],
+      });
+      renderContent();
+
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+      await user.click(
+        screen.getByRole("button", { name: "野球ノートを書く" }),
+      );
+
+      expect(
+        await screen.findByText("練習記録の保存に失敗しました"),
+      ).toBeVisible();
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(toast.success).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole("button", { name: "野球ノートを書く" }),
+      ).toBeEnabled();
+    });
+  });
+});

--- a/app/(app)/practice/record/__tests__/practiceRecordDraft.test.ts
+++ b/app/(app)/practice/record/__tests__/practiceRecordDraft.test.ts
@@ -1,0 +1,182 @@
+import type {
+  PracticeLog,
+  PracticeMenu,
+  PracticeSession,
+} from "@app/types/practice";
+import {
+  buildInitialAmounts,
+  buildInitialWeights,
+  buildItems,
+  isFutureDate,
+  parsePresetMenus,
+  resolveInitialDate,
+  toInputValue,
+  todayString,
+} from "../_utils/practiceRecordDraft";
+
+function buildMenu(overrides: Partial<PracticeMenu> = {}): PracticeMenu {
+  return {
+    id: 1,
+    name: "素振り",
+    category: "batting",
+    unit: "count",
+    unit_label: "本",
+    default_value: "200.0",
+    is_favorite: false,
+    sort_order: 1,
+    ...overrides,
+  };
+}
+
+function buildLog(overrides: Partial<PracticeLog> = {}): PracticeLog {
+  return {
+    id: 1,
+    practice_menu_id: 1,
+    schedule_id: null,
+    logged_on: "2026-08-01",
+    amount: "300.0",
+    weight: null,
+    menu_name: "素振り",
+    unit_label: "本",
+    source: "manual",
+    memo: null,
+    created_at: "2026-08-01T10:00:00+09:00",
+    ...overrides,
+  };
+}
+
+function buildSession(logs: PracticeLog[]): PracticeSession {
+  return {
+    id: 10,
+    logged_on: "2026-08-01",
+    memo: null,
+    improvement_theme_ids: [],
+    practice_logs: logs,
+    condition: null,
+    created_at: "2026-08-01T10:00:00+09:00",
+  };
+}
+
+describe("todayString", () => {
+  it("Asia/Tokyo の暦日を YYYY-MM-DD で返す", () => {
+    // UTC では 2026-08-02、Asia/Tokyo では 2026-08-03
+    expect(todayString(new Date("2026-08-02T20:00:00Z"))).toBe("2026-08-03");
+  });
+});
+
+describe("resolveInitialDate", () => {
+  it("未来日が指定されたら今日へ丸める", () => {
+    expect(resolveInitialDate("2026-08-10", "2026-08-03")).toBe("2026-08-03");
+  });
+
+  it("過去日はそのまま使う", () => {
+    expect(resolveInitialDate("2026-07-20", "2026-08-03")).toBe("2026-07-20");
+  });
+
+  it("形式が不正な指定は今日へフォールバックする", () => {
+    expect(resolveInitialDate("2026/07/20", "2026-08-03")).toBe("2026-08-03");
+    expect(resolveInitialDate(undefined, "2026-08-03")).toBe("2026-08-03");
+  });
+});
+
+describe("isFutureDate", () => {
+  it("今日は未来日ではない", () => {
+    expect(isFutureDate("2026-08-03", "2026-08-03")).toBe(false);
+    expect(isFutureDate("2026-08-04", "2026-08-03")).toBe(true);
+  });
+});
+
+describe("parsePresetMenus", () => {
+  it("JSON 配列を解釈する", () => {
+    expect(
+      parsePresetMenus('[{"practice_menu_id":3,"target_value":150}]'),
+    ).toEqual([{ practice_menu_id: 3, target_value: 150 }]);
+  });
+
+  it("壊れた JSON はプリセット無しとして扱う", () => {
+    expect(parsePresetMenus("{{")).toEqual([]);
+    expect(parsePresetMenus(undefined)).toEqual([]);
+  });
+
+  it("target_value が無い項目は null にする", () => {
+    expect(parsePresetMenus('[{"practice_menu_id":3}]')).toEqual([
+      { practice_menu_id: 3, target_value: null },
+    ]);
+  });
+});
+
+describe("toInputValue", () => {
+  it("back の decimal 文字列をそのまま出さない", () => {
+    expect(toInputValue("200.0")).toBe("200");
+    expect(toInputValue(null)).toBe("");
+  });
+});
+
+describe("buildInitialAmounts", () => {
+  it("既存の記録を初期値に入れる", () => {
+    const session = buildSession([buildLog({ practice_menu_id: 1 })]);
+    expect(buildInitialAmounts(session, [])).toEqual({ 1: "300" });
+  });
+
+  it("素振り自動ログは編集対象に含めない", () => {
+    const session = buildSession([
+      buildLog({ id: 2, practice_menu_id: 5, source: "shadow_swing" }),
+    ]);
+    expect(buildInitialAmounts(session, [])).toEqual({});
+  });
+
+  it("既存の記録があるメニューはプリセットで上書きしない", () => {
+    const session = buildSession([buildLog({ practice_menu_id: 1 })]);
+    expect(
+      buildInitialAmounts(session, [
+        { practice_menu_id: 1, target_value: 100 },
+        { practice_menu_id: 2, target_value: 50 },
+      ]),
+    ).toEqual({ 1: "300", 2: "50" });
+  });
+
+  it("記録が無い日は空になる", () => {
+    expect(buildInitialAmounts(null, [])).toEqual({});
+  });
+});
+
+describe("buildInitialWeights", () => {
+  it("既存の重さを初期値に入れる", () => {
+    const session = buildSession([
+      buildLog({ practice_menu_id: 4, amount: "10.0", weight: "60.0" }),
+    ]);
+    expect(buildInitialWeights(session, [], [])).toEqual({ 4: "60" });
+  });
+
+  it("プリセットの筋トレメニューは重さを空欄で用意する", () => {
+    const menus = [buildMenu({ id: 4, unit: "weight_reps" })];
+    expect(
+      buildInitialWeights(
+        null,
+        [{ practice_menu_id: 4, target_value: 10 }],
+        menus,
+      ),
+    ).toEqual({ 4: "" });
+  });
+});
+
+describe("buildItems", () => {
+  it("選択中のメニューを全件送る", () => {
+    expect(buildItems({ 1: "300", 2: "50" }, {})).toEqual([
+      { practice_menu_id: 1, amount: 300, weight: null },
+      { practice_menu_id: 2, amount: 50, weight: null },
+    ]);
+  });
+
+  it("空欄は未入力として null で送る", () => {
+    expect(buildItems({ 1: "" }, {})).toEqual([
+      { practice_menu_id: 1, amount: null, weight: null },
+    ]);
+  });
+
+  it("重さは入力があるメニューだけに付ける", () => {
+    expect(buildItems({ 4: "10" }, { 4: "60" })).toEqual([
+      { practice_menu_id: 4, amount: 10, weight: 60 },
+    ]);
+  });
+});

--- a/app/(app)/practice/record/_components/ImprovementThemeField.tsx
+++ b/app/(app)/practice/record/_components/ImprovementThemeField.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import type { ImprovementTheme } from "@app/types/improvementTheme";
+import FlagIcon from "@heroicons/react/24/outline/FlagIcon";
+import XMarkIcon from "@heroicons/react/24/outline/XMarkIcon";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import {
+  MULTI_THEME_LIMIT_MESSAGE,
+  THEME_EMPTY_MESSAGE,
+} from "./practiceRecordCopy";
+
+interface ImprovementThemeFieldProps {
+  /** 紐付け候補（取組中の課題）。 */
+  themes: ImprovementTheme[];
+  selectedThemeIds: number[];
+  /**
+   * 読み込み時点で紐付いていた件数。
+   * back は既存件数を超えて増やすときだけ Pro 判定するため（グランドファザリング）、
+   * 無料プランでも既存の複数紐付けは維持できるようにこの件数を上限に使う。
+   */
+  linkedThemeCountAtLoad: number;
+  onChange: (themeIds: number[]) => void;
+}
+
+/** 一覧に出ない課題（達成済みなど）に紐付いている場合の表示名。紐付けを黙って外さないために出す。 */
+const UNKNOWN_THEME_LABEL = "課題に紐付け済み";
+
+/**
+ * 練習記録に紐付ける課題を選ぶフィールド。
+ * 無料プランは1件まで（読み込み時点で複数紐付いていればその件数まで）で、
+ * 超えて追加しようとしたときは保存前に Pro 訴求へ倒す。
+ */
+export default function ImprovementThemeField({
+  themes,
+  selectedThemeIds,
+  linkedThemeCountAtLoad,
+  onChange,
+}: ImprovementThemeFieldProps) {
+  const { hasEntitlement, isLoading } = useEntitlement();
+  const { open: openProUpgradeModal } = useProUpgradeModal();
+
+  const maxWithoutPro = Math.max(1, linkedThemeCountAtLoad);
+  // 判定が確定するまでは上限扱いにしない。未確定のまま塞ぐと Pro 加入者に上限を誤って告知してしまう。
+  const isAtLimit =
+    !isLoading &&
+    !hasEntitlement("multi_improvement_theme_links") &&
+    selectedThemeIds.length >= maxWithoutPro;
+
+  const handleToggle = (themeId: number) => {
+    if (selectedThemeIds.includes(themeId)) {
+      onChange(selectedThemeIds.filter((id) => id !== themeId));
+      return;
+    }
+    if (isAtLimit) {
+      openProUpgradeModal({ trigger: "multi_improvement_theme_links" });
+      return;
+    }
+    onChange([...selectedThemeIds, themeId]);
+  };
+
+  const unlistedThemeIds = selectedThemeIds.filter(
+    (id) => !themes.some((theme) => theme.id === id),
+  );
+
+  return (
+    <div>
+      {themes.length === 0 && unlistedThemeIds.length === 0 ? (
+        <p className="text-sm text-zinc-400">{THEME_EMPTY_MESSAGE}</p>
+      ) : (
+        <ul className="space-y-2">
+          {themes.map((theme) => {
+            const isSelected = selectedThemeIds.includes(theme.id);
+            return (
+              <li key={theme.id}>
+                <button
+                  type="button"
+                  aria-pressed={isSelected}
+                  onClick={() => handleToggle(theme.id)}
+                  className={`flex w-full items-center gap-2 rounded-[10px] px-3.5 py-3 text-left text-sm ${
+                    isSelected
+                      ? "bg-sub text-white ring-1 ring-[#d08000]"
+                      : "bg-sub text-zinc-300"
+                  }`}
+                >
+                  <FlagIcon
+                    className="h-4 w-4 shrink-0 text-[#d08000]"
+                    aria-hidden
+                  />
+                  {theme.title}
+                </button>
+              </li>
+            );
+          })}
+          {unlistedThemeIds.map((themeId) => (
+            <li
+              key={themeId}
+              className="flex items-center gap-2 rounded-[10px] bg-sub px-3.5 py-3 text-sm text-zinc-300"
+            >
+              <FlagIcon
+                className="h-4 w-4 shrink-0 text-[#d08000]"
+                aria-hidden
+              />
+              <span className="flex-1">{UNKNOWN_THEME_LABEL}</span>
+              <button
+                type="button"
+                aria-label={`${UNKNOWN_THEME_LABEL}を外す`}
+                onClick={() => handleToggle(themeId)}
+                className="shrink-0 rounded-full p-1 text-zinc-400 transition-colors hover:text-white"
+              >
+                <XMarkIcon className="h-4 w-4" aria-hidden />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {isAtLimit ? (
+        <p className="mt-2 text-xs text-zinc-400">
+          {MULTI_THEME_LIMIT_MESSAGE}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/app/(app)/practice/record/_components/PracticeMenuChecklist.tsx
+++ b/app/(app)/practice/record/_components/PracticeMenuChecklist.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import type { PracticeMenu } from "@app/types/practice";
+import { Checkbox, Input } from "@heroui/react";
+import {
+  PRACTICE_CATEGORIES,
+  PRACTICE_CATEGORY_ICONS,
+  isWeightReps,
+} from "@app/constants/practice";
+
+interface PracticeMenuChecklistProps {
+  menus: PracticeMenu[];
+  /** 選択中メニューの量（menu_id → 入力文字列）。キーの有無が選択状態を表す。 */
+  amounts: Record<number, string>;
+  /** 筋トレメニューの重さ（menu_id → 入力文字列）。 */
+  weights: Record<number, string>;
+  onToggle: (menu: PracticeMenu) => void;
+  onAmountChange: (menuId: number, value: string) => void;
+  onWeightChange: (menuId: number, value: string) => void;
+}
+
+const NUMBER_INPUT_CLASS = "w-24";
+
+/** 量の入力欄のラベル。重さ×回数のメニューだけ「回数」と呼び分ける。 */
+function amountLabel(menu: PracticeMenu): string {
+  return isWeightReps(menu.unit) ? `${menu.name}の回数` : `${menu.name}の量`;
+}
+
+/**
+ * 練習メニューをカテゴリ別に並べ、選択と量の入力を受け持つ表示コンポーネント。
+ * 並び順は PRACTICE_CATEGORIES（back の CATEGORIES と同順）に従い、
+ * メニューが1件も無いカテゴリは見出しごと出さない。
+ */
+export default function PracticeMenuChecklist({
+  menus,
+  amounts,
+  weights,
+  onToggle,
+  onAmountChange,
+  onWeightChange,
+}: PracticeMenuChecklistProps) {
+  return (
+    <div className="space-y-6">
+      {PRACTICE_CATEGORIES.map((category) => {
+        const inCategory = menus.filter(
+          (menu) => menu.category === category.key,
+        );
+        if (inCategory.length === 0) return null;
+        const CategoryIcon = PRACTICE_CATEGORY_ICONS[category.key];
+
+        return (
+          <section
+            key={category.key}
+            aria-labelledby={`practice-record-group-${category.key}`}
+          >
+            <h3
+              id={`practice-record-group-${category.key}`}
+              className="flex items-center gap-1.5 text-sm font-bold text-zinc-400"
+            >
+              <CategoryIcon
+                className="h-4 w-4 shrink-0 text-[#d08000]"
+                aria-hidden
+              />
+              {category.label}
+            </h3>
+            <ul className="mt-2 space-y-2">
+              {inCategory.map((menu) => {
+                const isSelected = menu.id in amounts;
+
+                return (
+                  <li
+                    key={menu.id}
+                    className="rounded-[10px] bg-sub px-3.5 py-3"
+                  >
+                    <Checkbox
+                      isSelected={isSelected}
+                      onValueChange={() => onToggle(menu)}
+                      classNames={{ label: "text-sm font-bold text-white" }}
+                    >
+                      {menu.name}
+                    </Checkbox>
+                    {isSelected ? (
+                      <div className="mt-2.5 flex items-center gap-2 pl-8">
+                        {isWeightReps(menu.unit) ? (
+                          <>
+                            <Input
+                              type="number"
+                              inputMode="decimal"
+                              size="sm"
+                              radius="sm"
+                              className={NUMBER_INPUT_CLASS}
+                              aria-label={`${menu.name}の重さ（kg）`}
+                              placeholder="0"
+                              value={weights[menu.id] ?? ""}
+                              onChange={(event) =>
+                                onWeightChange(menu.id, event.target.value)
+                              }
+                            />
+                            <span className="text-sm text-zinc-400">kg ×</span>
+                          </>
+                        ) : null}
+                        <Input
+                          type="number"
+                          inputMode="decimal"
+                          size="sm"
+                          radius="sm"
+                          className={NUMBER_INPUT_CLASS}
+                          aria-label={amountLabel(menu)}
+                          placeholder="0"
+                          value={amounts[menu.id] ?? ""}
+                          onChange={(event) =>
+                            onAmountChange(menu.id, event.target.value)
+                          }
+                        />
+                        <span className="text-sm text-zinc-400">
+                          {isWeightReps(menu.unit)
+                            ? "回"
+                            : (menu.unit_label ?? "")}
+                        </span>
+                      </div>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(app)/practice/record/_components/PracticeRecordContent.tsx
+++ b/app/(app)/practice/record/_components/PracticeRecordContent.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import type { ImprovementTheme } from "@app/types/improvementTheme";
+import type {
+  PracticeMenu,
+  PracticeSession,
+  PresetMenu,
+} from "@app/types/practice";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import { Input } from "@heroui/react";
+import Link from "next/link";
+import { useRef, useState } from "react";
+import { getPracticeSessionByDate } from "@app/services/v2/practiceSessionService";
+import { isFutureDate } from "../_utils/practiceRecordDraft";
+import {
+  CREATE_FIRST_MENU_LABEL,
+  DATE_LABEL,
+  MENUS_EMPTY_DESCRIPTION,
+  MENUS_EMPTY_TITLE,
+  PAGE_DESCRIPTION,
+  PAGE_TITLE,
+  SESSION_LOADING_MESSAGE,
+  SESSION_LOAD_ERROR,
+} from "./practiceRecordCopy";
+import PracticeSessionForm from "./PracticeSessionForm";
+
+interface PracticeRecordContentProps {
+  /** Asia/Tokyo の今日。未来日を選ばせないための上限として使う。 */
+  today: string;
+  initialDate: string;
+  menus: PracticeMenu[];
+  initialSession: PracticeSession | null;
+  /** 初期表示の by_date が失敗したか。null（記録なし）と取り違えないためにフラグで分ける。 */
+  initialLoadFailed: boolean;
+  presetMenus: PresetMenu[];
+  themes: ImprovementTheme[];
+}
+
+/**
+ * 練習記録画面の Container。
+ * 日付の切り替えと既存セッションの読み込みを担い、入力フォームは日付ごとに作り直す。
+ */
+export default function PracticeRecordContent({
+  today,
+  initialDate,
+  menus,
+  initialSession,
+  initialLoadFailed,
+  presetMenus,
+  themes,
+}: PracticeRecordContentProps) {
+  const [date, setDate] = useState(initialDate);
+  const [session, setSession] = useState<PracticeSession | null>(
+    initialSession,
+  );
+  const [loadFailed, setLoadFailed] = useState(initialLoadFailed);
+  const [isLoading, setIsLoading] = useState(false);
+  // 日付を素早く切り替えたとき、古い応答が後から届いて別日の記録を表示しないようにする。
+  const latestRequest = useRef(0);
+
+  const handleDateChange = async (nextDate: string) => {
+    if (nextDate === "" || nextDate === date) return;
+    // 未来日は記録できないため、選ばれても切り替えない。
+    if (isFutureDate(nextDate, today)) return;
+
+    setDate(nextDate);
+    setIsLoading(true);
+    const requestId = latestRequest.current + 1;
+    latestRequest.current = requestId;
+
+    const result = await getPracticeSessionByDate(nextDate);
+    if (latestRequest.current !== requestId) return;
+
+    setIsLoading(false);
+    // status:"ok" かつ data:null は「その日はまだ記録なし」。取得失敗と区別して空フォームを出す。
+    if (result.status === "ok") {
+      setSession(result.data);
+      setLoadFailed(false);
+      return;
+    }
+    setSession(null);
+    setLoadFailed(true);
+  };
+
+  // プリセットは URL の日付に紐づく指示なので、別の日へ切り替えたら注入しない。
+  const activePresetMenus = date === initialDate ? presetMenus : [];
+
+  return (
+    <>
+      <h1 className="text-2xl font-bold">{PAGE_TITLE}</h1>
+      <p className="mt-2 text-sm text-zinc-300">{PAGE_DESCRIPTION}</p>
+
+      <div className="mt-6">
+        <Input
+          type="date"
+          size="sm"
+          radius="sm"
+          className="w-44"
+          label={DATE_LABEL}
+          labelPlacement="outside"
+          max={today}
+          value={date}
+          onChange={(event) => handleDateChange(event.target.value)}
+        />
+      </div>
+
+      {menus.length === 0 ? (
+        <div className="mt-10 flex flex-col items-center gap-2 text-center">
+          <p className="text-base font-bold text-white">{MENUS_EMPTY_TITLE}</p>
+          <p className="text-sm text-zinc-400">{MENUS_EMPTY_DESCRIPTION}</p>
+          <Link
+            href="/practice/menus"
+            className="mt-3 inline-flex items-center gap-1.5 rounded-[10px] bg-[#d08000] px-5 py-3 text-sm font-bold text-white"
+          >
+            <PlusIcon className="h-5 w-5" aria-hidden />
+            {CREATE_FIRST_MENU_LABEL}
+          </Link>
+        </div>
+      ) : isLoading ? (
+        <p className="mt-10 text-center text-sm text-zinc-400">
+          {SESSION_LOADING_MESSAGE}
+        </p>
+      ) : loadFailed ? (
+        <p role="alert" className="mt-10 text-center text-sm text-zinc-400">
+          {SESSION_LOAD_ERROR}
+        </p>
+      ) : (
+        <PracticeSessionForm
+          key={date}
+          date={date}
+          menus={menus}
+          session={session}
+          presetMenus={activePresetMenus}
+          themes={themes}
+          onSaved={setSession}
+        />
+      )}
+    </>
+  );
+}

--- a/app/(app)/practice/record/_components/PracticeSessionForm.tsx
+++ b/app/(app)/practice/record/_components/PracticeSessionForm.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import type { ImprovementTheme } from "@app/types/improvementTheme";
+import type {
+  PracticeMenu,
+  PracticeSession,
+  PresetMenu,
+} from "@app/types/practice";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import { Button } from "@heroui/react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+import { upsertPracticeSession } from "@app/services/v2/practiceSessionService";
+import {
+  buildInitialAmounts,
+  buildInitialWeights,
+  buildItems,
+  toInputValue,
+} from "../_utils/practiceRecordDraft";
+import ImprovementThemeField from "./ImprovementThemeField";
+import PracticeMenuChecklist from "./PracticeMenuChecklist";
+import {
+  ADD_MENU_LABEL,
+  MENU_SECTION_TITLE,
+  NO_ITEMS_ERROR,
+  SAVE_ONLY_LABEL,
+  SAVE_SUCCESS_MESSAGE,
+  SAVE_UPDATE_LABEL,
+  SAVE_WITH_NOTE_LABEL,
+  THEME_SECTION_TITLE,
+} from "./practiceRecordCopy";
+
+interface PracticeSessionFormProps {
+  /** 記録する日（YYYY-MM-DD）。 */
+  date: string;
+  menus: PracticeMenu[];
+  /** その日の既存セッション。まだ記録が無い日は null。 */
+  session: PracticeSession | null;
+  presetMenus: PresetMenu[];
+  themes: ImprovementTheme[];
+  onSaved: (session: PracticeSession) => void;
+}
+
+/**
+ * 野球ノート作成画面へ引き継ぐクエリ。パラメータ名・形式は mobile と揃える。
+ * 課題は未選択なら送らない（ノート側で「指定なし」と区別できるようにする）。
+ */
+function buildNoteQuery(
+  date: string,
+  practiceSessionId: number,
+  improvementThemeIds: number[],
+): string {
+  const query = new URLSearchParams();
+  query.set("date", date);
+  query.set("practiceSessionId", String(practiceSessionId));
+  if (improvementThemeIds.length > 0) {
+    query.set("improvementThemeIds", improvementThemeIds.join(","));
+  }
+  return query.toString();
+}
+
+/**
+ * 練習記録の入力フォーム。
+ * 日付ごとに状態を作り直すため、呼び出し側は日付を key にしてマウントし直す。
+ */
+export default function PracticeSessionForm({
+  date,
+  menus,
+  session,
+  presetMenus,
+  themes,
+  onSaved,
+}: PracticeSessionFormProps) {
+  const router = useRouter();
+  const { open: openProUpgradeModal } = useProUpgradeModal();
+  const [amounts, setAmounts] = useState<Record<number, string>>(() =>
+    buildInitialAmounts(session, presetMenus),
+  );
+  const [weights, setWeights] = useState<Record<number, string>>(() =>
+    buildInitialWeights(session, presetMenus, menus),
+  );
+  const [themeIds, setThemeIds] = useState<number[]>(
+    () => session?.improvement_theme_ids ?? [],
+  );
+  const [linkedThemeCountAtLoad] = useState(
+    () => session?.improvement_theme_ids.length ?? 0,
+  );
+  const [errors, setErrors] = useState<string[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleToggleMenu = (menu: PracticeMenu) => {
+    const isSelected = menu.id in amounts;
+    setAmounts((prev) => {
+      const next = { ...prev };
+      // 選択時はメニューの初期値を入れて、よく使う量をそのまま保存できるようにする。
+      if (isSelected) delete next[menu.id];
+      else next[menu.id] = toInputValue(menu.default_value);
+      return next;
+    });
+    setWeights((prev) => {
+      const next = { ...prev };
+      if (isSelected) delete next[menu.id];
+      else if (menu.unit === "weight_reps") next[menu.id] = "";
+      return next;
+    });
+  };
+
+  const handleAmountChange = (menuId: number, value: string) =>
+    setAmounts((prev) => ({ ...prev, [menuId]: value }));
+
+  const handleWeightChange = (menuId: number, value: string) =>
+    setWeights((prev) => ({ ...prev, [menuId]: value }));
+
+  const handleSave = async (withNote: boolean) => {
+    if (isSaving) return;
+    // 触っていない項目も含めて選択中の全メニューを送る。
+    // back は送らなかったメニューのログを削除するため、間引くと既存の記録が消える。
+    const items = buildItems(amounts, weights);
+    if (items.length === 0) {
+      setErrors([NO_ITEMS_ERROR]);
+      return;
+    }
+
+    setIsSaving(true);
+    setErrors([]);
+    const result = await upsertPracticeSession({
+      logged_on: date,
+      items,
+      improvement_theme_ids: themeIds,
+    });
+
+    if (!result.ok) {
+      setIsSaving(false);
+      // 403 は保存全体がロールバックされるため、成功表示も画面遷移もしない。
+      // 課題を複数送ったときだけ紐付け上限として Pro 訴求へ倒し、それ以外は back の文言をそのまま出す。
+      if (result.reason === "forbidden" && themeIds.length > 1) {
+        openProUpgradeModal({ trigger: "multi_improvement_theme_links" });
+      }
+      setErrors(result.errors);
+      return;
+    }
+
+    toast.success(SAVE_SUCCESS_MESSAGE);
+    onSaved(result.data);
+    if (withNote) {
+      // 遷移が完了するまで isSaving のままにして二重送信を防ぐ。
+      router.push(
+        `/note/new?${buildNoteQuery(date, result.data.id, themeIds)}`,
+      );
+      return;
+    }
+    setIsSaving(false);
+  };
+
+  return (
+    <div>
+      <div className="mt-8 flex items-center justify-between gap-3">
+        <h2 className="text-sm font-bold text-white">{MENU_SECTION_TITLE}</h2>
+        <Link
+          href="/practice/menus"
+          className="flex shrink-0 items-center gap-1 rounded-[10px] border border-[#d08000] px-3 py-1.5 text-xs font-bold text-[#d08000]"
+        >
+          <PlusIcon className="h-4 w-4" aria-hidden />
+          {ADD_MENU_LABEL}
+        </Link>
+      </div>
+      <div className="mt-3">
+        <PracticeMenuChecklist
+          menus={menus}
+          amounts={amounts}
+          weights={weights}
+          onToggle={handleToggleMenu}
+          onAmountChange={handleAmountChange}
+          onWeightChange={handleWeightChange}
+        />
+      </div>
+
+      <h2 className="mt-8 text-sm font-bold text-white">
+        {THEME_SECTION_TITLE}
+      </h2>
+      <div className="mt-3">
+        <ImprovementThemeField
+          themes={themes}
+          selectedThemeIds={themeIds}
+          linkedThemeCountAtLoad={linkedThemeCountAtLoad}
+          onChange={setThemeIds}
+        />
+      </div>
+
+      {errors.length > 0 ? (
+        <ul role="alert" className="mt-6 space-y-1">
+          {errors.map((message) => (
+            <li key={message} className="text-sm text-danger">
+              {message}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      <div className="mt-8 space-y-2.5">
+        <Button
+          color="primary"
+          fullWidth
+          radius="sm"
+          className="font-bold"
+          isDisabled={isSaving}
+          onPress={() => handleSave(true)}
+        >
+          {SAVE_WITH_NOTE_LABEL}
+        </Button>
+        <Button
+          fullWidth
+          radius="sm"
+          className="bg-sub font-bold text-white"
+          isDisabled={isSaving}
+          onPress={() => handleSave(false)}
+        >
+          {session ? SAVE_UPDATE_LABEL : SAVE_ONLY_LABEL}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/practice/record/_components/practiceRecordCopy.ts
+++ b/app/(app)/practice/record/_components/practiceRecordCopy.ts
@@ -1,0 +1,47 @@
+/**
+ * 練習記録（日次セッション）画面の文言。
+ * mobile の練習記録画面と表記を揃えるため1箇所にまとめる。
+ */
+
+export const PAGE_TITLE = "練習を記録する";
+
+export const PAGE_DESCRIPTION =
+  "日付ごとにその日やった練習をまとめて記録します。同じ日を選び直すと、記録済みの内容を読み込んで上書きできます。";
+
+export const DATE_LABEL = "日付";
+
+export const MENU_SECTION_TITLE = "練習メニュー（複数選択可）";
+
+export const ADD_MENU_LABEL = "新しいメニューを追加";
+
+export const MENUS_EMPTY_TITLE = "まだ練習メニューがありません";
+
+export const MENUS_EMPTY_DESCRIPTION =
+  "よくやる練習を登録すると、ワンタップで選べます";
+
+export const CREATE_FIRST_MENU_LABEL = "最初のメニューを作る";
+
+export const THEME_SECTION_TITLE = "取り組む課題（任意）";
+
+export const THEME_EMPTY_MESSAGE = "取組中の課題がありません";
+
+export const SAVE_WITH_NOTE_LABEL = "野球ノートを書く";
+
+export const SAVE_ONLY_LABEL = "練習記録のみ保存";
+
+export const SAVE_UPDATE_LABEL = "練習記録の変更を保存";
+
+export const SAVE_SUCCESS_MESSAGE = "練習記録を保存しました";
+
+export const NO_ITEMS_ERROR =
+  "記録する内容がありません。メニューを選んでください";
+
+/** 取得に失敗した日を「記録なし」と誤表示しないため、空フォームではなくこの文言を出す。 */
+export const SESSION_LOAD_ERROR =
+  "この日の練習記録を読み込めませんでした。時間を置いて再度お試しください。";
+
+export const SESSION_LOADING_MESSAGE = "この日の記録を読み込んでいます…";
+
+/** 無料プランで2件目の課題を選ぼうとしたときの案内（back の 403 と同じ意味）。 */
+export const MULTI_THEME_LIMIT_MESSAGE =
+  "無料プランでは1つの記録に課題を1件までしか紐付けられません。Pro プランなら複数の課題に紐付けられます。";

--- a/app/(app)/practice/record/_utils/practiceRecordDraft.ts
+++ b/app/(app)/practice/record/_utils/practiceRecordDraft.ts
@@ -1,0 +1,163 @@
+import type {
+  DecimalValue,
+  PracticeLog,
+  PracticeMenu,
+  PracticeSession,
+  PracticeSessionItemInput,
+  PresetMenu,
+} from "@app/types/practice";
+import { isWeightReps, parseDecimal } from "@app/constants/practice";
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * 「今日」の判定は back の集計（Asia/Tokyo）に合わせる。
+ * サーバーのロケール/タイムゾーンに依存させないことで、SSR と CSR で同じ日付になり
+ * 未来日ガードの基準もぶれない。
+ */
+const TIME_ZONE = "Asia/Tokyo";
+
+const DATE_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  timeZone: TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+/** 今日の日付を `YYYY-MM-DD` で返す。 */
+export function todayString(now: Date = new Date()): string {
+  return DATE_FORMATTER.format(now);
+}
+
+/** その日付が今日より後か。`YYYY-MM-DD` は辞書順比較で日付順になる。 */
+export function isFutureDate(date: string, today: string): boolean {
+  return date > today;
+}
+
+/**
+ * `?date=` を検証して初期表示日を決める。
+ * 形式が不正な場合と未来日の場合は今日へフォールバックし、未来日の記録を作らせない。
+ */
+export function resolveInitialDate(
+  raw: string | undefined,
+  today: string,
+): string {
+  if (!raw || !DATE_PATTERN.test(raw)) return today;
+  return isFutureDate(raw, today) ? today : raw;
+}
+
+/**
+ * `?presetMenus=`（JSON 配列）を解釈する。
+ * 外部から渡る文字列なので、壊れていても画面を落とさず「プリセット無し」に倒す。
+ */
+export function parsePresetMenus(raw: string | undefined): PresetMenu[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.flatMap((item) => {
+      if (typeof item !== "object" || item === null) return [];
+      const { practice_menu_id: menuId, target_value: target } = item as {
+        practice_menu_id?: unknown;
+        target_value?: unknown;
+      };
+      const id = Number(menuId);
+      if (!Number.isFinite(id)) return [];
+      const targetValue = Number(target);
+      return [
+        {
+          practice_menu_id: id,
+          target_value: Number.isFinite(targetValue) ? targetValue : null,
+        },
+      ];
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * 入力欄に流し込む文字列へ変換する。
+ * back の decimal は `"200.0"` のような文字列で返るため、そのまま出さず数値化してから文字列にする。
+ */
+export function toInputValue(value: DecimalValue | null | undefined): string {
+  const parsed = parseDecimal(value);
+  return parsed === null ? "" : String(parsed);
+}
+
+/** 入力欄の文字列を送信値へ変換する。空文字・非数は null（未入力）として送る。 */
+function toNumberOrNull(value: string | undefined): number | null {
+  if (value === undefined || value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * 編集対象になる練習ログ。
+ * 素振り自動ログ（source: shadow_swing）はこの画面の同期対象外なので除く。
+ * メニューが特定できないログも項目として扱えないため除く。
+ */
+function editableLogs(session: PracticeSession | null): PracticeLog[] {
+  return (session?.practice_logs ?? []).filter(
+    (log) => log.source === "manual" && log.practice_menu_id !== null,
+  );
+}
+
+/**
+ * 選択済みメニューの量（menu_id → 入力文字列）を組み立てる。
+ * 既存セッションの記録を土台にし、まだ選ばれていないプリセットだけを目標量つきで足す。
+ *
+ * back の保存は practice_menu_id をキーにした差分同期で、送らなかったメニューのログは
+ * 削除される。そのため一覧に出ないメニュー（削除済みなど）のログもここに残し、
+ * 保存時にそのまま送り返せるようにする。
+ */
+export function buildInitialAmounts(
+  session: PracticeSession | null,
+  presetMenus: PresetMenu[],
+): Record<number, string> {
+  const amounts: Record<number, string> = {};
+  editableLogs(session).forEach((log) => {
+    amounts[log.practice_menu_id as number] = toInputValue(log.amount);
+  });
+  presetMenus.forEach((preset) => {
+    if (preset.practice_menu_id in amounts) return;
+    amounts[preset.practice_menu_id] = toInputValue(preset.target_value);
+  });
+  return amounts;
+}
+
+/** 筋トレ（重さ×回数）の重さ（menu_id → 入力文字列）を組み立てる。 */
+export function buildInitialWeights(
+  session: PracticeSession | null,
+  presetMenus: PresetMenu[],
+  menus: PracticeMenu[],
+): Record<number, string> {
+  const weights: Record<number, string> = {};
+  editableLogs(session)
+    .filter((log) => log.weight !== null)
+    .forEach((log) => {
+      weights[log.practice_menu_id as number] = toInputValue(log.weight);
+    });
+  presetMenus.forEach((preset) => {
+    if (preset.practice_menu_id in weights) return;
+    const menu = menus.find((item) => item.id === preset.practice_menu_id);
+    if (menu && isWeightReps(menu.unit)) weights[preset.practice_menu_id] = "";
+  });
+  return weights;
+}
+
+/**
+ * 保存用の items を組み立てる。
+ * 選択中のメニューを常に全件返す（ユーザーが触っていない項目も含む）。
+ * back は送られなかったメニューのログを削除するため、間引くと既存の記録が消える。
+ */
+export function buildItems(
+  amounts: Record<number, string>,
+  weights: Record<number, string>,
+): PracticeSessionItemInput[] {
+  return Object.entries(amounts).map(([menuId, amount]) => ({
+    practice_menu_id: Number(menuId),
+    amount: toNumberOrNull(amount),
+    weight: toNumberOrNull(weights[Number(menuId)]),
+  }));
+}

--- a/app/(app)/practice/record/page.tsx
+++ b/app/(app)/practice/record/page.tsx
@@ -1,0 +1,74 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getImprovementThemes } from "@app/services/v2/improvementThemeService";
+import { getPracticeMenus } from "@app/services/v2/practiceMenuService";
+import { getPracticeSessionByDate } from "@app/services/v2/practiceSessionService";
+import PracticeRecordContent from "./_components/PracticeRecordContent";
+import {
+  parsePresetMenus,
+  resolveInitialDate,
+  todayString,
+} from "./_utils/practiceRecordDraft";
+
+export const metadata = {
+  title: "練習を記録する",
+};
+
+interface PracticeRecordSearchParams {
+  /** 記録する日（YYYY-MM-DD）。未指定・不正・未来日は今日にフォールバックする。 */
+  date?: string;
+  /** 事前選択するメニューの JSON 配列（[{ practice_menu_id, target_value }]）。 */
+  presetMenus?: string;
+}
+
+export default async function PracticeRecordPage({
+  searchParams,
+}: {
+  searchParams: Promise<PracticeRecordSearchParams>;
+}) {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const params = await searchParams;
+  const today = todayString();
+  const initialDate = resolveInitialDate(params.date, today);
+
+  const [menusResult, sessionResult, themesResult] = await Promise.all([
+    getPracticeMenus(),
+    getPracticeSessionByDate(initialDate),
+    getImprovementThemes({ status: "open" }),
+  ]);
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            {menusResult.status === "ok" ? (
+              <PracticeRecordContent
+                today={today}
+                initialDate={initialDate}
+                menus={menusResult.data}
+                initialSession={
+                  sessionResult.status === "ok" ? sessionResult.data : null
+                }
+                initialLoadFailed={sessionResult.status !== "ok"}
+                presetMenus={parsePresetMenus(params.presetMenus)}
+                themes={themesResult.status === "ok" ? themesResult.data : []}
+              />
+            ) : (
+              // 取得失敗を空配列に丸めるとメニュー未登録の空状態を誤表示してしまう。
+              <p className="py-8 text-center text-sm text-zinc-400">
+                練習メニューを取得できませんでした。時間を置いて再度お試しください。
+              </p>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/services/v2/improvementThemeService.ts
+++ b/app/services/v2/improvementThemeService.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import type {
+  ImprovementTheme,
+  ImprovementThemeStatus,
+} from "@app/types/improvementTheme";
+import { type FetchResult, buildQuery, fetchV2 } from "./requests";
+
+const BASE_PATH = "/api/v2/improvement_themes";
+
+interface GetImprovementThemesParams {
+  /** 取組状況で絞り込む。記録画面の紐付け候補は "open" のみを使う。 */
+  status?: ImprovementThemeStatus;
+}
+
+/**
+ * 課題一覧を取得する（GET /api/v2/improvement_themes）。
+ * back 側で sort_order 昇順に並べて返る。
+ */
+export async function getImprovementThemes(
+  params: GetImprovementThemesParams = {},
+): Promise<FetchResult<ImprovementTheme[]>> {
+  return fetchV2<ImprovementTheme[]>(
+    `${BASE_PATH}${buildQuery({ status: params.status })}`,
+    "getImprovementThemes",
+  );
+}

--- a/app/types/improvementTheme.ts
+++ b/app/types/improvementTheme.ts
@@ -1,0 +1,23 @@
+/**
+ * 課題（改善テーマ）の型。
+ * back/app/serializers/v2/improvement_theme_serializer.rb のレスポンスに対応する。
+ * キー名は back の JSON をそのまま使う（snake_case のまま扱い、変換しない）。
+ */
+
+/** 課題の取組状況。back の ImprovementTheme::STATUSES と完全一致させる。 */
+export type ImprovementThemeStatus = "open" | "achieved" | "archived";
+
+export interface ImprovementTheme {
+  id: number;
+  title: string;
+  category: string | null;
+  purpose: string | null;
+  status: ImprovementThemeStatus;
+  started_on: string;
+  achieved_on: string | null;
+  sort_order: number;
+  practice_logs_count: number;
+  notes_count: number;
+  active_days: number;
+  created_at: string;
+}


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#469

## 概要

練習ドメインで最大かつ最重要の画面です（mobile の該当画面は600行）。日付を選ぶとその日の既存セッションを `by_date` で読み込み、フォーム全体が差し替わる upsert UI を実装します。

## ⚠️ upsert で既存ログを消さないための実装（本 PR の核心）

back の `PracticeSessions::Upsert#sync_items` は `practice_menu_id` をキーに差分同期し、**`items` に含まれないメニューの manual ログを `destroy!` します**。つまり画面側が一部しか送らないと、送らなかった記録が消えます。

対策として以下を実装しました:

1. `buildInitialAmounts` が**既存セッションの manual ログ全件**を初期状態に取り込む（`shadow_swing` は同期対象外なので除外）
2. `buildItems` は選択中のマップを**フィルタせず全件**送る（ユーザーが触っていない項目・空欄の項目も送る。空欄は `amount: null`）
3. **一覧に出ないメニュー（削除済み等）のログも保持して送り返す** — 画面に描画されないログを黙って落とすと upsert で消えるため

3点ともテストで固定し、ミューテーションでも検証しています。

## `by_date` の `null` の扱い

back はセッション未作成の日に **200 + `null`** を返します（`render json: nil, status: :ok`）。これを取得失敗と取り違えると、**記録がある日に空フォームを出す／無い日にエラーを出す**ことになります。`{status:"ok", data:null}` を「記録なし」として正しく分岐させ、ミューテーション M01/M02 で両方向を検証しています。

## 403 の出し分け

back の 403 は2種類あり、意味が違います。

- **課題を2件以上送った保存の 403**（`ThemeLimitExceeded`）→ back の文言を表示し `ProUpgradeModal` を `multi_improvement_theme_links` で開く
- **それ以外の 403**（`NotEntitled`。web ではコンディションを送らないため通常発生しない防御）→ back の文言をそのまま表示し、**ペイウォールは開かない**（原因を特定できないのに「Pro 限定機能です」と断定しないため）

クライアント側の上限は `max(1, 読込時点の紐付け件数)` にして、**back のグランドファザリング**（既存件数までは無料でも維持・削減可）と一致させています。Pro 判定が未確定の間は上限扱いにしません。

**いずれの失敗でも成功トーストを出さず、遷移もしません**（楽観的更新をしていないため巻き戻しも不要）。

## プリセット無効化の条件

mobile は一方向のフラグではなく **「現在選択中の日付 ≠ URL の date」という導出条件**でした（日付を戻せば再び有効になる）。front も同じ導出条件にし、`key={date}` でフォームを作り直して注入タイミングも揃えています。

## 変更内容

- `app/(app)/practice/record/page.tsx` — Server Component。認証ガード、`?date=` / `?presetMenus=` の解釈、メニュー・`by_date`・課題を `Promise.all` で並列取得
- `_components/PracticeRecordContent.tsx` — Container。日付切替での再取得、`ok/null` と `error` の分岐、空状態・CTA
- `_components/PracticeSessionForm.tsx` — 入力状態、保存、403 出し分け、ノート遷移
- `_components/PracticeMenuChecklist.tsx` — カテゴリ別グループ + 量入力（`weight_reps` は kg × 回の2入力）
- `_components/ImprovementThemeField.tsx` — 課題の紐付けとグランドファザリング対応のガード
- `_utils/practiceRecordDraft.ts` — 純粋関数（JST の今日、未来日判定、パラメータ解釈、items 組み立て）
- `app/types/improvementTheme.ts` / `app/services/v2/improvementThemeService.ts` — 課題一覧取得（front 未整備だったため最小限で追加）

## レビューで確認いただきたい点

1. **「練習記録のみ保存」後の遷移先** — mobile は練習記録一覧へ `replace` しますが、**front にはまだそのルートがありません**。存在しない URL へ飛ばさないため、画面に留まって成功トーストを出し、ボタン表記を「練習記録の変更を保存」に切り替える方針にしました。一覧画面の issue が入ったら遷移に差し替えるのが良いと思います
2. **`?presetMenus=` を `date` 無しで渡した場合** — mobile ではプリセットが一切効きませんが、front は「初期表示日」基準にしたため今日に対して効きます。mobile に厳密に合わせるべきならご指摘ください
3. **課題ドメインの型・サービスを新設しました** — 紐付け要件に必要でしたが front に未整備だったため mobile の型を移植した最小構成です。**課題管理画面の issue と重複しないかご確認ください**
4. **コンディション入力は作っていません** — issue の実装対象になく、`proFeatureCatalog.ts` で `detailed_condition_log` が `app_only`（アプリ限定）のためです。web でも必要ならペイウォール付きで追加します

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る（エラー0・警告0）
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（**124 suites / 1329 tests**。新規 2 suites / 44 tests）
- [x] `yarn build` が通る（**ローカルで実行済み**）
- [x] ミューテーションテスト **26 設計 / 26 KILLED / 0 SURVIVED**

### ルート表について

同一環境で base 相当と head の両方をビルドして**ルート表を diff した結果、差分は `+ ƒ /practice/record` の1行のみ**で、**既存ルートの分類変化はゼロ**でした。

なお絶対値については、私（親）が別ブランチで計測した値と実装者の計測値が1件ずれています。現在ベースを実測して照合中で、**結果は本 PR にコメントで追記します**。既存ルートの分類が変わっていないことは diff で確認済みなので、マージ判断には影響しません。

<details>
<summary>ミューテーションテスト詳細</summary>

隔離複製で実施（無改変ベースライン通過を事前確認、検証後に削除）。

`by_date` の null をエラー扱い / 取得失敗を記録なし扱い / **upsert で一部項目を送らない（2件）** / 既存セッションを初期値に読まない / 未来日ガード除去（2件）/ `weight_reps` を1入力に / weight を送らない / `default_value` を入れない / `parseDecimal` を通さない / 素振り自動ログを編集対象に含める / 403 を成功扱い / 403 でペイウォールを出さない / 失敗でも遷移 / ノート引き継ぎパラメータ改変（3件）/ プリセット無効化の除去（2件）/ 空状態・CTA 削除 / 課題を送らない / `logged_on` 固定 / API パス改変 / メソッド改変 / 未選択でも送信 — 全 KILLED。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_