### PR TITLE
Add: 振り返りテンプレの管理とノートフォームへの組み込みを実装

### DIFF
--- a/app/(app)/note/[slulg]/_components/NoteEditForm.tsx
+++ b/app/(app)/note/[slulg]/_components/NoteEditForm.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
+import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
+import type { FetchResult } from "@app/services/v2/requests";
 import { Input } from "@heroui/react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
@@ -8,9 +10,16 @@ import { useMemo, useState } from "react";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import HeaderNote from "@app/components/header/HeaderNote";
 import NoteMenu from "@app/components/note/NoteMenu";
+import ReflectionTemplateSection from "@app/components/note/ReflectionTemplateSection";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import { updateBaseballNote } from "@app/services/v2/baseballNoteService";
-import { parseMemoToSlateValue } from "@app/utils/noteMemo";
+import {
+  buildAnswerList,
+  extractMemoText,
+  isReflectionMemo,
+  parseMemoToSlateValue,
+  resolveNoteMemo,
+} from "@app/utils/noteMemo";
 import {
   buildNoteUpdateInput,
   hasNoteChanges,
@@ -23,31 +32,72 @@ const NoteEditor = dynamic(() => import("@app/components/note/NoteEditor"), {
   ),
 });
 
-export default function NoteEditForm({ note }: { note: BaseballNoteV2 }) {
+interface NoteEditFormProps {
+  note: BaseballNoteV2;
+  templatesResult: FetchResult<ReflectionTemplate[]>;
+}
+
+export default function NoteEditForm({
+  note,
+  templatesResult,
+}: NoteEditFormProps) {
   const router = useRouter();
+  // 回答から自動合成された memo は回答欄と同じ内容が並ぶため、自由メモ欄へは流し込まない。
+  const isSynthesizedMemo = isReflectionMemo(
+    extractMemoText(note.memo),
+    note.reflection_answers,
+  );
   // エディタが最初の onChange で書き戻す形と揃えておくことで、カーソル移動だけで
   // 「変更あり」と判定されるのを防ぐ（v1 のプレーンテキスト memo でも同様）。
-  const initialMemo = useMemo(
-    () => JSON.stringify(parseMemoToSlateValue(note.memo)),
-    [note.memo],
-  );
-  const initialValues = useMemo(
-    () => ({ date: note.date, title: note.title ?? "", memo: initialMemo }),
-    [note.date, note.title, initialMemo],
+  const editorMemo = useMemo(
+    () =>
+      JSON.stringify(
+        parseMemoToSlateValue(isSynthesizedMemo ? null : note.memo),
+      ),
+    [note.memo, isSynthesizedMemo],
   );
 
-  const [date, setDate] = useState(initialValues.date);
-  const [title, setTitle] = useState(initialValues.title);
-  const [memo, setMemo] = useState(initialValues.memo);
+  // テンプレは更新のたびに id が変わり削除もされうるため、問いはノートに保存済みの回答を
+  // 正とする（テンプレから引き直すと過去ノートの問いが後から書き換わってしまう）。
+  const questions = useMemo(
+    () => note.reflection_answers.map((item) => item.question),
+    [note.reflection_answers],
+  );
+  const initialAnswerMap = useMemo(
+    () =>
+      Object.fromEntries(
+        note.reflection_answers.map((item) => [item.question, item.answer]),
+      ),
+    [note.reflection_answers],
+  );
+
+  const [date, setDate] = useState(note.date);
+  const [title, setTitle] = useState(note.title ?? "");
+  const [memo, setMemo] = useState(editorMemo);
+  const [answers, setAnswers] =
+    useState<Record<string, string>>(initialAnswerMap);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
 
-  // 送るのは変更したキーだけ。試合 / 課題 / タグの紐付けはこの画面で編集しないため
-  // キー自体を送らず、back 側の「未送信＝変更なし」に委ねる（送ると上書きされる）。
+  const initialAnswers = buildAnswerList(questions, initialAnswerMap);
+  const currentAnswers = buildAnswerList(questions, answers);
+  const initialValues = {
+    date: note.date,
+    title: note.title ?? "",
+    // 初期値も現在値と同じ手順で導出する。そうしないと合成メモのノートは開いただけで
+    // 「変更あり」と判定されてしまう。
+    memo: resolveNoteMemo(editorMemo, initialAnswers),
+    reflectionAnswers: initialAnswers,
+  };
+
+  // 送るのは変更したキーだけ。試合 / 課題 / タグの紐付けとテンプレ ID はこの画面で
+  // 編集しないためキー自体を送らず、back 側の「未送信＝変更なし」に委ねる（送ると上書きされる）。
   const updateInput = buildNoteUpdateInput(initialValues, {
     date,
     title,
-    memo,
+    // 回答を編集したら合成メモも作り直す。メモだけ古い回答のまま残すと本文と回答が食い違う。
+    memo: resolveNoteMemo(memo, currentAnswers),
+    reflectionAnswers: currentAnswers,
   });
   const hasChanges = hasNoteChanges(updateInput);
 
@@ -55,6 +105,9 @@ export default function NoteEditForm({ note }: { note: BaseballNoteV2 }) {
     setErrors(newErrors);
     setTimeout(() => setErrors([]), 2000);
   };
+
+  const handleChangeAnswer = (question: string, answer: string) =>
+    setAnswers((prev) => ({ ...prev, [question]: answer }));
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
@@ -112,8 +165,16 @@ export default function NoteEditForm({ note }: { note: BaseballNoteV2 }) {
                   />
                 </div>
                 <div className="mt-10 w-full h-full">
-                  <NoteEditor memo={initialValues.memo} setMemo={setMemo} />
+                  <NoteEditor memo={editorMemo} setMemo={setMemo} />
                 </div>
+                <ReflectionTemplateSection
+                  templatesResult={templatesResult}
+                  selectedTemplateId={note.reflection_template_id}
+                  questions={questions}
+                  answers={answers}
+                  onChangeAnswer={handleChangeAnswer}
+                  locked
+                />
               </div>
             </form>
           </div>

--- a/app/(app)/note/[slulg]/_components/__tests__/NoteEditForm.test.tsx
+++ b/app/(app)/note/[slulg]/_components/__tests__/NoteEditForm.test.tsx
@@ -30,6 +30,8 @@ jest.mock("next/dynamic", () => () => {
 });
 
 import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
+import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
+import type { FetchResult } from "@app/services/v2/requests";
 import type ReactModule from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { updateBaseballNote } from "@app/services/v2/baseballNoteService";
@@ -59,6 +61,29 @@ function sentPayload() {
   return mockUpdateBaseballNote.mock.calls[0][1];
 }
 
+const templatesResult: FetchResult<ReflectionTemplate[]> = {
+  status: "ok",
+  data: [
+    {
+      id: 3,
+      title: "試合の振り返り",
+      questions: ["課題"],
+      is_preset: true,
+      is_default: false,
+      sort_order: 1,
+    },
+  ],
+};
+
+function renderForm(overrides: Partial<BaseballNoteV2> = {}) {
+  return render(
+    <NoteEditForm
+      note={{ ...note, ...overrides }}
+      templatesResult={templatesResult}
+    />,
+  );
+}
+
 describe("NoteEditForm", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -66,7 +91,7 @@ describe("NoteEditForm", () => {
   });
 
   it("ノートの日付・タイトル・メモを初期表示する", () => {
-    render(<NoteEditForm note={note} />);
+    renderForm();
 
     expect(screen.getByLabelText("タイトル")).toHaveValue("気づき");
     expect(screen.getByLabelText("日付")).toHaveValue("2026-08-01");
@@ -74,7 +99,7 @@ describe("NoteEditForm", () => {
   });
 
   it("タイトルだけ変更した場合、title キーだけを送る（紐付けキーは送らない）", async () => {
-    render(<NoteEditForm note={note} />);
+    renderForm();
 
     fireEvent.change(screen.getByLabelText("タイトル"), {
       target: { value: "更新後タイトル" },
@@ -93,7 +118,7 @@ describe("NoteEditForm", () => {
   });
 
   it("メモだけ変更した場合、memo キーだけを送る", async () => {
-    render(<NoteEditForm note={note} />);
+    renderForm();
 
     fireEvent.change(screen.getByLabelText("メモ"), {
       target: { value: "書き換えたメモ" },
@@ -107,7 +132,7 @@ describe("NoteEditForm", () => {
   });
 
   it("タイトルを空にした場合は null を送る", async () => {
-    render(<NoteEditForm note={note} />);
+    renderForm();
 
     fireEvent.change(screen.getByLabelText("タイトル"), {
       target: { value: "" },
@@ -121,7 +146,7 @@ describe("NoteEditForm", () => {
   });
 
   it("変更が無ければ更新リクエストを送らずに一覧へ戻る", async () => {
-    render(<NoteEditForm note={note} />);
+    renderForm();
 
     fireEvent.click(screen.getByRole("button", { name: "保存" }));
 
@@ -134,7 +159,7 @@ describe("NoteEditForm", () => {
       ok: false,
       errors: ["タグ機能は Pro プラン限定です"],
     });
-    render(<NoteEditForm note={note} />);
+    renderForm();
 
     fireEvent.change(screen.getByLabelText("タイトル"), {
       target: { value: "更新後" },
@@ -148,11 +173,136 @@ describe("NoteEditForm", () => {
   });
 
   it("v1 のプレーンテキスト memo でも、編集しなければ更新を送らない", async () => {
-    render(<NoteEditForm note={{ ...note, memo: "素振り30分" }} />);
+    renderForm({ memo: "素振り30分" });
 
     fireEvent.click(screen.getByRole("button", { name: "保存" }));
 
     await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/note"));
     expect(mockUpdateBaseballNote).not.toHaveBeenCalled();
+  });
+
+  describe("振り返りテンプレ", () => {
+    const synthesizedNote: Partial<BaseballNoteV2> = {
+      memo: JSON.stringify([
+        {
+          type: "paragraph",
+          children: [{ text: "【課題】\n引きつけ\n\n【次やること】\n素振り" }],
+        },
+      ]),
+      reflection_answers: [
+        { question: "課題", answer: "引きつけ" },
+        { question: "次やること", answer: "素振り" },
+      ],
+    };
+
+    it("保存済みの回答を問いごとに表示する", () => {
+      renderForm();
+
+      expect(screen.getByLabelText("課題")).toHaveValue("引きつけ");
+    });
+
+    it("テンプレ名を見出しに出し、テンプレ選択チップは出さない（固定する）", () => {
+      renderForm();
+
+      expect(screen.getByText("振り返り（試合の振り返り）")).toBeVisible();
+      expect(
+        screen.queryByRole("group", { name: "振り返りテンプレ" }),
+      ).toBeNull();
+      expect(screen.queryByRole("button", { name: "なし" })).toBeNull();
+    });
+
+    it("合成されたメモは自由メモ欄へ流し込まない（回答欄との二重表示を防ぐ）", () => {
+      renderForm(synthesizedNote);
+
+      expect(screen.getByLabelText("メモ")).toHaveValue(
+        '[{"type":"paragraph","children":[{"text":""}]}]',
+      );
+      expect(screen.getByLabelText("課題")).toHaveValue("引きつけ");
+      expect(screen.getByLabelText("次やること")).toHaveValue("素振り");
+    });
+
+    it("合成メモのノートを開いただけでは更新を送らない", async () => {
+      renderForm(synthesizedNote);
+
+      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/note"));
+      expect(mockUpdateBaseballNote).not.toHaveBeenCalled();
+    });
+
+    it("回答を編集すると reflection_answers を送り、テンプレ ID は送らない", async () => {
+      renderForm();
+
+      fireEvent.change(screen.getByLabelText("課題"), {
+        target: { value: "体の開き" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() =>
+        expect(mockUpdateBaseballNote).toHaveBeenCalledTimes(1),
+      );
+      expect(sentPayload().reflection_answers).toEqual([
+        { question: "課題", answer: "体の開き" },
+      ]);
+      expect(sentPayload()).not.toHaveProperty("reflection_template_id");
+    });
+
+    it("合成メモのノートは回答を編集するとメモ本文も作り直す（回答との乖離を防ぐ）", async () => {
+      renderForm(synthesizedNote);
+
+      fireEvent.change(screen.getByLabelText("次やること"), {
+        target: { value: "ティー" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() =>
+        expect(mockUpdateBaseballNote).toHaveBeenCalledTimes(1),
+      );
+      expect(sentPayload().memo).toBe(
+        JSON.stringify([
+          {
+            type: "paragraph",
+            children: [
+              { text: "【課題】\n引きつけ\n\n【次やること】\nティー" },
+            ],
+          },
+        ]),
+      );
+    });
+
+    it("自由メモを書いたノートは回答を編集してもメモ本文を上書きしない", async () => {
+      renderForm();
+
+      fireEvent.change(screen.getByLabelText("課題"), {
+        target: { value: "体の開き" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() =>
+        expect(mockUpdateBaseballNote).toHaveBeenCalledTimes(1),
+      );
+      expect(sentPayload()).not.toHaveProperty("memo");
+    });
+
+    it("回答を全て消した場合は空配列を明示して送る", async () => {
+      renderForm();
+
+      fireEvent.change(screen.getByLabelText("課題"), {
+        target: { value: "" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() =>
+        expect(mockUpdateBaseballNote).toHaveBeenCalledTimes(1),
+      );
+      expect(sentPayload().reflection_answers).toEqual([]);
+    });
+
+    it("回答が無いノートでは振り返りの欄自体を出さない", () => {
+      renderForm({ reflection_answers: [], reflection_template_id: null });
+
+      expect(screen.queryByLabelText("課題")).toBeNull();
+      expect(screen.queryByText(/振り返り/)).toBeNull();
+    });
   });
 });

--- a/app/(app)/note/[slulg]/page.tsx
+++ b/app/(app)/note/[slulg]/page.tsx
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { getBaseballNote } from "@app/services/v2/baseballNoteService";
+import { getReflectionTemplates } from "@app/services/v2/reflectionTemplateService";
 import NoteEditForm from "./_components/NoteEditForm";
 
 function NoteLoadError({ message }: { message: string }) {
@@ -25,7 +26,11 @@ export default async function NoteDetail(props: {
     return <NoteLoadError message="野球ノートが見つかりません。" />;
   }
 
-  const result = await getBaseballNote(noteId);
+  // 互いに依存しない取得なので並列で待つ。
+  const [result, templatesResult] = await Promise.all([
+    getBaseballNote(noteId),
+    getReflectionTemplates(),
+  ]);
   if (result.status === "forbidden") {
     return <NoteLoadError message="このノートを表示する権限がありません。" />;
   }
@@ -33,5 +38,5 @@ export default async function NoteDetail(props: {
     return <NoteLoadError message="野球ノートの読み込みに失敗しました。" />;
   }
 
-  return <NoteEditForm note={result.data} />;
+  return <NoteEditForm note={result.data} templatesResult={templatesResult} />;
 }

--- a/app/(app)/note/new/_components/NoteCreateForm.tsx
+++ b/app/(app)/note/new/_components/NoteCreateForm.tsx
@@ -1,14 +1,18 @@
 "use client";
 
+import type { ReflectionAnswer } from "@app/interface/baseballNoteV2";
+import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
+import type { FetchResult } from "@app/services/v2/requests";
 import { Input } from "@heroui/react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import HeaderNote from "@app/components/header/HeaderNote";
+import ReflectionTemplateSection from "@app/components/note/ReflectionTemplateSection";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import { createBaseballNote } from "@app/services/v2/baseballNoteService";
-import { buildMemoJson } from "@app/utils/noteMemo";
+import { buildAnswerList, resolveNoteMemo } from "@app/utils/noteMemo";
 
 const NoteEditor = dynamic(() => import("@app/components/note/NoteEditor"), {
   ssr: false,
@@ -16,6 +20,10 @@ const NoteEditor = dynamic(() => import("@app/components/note/NoteEditor"), {
     <div className="w-full min-h-[400px] bg-zinc-800 rounded-lg animate-pulse" />
   ),
 });
+
+interface NoteCreateFormProps {
+  templatesResult: FetchResult<ReflectionTemplate[]>;
+}
 
 /** 日付入力（`type="date"`）が要求する `YYYY-MM-DD` をローカル時刻で組み立てる。 */
 function todayString(): string {
@@ -25,21 +33,44 @@ function todayString(): string {
   return `${today.getFullYear()}-${month}-${day}`;
 }
 
-export default function NoteCreateForm() {
+export default function NoteCreateForm({
+  templatesResult,
+}: NoteCreateFormProps) {
   const router = useRouter();
   const [initialDate] = useState(todayString);
   const [date, setDate] = useState(initialDate);
   const [title, setTitle] = useState("");
   const [memo, setMemo] = useState("");
+  const [templateId, setTemplateId] = useState<number | null>(null);
+  const [questions, setQuestions] = useState<string[]>([]);
+  // 回答は問い文をキーに保持する。テンプレを切り替えて戻ってきても入力済みの回答が残る。
+  const [answers, setAnswers] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
 
-  const hasChanges = date !== initialDate || title !== "" || memo !== "";
+  const reflectionAnswers: ReflectionAnswer[] = buildAnswerList(
+    questions,
+    answers,
+  );
+  const hasChanges =
+    date !== initialDate ||
+    title !== "" ||
+    memo !== "" ||
+    templateId !== null ||
+    reflectionAnswers.length > 0;
 
   const setErrorsWithTimeout = (newErrors: string[]) => {
     setErrors(newErrors);
     setTimeout(() => setErrors([]), 2000);
   };
+
+  const handleSelectTemplate = (template: ReflectionTemplate | null) => {
+    setTemplateId(template?.id ?? null);
+    setQuestions(template?.questions ?? []);
+  };
+
+  const handleChangeAnswer = (question: string, answer: string) =>
+    setAnswers((prev) => ({ ...prev, [question]: answer }));
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
@@ -47,7 +78,7 @@ export default function NoteCreateForm() {
       setErrorsWithTimeout(["日付が未設定です。"]);
       return;
     }
-    if (!title && !memo) {
+    if (!title && !memo && reflectionAnswers.length === 0) {
       setErrorsWithTimeout([
         "タイトルとメモ内容のどちらかを入力してください。",
       ]);
@@ -58,7 +89,9 @@ export default function NoteCreateForm() {
     const result = await createBaseballNote({
       date,
       title: title === "" ? null : title,
-      memo: memo === "" ? buildMemoJson("") : memo,
+      memo: resolveNoteMemo(memo, reflectionAnswers),
+      reflection_template_id: templateId,
+      reflection_answers: reflectionAnswers,
     });
     if (!result.ok) {
       setErrorsWithTimeout(result.errors);
@@ -109,6 +142,14 @@ export default function NoteCreateForm() {
                 <div className="mt-10 w-full h-full">
                   <NoteEditor memo={memo} setMemo={setMemo} />
                 </div>
+                <ReflectionTemplateSection
+                  templatesResult={templatesResult}
+                  selectedTemplateId={templateId}
+                  questions={questions}
+                  answers={answers}
+                  onSelectTemplate={handleSelectTemplate}
+                  onChangeAnswer={handleChangeAnswer}
+                />
               </div>
             </form>
           </div>

--- a/app/(app)/note/new/_components/__tests__/NoteCreateForm.test.tsx
+++ b/app/(app)/note/new/_components/__tests__/NoteCreateForm.test.tsx
@@ -1,0 +1,236 @@
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@app/services/v2/baseballNoteService", () => ({
+  createBaseballNote: jest.fn(),
+}));
+
+// 実エディタは Slate に依存するため、メモ入力だけを模した textarea に差し替える。
+jest.mock("next/dynamic", () => () => {
+  // ファクトリ内は外部スコープを参照できないため、React はここで解決する。
+  const react = jest.requireActual<typeof ReactModule>("react");
+  return function MockNoteEditor({
+    memo,
+    setMemo,
+  }: {
+    memo: string;
+    setMemo: (value: string) => void;
+  }) {
+    return react.createElement("textarea", {
+      "aria-label": "メモ",
+      defaultValue: memo,
+      onChange: (event: { target: { value: string } }) =>
+        setMemo(event.target.value),
+    });
+  };
+});
+
+import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
+import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
+import type { FetchResult } from "@app/services/v2/requests";
+import type ReactModule from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createBaseballNote } from "@app/services/v2/baseballNoteService";
+import NoteCreateForm from "../NoteCreateForm";
+
+const mockCreateBaseballNote = createBaseballNote as jest.MockedFunction<
+  typeof createBaseballNote
+>;
+
+const templates: ReflectionTemplate[] = [
+  {
+    id: 3,
+    title: "試合の振り返り",
+    questions: ["良かった点", "次やること"],
+    is_preset: true,
+    is_default: false,
+    sort_order: 1,
+  },
+  {
+    id: 8,
+    title: "練習の振り返り",
+    questions: ["意識したこと"],
+    is_preset: false,
+    is_default: false,
+    sort_order: 2,
+  },
+];
+
+const createdNote = { id: 1 } as BaseballNoteV2;
+
+function renderForm(
+  templatesResult: FetchResult<ReflectionTemplate[]> = {
+    status: "ok",
+    data: templates,
+  },
+) {
+  return render(<NoteCreateForm templatesResult={templatesResult} />);
+}
+
+function sentPayload() {
+  return mockCreateBaseballNote.mock.calls[0][0];
+}
+
+async function save() {
+  fireEvent.click(screen.getByRole("button", { name: "保存" }));
+  await waitFor(() => expect(mockCreateBaseballNote).toHaveBeenCalledTimes(1));
+}
+
+describe("NoteCreateForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateBaseballNote.mockResolvedValue({ ok: true, data: createdNote });
+  });
+
+  it("テンプレを選ぶとその問いが回答欄として並ぶ", () => {
+    renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "試合の振り返り" }));
+
+    expect(screen.getByLabelText("良かった点")).toBeVisible();
+    expect(screen.getByLabelText("次やること")).toBeVisible();
+  });
+
+  it("テンプレを選んで回答すると reflection_template_id と reflection_answers を送る", async () => {
+    renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "試合の振り返り" }));
+    fireEvent.change(screen.getByLabelText("良かった点"), {
+      target: { value: "初球から振れた" },
+    });
+    await save();
+
+    expect(sentPayload().reflection_template_id).toBe(3);
+    expect(sentPayload().reflection_answers).toEqual([
+      { question: "良かった点", answer: "初球から振れた" },
+    ]);
+  });
+
+  it("メモ未入力ならテンプレ回答からメモ本文を合成する", async () => {
+    renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "試合の振り返り" }));
+    fireEvent.change(screen.getByLabelText("良かった点"), {
+      target: { value: "初球から振れた" },
+    });
+    fireEvent.change(screen.getByLabelText("次やること"), {
+      target: { value: "ティー" },
+    });
+    await save();
+
+    expect(sentPayload().memo).toBe(
+      JSON.stringify([
+        {
+          type: "paragraph",
+          children: [
+            {
+              text: "【良かった点】\n初球から振れた\n\n【次やること】\nティー",
+            },
+          ],
+        },
+      ]),
+    );
+  });
+
+  it("メモを入力していればテンプレ回答で上書きしない", async () => {
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText("メモ"), {
+      target: {
+        value: '[{"type":"paragraph","children":[{"text":"自分の言葉"}]}]',
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "試合の振り返り" }));
+    fireEvent.change(screen.getByLabelText("良かった点"), {
+      target: { value: "初球から振れた" },
+    });
+    await save();
+
+    expect(sentPayload().memo).toBe(
+      '[{"type":"paragraph","children":[{"text":"自分の言葉"}]}]',
+    );
+  });
+
+  it("テンプレを切り替えて戻しても入力済みの回答は残る", async () => {
+    renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "試合の振り返り" }));
+    fireEvent.change(screen.getByLabelText("良かった点"), {
+      target: { value: "初球から振れた" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "練習の振り返り" }));
+    fireEvent.click(screen.getByRole("button", { name: "試合の振り返り" }));
+
+    expect(screen.getByLabelText("良かった点")).toHaveValue("初球から振れた");
+  });
+
+  it("テンプレを「なし」に戻すと回答欄が消え、テンプレ ID も送らない", async () => {
+    renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "試合の振り返り" }));
+    fireEvent.click(screen.getByRole("button", { name: "なし" }));
+
+    expect(screen.queryByLabelText("良かった点")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("タイトル"), {
+      target: { value: "気づき" },
+    });
+    await save();
+
+    expect(sentPayload().reflection_template_id).toBeNull();
+    expect(sentPayload().reflection_answers).toEqual([]);
+  });
+
+  it("未入力の問いは送らない", async () => {
+    renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "試合の振り返り" }));
+    fireEvent.change(screen.getByLabelText("良かった点"), {
+      target: { value: "初球から振れた" },
+    });
+    await save();
+
+    expect(sentPayload().reflection_answers).toEqual([
+      { question: "良かった点", answer: "初球から振れた" },
+    ]);
+  });
+
+  it("タイトルもメモも空でもテンプレ回答があれば保存できる", async () => {
+    renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "練習の振り返り" }));
+    fireEvent.change(screen.getByLabelText("意識したこと"), {
+      target: { value: "低い姿勢" },
+    });
+    await save();
+
+    expect(mockPush).toHaveBeenCalledWith("/note");
+  });
+
+  it("タイトル・メモ・回答が全て空なら保存しない", async () => {
+    renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    expect(
+      await screen.findByText(
+        "タイトルとメモ内容のどちらかを入力してください。",
+      ),
+    ).toBeInTheDocument();
+    expect(mockCreateBaseballNote).not.toHaveBeenCalled();
+  });
+
+  it("テンプレの取得に失敗したらチップを出さず、テンプレ未作成とは伝えない", () => {
+    renderForm({ status: "error" });
+
+    expect(
+      screen.getByText(
+        "振り返りテンプレを取得できませんでした。メモはそのまま入力できます。",
+      ),
+    ).toBeVisible();
+    expect(screen.queryByRole("button", { name: "試合の振り返り" })).toBeNull();
+  });
+});

--- a/app/(app)/note/new/page.tsx
+++ b/app/(app)/note/new/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getReflectionTemplates } from "@app/services/v2/reflectionTemplateService";
 import NoteCreateForm from "./_components/NoteCreateForm";
 
 export default async function NoteNew() {
@@ -7,5 +8,6 @@ export default async function NoteNew() {
   if (!cookieStore.get("access-token")) {
     redirect("/signup?auth_required=true");
   }
-  return <NoteCreateForm />;
+  const templatesResult = await getReflectionTemplates();
+  return <NoteCreateForm templatesResult={templatesResult} />;
 }

--- a/app/(app)/note/templates/__tests__/ReflectionTemplatesContent.test.tsx
+++ b/app/(app)/note/templates/__tests__/ReflectionTemplatesContent.test.tsx
@@ -1,0 +1,620 @@
+const mockOpenProUpgradeModal = jest.fn();
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({
+    open: mockOpenProUpgradeModal,
+    close: jest.fn(),
+  }),
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+jest.mock("@app/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@app/services/v2/reflectionTemplateService", () => ({
+  createReflectionTemplate: jest.fn(),
+  updateReflectionTemplate: jest.fn(),
+  deleteReflectionTemplate: jest.fn(),
+}));
+
+import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import {
+  createReflectionTemplate,
+  deleteReflectionTemplate,
+  updateReflectionTemplate,
+} from "@app/services/v2/reflectionTemplateService";
+import ReflectionTemplatesContent from "../_components/ReflectionTemplatesContent";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+const mockCreate = createReflectionTemplate as jest.MockedFunction<
+  typeof createReflectionTemplate
+>;
+const mockUpdate = updateReflectionTemplate as jest.MockedFunction<
+  typeof updateReflectionTemplate
+>;
+const mockDelete = deleteReflectionTemplate as jest.MockedFunction<
+  typeof deleteReflectionTemplate
+>;
+
+function buildTemplate(
+  overrides: Partial<ReflectionTemplate> = {},
+): ReflectionTemplate {
+  return {
+    id: 1,
+    title: "試合の振り返り",
+    questions: ["良かった点", "次やること"],
+    is_preset: false,
+    is_default: false,
+    sort_order: 1,
+    ...overrides,
+  };
+}
+
+function mockEntitlement({
+  granted = false,
+  isLoading = false,
+}: { granted?: boolean; isLoading?: boolean } = {}) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: granted,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading,
+    hasEntitlement: jest.fn(() => granted),
+  });
+}
+
+async function openCreateForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "テンプレを作る" }));
+}
+
+describe("ReflectionTemplatesContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEntitlement();
+  });
+
+  describe("一覧表示", () => {
+    it("プリセットと自作を区分して表示する", () => {
+      render(
+        <ReflectionTemplatesContent
+          initialTemplates={[
+            buildTemplate({ id: 1, title: "運営テンプレ", is_preset: true }),
+            buildTemplate({ id: 2, title: "マイテンプレ" }),
+          ]}
+        />,
+      );
+
+      const presetSection = screen.getByRole("region", { name: "プリセット" });
+      expect(within(presetSection).getByText("運営テンプレ")).toBeVisible();
+      expect(within(presetSection).queryByText("マイテンプレ")).toBeNull();
+
+      const customSection = screen.getByRole("region", {
+        name: "自作テンプレ",
+      });
+      expect(within(customSection).getByText("マイテンプレ")).toBeVisible();
+    });
+
+    it("問いを一覧に並べて内容が分かるようにする", () => {
+      render(
+        <ReflectionTemplatesContent
+          initialTemplates={[
+            buildTemplate({ questions: ["良かった点", "次やること"] }),
+          ]}
+        />,
+      );
+
+      expect(screen.getByText("良かった点 ・ 次やること")).toBeVisible();
+    });
+
+    it("自作が無いときは空状態を伝える", () => {
+      render(
+        <ReflectionTemplatesContent
+          initialTemplates={[buildTemplate({ is_preset: true })]}
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          "まだ自作の振り返りテンプレがありません。自分専用の問いかけを作れます。",
+        ),
+      ).toBeVisible();
+    });
+
+    it("プリセットには削除導線を出さない（back が削除を許さないため）", () => {
+      render(
+        <ReflectionTemplatesContent
+          initialTemplates={[
+            buildTemplate({ id: 1, title: "運営テンプレ", is_preset: true }),
+          ]}
+        />,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "運営テンプレを削除" }),
+      ).toBeNull();
+      expect(
+        screen.getByRole("button", { name: "運営テンプレを編集" }),
+      ).toBeVisible();
+    });
+  });
+
+  describe("作成", () => {
+    it("タイトルと問いを入力して作成できる", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({
+        ok: true,
+        data: buildTemplate({ id: 9, title: "マイテンプレ" }),
+      });
+      render(<ReflectionTemplatesContent initialTemplates={[]} />);
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText(/テンプレ名/), "マイテンプレ");
+      await user.type(screen.getByLabelText("問い 1"), "良かった点");
+      await user.type(screen.getByLabelText("問い 2"), "次やること");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+      expect(mockCreate).toHaveBeenCalledWith({
+        title: "マイテンプレ",
+        questions: ["良かった点", "次やること"],
+      });
+      expect(await screen.findByText("マイテンプレ")).toBeVisible();
+    });
+
+    it("テンプレ名が未入力なら送信しない", async () => {
+      const user = userEvent.setup();
+      render(<ReflectionTemplatesContent initialTemplates={[]} />);
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText("問い 1"), "良かった点");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      expect(
+        await screen.findByText("テンプレ名を入力してください"),
+      ).toBeInTheDocument();
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("問いが1つも無ければ送信しない", async () => {
+      const user = userEvent.setup();
+      render(<ReflectionTemplatesContent initialTemplates={[]} />);
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText(/テンプレ名/), "マイテンプレ");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      expect(
+        await screen.findByText("問いを1つ以上入力してください"),
+      ).toBeInTheDocument();
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("問いの可変追加・削除", () => {
+    it("問いを追加しても入力済みの問いは残る", async () => {
+      const user = userEvent.setup();
+      render(<ReflectionTemplatesContent initialTemplates={[]} />);
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText("問い 1"), "良かった点");
+      await user.click(screen.getByRole("button", { name: "問いを追加" }));
+
+      expect(screen.getByLabelText("問い 1")).toHaveValue("良かった点");
+      expect(screen.getByLabelText("問い 4")).toHaveValue("");
+    });
+
+    it("途中の問いを削除しても他の問いの入力は消えない", async () => {
+      const user = userEvent.setup();
+      render(<ReflectionTemplatesContent initialTemplates={[]} />);
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText("問い 1"), "A");
+      await user.type(screen.getByLabelText("問い 2"), "B");
+      await user.type(screen.getByLabelText("問い 3"), "C");
+      await user.click(screen.getByRole("button", { name: "問い 2を削除" }));
+
+      expect(screen.getByLabelText("問い 1")).toHaveValue("A");
+      expect(screen.getByLabelText("問い 2")).toHaveValue("C");
+      expect(screen.queryByLabelText("問い 3")).toBeNull();
+    });
+
+    it("削除した問いは送信されない", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({
+        ok: true,
+        data: buildTemplate({ id: 9 }),
+      });
+      render(<ReflectionTemplatesContent initialTemplates={[]} />);
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText(/テンプレ名/), "マイテンプレ");
+      await user.type(screen.getByLabelText("問い 1"), "A");
+      await user.type(screen.getByLabelText("問い 2"), "B");
+      await user.click(screen.getByRole("button", { name: "問い 1を削除" }));
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+      expect(mockCreate.mock.calls[0][0].questions).toEqual(["B"]);
+    });
+
+    it("問いが1つだけのときは削除できない", async () => {
+      const user = userEvent.setup();
+      render(
+        <ReflectionTemplatesContent
+          initialTemplates={[buildTemplate({ questions: ["良かった点"] })]}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: "試合の振り返りを編集" }),
+      );
+
+      expect(screen.queryByRole("button", { name: "問い 1を削除" })).toBeNull();
+    });
+  });
+
+  describe("編集", () => {
+    it("既存の値が入ったフォームが開き、更新できる", async () => {
+      const user = userEvent.setup();
+      const template = buildTemplate({ id: 4, title: "旧テンプレ" });
+      mockUpdate.mockResolvedValue({
+        ok: true,
+        data: buildTemplate({ id: 77, title: "新テンプレ" }),
+      });
+      render(<ReflectionTemplatesContent initialTemplates={[template]} />);
+
+      await user.click(
+        screen.getByRole("button", { name: "旧テンプレを編集" }),
+      );
+
+      expect(screen.getByLabelText(/テンプレ名/)).toHaveValue("旧テンプレ");
+      expect(screen.getByLabelText("問い 1")).toHaveValue("良かった点");
+
+      await user.clear(screen.getByLabelText(/テンプレ名/));
+      await user.type(screen.getByLabelText(/テンプレ名/), "新テンプレ");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      expect(mockUpdate.mock.calls[0][0]).toBe(4);
+      expect(await screen.findByText("新テンプレ")).toBeVisible();
+      expect(screen.queryByText("旧テンプレ")).toBeNull();
+    });
+
+    // back の update は原本を更新せず新バージョンを作るため、以降の操作は新 ID を指す必要がある
+    it("更新後は返却された新しい ID を使う（古い ID を使い続けない）", async () => {
+      const user = userEvent.setup();
+      mockUpdate.mockResolvedValue({
+        ok: true,
+        data: buildTemplate({ id: 77, title: "新テンプレ" }),
+      });
+      mockDelete.mockResolvedValue({
+        ok: true,
+        data: { message: "削除しました" },
+      });
+      render(
+        <ReflectionTemplatesContent
+          initialTemplates={[buildTemplate({ id: 4, title: "旧テンプレ" })]}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: "旧テンプレを編集" }),
+      );
+      await user.click(screen.getByRole("button", { name: "保存" }));
+      await screen.findByText("新テンプレ");
+
+      await user.click(
+        screen.getByRole("button", { name: "新テンプレを編集" }),
+      );
+      await user.click(screen.getByRole("button", { name: "保存" }));
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2));
+      expect(mockUpdate.mock.calls[1][0]).toBe(77);
+
+      await user.click(
+        screen.getByRole("button", { name: "新テンプレを削除" }),
+      );
+      await user.click(screen.getByRole("button", { name: "削除" }));
+      await waitFor(() => expect(mockDelete).toHaveBeenCalledWith(77));
+    });
+
+    it("プリセットを編集すると自作テンプレのコピーとして一覧に移る", async () => {
+      const user = userEvent.setup();
+      mockUpdate.mockResolvedValue({
+        ok: true,
+        data: buildTemplate({
+          id: 50,
+          title: "運営テンプレ",
+          is_preset: false,
+        }),
+      });
+      render(
+        <ReflectionTemplatesContent
+          initialTemplates={[
+            buildTemplate({ id: 1, title: "運営テンプレ", is_preset: true }),
+          ]}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: "運営テンプレを編集" }),
+      );
+      expect(
+        screen.getByText(
+          "プリセットを編集すると、自分専用のテンプレとして保存されます（元のプリセットは変わりません）。",
+        ),
+      ).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      const customSection = await screen.findByRole("region", {
+        name: "自作テンプレ",
+      });
+      expect(within(customSection).getByText("運営テンプレ")).toBeVisible();
+      const presetSection = screen.getByRole("region", { name: "プリセット" });
+      expect(within(presetSection).queryByText("運営テンプレ")).toBeNull();
+    });
+  });
+
+  describe("削除", () => {
+    it("確認を経てから削除する", async () => {
+      const user = userEvent.setup();
+      mockDelete.mockResolvedValue({
+        ok: true,
+        data: { message: "削除しました" },
+      });
+      render(
+        <ReflectionTemplatesContent
+          initialTemplates={[buildTemplate({ id: 7, title: "マイテンプレ" })]}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: "マイテンプレを削除" }),
+      );
+
+      expect(
+        screen.getByText("「マイテンプレ」を削除しますか？"),
+      ).toBeInTheDocument();
+      expect(mockDelete).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole("button", { name: "削除" }));
+
+      await waitFor(() => expect(mockDelete).toHaveBeenCalledWith(7));
+      await waitFor(() =>
+        expect(screen.queryByText("マイテンプレ")).toBeNull(),
+      );
+    });
+
+    it("確認をキャンセルすると削除しない", async () => {
+      const user = userEvent.setup();
+      render(
+        <ReflectionTemplatesContent
+          initialTemplates={[buildTemplate({ id: 7, title: "マイテンプレ" })]}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: "マイテンプレを削除" }),
+      );
+      await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+      expect(mockDelete).not.toHaveBeenCalled();
+      expect(screen.getByText("マイテンプレ")).toBeVisible();
+    });
+
+    // 使用中テンプレの削除は back が 422 で拒否する。理由を出さないと原因が分からない
+    it("使用中で削除できないときはサーバーの理由を表示し、一覧から消さない", async () => {
+      const user = userEvent.setup();
+      mockDelete.mockResolvedValue({
+        ok: false,
+        reason: "error",
+        errors: ["このテンプレは野球ノートで使用されているため削除できません"],
+      });
+      render(
+        <ReflectionTemplatesContent
+          initialTemplates={[buildTemplate({ id: 7, title: "マイテンプレ" })]}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: "マイテンプレを削除" }),
+      );
+      await user.click(screen.getByRole("button", { name: "削除" }));
+
+      expect(
+        await screen.findByText(
+          "このテンプレは野球ノートで使用されているため削除できません",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText("マイテンプレ")).toBeVisible();
+    });
+  });
+
+  describe("無料枠の上限", () => {
+    const oneCustom = [buildTemplate({ id: 1, title: "マイテンプレ" })];
+
+    it("無料ユーザーが2件目を作ろうとするとフォームではなくペイウォールが出る", async () => {
+      const user = userEvent.setup();
+      render(<ReflectionTemplatesContent initialTemplates={oneCustom} />);
+
+      await openCreateForm(user);
+
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "unlimited_reflection_templates",
+      });
+      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("上限に達すると Pro 限定ではなく件数上限として案内する", () => {
+      render(<ReflectionTemplatesContent initialTemplates={oneCustom} />);
+
+      expect(
+        screen.getByText("無料プランで作成できる振り返りテンプレは1件までです"),
+      ).toBeVisible();
+      expect(
+        screen.getByText(
+          "Pro プランなら2つ目以降の振り返りテンプレも自由に作成・編集できます。",
+        ),
+      ).toBeVisible();
+    });
+
+    it("プリセットは何件見えていても上限に数えない", async () => {
+      const user = userEvent.setup();
+      render(
+        <ReflectionTemplatesContent
+          initialTemplates={[
+            buildTemplate({ id: 1, title: "運営A", is_preset: true }),
+            buildTemplate({ id: 2, title: "運営B", is_preset: true }),
+            buildTemplate({ id: 3, title: "運営C", is_preset: true }),
+          ]}
+        />,
+      );
+
+      expect(
+        screen.queryByText(
+          "無料プランで作成できる振り返りテンプレは1件までです",
+        ),
+      ).toBeNull();
+
+      await openCreateForm(user);
+
+      expect(
+        screen.getByRole("dialog", { name: "テンプレを作る" }),
+      ).toBeInTheDocument();
+    });
+
+    it("Pro ユーザーは2件目以降も作成フォームを開ける", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ granted: true });
+      render(<ReflectionTemplatesContent initialTemplates={oneCustom} />);
+
+      expect(
+        screen.queryByText(
+          "無料プランで作成できる振り返りテンプレは1件までです",
+        ),
+      ).toBeNull();
+
+      await openCreateForm(user);
+
+      expect(
+        screen.getByRole("dialog", { name: "テンプレを作る" }),
+      ).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+
+    it("Pro 判定が未確定の間は上限の案内を出さない", () => {
+      mockEntitlement({ isLoading: true });
+      render(<ReflectionTemplatesContent initialTemplates={oneCustom} />);
+
+      expect(
+        screen.queryByText(
+          "無料プランで作成できる振り返りテンプレは1件までです",
+        ),
+      ).toBeNull();
+    });
+
+    // Pro 解約後も既存テンプレは維持・編集できる（back も自作の再編集は無料枠チェックの対象外）
+    it("無料で上限を超えて保有していても自作テンプレは編集できる", async () => {
+      const user = userEvent.setup();
+      render(
+        <ReflectionTemplatesContent
+          initialTemplates={[
+            buildTemplate({ id: 1, title: "マイA" }),
+            buildTemplate({ id: 2, title: "マイB" }),
+            buildTemplate({ id: 3, title: "マイC" }),
+          ]}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "マイBを編集" }));
+
+      expect(
+        screen.getByRole("dialog", { name: "テンプレを編集" }),
+      ).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+
+    // プリセットの編集は自作の新規作成に等しく、back も無料枠を超えていれば 403 を返す
+    it("上限に達している無料ユーザーはプリセットを編集できずペイウォールが出る", async () => {
+      const user = userEvent.setup();
+      render(
+        <ReflectionTemplatesContent
+          initialTemplates={[
+            buildTemplate({ id: 1, title: "マイテンプレ" }),
+            buildTemplate({ id: 2, title: "運営テンプレ", is_preset: true }),
+          ]}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: "運営テンプレを編集" }),
+      );
+
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "unlimited_reflection_templates",
+      });
+      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("サーバー側のエラー", () => {
+    it("作成が 403 で拒否されたら件数上限の文言とペイウォールを出す", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({
+        ok: false,
+        reason: "forbidden",
+        errors: ["Forbidden"],
+      });
+      render(<ReflectionTemplatesContent initialTemplates={[]} />);
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText(/テンプレ名/), "マイテンプレ");
+      await user.type(screen.getByLabelText("問い 1"), "良かった点");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      expect(
+        await screen.findByText(
+          "無料プランで作成できる振り返りテンプレは1件までです。Pro プランなら2つ目以降の振り返りテンプレも自由に作成・編集できます。",
+        ),
+      ).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "unlimited_reflection_templates",
+      });
+    });
+
+    it("作成が 422 で失敗したらサーバーのエラーメッセージを出す", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({
+        ok: false,
+        reason: "error",
+        errors: ["タイトルは50文字以内で入力してください"],
+      });
+      render(<ReflectionTemplatesContent initialTemplates={[]} />);
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText(/テンプレ名/), "マイテンプレ");
+      await user.type(screen.getByLabelText("問い 1"), "良かった点");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      expect(
+        await screen.findByText("タイトルは50文字以内で入力してください"),
+      ).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/(app)/note/templates/_components/ReflectionTemplateFormModal.tsx
+++ b/app/(app)/note/templates/_components/ReflectionTemplateFormModal.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import type {
+  ReflectionTemplate,
+  ReflectionTemplateInput,
+} from "@app/interface/reflectionTemplate";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import XMarkIcon from "@heroicons/react/24/outline/XMarkIcon";
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import { useState } from "react";
+import {
+  PRESET_EDIT_NOTICE,
+  QUESTION_REQUIRED_ERROR,
+  TITLE_REQUIRED_ERROR,
+} from "./reflectionTemplateCopy";
+
+interface ReflectionTemplateFormModalProps {
+  /** 編集対象。null なら新規作成。 */
+  template: ReflectionTemplate | null;
+  isSaving: boolean;
+  /** 保存に失敗したときにフォーム内へ出すサーバー由来のメッセージ。 */
+  serverErrors: string[];
+  onClose: () => void;
+  onSubmit: (input: ReflectionTemplateInput) => void;
+}
+
+/** 行の並べ替え・削除で入力中のテキストが他の行へずれないよう、行ごとに不変の id を持たせる。 */
+interface QuestionRow {
+  id: number;
+  text: string;
+}
+
+const DEFAULT_ROW_COUNT = 3;
+
+function buildInitialRows(template: ReflectionTemplate | null): QuestionRow[] {
+  const texts =
+    template && template.questions.length > 0
+      ? template.questions
+      : Array.from({ length: DEFAULT_ROW_COUNT }, () => "");
+  return texts.map((text, index) => ({ id: index, text }));
+}
+
+/**
+ * 振り返りテンプレの作成・編集フォーム。
+ *
+ * このコンポーネントは入力値の保持と必須チェックだけを担い、
+ * API 呼び出し・上限判定は呼び出し元（Container）に委ねる。
+ * 開くたびに呼び出し元が key を変えて再マウントするため、
+ * 初期値の同期に useEffect を使わずに済ませている。
+ */
+export default function ReflectionTemplateFormModal({
+  template,
+  isSaving,
+  serverErrors,
+  onClose,
+  onSubmit,
+}: ReflectionTemplateFormModalProps) {
+  const [title, setTitle] = useState(template?.title ?? "");
+  const [rows, setRows] = useState<QuestionRow[]>(() =>
+    buildInitialRows(template),
+  );
+  // 初期行の id は 0..n-1 なので、追加行はその続きから振れば衝突しない。
+  const [nextRowId, setNextRowId] = useState(rows.length);
+  const [titleError, setTitleError] = useState<string | null>(null);
+  const [questionError, setQuestionError] = useState<string | null>(null);
+
+  const setQuestion = (id: number, text: string) =>
+    setRows((prev) =>
+      prev.map((row) => (row.id === id ? { ...row, text } : row)),
+    );
+
+  const addQuestion = () => {
+    setRows((prev) => [...prev, { id: nextRowId, text: "" }]);
+    setNextRowId((prev) => prev + 1);
+  };
+
+  const removeQuestion = (id: number) =>
+    setRows((prev) => prev.filter((row) => row.id !== id));
+
+  const handleSubmit = () => {
+    const trimmedTitle = title.trim();
+    const questions = rows
+      .map((row) => row.text.trim())
+      .filter((text) => text.length > 0);
+
+    setTitleError(trimmedTitle ? null : TITLE_REQUIRED_ERROR);
+    setQuestionError(questions.length > 0 ? null : QUESTION_REQUIRED_ERROR);
+    if (!trimmedTitle || questions.length === 0) return;
+
+    onSubmit({ title: trimmedTitle, questions });
+  };
+
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      placement="center"
+      scrollBehavior="inside"
+      className="buzz-dark"
+    >
+      <ModalContent>
+        <ModalHeader className="text-white">
+          {template ? "テンプレを編集" : "テンプレを作る"}
+        </ModalHeader>
+        <ModalBody className="gap-4">
+          {template?.is_preset ? (
+            <p className="text-xs text-zinc-400">{PRESET_EDIT_NOTICE}</p>
+          ) : null}
+
+          <Input
+            type="text"
+            variant="bordered"
+            label="テンプレ名"
+            labelPlacement="outside"
+            isRequired
+            placeholder="例: 今日のフォーム意識"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            isInvalid={titleError !== null}
+            errorMessage={titleError}
+          />
+
+          <div>
+            <p className="mb-1.5 text-sm text-white">
+              問い<span className="ml-1 text-danger">*</span>
+            </p>
+            <ul className="space-y-2">
+              {rows.map((row, index) => (
+                <li key={row.id} className="flex items-center gap-2">
+                  <Input
+                    type="text"
+                    variant="bordered"
+                    aria-label={`問い ${index + 1}`}
+                    placeholder={`問い ${index + 1}`}
+                    value={row.text}
+                    onChange={(event) =>
+                      setQuestion(row.id, event.target.value)
+                    }
+                  />
+                  {rows.length > 1 ? (
+                    <button
+                      type="button"
+                      aria-label={`問い ${index + 1}を削除`}
+                      onClick={() => removeQuestion(row.id)}
+                      className="shrink-0 rounded-full p-1 text-zinc-400 transition-colors hover:text-danger"
+                    >
+                      <XMarkIcon className="h-5 w-5" aria-hidden />
+                    </button>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+            {questionError !== null ? (
+              <p className="mt-1.5 text-sm text-danger">{questionError}</p>
+            ) : null}
+            <button
+              type="button"
+              onClick={addQuestion}
+              className="mt-2 inline-flex items-center gap-1 text-sm font-bold text-[#d08000]"
+            >
+              <PlusIcon className="h-4 w-4" aria-hidden />
+              問いを追加
+            </button>
+          </div>
+
+          {serverErrors.length > 0 ? (
+            <ul role="alert" className="space-y-1 text-sm text-danger">
+              {serverErrors.map((message) => (
+                <li key={message}>{message}</li>
+              ))}
+            </ul>
+          ) : null}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="flat" onPress={onClose} isDisabled={isSaving}>
+            キャンセル
+          </Button>
+          <Button
+            color="primary"
+            onPress={handleSubmit}
+            isDisabled={isSaving}
+            isLoading={isSaving}
+            className="font-bold"
+          >
+            保存
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/app/(app)/note/templates/_components/ReflectionTemplateList.tsx
+++ b/app/(app)/note/templates/_components/ReflectionTemplateList.tsx
@@ -1,0 +1,111 @@
+import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
+import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
+import { CUSTOM_EMPTY_MESSAGE } from "./reflectionTemplateCopy";
+
+interface ReflectionTemplateListProps {
+  templates: ReflectionTemplate[];
+  onEdit: (template: ReflectionTemplate) => void;
+  onDelete: (template: ReflectionTemplate) => void;
+}
+
+interface TemplateRowProps {
+  template: ReflectionTemplate;
+  onEdit: (template: ReflectionTemplate) => void;
+  /** プリセットは back が削除を許さないため、自作テンプレでのみ渡す。 */
+  onDelete?: (template: ReflectionTemplate) => void;
+}
+
+function TemplateRow({ template, onEdit, onDelete }: TemplateRowProps) {
+  return (
+    <li className="flex items-center gap-3 rounded-[10px] bg-sub px-3.5 py-3">
+      <button
+        type="button"
+        onClick={() => onEdit(template)}
+        aria-label={`${template.title}を編集`}
+        className="flex-1 text-left"
+      >
+        <span className="block text-sm font-bold text-white">
+          {template.title}
+        </span>
+        <span className="mt-0.5 block text-xs text-zinc-400">
+          {template.questions.join(" ・ ")}
+        </span>
+      </button>
+      {onDelete ? (
+        <button
+          type="button"
+          onClick={() => onDelete(template)}
+          aria-label={`${template.title}を削除`}
+          className="shrink-0 rounded-full p-1 text-zinc-400 transition-colors hover:text-danger"
+        >
+          <TrashIcon className="h-5 w-5" aria-hidden />
+        </button>
+      ) : null}
+    </li>
+  );
+}
+
+/**
+ * 振り返りテンプレをプリセットと自作に分けて並べる表示コンポーネント。
+ * プリセットは back が削除を許さない（自分のレコードではない）ため削除導線を出さない。
+ * 編集は可能で、その場合は自分専用のコピーが作られる。
+ */
+export default function ReflectionTemplateList({
+  templates,
+  onEdit,
+  onDelete,
+}: ReflectionTemplateListProps) {
+  const presets = templates.filter((template) => template.is_preset);
+  const customs = templates.filter((template) => !template.is_preset);
+
+  return (
+    <div className="space-y-6">
+      <section aria-labelledby="reflection-template-preset">
+        <h3
+          id="reflection-template-preset"
+          className="text-sm font-bold text-zinc-400"
+        >
+          プリセット
+        </h3>
+        {presets.length === 0 ? (
+          <p className="mt-2 text-sm text-zinc-400">
+            利用できるプリセットはありません
+          </p>
+        ) : (
+          <ul className="mt-2 space-y-2">
+            {presets.map((template) => (
+              <TemplateRow
+                key={template.id}
+                template={template}
+                onEdit={onEdit}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section aria-labelledby="reflection-template-custom">
+        <h3
+          id="reflection-template-custom"
+          className="text-sm font-bold text-zinc-400"
+        >
+          自作テンプレ
+        </h3>
+        {customs.length === 0 ? (
+          <p className="mt-2 text-sm text-zinc-400">{CUSTOM_EMPTY_MESSAGE}</p>
+        ) : (
+          <ul className="mt-2 space-y-2">
+            {customs.map((template) => (
+              <TemplateRow
+                key={template.id}
+                template={template}
+                onEdit={onEdit}
+                onDelete={onDelete}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/(app)/note/templates/_components/ReflectionTemplatesContent.tsx
+++ b/app/(app)/note/templates/_components/ReflectionTemplatesContent.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import type {
+  ReflectionTemplate,
+  ReflectionTemplateInput,
+} from "@app/interface/reflectionTemplate";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
+import { REFLECTION_TEMPLATE_FREE_LIMIT } from "@app/constants/reflectionTemplate";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import {
+  createReflectionTemplate,
+  deleteReflectionTemplate,
+  updateReflectionTemplate,
+} from "@app/services/v2/reflectionTemplateService";
+import {
+  DELETE_NOTICE,
+  FREE_LIMIT_DESCRIPTION,
+  FREE_LIMIT_SERVER_ERROR,
+  FREE_LIMIT_TITLE,
+} from "./reflectionTemplateCopy";
+import ReflectionTemplateFormModal from "./ReflectionTemplateFormModal";
+import ReflectionTemplateList from "./ReflectionTemplateList";
+
+interface ReflectionTemplatesContentProps {
+  initialTemplates: ReflectionTemplate[];
+}
+
+/** フォームを開くたびに増やし、key の付け替えで入力状態を初期化するための識別子。 */
+interface FormTarget {
+  template: ReflectionTemplate | null;
+  token: number;
+}
+
+const PAYWALL_TRIGGER = "unlimited_reflection_templates";
+
+/**
+ * 振り返りテンプレ画面の Container。
+ * 一覧の状態保持・Server Action 呼び出し・無料枠の判定を担い、表示は子コンポーネントへ委ねる。
+ */
+export default function ReflectionTemplatesContent({
+  initialTemplates,
+}: ReflectionTemplatesContentProps) {
+  const [templates, setTemplates] =
+    useState<ReflectionTemplate[]>(initialTemplates);
+  const [form, setForm] = useState<FormTarget | null>(null);
+  const [formErrors, setFormErrors] = useState<string[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<ReflectionTemplate | null>(
+    null,
+  );
+  const [deleteErrors, setDeleteErrors] = useState<string[]>([]);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const { hasEntitlement, isLoading: isEntitlementLoading } = useEntitlement();
+  const { open: openProUpgradeModal } = useProUpgradeModal();
+
+  const hasUnlimited = hasEntitlement(PAYWALL_TRIGGER);
+  // 無料枠に数えるのは自作だけ（プリセットは何件見えていても上限に関係しない）。
+  const customCount = templates.filter(
+    (template) => !template.is_preset,
+  ).length;
+  // 判定が確定するまでは上限扱いにしない。未確定のまま塞ぐと Pro 加入者に上限を誤って告知してしまう。
+  const isAtFreeLimit =
+    !isEntitlementLoading &&
+    !hasUnlimited &&
+    customCount >= REFLECTION_TEMPLATE_FREE_LIMIT;
+
+  const openForm = (template: ReflectionTemplate | null) => {
+    setFormErrors([]);
+    setForm({ template, token: Date.now() + templates.length });
+  };
+
+  const handleAdd = () => {
+    if (isAtFreeLimit) {
+      openProUpgradeModal({ trigger: PAYWALL_TRIGGER });
+      return;
+    }
+    openForm(null);
+  };
+
+  // 自作テンプレの編集は旧版アーカイブ＋新版作成で件数が増えないため、上限を超えて
+  // 保有しているユーザー（Pro 解約後など）でも常に編集できる。
+  // プリセットの編集だけは自作テンプレの新規作成に等しく、back も 403 を返す。
+  const handleEdit = (template: ReflectionTemplate) => {
+    if (template.is_preset && isAtFreeLimit) {
+      openProUpgradeModal({ trigger: PAYWALL_TRIGGER });
+      return;
+    }
+    openForm(template);
+  };
+
+  const handleSubmit = async (input: ReflectionTemplateInput) => {
+    const editing = form?.template ?? null;
+    setIsSaving(true);
+    setFormErrors([]);
+
+    const result = editing
+      ? await updateReflectionTemplate(editing.id, input)
+      : await createReflectionTemplate(input);
+    setIsSaving(false);
+
+    if (result.ok) {
+      // back の更新は原本を書き換えず新しいバージョンを作るため、返却された
+      // テンプレ（id が変わっている）で置き換える。元の id を残すと以降の
+      // 編集・削除が既にアーカイブされたレコードを指してしまう。
+      setTemplates((prev) =>
+        editing
+          ? prev.map((item) => (item.id === editing.id ? result.data : item))
+          : [...prev, result.data],
+      );
+      setForm(null);
+      toast.success(
+        editing
+          ? "振り返りテンプレを更新しました"
+          : "振り返りテンプレを作成しました",
+      );
+      return;
+    }
+
+    // 403 は Pro 限定機能ではなく無料枠の超過を意味する。
+    // 別端末での追加などでクライアント側の件数判定とずれた場合にここへ入る。
+    if (result.reason === "forbidden") {
+      setFormErrors([FREE_LIMIT_SERVER_ERROR]);
+      openProUpgradeModal({ trigger: PAYWALL_TRIGGER });
+      return;
+    }
+    setFormErrors(result.errors);
+  };
+
+  const openDeleteConfirm = (template: ReflectionTemplate) => {
+    setDeleteErrors([]);
+    setDeleteTarget(template);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    setDeleteErrors([]);
+    const result = await deleteReflectionTemplate(deleteTarget.id);
+    setIsDeleting(false);
+
+    if (!result.ok) {
+      // ノートで使用中のテンプレは back が 422 で理由を返す。黙って閉じずにそれを見せる。
+      setDeleteErrors(result.errors);
+      return;
+    }
+    setTemplates((prev) => prev.filter((item) => item.id !== deleteTarget.id));
+    setDeleteTarget(null);
+    toast.success("振り返りテンプレを削除しました");
+  };
+
+  return (
+    <>
+      <h2 className="text-2xl font-bold">振り返りテンプレ</h2>
+      <p className="mt-2 text-sm text-zinc-300">
+        野球ノートに使う問いかけのセットです。空欄のメモより「何を書くか」が決まっている方が、振り返りが続きます。
+      </p>
+
+      <div className="my-6">
+        <ReflectionTemplateList
+          templates={templates}
+          onEdit={handleEdit}
+          onDelete={openDeleteConfirm}
+        />
+      </div>
+
+      {isAtFreeLimit ? (
+        <ProUpsellCard
+          feature={PAYWALL_TRIGGER}
+          title={FREE_LIMIT_TITLE}
+          description={FREE_LIMIT_DESCRIPTION}
+          ctaLabel="Pro プランを見る"
+          className="mb-4"
+        />
+      ) : null}
+
+      <Button
+        color="primary"
+        fullWidth
+        radius="sm"
+        className="font-bold"
+        startContent={<PlusIcon className="h-5 w-5" aria-hidden />}
+        isDisabled={isEntitlementLoading}
+        onPress={handleAdd}
+      >
+        テンプレを作る
+      </Button>
+
+      {form ? (
+        <ReflectionTemplateFormModal
+          key={form.token}
+          template={form.template}
+          isSaving={isSaving}
+          serverErrors={formErrors}
+          onClose={() => setForm(null)}
+          onSubmit={handleSubmit}
+        />
+      ) : null}
+
+      <Modal
+        isOpen={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        placement="center"
+        className="buzz-dark"
+      >
+        <ModalContent>
+          <ModalHeader className="text-white">テンプレの削除</ModalHeader>
+          <ModalBody>
+            <p className="text-sm text-white">
+              「{deleteTarget?.title}」を削除しますか？
+            </p>
+            <p className="text-xs text-zinc-400">{DELETE_NOTICE}</p>
+            {deleteErrors.length > 0 ? (
+              <ul role="alert" className="space-y-1 text-sm text-danger">
+                {deleteErrors.map((message) => (
+                  <li key={message}>{message}</li>
+                ))}
+              </ul>
+            ) : null}
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="flat"
+              onPress={() => setDeleteTarget(null)}
+              isDisabled={isDeleting}
+            >
+              キャンセル
+            </Button>
+            <Button
+              color="danger"
+              onPress={handleDelete}
+              isDisabled={isDeleting}
+              isLoading={isDeleting}
+            >
+              削除
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/app/(app)/note/templates/_components/reflectionTemplateCopy.ts
+++ b/app/(app)/note/templates/_components/reflectionTemplateCopy.ts
@@ -1,0 +1,34 @@
+import { REFLECTION_TEMPLATE_FREE_LIMIT } from "@app/constants/reflectionTemplate";
+
+/**
+ * 振り返りテンプレ画面の文言。
+ * 無料枠の上限は back の 403 と同じ意味（Pro 限定機能ではなく「自作の件数の上限超過」）で
+ * 伝えるため、上限にまつわる文言は件数を明示した表現に統一して1箇所で持つ。
+ */
+
+/** 無料枠を使い切ったユーザーに出す見出し。 */
+export const FREE_LIMIT_TITLE = `無料プランで作成できる振り返りテンプレは${REFLECTION_TEMPLATE_FREE_LIMIT}件までです`;
+
+/** 上限解放後に何ができるかの説明。 */
+export const FREE_LIMIT_DESCRIPTION = `Pro プランなら${REFLECTION_TEMPLATE_FREE_LIMIT + 1}つ目以降の振り返りテンプレも自由に作成・編集できます。`;
+
+/**
+ * 作成・プリセット編集が 403 を返したときにフォーム上へ出すエラー。
+ * クライアント側の件数判定をすり抜けた（別端末で作成した等）ケースで表示する。
+ */
+export const FREE_LIMIT_SERVER_ERROR = `${FREE_LIMIT_TITLE}。${FREE_LIMIT_DESCRIPTION}`;
+
+/** プリセットの編集は共有プリセットを書き換えず、自分専用のコピーになることを伝える。 */
+export const PRESET_EDIT_NOTICE =
+  "プリセットを編集すると、自分専用のテンプレとして保存されます（元のプリセットは変わりません）。";
+
+export const CUSTOM_EMPTY_MESSAGE =
+  "まだ自作の振り返りテンプレがありません。自分専用の問いかけを作れます。";
+
+export const TITLE_REQUIRED_ERROR = "テンプレ名を入力してください";
+
+export const QUESTION_REQUIRED_ERROR = "問いを1つ以上入力してください";
+
+/** 削除は使用中のノートがあると back に拒否されることを事前に伝える。 */
+export const DELETE_NOTICE =
+  "このテンプレを使っている野球ノートがある場合は削除できません。";

--- a/app/(app)/note/templates/page.tsx
+++ b/app/(app)/note/templates/page.tsx
@@ -1,0 +1,38 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getReflectionTemplates } from "@app/services/v2/reflectionTemplateService";
+import ReflectionTemplatesContent from "./_components/ReflectionTemplatesContent";
+
+export const metadata = {
+  title: "振り返りテンプレ",
+};
+
+export default async function ReflectionTemplatesPage() {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const result = await getReflectionTemplates();
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            {result.status === "ok" ? (
+              <ReflectionTemplatesContent initialTemplates={result.data} />
+            ) : (
+              // 取得失敗を空配列に丸めると「テンプレ未登録」と誤表示し、重複作成を招く。
+              <p className="py-8 text-center text-sm text-zinc-400">
+                振り返りテンプレを取得できませんでした。時間を置いて再度お試しください。
+              </p>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/components/header/HeaderRight.tsx
+++ b/app/components/header/HeaderRight.tsx
@@ -56,6 +56,16 @@ export default function HeaderRight() {
                   野球ノート
                 </DropdownItem>
                 <DropdownItem
+                  key="reflection-templates"
+                  as={Link}
+                  href="/note/templates"
+                  startContent={
+                    <NoteIcon fill="currentColor" width="18" height="18" />
+                  }
+                >
+                  振り返りテンプレ
+                </DropdownItem>
+                <DropdownItem
                   key="practice-menus"
                   as={Link}
                   href="/practice/menus"

--- a/app/components/header/__tests__/HeaderRight.test.tsx
+++ b/app/components/header/__tests__/HeaderRight.test.tsx
@@ -42,6 +42,14 @@ describe("HeaderRight のメニュー", () => {
     ).toHaveAttribute("href", "/practice/menus");
   });
 
+  it("振り返りテンプレへの導線を持つ", async () => {
+    await openMenu();
+
+    expect(
+      screen.getByRole("menuitem", { name: /振り返りテンプレ/ }),
+    ).toHaveAttribute("href", "/note/templates");
+  });
+
   it("野球ノートとシーズン管理の導線を維持する", async () => {
     await openMenu();
 

--- a/app/components/note/ReflectionTemplateSection.tsx
+++ b/app/components/note/ReflectionTemplateSection.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
+import type { FetchResult } from "@app/services/v2/requests";
+import { Textarea } from "@heroui/react";
+
+interface ReflectionTemplateSectionProps {
+  /** 一覧の取得結果。失敗を空配列に丸めるとテンプレ未作成と誤表示するため結果ごと受け取る。 */
+  templatesResult: FetchResult<ReflectionTemplate[]>;
+  selectedTemplateId: number | null;
+  /** 表示する問い。新規作成は選択テンプレの問い、編集はノートに保存済みの問い。 */
+  questions: string[];
+  answers: Record<string, string>;
+  /** テンプレ選択チップの操作。locked では選択チップを出さないため不要。 */
+  onSelectTemplate?: (template: ReflectionTemplate | null) => void;
+  onChangeAnswer: (question: string, answer: string) => void;
+  /** 編集時などテンプレ選択を固定し、このノートの問いだけを編集させる（切替による回答消失を防ぐ）。 */
+  locked?: boolean;
+}
+
+/**
+ * 振り返りテンプレの選択と、問い→回答の入力欄。
+ * 空欄の自由メモより「何を書くか」を問いで示し、内省の質を上げる。
+ * locked のときはテンプレ選択チップを出さず、ノートに保存済みの問いだけを扱う
+ * （テンプレは更新で id が変わる・削除されることがあるため、問いはノート側の回答を正とする）。
+ */
+export default function ReflectionTemplateSection({
+  templatesResult,
+  selectedTemplateId,
+  questions,
+  answers,
+  onSelectTemplate,
+  onChangeAnswer,
+  locked = false,
+}: ReflectionTemplateSectionProps) {
+  const templates =
+    templatesResult.status === "ok" ? templatesResult.data : null;
+  const selected =
+    templates?.find((template) => template.id === selectedTemplateId) ?? null;
+
+  if (locked && questions.length === 0) return null;
+
+  return (
+    <section aria-labelledby="reflection-section-heading" className="mt-8">
+      <h3
+        id="reflection-section-heading"
+        className="text-sm font-bold text-zinc-400"
+      >
+        {locked
+          ? `振り返り${selected ? `（${selected.title}）` : ""}`
+          : "振り返りテンプレ（任意）"}
+      </h3>
+
+      {locked ? null : templates === null ? (
+        <p className="mt-2 text-xs text-zinc-400">
+          振り返りテンプレを取得できませんでした。メモはそのまま入力できます。
+        </p>
+      ) : (
+        <div
+          className="mt-2 flex flex-wrap gap-2"
+          role="group"
+          aria-label="振り返りテンプレ"
+        >
+          <button
+            type="button"
+            aria-pressed={selectedTemplateId === null}
+            onClick={() => onSelectTemplate?.(null)}
+            className={`rounded-full px-3.5 py-2 text-xs font-bold transition-colors ${
+              selectedTemplateId === null
+                ? "bg-[#d08000] text-white"
+                : "bg-sub text-zinc-400 hover:text-white"
+            }`}
+          >
+            なし
+          </button>
+          {templates.map((template) => (
+            <button
+              key={template.id}
+              type="button"
+              aria-pressed={selectedTemplateId === template.id}
+              onClick={() => onSelectTemplate?.(template)}
+              className={`rounded-full px-3.5 py-2 text-xs font-bold transition-colors ${
+                selectedTemplateId === template.id
+                  ? "bg-[#d08000] text-white"
+                  : "bg-sub text-zinc-400 hover:text-white"
+              }`}
+            >
+              {template.title}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {questions.length > 0 ? (
+        <div className="mt-4 space-y-4">
+          {questions.map((question) => (
+            <Textarea
+              key={question}
+              variant="bordered"
+              minRows={2}
+              label={question}
+              labelPlacement="outside"
+              placeholder="ここに書く"
+              value={answers[question] ?? ""}
+              onChange={(event) => onChangeAnswer(question, event.target.value)}
+            />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/app/constants/reflectionTemplate.ts
+++ b/app/constants/reflectionTemplate.ts
@@ -1,0 +1,3 @@
+// back/app/models/concerns/plan_limits.rb の REFLECTION_TEMPLATE_FREE_LIMIT と一致させる。
+// 数えるのは「自作テンプレ（アーカイブ済みを除く）」だけで、プリセットは上限に含まれない。
+export const REFLECTION_TEMPLATE_FREE_LIMIT = 1;

--- a/app/interface/reflectionTemplate.ts
+++ b/app/interface/reflectionTemplate.ts
@@ -1,0 +1,23 @@
+// v2 振り返りテンプレ API（/api/v2/reflection_templates）の型。
+// キー名は back のシリアライザ（V2::ReflectionTemplateSerializer）に合わせて snake_case のまま扱う。
+
+/**
+ * 振り返りテンプレ（問いかけ）。
+ * `is_preset` が true のものは運営提供のプリセットで、全ユーザーに共通で見える。
+ * プリセットを編集すると back 側でユーザー専用のコピー（`is_preset: false`）が作られ、
+ * 元のプリセットは本人の一覧から消える。
+ */
+export interface ReflectionTemplate {
+  id: number;
+  title: string;
+  questions: string[];
+  is_preset: boolean;
+  is_default: boolean;
+  sort_order: number;
+}
+
+/** テンプレの作成・更新パラメータ。 */
+export interface ReflectionTemplateInput {
+  title: string;
+  questions: string[];
+}

--- a/app/services/v2/__tests__/reflectionTemplateService.test.ts
+++ b/app/services/v2/__tests__/reflectionTemplateService.test.ts
@@ -1,0 +1,176 @@
+const mockGet = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(() => Promise.resolve({ get: mockGet })),
+}));
+
+jest.mock("@app/constants/api", () => ({
+  RAILS_API_URL: "http://back:3000",
+}));
+
+jest.mock("../../../../lib/sentry-helpers", () => ({
+  captureServerActionError: jest.fn(),
+}));
+
+import {
+  createReflectionTemplate,
+  deleteReflectionTemplate,
+  getReflectionTemplates,
+  updateReflectionTemplate,
+} from "../reflectionTemplateService";
+
+function setupAuthCookies() {
+  mockGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: "test-uid" },
+    };
+    return values[key];
+  });
+}
+
+function mockResponse(status: number, body: unknown) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+function requestedUrl(callIndex = 0): string {
+  return (global.fetch as jest.Mock).mock.calls[callIndex][0] as string;
+}
+
+function requestedInit(callIndex = 0): RequestInit {
+  return (global.fetch as jest.Mock).mock.calls[callIndex][1] as RequestInit;
+}
+
+function sentBody(callIndex = 0): unknown {
+  return JSON.parse(requestedInit(callIndex).body as string);
+}
+
+const template = {
+  id: 1,
+  title: "試合の振り返り",
+  questions: ["良かった点", "次やること"],
+  is_preset: false,
+  is_default: false,
+  sort_order: 0,
+};
+
+describe("振り返りテンプレの v2 Server Actions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    setupAuthCookies();
+  });
+
+  describe("getReflectionTemplates", () => {
+    it("一覧を取得する", async () => {
+      mockResponse(200, [template]);
+
+      const result = await getReflectionTemplates();
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/reflection_templates",
+      );
+      expect(result).toEqual({ status: "ok", data: [template] });
+    });
+
+    it("取得に失敗しても空配列に丸めず error を返す", async () => {
+      mockResponse(500, {});
+
+      expect(await getReflectionTemplates()).toEqual({ status: "error" });
+    });
+
+    it("Cookie が欠けていればリクエストしない", async () => {
+      mockGet.mockReturnValue(undefined);
+
+      expect(await getReflectionTemplates()).toEqual({ status: "error" });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("createReflectionTemplate", () => {
+    it("reflection_template で包んで POST する", async () => {
+      mockResponse(201, template);
+
+      const result = await createReflectionTemplate({
+        title: "試合の振り返り",
+        questions: ["良かった点"],
+      });
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/reflection_templates",
+      );
+      expect(requestedInit().method).toBe("POST");
+      expect(sentBody()).toEqual({
+        reflection_template: {
+          title: "試合の振り返り",
+          questions: ["良かった点"],
+        },
+      });
+      expect(result).toEqual({ ok: true, data: template });
+    });
+
+    it("無料枠超過の 403 は forbidden として返す", async () => {
+      mockResponse(403, { error: "自作テンプレは無料プランで1つまでです" });
+
+      expect(
+        await createReflectionTemplate({ title: "t", questions: ["q"] }),
+      ).toEqual({
+        ok: false,
+        reason: "forbidden",
+        errors: ["自作テンプレは無料プランで1つまでです"],
+      });
+    });
+  });
+
+  describe("updateReflectionTemplate", () => {
+    it("id を指定して PATCH する", async () => {
+      mockResponse(200, { ...template, id: 77 });
+
+      const result = await updateReflectionTemplate(4, {
+        title: "改訂版",
+        questions: ["新しい問い"],
+      });
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/reflection_templates/4",
+      );
+      expect(requestedInit().method).toBe("PATCH");
+      expect(sentBody()).toEqual({
+        reflection_template: { title: "改訂版", questions: ["新しい問い"] },
+      });
+      // back は原本を更新せず新バージョンを作るため、返るのは別 ID のレコード
+      expect(result).toEqual({ ok: true, data: { ...template, id: 77 } });
+    });
+  });
+
+  describe("deleteReflectionTemplate", () => {
+    it("id を指定して DELETE する", async () => {
+      mockResponse(200, { message: "削除しました" });
+
+      const result = await deleteReflectionTemplate(7);
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/reflection_templates/7",
+      );
+      expect(requestedInit().method).toBe("DELETE");
+      expect(result).toEqual({ ok: true, data: { message: "削除しました" } });
+    });
+
+    it("使用中の 422 は理由をそのまま返す", async () => {
+      mockResponse(422, {
+        error: "このテンプレは野球ノートで使用されているため削除できません",
+      });
+
+      expect(await deleteReflectionTemplate(7)).toEqual({
+        ok: false,
+        reason: "error",
+        errors: ["このテンプレは野球ノートで使用されているため削除できません"],
+      });
+    });
+  });
+});

--- a/app/services/v2/reflectionTemplateService.ts
+++ b/app/services/v2/reflectionTemplateService.ts
@@ -1,0 +1,76 @@
+"use server";
+
+import type {
+  ReflectionTemplate,
+  ReflectionTemplateInput,
+} from "@app/interface/reflectionTemplate";
+import {
+  type DeletedResponse,
+  type FetchResult,
+  type MutationResult,
+  fetchV2,
+  mutateV2,
+} from "./requests";
+
+const BASE_PATH = "/api/v2/reflection_templates";
+
+/**
+ * 振り返りテンプレ一覧を取得する（GET /api/v2/reflection_templates）。
+ * プリセットと自分の自作テンプレが混在して返る（`is_preset` で区別する）。
+ * 自分がプリセットを編集済みの場合、そのプリセットは返らずコピーだけが返る。
+ */
+export async function getReflectionTemplates(): Promise<
+  FetchResult<ReflectionTemplate[]>
+> {
+  return fetchV2<ReflectionTemplate[]>(BASE_PATH, "getReflectionTemplates");
+}
+
+/**
+ * 自作テンプレを新規作成する（POST /api/v2/reflection_templates）。
+ * 無料プランは自作が REFLECTION_TEMPLATE_FREE_LIMIT 件を超えると 403 になるため、
+ * reason:"forbidden" を Pro 訴求の分岐に使う。
+ */
+export async function createReflectionTemplate(
+  input: ReflectionTemplateInput,
+): Promise<MutationResult<ReflectionTemplate>> {
+  return mutateV2<ReflectionTemplate>(BASE_PATH, {
+    method: "POST",
+    body: { reflection_template: input },
+    action: "createReflectionTemplate",
+    fallbackMessage: "振り返りテンプレの作成に失敗しました",
+  });
+}
+
+/**
+ * テンプレを更新する（PATCH /api/v2/reflection_templates/:id）。
+ *
+ * back は原本を書き換えず「新しいバージョン」を別レコードとして作り、それを返す
+ * （過去ノートが参照する原本を壊さないため）。したがって **返り値の id は渡した id と異なる**。
+ * 呼び出し側は必ず返却された新しいテンプレで手元の状態を差し替えること。
+ * プリセットを編集した場合は自作テンプレの新規作成に等しいため、無料枠を使い切っていると 403 になる。
+ */
+export async function updateReflectionTemplate(
+  id: number,
+  input: ReflectionTemplateInput,
+): Promise<MutationResult<ReflectionTemplate>> {
+  return mutateV2<ReflectionTemplate>(`${BASE_PATH}/${id}`, {
+    method: "PATCH",
+    body: { reflection_template: input },
+    action: "updateReflectionTemplate",
+    fallbackMessage: "振り返りテンプレの更新に失敗しました",
+  });
+}
+
+/**
+ * 自作テンプレを削除する（DELETE /api/v2/reflection_templates/:id）。
+ * 野球ノートで使用中のテンプレは参照整合性のため 422 で拒否され、理由が errors に入る。
+ */
+export async function deleteReflectionTemplate(
+  id: number,
+): Promise<MutationResult<DeletedResponse>> {
+  return mutateV2<DeletedResponse>(`${BASE_PATH}/${id}`, {
+    method: "DELETE",
+    action: "deleteReflectionTemplate",
+    fallbackMessage: "振り返りテンプレの削除に失敗しました",
+  });
+}

--- a/app/utils/__tests__/noteMemo.test.ts
+++ b/app/utils/__tests__/noteMemo.test.ts
@@ -1,9 +1,11 @@
 import {
+  buildAnswerList,
   buildMemoJson,
   buildReflectionMemoText,
   extractMemoText,
   isReflectionMemo,
   parseMemoToSlateValue,
+  resolveNoteMemo,
 } from "../noteMemo";
 
 describe("buildMemoJson / extractMemoText", () => {
@@ -155,5 +157,59 @@ describe("parseMemoToSlateValue", () => {
   it("buildMemoJson の出力は正規化しても同じ JSON に戻る（無変更が変更扱いにならない）", () => {
     const memo = buildMemoJson("外角が詰まる");
     expect(JSON.stringify(parseMemoToSlateValue(memo))).toBe(memo);
+  });
+});
+
+describe("buildAnswerList", () => {
+  it("問いの並び順で回答を組み立てる", () => {
+    expect(buildAnswerList(["A", "B"], { B: "答えB", A: "答えA" })).toEqual([
+      { question: "A", answer: "答えA" },
+      { question: "B", answer: "答えB" },
+    ]);
+  });
+
+  it("未入力・空白だけの回答は落とす", () => {
+    expect(buildAnswerList(["A", "B", "C"], { A: "答え", B: "   " })).toEqual([
+      { question: "A", answer: "答え" },
+    ]);
+  });
+
+  it("問いから外れた回答は残っていても送らない（他の回答は消えない）", () => {
+    expect(buildAnswerList(["A"], { A: "答えA", B: "答えB" })).toEqual([
+      { question: "A", answer: "答えA" },
+    ]);
+  });
+});
+
+describe("resolveNoteMemo", () => {
+  const answers = [
+    { question: "課題", answer: "引きつけ" },
+    { question: "次やること", answer: "素振り" },
+  ];
+
+  it("自由メモが空なら回答から本文を合成する", () => {
+    expect(resolveNoteMemo("", answers)).toBe(
+      buildMemoJson("【課題】\n引きつけ\n\n【次やること】\n素振り"),
+    );
+  });
+
+  it("空段落だけの Slate JSON も未入力として合成する", () => {
+    expect(resolveNoteMemo(buildMemoJson(""), answers)).toBe(
+      buildMemoJson("【課題】\n引きつけ\n\n【次やること】\n素振り"),
+    );
+  });
+
+  it("自由メモがあれば合成で上書きしない", () => {
+    const memo = buildMemoJson("自分の言葉");
+    expect(resolveNoteMemo(memo, answers)).toBe(memo);
+  });
+
+  it("回答が無ければ空メモを返す", () => {
+    expect(resolveNoteMemo("", [])).toBe(buildMemoJson(""));
+  });
+
+  it("合成した本文は isReflectionMemo で合成と判定できる", () => {
+    const memo = resolveNoteMemo("", answers);
+    expect(isReflectionMemo(extractMemoText(memo), answers)).toBe(true);
   });
 });

--- a/app/utils/__tests__/noteUpdateInput.test.ts
+++ b/app/utils/__tests__/noteUpdateInput.test.ts
@@ -38,6 +38,41 @@ describe("buildNoteUpdateInput", () => {
     expect(input).toEqual({ title: null });
   });
 
+  it("テンプレ回答を変えたときだけ reflection_answers を送る", () => {
+    const withAnswers: NoteEditableFields = {
+      ...initial,
+      reflectionAnswers: [{ question: "課題", answer: "引きつけ" }],
+    };
+    expect(buildNoteUpdateInput(withAnswers, { ...withAnswers })).toEqual({});
+    expect(
+      buildNoteUpdateInput(withAnswers, {
+        ...withAnswers,
+        reflectionAnswers: [{ question: "課題", answer: "体の開き" }],
+      }),
+    ).toEqual({
+      reflection_answers: [{ question: "課題", answer: "体の開き" }],
+    });
+  });
+
+  it("回答を全て消したときは空配列を明示して送る（未送信では消えないため）", () => {
+    const withAnswers: NoteEditableFields = {
+      ...initial,
+      reflectionAnswers: [{ question: "課題", answer: "引きつけ" }],
+    };
+    expect(
+      buildNoteUpdateInput(withAnswers, {
+        ...withAnswers,
+        reflectionAnswers: [],
+      }),
+    ).toEqual({ reflection_answers: [] });
+  });
+
+  it("回答を扱わない呼び出し元には reflection_answers キーを生やさない", () => {
+    expect(
+      buildNoteUpdateInput(initial, { ...initial, title: "更新後" }),
+    ).not.toHaveProperty("reflection_answers");
+  });
+
   it("紐付け・タグのキーは決して生やさない（既存の紐付けを消さない）", () => {
     const input = buildNoteUpdateInput(initial, {
       date: "2026-08-02",
@@ -47,6 +82,7 @@ describe("buildNoteUpdateInput", () => {
     expect(input).not.toHaveProperty("game_result_ids");
     expect(input).not.toHaveProperty("improvement_theme_ids");
     expect(input).not.toHaveProperty("tag_ids");
+    expect(input).not.toHaveProperty("reflection_template_id");
     expect(Object.keys(input).sort()).toEqual(["date", "memo", "title"]);
   });
 });

--- a/app/utils/noteMemo.ts
+++ b/app/utils/noteMemo.ts
@@ -56,6 +56,35 @@ export const isReflectionMemo = (
   return memoText === buildReflectionMemoText(answers) || memoText === legacy;
 };
 
+/**
+ * 問いの並び順どおりに回答を組み立てる。未入力（空白のみ）の問いは落とす。
+ * 回答は問い文をキーにしたマップで持つため、問いを出し入れしても他の回答が消えない。
+ */
+export const buildAnswerList = (
+  questions: string[],
+  answers: Record<string, string>,
+): ReflectionAnswer[] =>
+  questions
+    .map((question) => ({ question, answer: (answers[question] ?? "").trim() }))
+    .filter((item) => item.answer.length > 0);
+
+/**
+ * 保存する memo を決める。自由メモが空のときだけテンプレ回答から本文を合成する。
+ *
+ * 一覧のプレビューは memo から作られるため、テンプレだけで書いたノートが
+ * 「本文なし」に見えないよう合成する。自由メモが入力されていればそちらを正とし、
+ * 合成で上書きしない（ユーザーが書いた本文を失わせない）。
+ */
+export const resolveNoteMemo = (
+  memo: string,
+  answers: ReflectionAnswer[],
+): string => {
+  if (extractMemoText(memo).trim() !== "") return memo;
+  return buildMemoJson(
+    answers.length > 0 ? buildReflectionMemoText(answers) : "",
+  );
+};
+
 const isMemoParagraph = (value: unknown): value is MemoParagraph => {
   if (typeof value !== "object" || value === null) return false;
   const children = (value as { children?: unknown }).children;

--- a/app/utils/noteUpdateInput.ts
+++ b/app/utils/noteUpdateInput.ts
@@ -1,10 +1,23 @@
-import type { BaseballNoteUpdateInput } from "@app/interface/baseballNoteV2";
+import type {
+  BaseballNoteUpdateInput,
+  ReflectionAnswer,
+} from "@app/interface/baseballNoteV2";
 
 /** ノート編集画面が扱う入力項目（紐付け・タグはこの画面では編集しない）。 */
 export interface NoteEditableFields {
   date: string;
   title: string;
   memo: string;
+  /**
+   * テンプレ回答。回答を扱わない呼び出し元は省略する
+   * （省略した場合は `reflection_answers` キー自体を生やさない）。
+   */
+  reflectionAnswers?: ReflectionAnswer[];
+}
+
+/** 回答の比較用の正規形。並び順も表示順として意味を持つため配列のまま比較する。 */
+function serializeAnswers(answers: ReflectionAnswer[] = []): string {
+  return JSON.stringify(answers.map((item) => [item.question, item.answer]));
 }
 
 /**
@@ -14,6 +27,7 @@ export interface NoteEditableFields {
  * キーごと落とす。特に試合 / 課題 / タグの紐付けは本画面の管轄外なので、
  * ここでキーを生やしてはならない（送った時点でその内容に置き換えられる）。
  * タイトルの空文字は「消す」操作なので、`undefined` ではなく `null` を明示して送る。
+ * テンプレ回答も全消しは `[]` を明示して送る（未送信では消えない）。
  */
 export function buildNoteUpdateInput(
   initial: NoteEditableFields,
@@ -24,6 +38,12 @@ export function buildNoteUpdateInput(
   if (current.title !== initial.title)
     input.title = current.title === "" ? null : current.title;
   if (current.memo !== initial.memo) input.memo = current.memo;
+  if (
+    serializeAnswers(current.reflectionAnswers) !==
+    serializeAnswers(initial.reflectionAnswers)
+  ) {
+    input.reflection_answers = current.reflectionAnswers ?? [];
+  }
   return input;
 }
 


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#475

## 概要

プリセット＋自作の振り返りテンプレートを管理し、ノート作成/編集時に「問い→回答」形式で記入できるようにします。front に全く存在しなかった機能です。

## ⚠️ 「update が新バージョンを作る」仕様への対応（本 PR の核心）

issue で警告されていた点です。back の `PATCH` は**原本を更新せず新バージョンを作り、別 ID のレコードを返します**（`create_edited_version`。過去ノートの整合性維持のため）。

古い ID を保持し続けると不整合が起きるため、**返却された新レコードで丸ごと差し替える**実装にしました。

```ts
setTemplates((prev) =>
  editing
    ? prev.map((item) => (item.id === editing.id ? result.data : item))
    : [...prev, result.data],
);
```

副次的に、**プリセットを編集すると `is_preset: false` のコピーに入れ替わり「プリセット節から消えて自作節に現れる」**という back の `available_for` の挙動とも自動的に一致します。両方ともテストで固定しています。

## back の契約（調査結果）

| 操作 | 契約 |
| --- | --- |
| `GET` | 本人の未アーカイブ自作 + 「本人が編集コピーを持たないプリセット」 |
| `POST` | 上限超過で **403** + `{ error: "自作テンプレは無料プランで1つまでです…" }` |
| `PATCH` | **新バージョンを作り別 ID を返す**。プリセット編集時のみ、無料枠を使い切っていると 403（**自作の再編集は差し引き0なのでチェック対象外**） |
| `DELETE` | **プリセットは 404**（削除不可）。ノートで使用中なら **422** + `{ error: "このテンプレは野球ノートで使用されているため削除できません" }` |

**上限にプリセットは数えません**（`custom_reflection_templates_count` は自作かつ未アーカイブのみ）。`REFLECTION_TEMPLATE_FREE_LIMIT = 1`。

## 前 PR の申し送りを解消しました

#419（ノート v2）の実装者が残した宿題です。

> テンプレ機能を実装する際は `isReflectionMemo` を使い、合成メモを自由メモ欄に流し込まないでください。**メモ本文だけ書き換えると回答との乖離が起きます。テンプレ UI を載せる際に合わせて解消してください**

`resolveNoteMemo` を**初期値・現在値の両方に同じ手順で通す**ことで解決しました。これにより「合成メモのノートを開いただけで変更あり扱い」にならず、かつ「回答だけ編集した場合にメモ本文も追随」します。編集画面はテンプレを固定するため `reflection_template_id` キーは一切送りません。

## メモ合成の仕様（mobile と一致）

- 送信時 `memo.trim() || buildReflectionMemoText(answers)` — **自由メモが空のときだけ**合成
- 表示側は `isReflectionMemo` が true なら自由メモを描画しない
- **`locked` 時の問いはテンプレではなくノートの回答から引く**（テンプレ更新で ID が変わる／削除されるため）

## 変更内容

- `app/services/v2/reflectionTemplateService.ts` / `app/interface/reflectionTemplate.ts` / `app/constants/reflectionTemplate.ts`
- `app/(app)/note/templates/` — 管理画面（一覧・作成・編集・削除）
- `app/components/note/ReflectionTemplateSection.tsx` — 新規/編集の両画面で使う共通セクション
- `app/utils/noteMemo.ts` に `buildAnswerList` / `resolveNoteMemo` を追加
- `app/utils/noteUpdateInput.ts` — 変化時のみ `reflection_answers` を生やす
- `HeaderRight.tsx` に `/note/templates` への導線

## 確認手順

1. ヘッダーメニューから「振り返りテンプレ」を開く
2. プリセットと自作が区分表示され、プリセットに削除導線が無いこと
3. **プリセットを編集すると自作テンプレのコピーとして一覧に移ること**
4. **使用中のテンプレを削除しようとすると 422 の理由が表示されること**
5. ノート作成でテンプレを選び回答を入力 → 自由メモが空なら回答から本文が合成されること
6. そのノートを編集で開いたとき、**合成メモが自由メモ欄に流し込まれていないこと**

## レビューで確認いただきたい点

1. **旧フォーマットのメモが移行します。** 旧形式（`問い: 回答`）の合成メモを持つノートは、**回答を1文字でも編集すると新フォーマット（`【問い】`）へ移行**します（何も編集しなければ送信ゼロ）。この移行を許容してよいかご確認ください
2. **プリセット編集時だけ事前ペイウォールを出しています。** back が「自作を上限まで持った状態でのプリセット編集」を 403 にするためです。一方**自作の再編集は常に許可**（back も差し引き0で許可＝Pro 解約後のグランドファザリング）。この非対称な UX が意図どおりか確認ください
3. **削除の 422 はトーストではなく確認モーダル内にインライン表示**（`role="alert"`）にしました。`practice/menus` は `toast.error` ですが、「使用中だから消せない」は理由が長くモーダルを開いたまま見せる方が伝わると判断しています。揃えるべきなら変更します
4. **編集画面では問いを増減できません**（テンプレ固定＝mobile と同じ）。既存の問いの回答編集と全消し（`[]` 送信）のみ可能です
5. `is_default` / `sort_order` は back が受け付けますが mobile も UI を持たないため送っていません

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る（0 errors / 0 warnings）
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（**125 suites / 1350 tests**。+4 suites / +63 tests）
- [x] `yarn build` が通る（**ローカルで実行済み**）
- [x] ミューテーションテスト **29 設計 / 29 KILLED / 0 SURVIVED**

### ルート表

base と head の両方をビルドして diff した結果、**追加は `ƒ /note/templates` の1行のみ**で既存ルートの分類変化はありません（base: 静的 87 / 動的 43 → head: 静的 87 / 動的 44）。

<details>
<summary>ミューテーションテスト詳細</summary>

隔離複製で実施（無改変で 125 suites / 1350 tests 全 PASS を確認後、検証終了時に削除）。

**更新後に古い ID を使う 2件** / 422 の理由を表示しない 3件 / 上限値の変更 2件 / グランドファザリング無視・プリセット計上 4件 / 問い削除時に回答も消す 4件 / `reflection_answers` のキー改変 3件 / 部分更新で余計なキー 2件 / 合成メモ・`isReflectionMemo` 6件 / API パス・メソッド・ボディ 3件 — 全 KILLED。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_