### PR TITLE
Add: 練習記録にコンディション入力（Pro限定）を実装

### DIFF
--- a/app/(app)/practice/record/__tests__/PracticeRecordContent.test.tsx
+++ b/app/(app)/practice/record/__tests__/PracticeRecordContent.test.tsx
@@ -27,9 +27,11 @@ jest.mock("@app/services/v2/practiceSessionService", () => ({
 
 import type { ImprovementTheme } from "@app/types/improvementTheme";
 import type {
+  ConditionLog,
   PracticeLog,
   PracticeMenu,
   PracticeSession,
+  PracticeSessionInput,
   PracticeSessionItemInput,
 } from "@app/types/practice";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -192,6 +194,27 @@ function savedItems(): PracticeSessionItemInput[] {
   return [...(input?.items ?? [])].sort(
     (a, b) => a.practice_menu_id - b.practice_menu_id,
   );
+}
+
+/** 直近の保存リクエスト本体。condition キーの有無ごと検証するために生のまま返す。 */
+function savedInput(): PracticeSessionInput {
+  const input = mockUpsert.mock.calls.at(-1)?.[0];
+  if (!input) throw new Error("保存リクエストが送られていない");
+  return input;
+}
+
+function buildCondition(overrides: Partial<ConditionLog> = {}): ConditionLog {
+  return {
+    id: 5,
+    logged_on: YESTERDAY,
+    fatigue_level: 3,
+    physical_level: 2,
+    sleep_hours: "7.0",
+    mood: "普通",
+    memo: "全体的に体は軽かった",
+    injuries: [{ part: "腰", memo: "重い" }],
+    ...overrides,
+  };
 }
 
 describe("PracticeRecordContent", () => {
@@ -679,6 +702,368 @@ describe("PracticeRecordContent", () => {
       expect(
         screen.getByRole("button", { name: "野球ノートを書く" }),
       ).toBeEnabled();
+    });
+  });
+
+  describe("コンディション", () => {
+    /** 練習量とコンディションを両方入力したうえで保存する。 */
+    async function saveWithCondition(user: ReturnType<typeof userEvent.setup>) {
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+      await user.click(screen.getByRole("button", { name: "疲労度: 元気" }));
+      await user.click(screen.getByRole("button", { name: "体調: 不調" }));
+      await user.type(screen.getByLabelText("睡眠時間"), "7.5");
+      await user.click(screen.getByRole("button", { name: "好調" }));
+      await user.type(screen.getByLabelText("気分のメモ"), "よく眠れた");
+      await user.click(
+        screen.getByRole("button", { name: "練習記録のみ保存" }),
+      );
+    }
+
+    describe("無料プラン", () => {
+      it("暗幕越しにサンプルのコンディションをプレビューする", () => {
+        renderContent();
+
+        expect(screen.getByTestId("pro-upsell-scrim")).toBeInTheDocument();
+        expect(
+          screen.getByText("サンプルデータ（実際の記録ではありません）"),
+        ).toBeVisible();
+        expect(screen.getByText("やや疲れ")).toBeVisible();
+        expect(screen.getByText("睡眠 7.5時間")).toBeVisible();
+        expect(screen.getByText("Pro限定")).toBeVisible();
+      });
+
+      it("入力フォームは出さない", () => {
+        renderContent();
+
+        expect(
+          screen.queryByRole("button", { name: "疲労度: 元気" }),
+        ).toBeNull();
+        expect(screen.queryByLabelText("睡眠時間")).toBeNull();
+      });
+
+      it("既存の記録があればサンプルではなく自分のコンディションをプレビューする", () => {
+        renderContent({
+          initialSession: buildSession({ condition: buildCondition() }),
+        });
+
+        // decimal は "7.0" の文字列で返るため、数値化して "7時間" と出す。
+        expect(screen.getByText("睡眠 7時間")).toBeVisible();
+        expect(screen.getByText("全体的に体は軽かった")).toBeVisible();
+        expect(screen.getByText("腰（重い）")).toBeVisible();
+        expect(
+          screen.queryByText("サンプルデータ（実際の記録ではありません）"),
+        ).toBeNull();
+      });
+
+      it("既存のコンディションが残っていても condition を送らない", async () => {
+        const user = userEvent.setup();
+        renderContent({
+          initialSession: buildSession({
+            condition: buildCondition(),
+            practice_logs: [buildLog({ practice_menu_id: 1 })],
+          }),
+        });
+
+        await user.click(
+          screen.getByRole("button", { name: "練習記録の変更を保存" }),
+        );
+
+        await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+        expect(savedInput()).not.toHaveProperty("condition");
+        expect(savedItems()).toEqual([
+          { practice_menu_id: 1, amount: 300, weight: null },
+        ]);
+      });
+    });
+
+    describe("Pro 判定が未確定の間", () => {
+      it("既存のコンディションがあっても condition を送らない", async () => {
+        const user = userEvent.setup();
+        mockEntitlement({ granted: true, isLoading: true });
+        renderContent({
+          initialSession: buildSession({
+            condition: buildCondition(),
+            practice_logs: [buildLog({ practice_menu_id: 1 })],
+          }),
+        });
+
+        await user.click(
+          screen.getByRole("button", { name: "練習記録の変更を保存" }),
+        );
+
+        await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+        expect(savedInput()).not.toHaveProperty("condition");
+      });
+
+      it("Pro 限定バッジも入力フォームも出さない", () => {
+        mockEntitlement({ granted: true, isLoading: true });
+        renderContent();
+
+        expect(screen.queryByText("Pro限定")).toBeNull();
+        expect(
+          screen.queryByRole("button", { name: "疲労度: 元気" }),
+        ).toBeNull();
+      });
+    });
+
+    describe("Pro プラン", () => {
+      beforeEach(() => {
+        mockEntitlement({ granted: true });
+      });
+
+      it("疲労度・体調とも4段階を出し、色以外にラベルでも段階が分かる", () => {
+        renderContent();
+
+        ["かなり疲れ", "やや疲れ", "ふつう", "元気"].forEach((label) => {
+          expect(
+            screen.getByRole("button", { name: `疲労度: ${label}` }),
+          ).toHaveTextContent(label);
+        });
+        ["不調", "やや不調", "ふつう", "好調"].forEach((label) => {
+          expect(
+            screen.getByRole("button", { name: `体調: ${label}` }),
+          ).toHaveTextContent(label);
+        });
+        expect(screen.queryByTestId("pro-upsell-scrim")).toBeNull();
+      });
+
+      it("入力したコンディションを練習記録と一緒に送る", async () => {
+        const user = userEvent.setup();
+        renderContent();
+
+        await saveWithCondition(user);
+
+        await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+        expect(savedInput().condition).toEqual({
+          fatigue_level: 4,
+          physical_level: 1,
+          sleep_hours: 7.5,
+          mood: "好調",
+          memo: "よく眠れた",
+          injuries: [],
+        });
+        expect(savedItems()).toEqual([
+          { practice_menu_id: 1, amount: 200, weight: null },
+        ]);
+      });
+
+      it("同じ段階をもう一度押すと選択を外す", async () => {
+        const user = userEvent.setup();
+        renderContent();
+
+        await user.click(screen.getByRole("button", { name: "疲労度: 元気" }));
+        expect(
+          screen.getByRole("button", { name: "疲労度: 元気" }),
+        ).toHaveAttribute("aria-pressed", "true");
+
+        await user.click(screen.getByRole("button", { name: "疲労度: 元気" }));
+        expect(
+          screen.getByRole("button", { name: "疲労度: 元気" }),
+        ).toHaveAttribute("aria-pressed", "false");
+      });
+
+      it("気分は3つのチップから選び、もう一度押すと外れる", async () => {
+        const user = userEvent.setup();
+        renderContent();
+
+        ["好調", "普通", "不調"].forEach((mood) => {
+          expect(screen.getByRole("button", { name: mood })).toBeVisible();
+        });
+
+        await user.click(screen.getByRole("button", { name: "不調" }));
+        expect(screen.getByRole("button", { name: "不調" })).toHaveAttribute(
+          "aria-pressed",
+          "true",
+        );
+
+        await user.click(screen.getByRole("button", { name: "不調" }));
+        await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+        await user.click(
+          screen.getByRole("button", { name: "練習記録のみ保存" }),
+        );
+
+        await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+        expect(savedInput()).not.toHaveProperty("condition");
+      });
+
+      it("怪我は部位プリセット8種から選び、メモを添えて送れる", async () => {
+        const user = userEvent.setup();
+        renderContent();
+
+        await user.click(screen.getByRole("button", { name: "部位を追加" }));
+
+        ["肩", "肘", "手首", "腰", "股関節", "膝", "足首", "その他"].forEach(
+          (part) => {
+            expect(
+              screen.getByRole("button", {
+                name: `1件目の怪我・痛みの部位: ${part}`,
+              }),
+            ).toBeVisible();
+          },
+        );
+
+        await user.click(
+          screen.getByRole("button", { name: "1件目の怪我・痛みの部位: 肘" }),
+        );
+        await user.type(
+          screen.getByLabelText("1件目の怪我・痛みのメモ"),
+          "軽い張り",
+        );
+        await user.click(
+          screen.getByRole("button", { name: "練習記録のみ保存" }),
+        );
+
+        await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+        expect(savedInput().condition?.injuries).toEqual([
+          { part: "肘", memo: "軽い張り" },
+        ]);
+      });
+
+      it("怪我を削除しても他の入力は消えない", async () => {
+        const user = userEvent.setup();
+        renderContent();
+
+        await user.type(screen.getByLabelText("睡眠時間"), "6");
+        await user.click(screen.getByRole("button", { name: "部位を追加" }));
+        await user.type(
+          screen.getByLabelText("1件目の怪我・痛みのメモ"),
+          "1件目",
+        );
+        await user.click(screen.getByRole("button", { name: "部位を追加" }));
+        await user.click(
+          screen.getByRole("button", { name: "2件目の怪我・痛みの部位: 膝" }),
+        );
+        await user.type(
+          screen.getByLabelText("2件目の怪我・痛みのメモ"),
+          "2件目",
+        );
+
+        await user.click(
+          screen.getByRole("button", { name: "1件目の怪我・痛みを削除" }),
+        );
+
+        expect(screen.getByLabelText("睡眠時間")).toHaveValue(6);
+        expect(screen.getByLabelText("1件目の怪我・痛みのメモ")).toHaveValue(
+          "2件目",
+        );
+        expect(screen.queryByLabelText("2件目の怪我・痛みのメモ")).toBeNull();
+
+        await user.click(
+          screen.getByRole("button", { name: "練習記録のみ保存" }),
+        );
+
+        await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+        expect(savedInput().condition?.injuries).toEqual([
+          { part: "膝", memo: "2件目" },
+        ]);
+        expect(savedInput().condition?.sleep_hours).toBe(6);
+      });
+
+      it("既存セッションのコンディションを初期表示して送り直す", async () => {
+        const user = userEvent.setup();
+        renderContent({
+          initialSession: buildSession({
+            condition: buildCondition(),
+            practice_logs: [buildLog({ practice_menu_id: 1 })],
+          }),
+        });
+
+        expect(
+          screen.getByRole("button", { name: "疲労度: ふつう" }),
+        ).toHaveAttribute("aria-pressed", "true");
+        expect(
+          screen.getByRole("button", { name: "体調: やや不調" }),
+        ).toHaveAttribute("aria-pressed", "true");
+        // decimal の "7.0" をそのまま入力欄へ流し込まない。
+        expect(screen.getByLabelText("睡眠時間")).toHaveDisplayValue("7");
+        expect(screen.getByRole("button", { name: "普通" })).toHaveAttribute(
+          "aria-pressed",
+          "true",
+        );
+        expect(screen.getByLabelText("気分のメモ")).toHaveValue(
+          "全体的に体は軽かった",
+        );
+        expect(screen.getByLabelText("1件目の怪我・痛みのメモ")).toHaveValue(
+          "重い",
+        );
+
+        await user.click(
+          screen.getByRole("button", { name: "練習記録の変更を保存" }),
+        );
+
+        await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+        expect(savedInput().condition).toEqual({
+          fatigue_level: 3,
+          physical_level: 2,
+          sleep_hours: 7,
+          mood: "普通",
+          memo: "全体的に体は軽かった",
+          injuries: [{ part: "腰", memo: "重い" }],
+        });
+      });
+
+      it("コンディション未入力なら condition を送らない", async () => {
+        const user = userEvent.setup();
+        renderContent();
+
+        await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+        await user.click(
+          screen.getByRole("button", { name: "練習記録のみ保存" }),
+        );
+
+        await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+        expect(savedInput()).not.toHaveProperty("condition");
+      });
+
+      it("触っていないメニュー項目もコンディションと一緒に全件送る", async () => {
+        const user = userEvent.setup();
+        renderContent({
+          initialSession: buildSession({
+            condition: buildCondition(),
+            practice_logs: [
+              buildLog({ id: 1, practice_menu_id: 1, amount: "300.0" }),
+              buildLog({
+                id: 2,
+                practice_menu_id: 99,
+                amount: "20.0",
+                menu_name: "削除済みメニュー",
+              }),
+            ],
+          }),
+        });
+
+        await user.click(screen.getByRole("button", { name: "疲労度: 元気" }));
+        await user.click(
+          screen.getByRole("button", { name: "練習記録の変更を保存" }),
+        );
+
+        await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+        expect(savedItems()).toEqual([
+          { practice_menu_id: 1, amount: 300, weight: null },
+          { practice_menu_id: 99, amount: 20, weight: null },
+        ]);
+        expect(savedInput().condition?.fatigue_level).toBe(4);
+      });
+
+      it("コンディション付きの保存が 403 ならコンディションの Pro 訴求を出す", async () => {
+        const user = userEvent.setup();
+        mockUpsert.mockResolvedValue({
+          ok: false,
+          reason: "forbidden",
+          errors: ["コンディション記録は Pro プラン限定です"],
+        });
+        renderContent();
+
+        await saveWithCondition(user);
+
+        expect(
+          await screen.findByText("コンディション記録は Pro プラン限定です"),
+        ).toBeVisible();
+        expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+          trigger: "detailed_condition_log",
+        });
+        expect(toast.success).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/app/(app)/practice/record/__tests__/conditionDraft.test.ts
+++ b/app/(app)/practice/record/__tests__/conditionDraft.test.ts
@@ -1,0 +1,146 @@
+import type { ConditionLog, PracticeSession } from "@app/types/practice";
+import {
+  type ConditionDraft,
+  EMPTY_CONDITION_DRAFT,
+  buildConditionPayload,
+  buildInitialCondition,
+  hasConditionContent,
+} from "../_utils/conditionDraft";
+
+function buildCondition(overrides: Partial<ConditionLog> = {}): ConditionLog {
+  return {
+    id: 1,
+    logged_on: "2026-08-03",
+    fatigue_level: 3,
+    physical_level: 2,
+    sleep_hours: "7.5",
+    mood: "普通",
+    memo: "体は軽かった",
+    injuries: [{ part: "肩", memo: "軽い張り" }],
+    ...overrides,
+  };
+}
+
+function buildSession(condition: ConditionLog | null): PracticeSession {
+  return {
+    id: 1,
+    logged_on: "2026-08-03",
+    memo: null,
+    improvement_theme_ids: [],
+    practice_logs: [],
+    condition,
+    created_at: "2026-08-03T10:00:00+09:00",
+  };
+}
+
+function buildDraft(overrides: Partial<ConditionDraft> = {}): ConditionDraft {
+  return { ...EMPTY_CONDITION_DRAFT, ...overrides };
+}
+
+const PRO = { hasConditionEntitlement: true, isEntitlementLoading: false };
+
+describe("buildInitialCondition", () => {
+  it("コンディションの無いセッションは空の編集状態にする", () => {
+    expect(buildInitialCondition(buildSession(null))).toEqual(
+      EMPTY_CONDITION_DRAFT,
+    );
+    expect(buildInitialCondition(null)).toEqual(EMPTY_CONDITION_DRAFT);
+  });
+
+  it("既存のコンディションを読み込む", () => {
+    expect(buildInitialCondition(buildSession(buildCondition()))).toEqual({
+      fatigue_level: 3,
+      physical_level: 2,
+      sleep_hours: "7.5",
+      mood: "普通",
+      memo: "体は軽かった",
+      injuries: [{ part: "肩", memo: "軽い張り" }],
+    });
+  });
+
+  it("文字列で返る decimal の睡眠時間を数値化してから入力欄へ渡す", () => {
+    const draft = buildInitialCondition(
+      buildSession(buildCondition({ sleep_hours: "7.0" })),
+    );
+
+    expect(draft.sleep_hours).toBe("7");
+  });
+});
+
+describe("hasConditionContent", () => {
+  it("すべて未入力なら false", () => {
+    expect(hasConditionContent(EMPTY_CONDITION_DRAFT)).toBe(false);
+    expect(hasConditionContent(buildDraft({ sleep_hours: "  " }))).toBe(false);
+  });
+
+  it("いずれか1つでも入力があれば true", () => {
+    expect(hasConditionContent(buildDraft({ fatigue_level: 1 }))).toBe(true);
+    expect(hasConditionContent(buildDraft({ physical_level: 4 }))).toBe(true);
+    expect(hasConditionContent(buildDraft({ sleep_hours: "7" }))).toBe(true);
+    expect(hasConditionContent(buildDraft({ mood: "好調" }))).toBe(true);
+    expect(hasConditionContent(buildDraft({ memo: "眠い" }))).toBe(true);
+    expect(
+      hasConditionContent(buildDraft({ injuries: [{ part: "肩" }] })),
+    ).toBe(true);
+  });
+});
+
+describe("buildConditionPayload", () => {
+  const filledDraft = buildDraft({
+    fatigue_level: 4,
+    physical_level: 1,
+    sleep_hours: "7.5",
+    mood: "好調",
+    memo: " よく眠れた ",
+    injuries: [{ part: "肘", memo: " 軽い張り " }],
+  });
+
+  it("entitlement が無ければ値が残っていても送らない", () => {
+    expect(
+      buildConditionPayload(filledDraft, {
+        hasConditionEntitlement: false,
+        isEntitlementLoading: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("Pro 判定が未確定の間は送らない", () => {
+    expect(
+      buildConditionPayload(filledDraft, {
+        hasConditionEntitlement: true,
+        isEntitlementLoading: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("入力が無ければ送らない（既存のコンディションを空で上書きしない）", () => {
+    expect(buildConditionPayload(EMPTY_CONDITION_DRAFT, PRO)).toBeNull();
+  });
+
+  it("Pro なら back のキー名のまま送る", () => {
+    expect(buildConditionPayload(filledDraft, PRO)).toEqual({
+      fatigue_level: 4,
+      physical_level: 1,
+      sleep_hours: 7.5,
+      mood: "好調",
+      memo: "よく眠れた",
+      injuries: [{ part: "肘", memo: "軽い張り" }],
+    });
+  });
+
+  it("空の睡眠時間・メモは未入力として null で送る", () => {
+    expect(
+      buildConditionPayload(
+        buildDraft({ fatigue_level: 2, sleep_hours: "", memo: "  " }),
+        PRO,
+      ),
+    ).toEqual({
+      fatigue_level: 2,
+      physical_level: null,
+      sleep_hours: null,
+      mood: null,
+      memo: null,
+      injuries: [],
+    });
+  });
+});

--- a/app/(app)/practice/record/_components/ConditionForm.tsx
+++ b/app/(app)/practice/record/_components/ConditionForm.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import type { ConditionDraft } from "../_utils/conditionDraft";
+import type { Injury } from "@app/types/practice";
+import { Input, Textarea } from "@heroui/react";
+import {
+  CONDITION_LEVELS,
+  CONDITION_MOODS,
+  type ConditionLevelKind,
+} from "@app/constants/practice";
+import InjuryInput from "./InjuryInput";
+import {
+  CONDITION_FATIGUE_LABEL,
+  CONDITION_INJURY_LABEL,
+  CONDITION_MEMO_LABEL,
+  CONDITION_MEMO_PLACEHOLDER,
+  CONDITION_MOOD_LABEL,
+  CONDITION_PHYSICAL_LABEL,
+  CONDITION_SLEEP_LABEL,
+  CONDITION_SLEEP_UNIT,
+  conditionLevelOptionLabel,
+} from "./practiceRecordCopy";
+
+interface ConditionFormProps {
+  value: ConditionDraft;
+  onChange: (next: ConditionDraft) => void;
+}
+
+const FIELD_LABEL_CLASS = "text-xs font-bold text-zinc-400";
+
+interface LevelSelectorProps {
+  kind: ConditionLevelKind;
+  title: string;
+  value: number | null;
+  onSelect: (level: number | null) => void;
+}
+
+/**
+ * 4段階の選択。色は悪い→良いで赤→緑に変わるが、
+ * 色を認識できなくても段階が分かるよう表情の向き・塗りとテキストラベルを必ず添える。
+ */
+function LevelSelector({ kind, title, value, onSelect }: LevelSelectorProps) {
+  return (
+    <div>
+      <p className={FIELD_LABEL_CLASS}>{title}</p>
+      <div className="mt-2 grid grid-cols-4 gap-2">
+        {CONDITION_LEVELS.map((level) => {
+          const label =
+            kind === "fatigue" ? level.fatigueLabel : level.physicalLabel;
+          const isSelected = value === level.value;
+          const LevelIcon = level.icon;
+
+          return (
+            <button
+              key={level.value}
+              type="button"
+              aria-pressed={isSelected}
+              aria-label={conditionLevelOptionLabel(title, label)}
+              onClick={() => onSelect(isSelected ? null : level.value)}
+              className={`flex flex-col items-center gap-1 rounded-[10px] bg-sub px-1 py-2.5 ${
+                isSelected ? "ring-2 ring-[#d08000]" : "ring-1 ring-transparent"
+              }`}
+            >
+              <LevelIcon
+                className={`h-6 w-6 shrink-0 ${level.colorClass}`}
+                aria-hidden
+              />
+              <span
+                className={`text-[11px] font-bold ${
+                  isSelected ? "text-white" : "text-zinc-400"
+                }`}
+              >
+                {label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * コンディション（疲労度・体調・睡眠・気分・怪我）の入力フォーム。
+ * 値と onChange を親が持つ制御コンポーネントで、保存はセッション保存に相乗りする。
+ */
+export default function ConditionForm({ value, onChange }: ConditionFormProps) {
+  const patch = (partial: Partial<ConditionDraft>) =>
+    onChange({ ...value, ...partial });
+
+  return (
+    <div className="space-y-5">
+      <LevelSelector
+        kind="fatigue"
+        title={CONDITION_FATIGUE_LABEL}
+        value={value.fatigue_level}
+        onSelect={(fatigue_level) => patch({ fatigue_level })}
+      />
+      <LevelSelector
+        kind="physical"
+        title={CONDITION_PHYSICAL_LABEL}
+        value={value.physical_level}
+        onSelect={(physical_level) => patch({ physical_level })}
+      />
+
+      <div>
+        <p className={FIELD_LABEL_CLASS}>{CONDITION_SLEEP_LABEL}</p>
+        <div className="mt-2 flex items-center gap-2">
+          <Input
+            type="number"
+            inputMode="decimal"
+            size="sm"
+            radius="sm"
+            className="w-24"
+            // back の sleep_hours は小数第1位まで（0〜24）。
+            step={0.1}
+            min={0}
+            max={24}
+            aria-label={CONDITION_SLEEP_LABEL}
+            placeholder="7.0"
+            value={value.sleep_hours}
+            onChange={(event) => patch({ sleep_hours: event.target.value })}
+          />
+          <span className="text-sm text-zinc-400">{CONDITION_SLEEP_UNIT}</span>
+        </div>
+      </div>
+
+      <div>
+        <p className={FIELD_LABEL_CLASS}>{CONDITION_MOOD_LABEL}</p>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {CONDITION_MOODS.map((mood) => {
+            const isSelected = value.mood === mood;
+            return (
+              <button
+                key={mood}
+                type="button"
+                aria-pressed={isSelected}
+                onClick={() => patch({ mood: isSelected ? null : mood })}
+                className={`rounded-full px-4 py-2 text-sm font-bold transition-colors ${
+                  isSelected
+                    ? "bg-[#d08000] text-white"
+                    : "bg-sub text-zinc-400"
+                }`}
+              >
+                {mood}
+              </button>
+            );
+          })}
+        </div>
+        <Textarea
+          size="sm"
+          radius="sm"
+          minRows={2}
+          className="mt-2"
+          aria-label={CONDITION_MEMO_LABEL}
+          placeholder={CONDITION_MEMO_PLACEHOLDER}
+          value={value.memo}
+          onChange={(event) => patch({ memo: event.target.value })}
+        />
+      </div>
+
+      <div>
+        <p className={FIELD_LABEL_CLASS}>{CONDITION_INJURY_LABEL}</p>
+        <div className="mt-2">
+          <InjuryInput
+            injuries={value.injuries}
+            onChange={(injuries: Injury[]) => patch({ injuries })}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/practice/record/_components/InjuryInput.tsx
+++ b/app/(app)/practice/record/_components/InjuryInput.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import type { Injury } from "@app/types/practice";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import XMarkIcon from "@heroicons/react/24/outline/XMarkIcon";
+import { Input } from "@heroui/react";
+import { INJURY_PARTS } from "@app/constants/practice";
+import {
+  INJURY_ADD_LABEL,
+  INJURY_MEMO_PLACEHOLDER,
+  injuryMemoLabel,
+  injuryPartLabel,
+  injuryRemoveLabel,
+  injuryRowLabel,
+} from "./practiceRecordCopy";
+
+interface InjuryInputProps {
+  injuries: Injury[];
+  onChange: (injuries: Injury[]) => void;
+}
+
+/**
+ * 怪我・痛みの入力。部位プリセット＋任意の自由メモを1件ずつ足していく。
+ * 部位は back が jsonb の自由文字列で持つため、プリセットは入力補助として扱う。
+ */
+export default function InjuryInput({ injuries, onChange }: InjuryInputProps) {
+  const handleAdd = () =>
+    onChange([...injuries, { part: INJURY_PARTS[0], memo: "" }]);
+
+  const handleUpdate = (index: number, patch: Partial<Injury>) =>
+    onChange(
+      injuries.map((injury, i) =>
+        i === index ? { ...injury, ...patch } : injury,
+      ),
+    );
+
+  const handleRemove = (index: number) =>
+    onChange(injuries.filter((_, i) => i !== index));
+
+  return (
+    <div>
+      <ul className="space-y-2">
+        {injuries.map((injury, index) => (
+          <li
+            // 並べ替えはせず、値は props から描画するため index を key にしてよい。
+            key={index}
+            className="rounded-[10px] bg-[#3A3A3A] p-2.5"
+            aria-label={injuryRowLabel(index)}
+          >
+            <div className="flex flex-wrap gap-1.5">
+              {INJURY_PARTS.map((part) => {
+                const isSelected = part === injury.part;
+                return (
+                  <button
+                    key={part}
+                    type="button"
+                    aria-pressed={isSelected}
+                    aria-label={injuryPartLabel(index, part)}
+                    onClick={() => handleUpdate(index, { part })}
+                    className={`rounded-full px-3 py-1.5 text-xs font-bold transition-colors ${
+                      isSelected
+                        ? "bg-[#d08000] text-white"
+                        : "bg-sub text-zinc-400"
+                    }`}
+                  >
+                    {part}
+                  </button>
+                );
+              })}
+            </div>
+            <div className="mt-2 flex items-center gap-2">
+              <Input
+                size="sm"
+                radius="sm"
+                className="flex-1"
+                aria-label={injuryMemoLabel(index)}
+                placeholder={INJURY_MEMO_PLACEHOLDER}
+                value={injury.memo ?? ""}
+                onChange={(event) =>
+                  handleUpdate(index, { memo: event.target.value })
+                }
+              />
+              <button
+                type="button"
+                aria-label={injuryRemoveLabel(index)}
+                onClick={() => handleRemove(index)}
+                className="shrink-0 rounded-full p-1 text-zinc-400 transition-colors hover:text-white"
+              >
+                <XMarkIcon className="h-4 w-4" aria-hidden />
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        onClick={handleAdd}
+        className="mt-2 inline-flex items-center gap-1 py-1.5 text-sm font-bold text-[#d08000]"
+      >
+        <PlusIcon className="h-4 w-4 shrink-0" aria-hidden />
+        {INJURY_ADD_LABEL}
+      </button>
+    </div>
+  );
+}

--- a/app/(app)/practice/record/_components/PracticeSessionForm.tsx
+++ b/app/(app)/practice/record/_components/PracticeSessionForm.tsx
@@ -12,18 +12,30 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
+import ConditionCard from "@app/components/practice/ConditionCard";
+import { ProUpsellOverlay } from "@app/components/pro/ProUpsellOverlay";
+import { SampleDataLabel } from "@app/components/pro/SampleDataLabel";
 import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
 import { upsertPracticeSession } from "@app/services/v2/practiceSessionService";
+import {
+  buildConditionPayload,
+  buildInitialCondition,
+} from "../_utils/conditionDraft";
 import {
   buildInitialAmounts,
   buildInitialWeights,
   buildItems,
   toInputValue,
 } from "../_utils/practiceRecordDraft";
+import ConditionForm from "./ConditionForm";
+import { SAMPLE_CONDITION } from "./conditionSample";
 import ImprovementThemeField from "./ImprovementThemeField";
 import PracticeMenuChecklist from "./PracticeMenuChecklist";
 import {
   ADD_MENU_LABEL,
+  CONDITION_PRO_BADGE,
+  CONDITION_SECTION_TITLE,
   MENU_SECTION_TITLE,
   NO_ITEMS_ERROR,
   SAVE_ONLY_LABEL,
@@ -76,6 +88,7 @@ export default function PracticeSessionForm({
 }: PracticeSessionFormProps) {
   const router = useRouter();
   const { open: openProUpgradeModal } = useProUpgradeModal();
+  const { hasEntitlement, isLoading: isEntitlementLoading } = useEntitlement();
   const [amounts, setAmounts] = useState<Record<number, string>>(() =>
     buildInitialAmounts(session, presetMenus),
   );
@@ -88,8 +101,15 @@ export default function PracticeSessionForm({
   const [linkedThemeCountAtLoad] = useState(
     () => session?.improvement_theme_ids.length ?? 0,
   );
+  const [condition, setCondition] = useState(() =>
+    buildInitialCondition(session),
+  );
   const [errors, setErrors] = useState<string[]>([]);
   const [isSaving, setIsSaving] = useState(false);
+
+  const hasConditionEntitlement = hasEntitlement("detailed_condition_log");
+  // 判定確定前は入力させない。未確定のまま送るとコンディションの 403 で保存全体が失敗しうる。
+  const canRecordCondition = !isEntitlementLoading && hasConditionEntitlement;
 
   const handleToggleMenu = (menu: PracticeMenu) => {
     const isSelected = menu.id in amounts;
@@ -119,7 +139,12 @@ export default function PracticeSessionForm({
     // 触っていない項目も含めて選択中の全メニューを送る。
     // back は送らなかったメニューのログを削除するため、間引くと既存の記録が消える。
     const items = buildItems(amounts, weights);
-    if (items.length === 0) {
+    // entitlement を持たない間は、入力状態に値が残っていてもコンディションを送らない。
+    const conditionPayload = buildConditionPayload(condition, {
+      hasConditionEntitlement,
+      isEntitlementLoading,
+    });
+    if (items.length === 0 && conditionPayload === null) {
       setErrors([NO_ITEMS_ERROR]);
       return;
     }
@@ -130,14 +155,21 @@ export default function PracticeSessionForm({
       logged_on: date,
       items,
       improvement_theme_ids: themeIds,
+      // 送らない場合はキーごと落とす。back は condition が有ると Pro 判定に入る。
+      ...(conditionPayload === null ? {} : { condition: conditionPayload }),
     });
 
     if (!result.ok) {
       setIsSaving(false);
       // 403 は保存全体がロールバックされるため、成功表示も画面遷移もしない。
-      // 課題を複数送ったときだけ紐付け上限として Pro 訴求へ倒し、それ以外は back の文言をそのまま出す。
-      if (result.reason === "forbidden" && themeIds.length > 1) {
-        openProUpgradeModal({ trigger: "multi_improvement_theme_links" });
+      // back は課題の紐付けをコンディションより先に判定するため、訴求もその順で出し分ける。
+      // どちらでもなければ back の文言をそのまま出す。
+      if (result.reason === "forbidden") {
+        if (themeIds.length > 1) {
+          openProUpgradeModal({ trigger: "multi_improvement_theme_links" });
+        } else if (conditionPayload !== null) {
+          openProUpgradeModal({ trigger: "detailed_condition_log" });
+        }
       }
       setErrors(result.errors);
       return;
@@ -176,6 +208,37 @@ export default function PracticeSessionForm({
           onAmountChange={handleAmountChange}
           onWeightChange={handleWeightChange}
         />
+      </div>
+
+      <div className="mt-8 flex items-center gap-2">
+        <h2 className="text-sm font-bold text-white">
+          {CONDITION_SECTION_TITLE}
+        </h2>
+        {/* 判定確定前はロック表示を出さず、Pro ユーザーにバッジが一瞬見えるのを防ぐ。 */}
+        {isEntitlementLoading || canRecordCondition ? null : (
+          <span className="rounded-full bg-[#3A3A3A] px-2 py-0.5 text-[11px] font-bold text-[#d08000]">
+            {CONDITION_PRO_BADGE}
+          </span>
+        )}
+      </div>
+      <div className="mt-3">
+        {canRecordCondition ? (
+          <ConditionForm value={condition} onChange={setCondition} />
+        ) : (
+          <div className="flex flex-col gap-y-2">
+            {/* 過去に記録したコンディションがあるときは、それを暗幕越しのプレビューにする。 */}
+            {isEntitlementLoading || session?.condition ? null : (
+              <SampleDataLabel />
+            )}
+            <ProUpsellOverlay feature="detailed_condition_log">
+              <ConditionCard
+                condition={session?.condition ?? SAMPLE_CONDITION}
+                showTitle={false}
+                className="p-1"
+              />
+            </ProUpsellOverlay>
+          </div>
+        )}
       </div>
 
       <h2 className="mt-8 text-sm font-bold text-white">

--- a/app/(app)/practice/record/_components/conditionSample.ts
+++ b/app/(app)/practice/record/_components/conditionSample.ts
@@ -1,0 +1,17 @@
+import type { ConditionLog } from "@app/types/practice";
+
+/**
+ * 無料ユーザーに見せる Pro 機能プレビュー用のコンディション。
+ * 実データではないため SampleDataLabel と併せて表示する。
+ * id / logged_on は表示に使わないダミー値。
+ */
+export const SAMPLE_CONDITION: ConditionLog = {
+  id: 0,
+  logged_on: "",
+  fatigue_level: 2,
+  physical_level: 3,
+  sleep_hours: "7.5",
+  mood: "普通",
+  memo: "後半は集中が切れた。明日は早めに寝る。",
+  injuries: [{ part: "肩", memo: "軽い張り" }],
+};

--- a/app/(app)/practice/record/_components/practiceRecordCopy.ts
+++ b/app/(app)/practice/record/_components/practiceRecordCopy.ts
@@ -42,6 +42,52 @@ export const SESSION_LOAD_ERROR =
 
 export const SESSION_LOADING_MESSAGE = "この日の記録を読み込んでいます…";
 
+export const CONDITION_SECTION_TITLE = "コンディション（任意）";
+
+export const CONDITION_PRO_BADGE = "Pro限定";
+
+export const CONDITION_FATIGUE_LABEL = "疲労度";
+
+export const CONDITION_PHYSICAL_LABEL = "体調";
+
+export const CONDITION_SLEEP_LABEL = "睡眠時間";
+
+export const CONDITION_SLEEP_UNIT = "時間";
+
+export const CONDITION_MOOD_LABEL = "気分";
+
+export const CONDITION_MEMO_LABEL = "気分のメモ";
+
+export const CONDITION_MEMO_PLACEHOLDER = "気分のメモ（任意）";
+
+export const CONDITION_INJURY_LABEL = "怪我・痛み";
+
+export const INJURY_ADD_LABEL = "部位を追加";
+
+export const INJURY_MEMO_PLACEHOLDER = "軽い張り など（任意）";
+
+/**
+ * 4段階ボタンの読み上げ名。
+ * 疲労度と体調で同じラベル（「ふつう」）が並ぶため、どちらの段階かを名前に含める。
+ */
+export const conditionLevelOptionLabel = (
+  title: string,
+  label: string,
+): string => `${title}: ${label}`;
+
+/** 怪我の入力欄は複数行に増えるため、読み上げ名に何件目かを含めて区別できるようにする。 */
+export const injuryRowLabel = (index: number): string =>
+  `${index + 1}件目の怪我・痛み`;
+
+export const injuryPartLabel = (index: number, part: string): string =>
+  `${injuryRowLabel(index)}の部位: ${part}`;
+
+export const injuryMemoLabel = (index: number): string =>
+  `${injuryRowLabel(index)}のメモ`;
+
+export const injuryRemoveLabel = (index: number): string =>
+  `${injuryRowLabel(index)}を削除`;
+
 /** 無料プランで2件目の課題を選ぼうとしたときの案内（back の 403 と同じ意味）。 */
 export const MULTI_THEME_LIMIT_MESSAGE =
   "無料プランでは1つの記録に課題を1件までしか紐付けられません。Pro プランなら複数の課題に紐付けられます。";

--- a/app/(app)/practice/record/_utils/conditionDraft.ts
+++ b/app/(app)/practice/record/_utils/conditionDraft.ts
@@ -1,0 +1,104 @@
+import type {
+  ConditionInput,
+  Injury,
+  PracticeSession,
+} from "@app/types/practice";
+import { parseDecimal } from "@app/constants/practice";
+
+/**
+ * コンディション入力の編集状態。
+ * 睡眠時間は「7.」のような打鍵途中を数値へ丸めないよう文字列で持つ。
+ */
+export interface ConditionDraft {
+  fatigue_level: number | null;
+  physical_level: number | null;
+  sleep_hours: string;
+  mood: string | null;
+  memo: string;
+  injuries: Injury[];
+}
+
+export const EMPTY_CONDITION_DRAFT: ConditionDraft = {
+  fatigue_level: null,
+  physical_level: null,
+  sleep_hours: "",
+  mood: null,
+  memo: "",
+  injuries: [],
+};
+
+/**
+ * 既存セッションのコンディションを編集状態へ読み込む。
+ * back の decimal は "7.0" のような文字列で返るため、睡眠時間は数値化してから文字列に戻す。
+ */
+export function buildInitialCondition(
+  session: PracticeSession | null,
+): ConditionDraft {
+  const condition = session?.condition;
+  if (!condition) return EMPTY_CONDITION_DRAFT;
+
+  const sleepHours = parseDecimal(condition.sleep_hours);
+  return {
+    fatigue_level: condition.fatigue_level,
+    physical_level: condition.physical_level,
+    sleep_hours: sleepHours === null ? "" : String(sleepHours),
+    mood: condition.mood,
+    memo: condition.memo ?? "",
+    injuries: condition.injuries ?? [],
+  };
+}
+
+/** 1つでも入力があるか。何も無いまま送ると既存のコンディションを空で上書きしてしまう。 */
+export function hasConditionContent(draft: ConditionDraft): boolean {
+  return (
+    draft.fatigue_level !== null ||
+    draft.physical_level !== null ||
+    draft.sleep_hours.trim() !== "" ||
+    draft.mood !== null ||
+    draft.memo.trim() !== "" ||
+    draft.injuries.length > 0
+  );
+}
+
+/** 編集状態を送信値へ変換する。空文字・非数の睡眠時間は未入力（null）として送る。 */
+function toConditionInput(draft: ConditionDraft): ConditionInput {
+  const sleepHours = Number(draft.sleep_hours);
+  return {
+    fatigue_level: draft.fatigue_level,
+    physical_level: draft.physical_level,
+    sleep_hours:
+      draft.sleep_hours.trim() === "" || Number.isNaN(sleepHours)
+        ? null
+        : sleepHours,
+    mood: draft.mood,
+    memo: draft.memo.trim() === "" ? null : draft.memo.trim(),
+    injuries: draft.injuries.map((injury) => ({
+      part: injury.part,
+      memo: injury.memo?.trim() ? injury.memo.trim() : null,
+    })),
+  };
+}
+
+interface ConditionPayloadOptions {
+  /** detailed_condition_log を持っているか。 */
+  hasConditionEntitlement: boolean;
+  /** Pro 判定が未確定か。 */
+  isEntitlementLoading: boolean;
+}
+
+/**
+ * 保存リクエストに載せるコンディションを決める。載せない場合は null。
+ *
+ * back はコンディション付きの保存を Pro 限定として 403 で弾き、そのとき
+ * 練習量やメモを含む更新全体がロールバックされる。Pro から無料へ戻ったユーザーの
+ * 編集状態に値が残っていても保存そのものを失敗させないよう、
+ * entitlement が無いとき・判定が未確定のときは値の有無に関わらず送らない。
+ */
+export function buildConditionPayload(
+  draft: ConditionDraft,
+  { hasConditionEntitlement, isEntitlementLoading }: ConditionPayloadOptions,
+): ConditionInput | null {
+  if (isEntitlementLoading || !hasConditionEntitlement) return null;
+  if (!hasConditionContent(draft)) return null;
+  return toConditionInput(draft);
+}

--- a/app/components/practice/ConditionCard.tsx
+++ b/app/components/practice/ConditionCard.tsx
@@ -1,0 +1,131 @@
+import type { ConditionLog } from "@app/types/practice";
+import ExclamationTriangleIcon from "@heroicons/react/24/outline/ExclamationTriangleIcon";
+import HeartIcon from "@heroicons/react/24/outline/HeartIcon";
+import MoonIcon from "@heroicons/react/24/outline/MoonIcon";
+import {
+  type ConditionLevelKind,
+  conditionLevelLabel,
+  conditionLevelMeta,
+  parseDecimal,
+} from "@app/constants/practice";
+
+interface ConditionCardProps {
+  condition: ConditionLog;
+  /** 呼び出し元が独自に見出しを描画する場合は false にして二重表示を防ぐ。 */
+  showTitle?: boolean;
+  className?: string;
+}
+
+const SECTION_TITLE = "コンディション";
+
+const LEVEL_TITLES: Record<ConditionLevelKind, string> = {
+  fatigue: "疲労度",
+  physical: "体調",
+};
+
+interface ConditionLevelTileProps {
+  kind: ConditionLevelKind;
+  level: number;
+}
+
+/** 段階を表情アイコンで示すタイル。色を認識できなくても読めるようラベルを併記する。 */
+function ConditionLevelTile({ kind, level }: ConditionLevelTileProps) {
+  const meta = conditionLevelMeta(level);
+  if (!meta) return null;
+  const LevelIcon = meta.icon;
+
+  return (
+    <div className="flex flex-1 flex-col items-center gap-1 rounded-[10px] bg-[#3A3A3A] py-3">
+      <p className="text-[11px] font-bold text-zinc-400">
+        {LEVEL_TITLES[kind]}
+      </p>
+      <LevelIcon
+        className={`h-7 w-7 shrink-0 ${meta.colorClass}`}
+        aria-hidden
+      />
+      <p className="text-[13px] font-bold text-white">
+        {conditionLevelLabel(kind, level)}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * 記録済みコンディションの表示カード。
+ * 練習記録の詳細表示と、無料ユーザー向けのプレビューで共通利用する。
+ */
+export default function ConditionCard({
+  condition,
+  showTitle = true,
+  className,
+}: ConditionCardProps) {
+  // back の decimal は "7.0" のような文字列で返るため、そのまま出さず数値化して表示する。
+  const sleepHours = parseDecimal(condition.sleep_hours);
+  const injuries = condition.injuries ?? [];
+  const hasLevel =
+    conditionLevelMeta(condition.fatigue_level) !== null ||
+    conditionLevelMeta(condition.physical_level) !== null;
+
+  return (
+    <div className={className}>
+      {showTitle ? (
+        <h3 className="mb-2.5 text-xs font-bold text-zinc-400">
+          {SECTION_TITLE}
+        </h3>
+      ) : null}
+      {hasLevel ? (
+        <div className="flex gap-2.5">
+          {condition.fatigue_level !== null ? (
+            <ConditionLevelTile
+              kind="fatigue"
+              level={condition.fatigue_level}
+            />
+          ) : null}
+          {condition.physical_level !== null ? (
+            <ConditionLevelTile
+              kind="physical"
+              level={condition.physical_level}
+            />
+          ) : null}
+        </div>
+      ) : null}
+      {sleepHours !== null || condition.mood ? (
+        <div className="mt-2.5 flex flex-wrap gap-2">
+          {sleepHours !== null ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-[#3A3A3A] px-2.5 py-1.5 text-xs font-bold text-white">
+              <MoonIcon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              睡眠 {sleepHours}時間
+            </span>
+          ) : null}
+          {condition.mood ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-[#3A3A3A] px-2.5 py-1.5 text-xs font-bold text-white">
+              <HeartIcon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              {condition.mood}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+      {injuries.length > 0 ? (
+        <ul className="mt-2.5 flex flex-wrap gap-2">
+          {injuries.map((injury, index) => (
+            <li
+              key={`${injury.part}-${index}`}
+              className="inline-flex items-center gap-1 rounded-full bg-[#ef4444]/15 px-2.5 py-1.5 text-xs font-bold text-[#fca5a5]"
+            >
+              <ExclamationTriangleIcon
+                className="h-3.5 w-3.5 shrink-0"
+                aria-hidden
+              />
+              {injury.memo ? `${injury.part}（${injury.memo}）` : injury.part}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {condition.memo ? (
+        <p className="mt-2.5 text-[13px] leading-5 text-zinc-300">
+          {condition.memo}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/pro/__tests__/proFeatureCatalog.test.ts
+++ b/app/components/pro/__tests__/proFeatureCatalog.test.ts
@@ -41,6 +41,7 @@ const FREE_LIMITS_FROM_BACK: Partial<Record<ProFeature, string>> = {
 /** Web（front）で実際に entitlement ゲートを実装済みの機能。 */
 const WEB_DELIVERED_FEATURES: ProFeature[] = [
   "no_ads",
+  "detailed_condition_log",
   "season_transition_graph",
   "hit_direction_average",
   "count_situation_average",

--- a/app/components/pro/proFeatureCatalog.ts
+++ b/app/components/pro/proFeatureCatalog.ts
@@ -61,7 +61,7 @@ export const FEATURE_COMPARISONS: Record<ProFeature, FeatureComparison> = {
     pro: "自由編集",
     availability: "app_only",
   },
-  detailed_condition_log: { free: "✕", pro: "○", availability: "app_only" },
+  detailed_condition_log: { free: "✕", pro: "○", availability: "web_and_app" },
   unlimited_improvement_themes: {
     free: "2件",
     pro: "無制限",

--- a/app/constants/practice.ts
+++ b/app/constants/practice.ts
@@ -8,12 +8,16 @@ import type { ComponentType, SVGProps } from "react";
 import ArrowTrendingUpIcon from "@heroicons/react/24/outline/ArrowTrendingUpIcon";
 import BoltIcon from "@heroicons/react/24/outline/BoltIcon";
 import EllipsisHorizontalCircleIcon from "@heroicons/react/24/outline/EllipsisHorizontalCircleIcon";
+import FaceFrownIcon from "@heroicons/react/24/outline/FaceFrownIcon";
+import FaceSmileIcon from "@heroicons/react/24/outline/FaceSmileIcon";
 import FireIcon from "@heroicons/react/24/outline/FireIcon";
 import HandRaisedIcon from "@heroicons/react/24/outline/HandRaisedIcon";
 import HeartIcon from "@heroicons/react/24/outline/HeartIcon";
 import ScaleIcon from "@heroicons/react/24/outline/ScaleIcon";
 import ShieldCheckIcon from "@heroicons/react/24/outline/ShieldCheckIcon";
 import SolidBoltIcon from "@heroicons/react/24/solid/BoltIcon";
+import SolidFaceFrownIcon from "@heroicons/react/24/solid/FaceFrownIcon";
+import SolidFaceSmileIcon from "@heroicons/react/24/solid/FaceSmileIcon";
 
 // back/app/models/concerns/plan_limits.rb の PRACTICE_MENU_FREE_LIMIT と一致させる。
 export const PRACTICE_MENU_FREE_LIMIT = 3;
@@ -78,6 +82,67 @@ export const PRACTICE_CATEGORY_ICONS: Readonly<
 
 /** 気分の選択肢。back は自由文字列カラムのため、選択肢は front / mobile 側で揃える。 */
 export const CONDITION_MOODS: ReadonlyArray<string> = ["好調", "普通", "不調"];
+
+/** コンディションの4段階を疲労度・体調のどちらとして読むか。 */
+export type ConditionLevelKind = "fatigue" | "physical";
+
+/**
+ * 疲労度・体調の4段階。value は back の ConditionLog::LEVEL_RANGE（1..4）と一致させる。
+ * 悪い→良いで赤→緑に変わるが、色覚特性があっても段階を読み取れるよう
+ * 表情（しかめ面 / 笑顔）と塗り（塗りつぶし / 輪郭）でも差を付け、必ずラベルを併記して使う。
+ */
+export const CONDITION_LEVELS: ReadonlyArray<{
+  value: number;
+  fatigueLabel: string;
+  physicalLabel: string;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  colorClass: string;
+}> = [
+  {
+    value: 1,
+    fatigueLabel: "かなり疲れ",
+    physicalLabel: "不調",
+    icon: SolidFaceFrownIcon,
+    colorClass: "text-[#ef4444]",
+  },
+  {
+    value: 2,
+    fatigueLabel: "やや疲れ",
+    physicalLabel: "やや不調",
+    icon: FaceFrownIcon,
+    colorClass: "text-[#f59e0b]",
+  },
+  {
+    value: 3,
+    fatigueLabel: "ふつう",
+    physicalLabel: "ふつう",
+    icon: FaceSmileIcon,
+    colorClass: "text-[#84cc16]",
+  },
+  {
+    value: 4,
+    fatigueLabel: "元気",
+    physicalLabel: "好調",
+    icon: SolidFaceSmileIcon,
+    colorClass: "text-[#22c55e]",
+  },
+];
+
+/** 段階の表示情報を返す。範囲外（back の値域変更やデータ不整合）は null。 */
+export const conditionLevelMeta = (
+  level: number | null | undefined,
+): (typeof CONDITION_LEVELS)[number] | null =>
+  CONDITION_LEVELS.find((item) => item.value === level) ?? null;
+
+/** 段階のラベルを返す。疲労度と体調で語彙が違うため kind で呼び分ける。 */
+export const conditionLevelLabel = (
+  kind: ConditionLevelKind,
+  level: number | null | undefined,
+): string | null => {
+  const meta = conditionLevelMeta(level);
+  if (!meta) return null;
+  return kind === "fatigue" ? meta.fatigueLabel : meta.physicalLabel;
+};
 
 /** 故障箇所のプリセット。back は jsonb の自由文字列のため、入力補助としてのみ使う。 */
 export const INJURY_PARTS: ReadonlyArray<string> = [


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#470

## 概要

練習記録に付随する疲労度・体調・睡眠時間・気分・メモ・怪我の記録を実装します。Pro 限定（`detailed_condition_log`）で、無料ユーザーにはオーバーレイ越しにプレビューを見せます。

## ⚠️ 「無料では送らない」の実装（本 PR の核心）

issue の要件「**state に値が残っていても送信しない**」への対応です。これは単なる UI の話ではなく、**送ると練習記録そのものが保存できなくなる**問題です。

back の `PracticeSessions::Upsert#call` は `upsert_condition if @condition.present?` で、**`@condition.present?` は「全部 nil のハッシュ」でも true** になります。つまり空のコンディションを送るだけで無料ユーザーは 403 になり、**403 は更新全体をロールバックする**ため、メモもメニュー項目も保存されません。

そのため UI を隠すのではなく、**送信ペイロードの組み立て時点で落としています**:

```ts
export function buildConditionPayload(draft, { hasConditionEntitlement, isEntitlementLoading }) {
  if (isEntitlementLoading || !hasConditionEntitlement) return null;  // 値が残っていても送らない
  if (!hasConditionContent(draft)) return null;                       // 空で既存を潰さない
  return toConditionInput(draft);
}
```

呼び出し側は `...(conditionPayload === null ? {} : { condition: conditionPayload })` で **`condition` キーごと落とします**（`condition: null` すら送りません）。Pro 判定が未確定の間も送りません。

## back の upsert 挙動（調査結果）

- **`condition` を送らなければ既存のコンディションには一切触りません**（削除されない）
- 送った場合は `find_or_initialize_by(logged_on)` → `update!(送ったキー)` で、送ったキーだけが上書き
- 403 の発生順は `assign_themes`（ThemeLimitExceeded）→ `sync_items` → `upsert_condition`（NotEntitled）。課題エラーが先に出る前提で訴求を出し分けています

**#469 の upsert 対策（触っていない項目も全件送る）は無改変**で、ミューテーション M16 で破壊を検出できることも確認しています。

## 色以外での段階の区別（アクセシビリティ）

4段階を色だけで区別しないよう、3重に冗長化しています。

- 4段階すべてに**テキストラベルを常時表示**（かなり疲れ/やや疲れ/ふつう/元気、不調/やや不調/ふつう/好調）
- アイコンの**形（しかめ面 vs 笑顔）と塗り（solid vs outline）**で4段階を区別（色を落としても4値が判別可能）
- 選択状態は色ではなく `ring-2` と `aria-pressed`、読み上げ名は「疲労度: 元気」のように系列名込み

「ラベルを削除する」ミューテーションで検出できることを確認済みです。

## mobile との突き合わせ

4段階アイコンの表情と塗りの対応、色（`#ef4444` → `#f59e0b` → `#84cc16` → `#22c55e`）、疲労度・体調のラベル、気分チップ（再タップで解除）、怪我部位8種の並びと文言、怪我の追加/削除の操作感まで一致させています。

睡眠時間のみ、mobile は自由入力ですが **back の `decimal(4,1)` に合わせて `step=0.1`** にしました。

## LP の表記も更新しました

Web で提供開始したため、`proFeatureCatalog.ts` の `detailed_condition_log` を `app_only` → `web_and_app` に変更しています（`no_ads` と同じ扱い）。テストの `WEB_DELIVERED_FEATURES` も更新済みです。

## 変更内容

- `_utils/conditionDraft.ts`（新規）— 型・初期化（`parseDecimal` 経由）・入力有無判定・**entitlement ゲート付き送信値組み立て**
- `_components/ConditionForm.tsx` / `InjuryInput.tsx`（新規）
- `app/components/practice/ConditionCard.tsx`（新規）— **`@heroui/react` 非依存**にして将来の Server Component から使えるようにしています
- `PracticeSessionForm.tsx` — コンディション state・ペイロードのゲート・403 の `NotEntitled` 分岐
- `app/constants/practice.ts` — `CONDITION_LEVELS`（値 1..4 / ラベル / アイコン / 色）を追加

## レビューで確認いただきたい点

1. **無料ユーザーのプレビューを「フォームの無効化」ではなく `ConditionCard` にしました。** mobile は disabled なフォームを暗幕で覆いますが、front は既存の `AnalysisContainer` の作法（サンプルデータ＋`ProUpsellOverlay`）に寄せ、暗幕越しでも「何が記録できるか」が読めるカードにしています。過去に記録があれば自分の記録を、無ければ `SampleDataLabel` 付きでサンプルを表示します。mobile と完全に揃えるなら無効化フォームに変更できます
2. **Pro ユーザーが「コンディションを全消し」できません**（未入力＝送らない、なので back の既存レコードが残る）。mobile と同じ挙動ですが、明示的な削除 UI は将来の issue 向けの余地です

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る（0 errors / 0 warnings）
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（**125 suites / 1355 tests**）
- [x] `yarn build` が通る（**ローカルで実行済み**）
- [x] ミューテーションテスト **21 設計 / 21 KILLED / 0 SURVIVED**

### ルート表

**静的 87 / 動的 44** — ベースライン（`879a4a4`）と**完全一致**（新規ルートなし）。行頭の罫線 `┌ ├ └ │` をすべて対象に、凡例行を除いて集計しています。

<details>
<summary>ミューテーションテスト詳細</summary>

隔離複製で実施（無改変で全通過を事前確認、検証後に削除）。

**M01 無料でも送る / M02 判定未確定でも送る / M03 フォーム側で entitlement 無視 / M04 `condition` キーを常に載せる**（最重要4件）/ オーバーレイ表示条件の反転2件 / 値域 1..4 改変2件 / 気分の値 / 怪我部位プリセット / 怪我の削除・更新で他が消える2件 / `parseDecimal` を通さない2件 / 既存コンディションを読み込まない / **#469 の upsert 対策の破壊** / API キー名2件 / 未入力でも送る / 403 訴求の取り違え / 色だけの区別 — 全 KILLED。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_