### PR TITLE
Add: ノートタグ（Pro）と一覧の検索・絞り込み・月次ページングを実装

### DIFF
--- a/app/(app)/note/[slulg]/_components/NoteEditForm.tsx
+++ b/app/(app)/note/[slulg]/_components/NoteEditForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
+import type { BaseballNoteV2, NoteTag } from "@app/interface/baseballNoteV2";
 import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
 import type { FetchResult } from "@app/services/v2/requests";
 import { Input } from "@heroui/react";
@@ -10,8 +10,10 @@ import { useMemo, useState } from "react";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import HeaderNote from "@app/components/header/HeaderNote";
 import NoteMenu from "@app/components/note/NoteMenu";
+import NoteTagSection from "@app/components/note/NoteTagSection";
 import ReflectionTemplateSection from "@app/components/note/ReflectionTemplateSection";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
+import { useNoteTagEditing } from "@app/hooks/note/useNoteTagEditing";
 import { updateBaseballNote } from "@app/services/v2/baseballNoteService";
 import {
   buildAnswerList,
@@ -20,6 +22,7 @@ import {
   parseMemoToSlateValue,
   resolveNoteMemo,
 } from "@app/utils/noteMemo";
+import { buildTagIdsUpdate } from "@app/utils/noteTags";
 import {
   buildNoteUpdateInput,
   hasNoteChanges,
@@ -35,13 +38,16 @@ const NoteEditor = dynamic(() => import("@app/components/note/NoteEditor"), {
 interface NoteEditFormProps {
   note: BaseballNoteV2;
   templatesResult: FetchResult<ReflectionTemplate[]>;
+  tagsResult: FetchResult<NoteTag[]>;
 }
 
 export default function NoteEditForm({
   note,
   templatesResult,
+  tagsResult,
 }: NoteEditFormProps) {
   const router = useRouter();
+  const { canEditTags } = useNoteTagEditing();
   // 回答から自動合成された memo は回答欄と同じ内容が並ぶため、自由メモ欄へは流し込まない。
   const isSynthesizedMemo = isReflectionMemo(
     extractMemoText(note.memo),
@@ -76,6 +82,11 @@ export default function NoteEditForm({
   const [memo, setMemo] = useState(editorMemo);
   const [answers, setAnswers] =
     useState<Record<string, string>>(initialAnswerMap);
+  const initialTagIds = useMemo(
+    () => note.tags.map((tag) => tag.id),
+    [note.tags],
+  );
+  const [tagIds, setTagIds] = useState<number[]>(initialTagIds);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
 
@@ -90,15 +101,19 @@ export default function NoteEditForm({
     reflectionAnswers: initialAnswers,
   };
 
-  // 送るのは変更したキーだけ。試合 / 課題 / タグの紐付けとテンプレ ID はこの画面で
-  // 編集しないためキー自体を送らず、back 側の「未送信＝変更なし」に委ねる（送ると上書きされる）。
-  const updateInput = buildNoteUpdateInput(initialValues, {
-    date,
-    title,
-    // 回答を編集したら合成メモも作り直す。メモだけ古い回答のまま残すと本文と回答が食い違う。
-    memo: resolveNoteMemo(memo, currentAnswers),
-    reflectionAnswers: currentAnswers,
-  });
+  // 送るのは変更したキーだけ。試合 / 課題の紐付けとテンプレ ID はこの画面で編集しないため
+  // キー自体を送らず、back 側の「未送信＝変更なし」に委ねる（送ると上書きされる）。
+  // タグも Pro 判定が確定して entitlement を持ち、かつ実際に選択が変わったときだけキーを生やす。
+  const updateInput = {
+    ...buildNoteUpdateInput(initialValues, {
+      date,
+      title,
+      // 回答を編集したら合成メモも作り直す。メモだけ古い回答のまま残すと本文と回答が食い違う。
+      memo: resolveNoteMemo(memo, currentAnswers),
+      reflectionAnswers: currentAnswers,
+    }),
+    ...buildTagIdsUpdate({ canEditTags, initialTagIds, tagIds }),
+  };
   const hasChanges = hasNoteChanges(updateInput);
 
   const setErrorsWithTimeout = (newErrors: string[]) => {
@@ -174,6 +189,12 @@ export default function NoteEditForm({
                   answers={answers}
                   onChangeAnswer={handleChangeAnswer}
                   locked
+                />
+                <NoteTagSection
+                  tagsResult={tagsResult}
+                  selectedIds={tagIds}
+                  onChange={setTagIds}
+                  canEdit={canEditTags}
                 />
               </div>
             </form>

--- a/app/(app)/note/[slulg]/_components/__tests__/NoteEditForm.test.tsx
+++ b/app/(app)/note/[slulg]/_components/__tests__/NoteEditForm.test.tsx
@@ -9,6 +9,23 @@ jest.mock("@app/services/v2/baseballNoteService", () => ({
   deleteBaseballNote: jest.fn(),
 }));
 
+jest.mock("@app/services/v2/noteTagService", () => ({
+  createNoteTag: jest.fn(),
+}));
+
+const mockHasEntitlement = jest.fn(() => false);
+const mockIsEntitlementLoading = jest.fn(() => false);
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: () => ({
+    isPro: false,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading: mockIsEntitlementLoading(),
+    hasEntitlement: mockHasEntitlement,
+  }),
+}));
+
 // 実エディタは Slate に依存するため、メモ入力だけを模した textarea に差し替える。
 jest.mock("next/dynamic", () => () => {
   // ファクトリ内は外部スコープを参照できないため、React はここで解決する。
@@ -29,7 +46,7 @@ jest.mock("next/dynamic", () => () => {
   };
 });
 
-import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
+import type { BaseballNoteV2, NoteTag } from "@app/interface/baseballNoteV2";
 import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
 import type { FetchResult } from "@app/services/v2/requests";
 import type ReactModule from "react";
@@ -75,11 +92,19 @@ const templatesResult: FetchResult<ReflectionTemplate[]> = {
   ],
 };
 
+const tags: NoteTag[] = [
+  { id: 301, name: "打撃", is_preset: true },
+  { id: 302, name: "メンタル", is_preset: false },
+];
+
+const tagsResult: FetchResult<NoteTag[]> = { status: "ok", data: tags };
+
 function renderForm(overrides: Partial<BaseballNoteV2> = {}) {
   return render(
     <NoteEditForm
       note={{ ...note, ...overrides }}
       templatesResult={templatesResult}
+      tagsResult={tagsResult}
     />,
   );
 }
@@ -87,6 +112,8 @@ function renderForm(overrides: Partial<BaseballNoteV2> = {}) {
 describe("NoteEditForm", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockHasEntitlement.mockReturnValue(false);
+    mockIsEntitlementLoading.mockReturnValue(false);
     mockUpdateBaseballNote.mockResolvedValue({ ok: true, data: note });
   });
 
@@ -303,6 +330,106 @@ describe("NoteEditForm", () => {
 
       expect(screen.queryByLabelText("課題")).toBeNull();
       expect(screen.queryByText(/振り返り/)).toBeNull();
+    });
+  });
+
+  describe("タグ", () => {
+    async function saveAfter(action: () => void) {
+      action();
+      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+      await waitFor(() =>
+        expect(mockUpdateBaseballNote).toHaveBeenCalledTimes(1),
+      );
+    }
+
+    it("ノートに付いているタグは選択済みで表示する（# 付き）", () => {
+      mockHasEntitlement.mockReturnValue(true);
+      renderForm();
+
+      expect(screen.getByRole("button", { name: "#打撃" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(screen.getByRole("button", { name: "#メンタル" })).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
+
+    it("無料ユーザーがタイトルだけ更新しても tag_ids を送らない（既存タグを消さない）", async () => {
+      renderForm();
+
+      await saveAfter(() =>
+        fireEvent.change(screen.getByLabelText("タイトル"), {
+          target: { value: "更新後" },
+        }),
+      );
+
+      expect(sentPayload()).not.toHaveProperty("tag_ids");
+    });
+
+    it("無料ユーザーはタグを外そうとしても tag_ids を送らない", async () => {
+      renderForm();
+
+      await saveAfter(() => {
+        // 暗幕の裏でも要素自体は描画されるため、押せてしまった場合も送らないことを確かめる。
+        fireEvent.click(screen.getByText("#打撃"));
+        fireEvent.change(screen.getByLabelText("タイトル"), {
+          target: { value: "更新後" },
+        });
+      });
+
+      expect(sentPayload()).not.toHaveProperty("tag_ids");
+    });
+
+    it("Pro 判定が未確定の間は tag_ids を送らない", async () => {
+      mockHasEntitlement.mockReturnValue(true);
+      mockIsEntitlementLoading.mockReturnValue(true);
+      renderForm();
+
+      await saveAfter(() => {
+        fireEvent.click(screen.getByText("#メンタル"));
+        fireEvent.change(screen.getByLabelText("タイトル"), {
+          target: { value: "更新後" },
+        });
+      });
+
+      expect(sentPayload()).not.toHaveProperty("tag_ids");
+    });
+
+    it("Pro ユーザーがタグを追加すると tag_ids を送る", async () => {
+      mockHasEntitlement.mockReturnValue(true);
+      renderForm();
+
+      await saveAfter(() =>
+        fireEvent.click(screen.getByRole("button", { name: "#メンタル" })),
+      );
+
+      expect(sentPayload().tag_ids).toEqual([301, 302]);
+    });
+
+    it("Pro ユーザーがタグを全て外すと空配列を明示して送る", async () => {
+      mockHasEntitlement.mockReturnValue(true);
+      renderForm();
+
+      await saveAfter(() =>
+        fireEvent.click(screen.getByRole("button", { name: "#打撃" })),
+      );
+
+      expect(sentPayload().tag_ids).toEqual([]);
+    });
+
+    it("Pro ユーザーでもタグを変えていなければ tag_ids を送らない", async () => {
+      mockHasEntitlement.mockReturnValue(true);
+      renderForm();
+
+      await saveAfter(() =>
+        fireEvent.change(screen.getByLabelText("タイトル"), {
+          target: { value: "更新後" },
+        }),
+      );
+
+      expect(sentPayload()).not.toHaveProperty("tag_ids");
     });
   });
 });

--- a/app/(app)/note/[slulg]/_components/__tests__/NoteFormTagPayload.test.tsx
+++ b/app/(app)/note/[slulg]/_components/__tests__/NoteFormTagPayload.test.tsx
@@ -1,0 +1,213 @@
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@app/services/v2/baseballNoteService", () => ({
+  createBaseballNote: jest.fn(),
+  updateBaseballNote: jest.fn(),
+  deleteBaseballNote: jest.fn(),
+}));
+
+// タグ選択 UI 側のガードを外し、フォームの送信ペイロード組み立てだけを検証する。
+// UI を隠すだけでは不十分で、ペイロード組み立ての時点で entitlement を見て
+// tag_ids キーごと落としていることを担保する。
+jest.mock("@app/components/note/NoteTagSection", () => {
+  const react = jest.requireActual<typeof ReactModule>("react");
+  return function StubTagSection({
+    selectedIds,
+    onChange,
+  }: {
+    selectedIds: number[];
+    onChange: (ids: number[]) => void;
+  }) {
+    return react.createElement(
+      "button",
+      {
+        type: "button",
+        onClick: () => onChange([...selectedIds, 999]),
+      },
+      "タグを足す",
+    );
+  };
+});
+
+jest.mock("next/dynamic", () => () => {
+  const react = jest.requireActual<typeof ReactModule>("react");
+  return function MockNoteEditor({
+    memo,
+    setMemo,
+  }: {
+    memo: string;
+    setMemo: (value: string) => void;
+  }) {
+    return react.createElement("textarea", {
+      "aria-label": "メモ",
+      defaultValue: memo,
+      onChange: (event: { target: { value: string } }) =>
+        setMemo(event.target.value),
+    });
+  };
+});
+
+const mockHasEntitlement = jest.fn(() => false);
+const mockIsEntitlementLoading = jest.fn(() => false);
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: () => ({
+    isPro: false,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading: mockIsEntitlementLoading(),
+    hasEntitlement: mockHasEntitlement,
+  }),
+}));
+
+import type { BaseballNoteV2, NoteTag } from "@app/interface/baseballNoteV2";
+import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
+import type { FetchResult } from "@app/services/v2/requests";
+import type ReactModule from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import NoteCreateForm from "@app/(app)/note/new/_components/NoteCreateForm";
+import {
+  createBaseballNote,
+  updateBaseballNote,
+} from "@app/services/v2/baseballNoteService";
+import NoteEditForm from "../NoteEditForm";
+
+const mockCreate = createBaseballNote as jest.MockedFunction<
+  typeof createBaseballNote
+>;
+const mockUpdate = updateBaseballNote as jest.MockedFunction<
+  typeof updateBaseballNote
+>;
+
+const templatesResult: FetchResult<ReflectionTemplate[]> = {
+  status: "ok",
+  data: [],
+};
+const tagsResult: FetchResult<NoteTag[]> = { status: "ok", data: [] };
+
+const note: BaseballNoteV2 = {
+  id: 12,
+  title: "気づき",
+  date: "2026-08-01",
+  memo: '[{"type":"paragraph","children":[{"text":"外角が詰まる"}]}]',
+  memo_preview: "外角が詰まる",
+  game_result_ids: [],
+  practice_log_id: null,
+  practice_session_id: null,
+  improvement_theme_ids: [],
+  reflection_template_id: null,
+  reflection_answers: [],
+  tags: [{ id: 301, name: "打撃", is_preset: true }],
+  media_attachments: [],
+};
+
+function addTagAndSave() {
+  fireEvent.click(screen.getByRole("button", { name: "タグを足す" }));
+  fireEvent.click(screen.getByRole("button", { name: "保存" }));
+}
+
+describe("ノートフォームの tag_ids 送信ガード（UI を迂回してタグが変わった場合）", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasEntitlement.mockReturnValue(false);
+    mockIsEntitlementLoading.mockReturnValue(false);
+    mockCreate.mockResolvedValue({ ok: true, data: note });
+    mockUpdate.mockResolvedValue({ ok: true, data: note });
+  });
+
+  describe("新規作成", () => {
+    function renderCreateForm() {
+      render(
+        <NoteCreateForm
+          templatesResult={templatesResult}
+          tagsResult={tagsResult}
+        />,
+      );
+      fireEvent.change(screen.getByLabelText("タイトル"), {
+        target: { value: "気づき" },
+      });
+    }
+
+    it("無料ユーザーはタグが選ばれていても tag_ids キーを送らない", async () => {
+      renderCreateForm();
+
+      addTagAndSave();
+
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+      expect("tag_ids" in mockCreate.mock.calls[0][0]).toBe(false);
+    });
+
+    it("Pro 判定が未確定の間はタグが選ばれていても tag_ids キーを送らない", async () => {
+      mockHasEntitlement.mockReturnValue(true);
+      mockIsEntitlementLoading.mockReturnValue(true);
+      renderCreateForm();
+
+      addTagAndSave();
+
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+      expect("tag_ids" in mockCreate.mock.calls[0][0]).toBe(false);
+    });
+
+    it("Pro ユーザーは tag_ids を送る", async () => {
+      mockHasEntitlement.mockReturnValue(true);
+      renderCreateForm();
+
+      addTagAndSave();
+
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+      expect(mockCreate.mock.calls[0][0].tag_ids).toEqual([999]);
+    });
+  });
+
+  describe("編集", () => {
+    function renderEditForm() {
+      render(
+        <NoteEditForm
+          note={note}
+          templatesResult={templatesResult}
+          tagsResult={tagsResult}
+        />,
+      );
+    }
+
+    it("無料ユーザーはタグが変わっても tag_ids キーを送らない（既存タグを消さない）", async () => {
+      renderEditForm();
+      fireEvent.change(screen.getByLabelText("タイトル"), {
+        target: { value: "更新後" },
+      });
+
+      addTagAndSave();
+
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      expect(mockUpdate.mock.calls[0][1]).not.toHaveProperty("tag_ids");
+    });
+
+    it("Pro 判定が未確定の間はタグが変わっても tag_ids キーを送らない", async () => {
+      mockHasEntitlement.mockReturnValue(true);
+      mockIsEntitlementLoading.mockReturnValue(true);
+      renderEditForm();
+      fireEvent.change(screen.getByLabelText("タイトル"), {
+        target: { value: "更新後" },
+      });
+
+      addTagAndSave();
+
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      expect(mockUpdate.mock.calls[0][1]).not.toHaveProperty("tag_ids");
+    });
+
+    it("Pro ユーザーは変更後のタグを tag_ids で送る", async () => {
+      mockHasEntitlement.mockReturnValue(true);
+      renderEditForm();
+
+      addTagAndSave();
+
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      expect(mockUpdate.mock.calls[0][1].tag_ids).toEqual([301, 999]);
+    });
+  });
+});

--- a/app/(app)/note/[slulg]/page.tsx
+++ b/app/(app)/note/[slulg]/page.tsx
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { getBaseballNote } from "@app/services/v2/baseballNoteService";
+import { getNoteTags } from "@app/services/v2/noteTagService";
 import { getReflectionTemplates } from "@app/services/v2/reflectionTemplateService";
 import NoteEditForm from "./_components/NoteEditForm";
 
@@ -27,9 +28,10 @@ export default async function NoteDetail(props: {
   }
 
   // 互いに依存しない取得なので並列で待つ。
-  const [result, templatesResult] = await Promise.all([
+  const [result, templatesResult, tagsResult] = await Promise.all([
     getBaseballNote(noteId),
     getReflectionTemplates(),
+    getNoteTags(),
   ]);
   if (result.status === "forbidden") {
     return <NoteLoadError message="このノートを表示する権限がありません。" />;
@@ -38,5 +40,11 @@ export default async function NoteDetail(props: {
     return <NoteLoadError message="野球ノートの読み込みに失敗しました。" />;
   }
 
-  return <NoteEditForm note={result.data} templatesResult={templatesResult} />;
+  return (
+    <NoteEditForm
+      note={result.data}
+      templatesResult={templatesResult}
+      tagsResult={tagsResult}
+    />
+  );
 }

--- a/app/(app)/note/new/_components/NoteCreateForm.tsx
+++ b/app/(app)/note/new/_components/NoteCreateForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReflectionAnswer } from "@app/interface/baseballNoteV2";
+import type { NoteTag, ReflectionAnswer } from "@app/interface/baseballNoteV2";
 import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
 import type { FetchResult } from "@app/services/v2/requests";
 import { Input } from "@heroui/react";
@@ -9,10 +9,13 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import HeaderNote from "@app/components/header/HeaderNote";
+import NoteTagSection from "@app/components/note/NoteTagSection";
 import ReflectionTemplateSection from "@app/components/note/ReflectionTemplateSection";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
+import { useNoteTagEditing } from "@app/hooks/note/useNoteTagEditing";
 import { createBaseballNote } from "@app/services/v2/baseballNoteService";
 import { buildAnswerList, resolveNoteMemo } from "@app/utils/noteMemo";
+import { buildTagIdsPayload } from "@app/utils/noteTags";
 
 const NoteEditor = dynamic(() => import("@app/components/note/NoteEditor"), {
   ssr: false,
@@ -23,6 +26,7 @@ const NoteEditor = dynamic(() => import("@app/components/note/NoteEditor"), {
 
 interface NoteCreateFormProps {
   templatesResult: FetchResult<ReflectionTemplate[]>;
+  tagsResult: FetchResult<NoteTag[]>;
 }
 
 /** 日付入力（`type="date"`）が要求する `YYYY-MM-DD` をローカル時刻で組み立てる。 */
@@ -35,8 +39,10 @@ function todayString(): string {
 
 export default function NoteCreateForm({
   templatesResult,
+  tagsResult,
 }: NoteCreateFormProps) {
   const router = useRouter();
+  const { canEditTags } = useNoteTagEditing();
   const [initialDate] = useState(todayString);
   const [date, setDate] = useState(initialDate);
   const [title, setTitle] = useState("");
@@ -45,6 +51,7 @@ export default function NoteCreateForm({
   const [questions, setQuestions] = useState<string[]>([]);
   // 回答は問い文をキーに保持する。テンプレを切り替えて戻ってきても入力済みの回答が残る。
   const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [tagIds, setTagIds] = useState<number[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
 
@@ -57,7 +64,8 @@ export default function NoteCreateForm({
     title !== "" ||
     memo !== "" ||
     templateId !== null ||
-    reflectionAnswers.length > 0;
+    reflectionAnswers.length > 0 ||
+    tagIds.length > 0;
 
   const setErrorsWithTimeout = (newErrors: string[]) => {
     setErrors(newErrors);
@@ -85,13 +93,15 @@ export default function NoteCreateForm({
       return;
     }
     setIsSubmitting(true);
-    // 紐付け・タグは新規作成画面では扱わないためキーごと送らない。
+    // 試合 / 課題の紐付けは新規作成画面では扱わないためキーごと送らない。
+    // タグも Pro 判定が確定して entitlement を持つときだけキーを生やす。
     const result = await createBaseballNote({
       date,
       title: title === "" ? null : title,
       memo: resolveNoteMemo(memo, reflectionAnswers),
       reflection_template_id: templateId,
       reflection_answers: reflectionAnswers,
+      ...buildTagIdsPayload({ canEditTags, tagIds }),
     });
     if (!result.ok) {
       setErrorsWithTimeout(result.errors);
@@ -149,6 +159,12 @@ export default function NoteCreateForm({
                   answers={answers}
                   onSelectTemplate={handleSelectTemplate}
                   onChangeAnswer={handleChangeAnswer}
+                />
+                <NoteTagSection
+                  tagsResult={tagsResult}
+                  selectedIds={tagIds}
+                  onChange={setTagIds}
+                  canEdit={canEditTags}
                 />
               </div>
             </form>

--- a/app/(app)/note/new/_components/__tests__/NoteCreateForm.test.tsx
+++ b/app/(app)/note/new/_components/__tests__/NoteCreateForm.test.tsx
@@ -8,6 +8,23 @@ jest.mock("@app/services/v2/baseballNoteService", () => ({
   createBaseballNote: jest.fn(),
 }));
 
+jest.mock("@app/services/v2/noteTagService", () => ({
+  createNoteTag: jest.fn(),
+}));
+
+const mockHasEntitlement = jest.fn(() => false);
+const mockIsEntitlementLoading = jest.fn(() => false);
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: () => ({
+    isPro: false,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading: mockIsEntitlementLoading(),
+    hasEntitlement: mockHasEntitlement,
+  }),
+}));
+
 // 実エディタは Slate に依存するため、メモ入力だけを模した textarea に差し替える。
 jest.mock("next/dynamic", () => () => {
   // ファクトリ内は外部スコープを参照できないため、React はここで解決する。
@@ -28,7 +45,7 @@ jest.mock("next/dynamic", () => () => {
   };
 });
 
-import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
+import type { BaseballNoteV2, NoteTag } from "@app/interface/baseballNoteV2";
 import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
 import type { FetchResult } from "@app/services/v2/requests";
 import type ReactModule from "react";
@@ -61,13 +78,36 @@ const templates: ReflectionTemplate[] = [
 
 const createdNote = { id: 1 } as BaseballNoteV2;
 
+const tags: NoteTag[] = [
+  { id: 11, name: "打撃", is_preset: true },
+  { id: 12, name: "メンタル", is_preset: false },
+];
+
+const tagsResult: FetchResult<NoteTag[]> = { status: "ok", data: tags };
+
 function renderForm(
   templatesResult: FetchResult<ReflectionTemplate[]> = {
     status: "ok",
     data: templates,
   },
 ) {
-  return render(<NoteCreateForm templatesResult={templatesResult} />);
+  return render(
+    <NoteCreateForm
+      templatesResult={templatesResult}
+      tagsResult={tagsResult}
+    />,
+  );
+}
+
+/** `note_tags` entitlement を持つ Pro ユーザーとして描画する。 */
+function asProUser() {
+  mockHasEntitlement.mockReturnValue(true);
+}
+
+/** Pro 判定がまだ確定していない状態にする。 */
+function asResolvingUser() {
+  mockHasEntitlement.mockReturnValue(true);
+  mockIsEntitlementLoading.mockReturnValue(true);
 }
 
 function sentPayload() {
@@ -82,6 +122,8 @@ async function save() {
 describe("NoteCreateForm", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockHasEntitlement.mockReturnValue(false);
+    mockIsEntitlementLoading.mockReturnValue(false);
     mockCreateBaseballNote.mockResolvedValue({ ok: true, data: createdNote });
   });
 
@@ -232,5 +274,61 @@ describe("NoteCreateForm", () => {
       ),
     ).toBeVisible();
     expect(screen.queryByRole("button", { name: "試合の振り返り" })).toBeNull();
+  });
+});
+
+describe("NoteCreateForm のタグ送信", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasEntitlement.mockReturnValue(false);
+    mockIsEntitlementLoading.mockReturnValue(false);
+    mockCreateBaseballNote.mockResolvedValue({ ok: true, data: createdNote });
+  });
+
+  async function fillTitleAndSave() {
+    fireEvent.change(screen.getByLabelText("タイトル"), {
+      target: { value: "気づき" },
+    });
+    await save();
+  }
+
+  it("無料ユーザーはタグを選ぼうとしても tag_ids キー自体を送らない", async () => {
+    renderForm();
+    // 暗幕の裏でも要素自体は描画されるため、押せてしまった場合も送らないことを確かめる。
+    fireEvent.click(screen.getByText("#打撃"));
+
+    await fillTitleAndSave();
+
+    expect("tag_ids" in sentPayload()).toBe(false);
+  });
+
+  it("Pro 判定が未確定の間は tag_ids キー自体を送らない", async () => {
+    asResolvingUser();
+    renderForm();
+    fireEvent.click(screen.getByText("#打撃"));
+
+    await fillTitleAndSave();
+
+    expect("tag_ids" in sentPayload()).toBe(false);
+  });
+
+  it("Pro ユーザーは選択したタグを tag_ids で送る", async () => {
+    asProUser();
+    renderForm();
+    fireEvent.click(screen.getByRole("button", { name: "#打撃" }));
+    fireEvent.click(screen.getByRole("button", { name: "#メンタル" }));
+
+    await fillTitleAndSave();
+
+    expect(sentPayload().tag_ids).toEqual([11, 12]);
+  });
+
+  it("Pro ユーザーが何も選ばなければ空配列を送る", async () => {
+    asProUser();
+    renderForm();
+
+    await fillTitleAndSave();
+
+    expect(sentPayload().tag_ids).toEqual([]);
   });
 });

--- a/app/(app)/note/new/page.tsx
+++ b/app/(app)/note/new/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getNoteTags } from "@app/services/v2/noteTagService";
 import { getReflectionTemplates } from "@app/services/v2/reflectionTemplateService";
 import NoteCreateForm from "./_components/NoteCreateForm";
 
@@ -8,6 +9,12 @@ export default async function NoteNew() {
   if (!cookieStore.get("access-token")) {
     redirect("/signup?auth_required=true");
   }
-  const templatesResult = await getReflectionTemplates();
-  return <NoteCreateForm templatesResult={templatesResult} />;
+  // 互いに依存しない取得なので並列で待つ。
+  const [templatesResult, tagsResult] = await Promise.all([
+    getReflectionTemplates(),
+    getNoteTags(),
+  ]);
+  return (
+    <NoteCreateForm templatesResult={templatesResult} tagsResult={tagsResult} />
+  );
 }

--- a/app/(app)/note/page.tsx
+++ b/app/(app)/note/page.tsx
@@ -6,13 +6,18 @@ import NoteAddButton from "@app/components/button/NoteAddButton";
 import Header from "@app/components/header/Header";
 import NoteListComponent from "@app/components/note/NoteListComponent";
 import { getBaseballNotes } from "@app/services/v2/baseballNoteService";
+import { getNoteTags } from "@app/services/v2/noteTagService";
 
 export default async function NoteList() {
   const cookieStore = await cookies();
   if (!cookieStore.get("access-token")) {
     redirect("/signup?auth_required=true");
   }
-  const result = await getBaseballNotes();
+  // 互いに依存しない取得なので並列で待つ。
+  const [result, tagsResult] = await Promise.all([
+    getBaseballNotes(),
+    getNoteTags(),
+  ]);
   return (
     <>
       <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
@@ -22,7 +27,7 @@ export default async function NoteList() {
             <div className="pt-20 px-4 lg:px-6">
               <h2 className="text-2xl font-bold">野球ノート</h2>
               <div className="my-6">
-                <NoteListComponent result={result} />
+                <NoteListComponent result={result} tagsResult={tagsResult} />
               </div>
               <AdInFeed
                 slot={adSlots.noteListInFeed}

--- a/app/components/note/NoteListBoard.tsx
+++ b/app/components/note/NoteListBoard.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import type { BaseballNoteV2, NoteTag } from "@app/interface/baseballNoteV2";
+import type { NoteListFilterValues } from "@app/utils/noteListFilter";
+import { Card } from "@heroui/react";
+import { useState } from "react";
+import NoteListFilterBar from "@app/components/note/NoteListFilterBar";
+import NoteListItem from "@app/components/note/NoteListItem";
+import {
+  EMPTY_NOTE_FILTERS,
+  collectNoteMonths,
+  filterNotes,
+  formatMonthLabel,
+  notesInMonth,
+} from "@app/utils/noteListFilter";
+
+interface NoteListBoardProps {
+  notes: BaseballNoteV2[];
+  tags: NoteTag[];
+}
+
+/**
+ * 絞り込み済みノートを月単位で1ページずつ表示する。
+ * ページ送りの対象はノートが存在する月だけ（記録の無い月を空ページとして挟まない）。
+ */
+export default function NoteListBoard({ notes, tags }: NoteListBoardProps) {
+  const [filters, setFilters] = useState<NoteListFilterValues>(
+    () => EMPTY_NOTE_FILTERS,
+  );
+  const [monthIndex, setMonthIndex] = useState(0);
+
+  const filtered = filterNotes(notes, filters);
+  const months = collectNoteMonths(filtered);
+  // 絞り込みで月の並びが短くなっても範囲外を指さないよう、描画時に丸める。
+  const currentIndex = Math.min(monthIndex, Math.max(months.length - 1, 0));
+  const currentMonth = months[currentIndex];
+  const visibleNotes = currentMonth ? notesInMonth(filtered, currentMonth) : [];
+
+  // 絞り込みを変えたら必ず最新の月へ戻す。古いページ番号のまま検索すると
+  // 該当ノートがあるのに「結果なし」に見えてしまう。
+  const handleFilterChange = (next: NoteListFilterValues) => {
+    setFilters(next);
+    setMonthIndex(0);
+  };
+
+  return (
+    <div className="space-y-4">
+      <NoteListFilterBar
+        values={filters}
+        onChange={handleFilterChange}
+        tags={tags}
+      />
+      {months.length > 0 ? (
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => setMonthIndex(currentIndex + 1)}
+            disabled={currentIndex >= months.length - 1}
+            className="px-2 py-1.5 text-xs font-bold text-zinc-400 disabled:opacity-40"
+          >
+            前の月
+          </button>
+          <p className="text-sm font-bold" aria-live="polite">
+            {formatMonthLabel(currentMonth)}（{visibleNotes.length}件）
+          </p>
+          <button
+            type="button"
+            onClick={() => setMonthIndex(currentIndex - 1)}
+            disabled={currentIndex <= 0}
+            className="px-2 py-1.5 text-xs font-bold text-zinc-400 disabled:opacity-40"
+          >
+            次の月
+          </button>
+        </div>
+      ) : null}
+      <Card className="pt-2 pb-8 px-6">
+        {visibleNotes.length > 0 ? (
+          visibleNotes.map((note) => <NoteListItem key={note.id} note={note} />)
+        ) : (
+          <p className="text-sm text-zinc-400 text-center">
+            {notes.length === 0
+              ? "まだ野球ノートが作成されていません。"
+              : "条件に一致するノートがありません。"}
+          </p>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/app/components/note/NoteListComponent.tsx
+++ b/app/components/note/NoteListComponent.tsx
@@ -3,15 +3,21 @@
 import type {
   BaseballNoteV2,
   NoteFetchResult,
+  NoteTag,
 } from "@app/interface/baseballNoteV2";
-import { Card } from "@heroui/react";
-import NoteListItem from "@app/components/note/NoteListItem";
+import type { FetchResult } from "@app/services/v2/requests";
+import NoteListBoard from "@app/components/note/NoteListBoard";
 
 interface NoteListComponentProps {
   result: NoteFetchResult<BaseballNoteV2[]>;
+  /** タグチップの候補。取得に失敗しても一覧自体は出したいのでチップだけ落とす。 */
+  tagsResult: FetchResult<NoteTag[]>;
 }
 
-export default function NoteListComponent({ result }: NoteListComponentProps) {
+export default function NoteListComponent({
+  result,
+  tagsResult,
+}: NoteListComponentProps) {
   if (result.status === "forbidden") {
     return (
       <p className="text-sm text-zinc-400 text-center">
@@ -28,16 +34,9 @@ export default function NoteListComponent({ result }: NoteListComponentProps) {
   }
 
   return (
-    <div>
-      <Card className="pt-2 pb-8 px-6">
-        {result.data.length > 0 ? (
-          result.data.map((note) => <NoteListItem key={note.id} note={note} />)
-        ) : (
-          <p className="text-sm text-zinc-400 text-center">
-            まだ野球ノートが作成されていません。
-          </p>
-        )}
-      </Card>
-    </div>
+    <NoteListBoard
+      notes={result.data}
+      tags={tagsResult.status === "ok" ? tagsResult.data : []}
+    />
   );
 }

--- a/app/components/note/NoteListFilterBar.tsx
+++ b/app/components/note/NoteListFilterBar.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import type { NoteTag } from "@app/interface/baseballNoteV2";
+import type { NoteListFilterValues } from "@app/utils/noteListFilter";
+import FilterChipGroup from "@app/components/filter/FilterChipGroup";
+import {
+  EMPTY_NOTE_FILTERS,
+  hasActiveNoteFilter,
+} from "@app/utils/noteListFilter";
+import { tagLabel } from "@app/utils/noteTags";
+
+interface NoteListFilterBarProps {
+  values: NoteListFilterValues;
+  onChange: (values: NoteListFilterValues) => void;
+  /** タグチップの候補。取得に失敗した場合は空配列を渡してチップを出さない。 */
+  tags: NoteTag[];
+}
+
+/**
+ * ノート一覧の絞り込みバー（フリーワード / 期間 / タグ）。
+ *
+ * 成績・試合一覧で使う FilterBar は「年・月粒度の単一選択ドロップダウン」専用で、
+ * フリーワード・日単位の期間・複数選択タグを表現できないため、チップの並びだけ
+ * FilterChipGroup を共有してノート専用のバーを組んでいる。
+ */
+export default function NoteListFilterBar({
+  values,
+  onChange,
+  tags,
+}: NoteListFilterBarProps) {
+  const toggleTag = (id: number) => {
+    onChange({
+      ...values,
+      tagIds: values.tagIds.includes(id)
+        ? values.tagIds.filter((selected) => selected !== id)
+        : [...values.tagIds, id],
+    });
+  };
+
+  // 開始日が終了日より後になると常に0件になるため、片方を動かしたらもう片方を寄せる。
+  const handleStartDate = (startDate: string) => {
+    const endDate =
+      values.endDate !== "" && startDate !== "" && values.endDate < startDate
+        ? startDate
+        : values.endDate;
+    onChange({ ...values, startDate, endDate });
+  };
+
+  const handleEndDate = (endDate: string) => {
+    const startDate =
+      values.startDate !== "" && endDate !== "" && values.startDate > endDate
+        ? endDate
+        : values.startDate;
+    onChange({ ...values, startDate, endDate });
+  };
+
+  return (
+    <div className="space-y-3">
+      <input
+        type="search"
+        aria-label="ノートを検索"
+        placeholder="タイトル・本文・タグで検索"
+        value={values.keyword}
+        onChange={(event) =>
+          onChange({ ...values, keyword: event.target.value })
+        }
+        className="w-full rounded-lg bg-sub px-3 py-2 text-sm text-white placeholder:text-zinc-500"
+      />
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="date"
+          aria-label="開始日"
+          value={values.startDate}
+          onChange={(event) => handleStartDate(event.target.value)}
+          className="rounded-lg bg-sub px-3 py-2 text-sm text-white"
+        />
+        <span className="text-xs text-zinc-400">〜</span>
+        <input
+          type="date"
+          aria-label="終了日"
+          value={values.endDate}
+          onChange={(event) => handleEndDate(event.target.value)}
+          className="rounded-lg bg-sub px-3 py-2 text-sm text-white"
+        />
+        {hasActiveNoteFilter(values) ? (
+          <button
+            type="button"
+            onClick={() => onChange({ ...EMPTY_NOTE_FILTERS })}
+            className="px-2 py-1.5 text-xs font-medium text-[#A1A1AA]"
+          >
+            クリア
+          </button>
+        ) : null}
+      </div>
+      {tags.length > 0 ? (
+        <FilterChipGroup wrap>
+          {tags.map((tag) => (
+            <button
+              key={tag.id}
+              type="button"
+              aria-pressed={values.tagIds.includes(tag.id)}
+              onClick={() => toggleTag(tag.id)}
+              className={`shrink-0 rounded-full px-3 py-1.5 text-xs font-bold transition-colors ${
+                values.tagIds.includes(tag.id)
+                  ? "bg-[#d08000] text-white"
+                  : "bg-sub text-zinc-400 hover:text-white"
+              }`}
+            >
+              {tagLabel(tag.name)}
+            </button>
+          ))}
+        </FilterChipGroup>
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/note/NoteListItem.tsx
+++ b/app/components/note/NoteListItem.tsx
@@ -3,12 +3,29 @@
 import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
 import { Divider } from "@heroui/react";
 import Link from "next/link";
+import { tagLabel } from "@app/utils/noteTags";
 
 interface NoteListItemProps {
   note: BaseballNoteV2;
 }
 
+/** ノートが何に紐付いているかを一覧から分かるようにするチップの文言。 */
+function linkLabels(note: BaseballNoteV2): string[] {
+  const labels: string[] = [];
+  if (note.game_result_ids.length > 0)
+    labels.push(`試合 ${note.game_result_ids.length}件`);
+  if (note.improvement_theme_ids.length > 0)
+    labels.push(`課題 ${note.improvement_theme_ids.length}件`);
+  if (note.practice_session_id !== null) labels.push("練習記録");
+  if (note.practice_log_id !== null) labels.push("練習");
+  if (note.media_attachments.length > 0)
+    labels.push(`メディア ${note.media_attachments.length}件`);
+  return labels;
+}
+
 export default function NoteListItem({ note }: NoteListItemProps) {
+  const links = linkLabels(note);
+
   return (
     <div>
       <Link href={`/note/${note.id}`} className="block pt-4">
@@ -25,6 +42,26 @@ export default function NoteListItem({ note }: NoteListItemProps) {
               {note.memo_preview}
             </p>
           </div>
+          {note.tags.length > 0 || links.length > 0 ? (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {note.tags.map((tag) => (
+                <span
+                  key={tag.id}
+                  className="rounded-full bg-[#d08000]/15 px-2 py-0.5 text-[11px] font-bold text-[#d08000]"
+                >
+                  {tagLabel(tag.name)}
+                </span>
+              ))}
+              {links.map((label) => (
+                <span
+                  key={label}
+                  className="rounded-full bg-sub px-2 py-0.5 text-[11px] font-bold text-zinc-400"
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
+          ) : null}
         </div>
         <Divider className="mt-4" />
       </Link>

--- a/app/components/note/NoteTagSection.tsx
+++ b/app/components/note/NoteTagSection.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import type { NoteTag } from "@app/interface/baseballNoteV2";
+import type { FetchResult } from "@app/services/v2/requests";
+import { useState } from "react";
+import { ProUpsellOverlay } from "@app/components/pro/ProUpsellOverlay";
+import { createNoteTag } from "@app/services/v2/noteTagService";
+import { normalizeTagName, tagLabel } from "@app/utils/noteTags";
+
+interface NoteTagSectionProps {
+  /** タグ一覧の取得結果。失敗を空配列に丸めるとタグ未登録と誤表示するため結果ごと受け取る。 */
+  tagsResult: FetchResult<NoteTag[]>;
+  selectedIds: number[];
+  onChange: (ids: number[]) => void;
+  /**
+   * タグを編集できるか（`note_tags` entitlement を持ち、かつ Pro 判定が確定している）。
+   * false の間は操作させない。呼び出し側は同じ値で `tag_ids` の送信可否も決めること。
+   */
+  canEdit: boolean;
+}
+
+const MAX_TAG_NAME_LENGTH = 20;
+
+/**
+ * ノートのタグ選択。運営プリセット＋自作タグをトグルチップで複数選択でき、
+ * 未登録の名前はその場で作成して選択に加える（mobile の TagSection と同じ操作感）。
+ *
+ * 表示は `#` 付き、保存名には `#` を含めない。無料ユーザーには ProUpsellOverlay で
+ * 覆ったプレビューを見せる（暗幕側で inert になるため操作はできない）。
+ */
+export default function NoteTagSection({
+  tagsResult,
+  selectedIds,
+  onChange,
+  canEdit,
+}: NoteTagSectionProps) {
+  // 作成したタグは一覧の再取得なしにその場で選べるようにするため手元に足す。
+  const [createdTags, setCreatedTags] = useState<NoteTag[]>([]);
+  const [draftName, setDraftName] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const fetchedTags = tagsResult.status === "ok" ? tagsResult.data : null;
+  const tags = fetchedTags === null ? null : [...fetchedTags, ...createdTags];
+
+  const toggle = (id: number) => {
+    if (!canEdit) return;
+    onChange(
+      selectedIds.includes(id)
+        ? selectedIds.filter((selected) => selected !== id)
+        : [...selectedIds, id],
+    );
+  };
+
+  const handleCreate = async () => {
+    if (!canEdit || isCreating) return;
+    const name = normalizeTagName(draftName);
+    if (name === "") return;
+
+    // 同名が既にあれば作成せず選択に加えるだけ（back の一意制約で 422 になるのを避ける）。
+    const existing = tags?.find((tag) => tag.name === name);
+    if (existing) {
+      if (!selectedIds.includes(existing.id))
+        onChange([...selectedIds, existing.id]);
+      setDraftName("");
+      setCreateError(null);
+      return;
+    }
+
+    setIsCreating(true);
+    setCreateError(null);
+    const result = await createNoteTag({ name });
+    setIsCreating(false);
+    if (!result.ok) {
+      // 入力はそのまま残す。作り直しのために打ち直させない。
+      setCreateError(result.errors[0] ?? "タグの作成に失敗しました");
+      return;
+    }
+    setCreatedTags((prev) => [...prev, result.data]);
+    onChange([...selectedIds, result.data.id]);
+    setDraftName("");
+  };
+
+  return (
+    <section aria-labelledby="note-tag-section-heading" className="mt-8">
+      <h3
+        id="note-tag-section-heading"
+        className="text-sm font-bold text-zinc-400"
+      >
+        タグ（任意・複数選択可）
+      </h3>
+      <ProUpsellOverlay
+        feature="note_tags"
+        lockedIndicator="badge"
+        className="mt-2"
+      >
+        {tags === null ? (
+          <p className="text-xs text-zinc-400">
+            タグを取得できませんでした。メモはそのまま入力できます。
+          </p>
+        ) : (
+          <>
+            <div
+              className="flex flex-wrap gap-2"
+              role="group"
+              aria-label="タグ"
+            >
+              {tags.length === 0 ? (
+                <p className="text-xs text-zinc-400">
+                  タグがまだありません。下の入力欄から作成できます。
+                </p>
+              ) : (
+                tags.map((tag) => (
+                  <button
+                    key={tag.id}
+                    type="button"
+                    aria-pressed={selectedIds.includes(tag.id)}
+                    onClick={() => toggle(tag.id)}
+                    className={`rounded-full px-3.5 py-2 text-xs font-bold transition-colors ${
+                      selectedIds.includes(tag.id)
+                        ? "bg-[#d08000] text-white"
+                        : "bg-sub text-zinc-400 hover:text-white"
+                    }`}
+                  >
+                    {tagLabel(tag.name)}
+                  </button>
+                ))
+              )}
+            </div>
+            <div className="mt-3 flex gap-2">
+              <input
+                type="text"
+                aria-label="新しいタグ"
+                placeholder="新しいタグを追加"
+                maxLength={MAX_TAG_NAME_LENGTH + 1}
+                value={draftName}
+                onChange={(event) => setDraftName(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter") return;
+                  // ノート保存フォームの中にあるため Enter で submit させない。
+                  event.preventDefault();
+                  void handleCreate();
+                }}
+                className="min-w-0 flex-1 rounded-lg bg-sub px-3 py-2 text-sm text-white placeholder:text-zinc-500"
+              />
+              <button
+                type="button"
+                onClick={() => void handleCreate()}
+                disabled={normalizeTagName(draftName) === "" || isCreating}
+                className="shrink-0 rounded-lg bg-[#d08000] px-4 py-2 text-xs font-bold text-white disabled:opacity-50"
+              >
+                追加
+              </button>
+            </div>
+            {createError ? (
+              <p role="alert" className="mt-2 text-xs text-red-400">
+                {createError}
+              </p>
+            ) : null}
+          </>
+        )}
+      </ProUpsellOverlay>
+    </section>
+  );
+}

--- a/app/components/note/__tests__/NoteListComponent.test.tsx
+++ b/app/components/note/__tests__/NoteListComponent.test.tsx
@@ -1,6 +1,11 @@
-import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
-import { render, screen } from "@testing-library/react";
+import type { BaseballNoteV2, NoteTag } from "@app/interface/baseballNoteV2";
+import type { FetchResult } from "@app/services/v2/requests";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { buildMemoJson } from "@app/utils/noteMemo";
 import NoteListComponent from "../NoteListComponent";
+
+const battingTag: NoteTag = { id: 1, name: "打撃", is_preset: true };
+const mentalTag: NoteTag = { id: 2, name: "メンタル", is_preset: false };
 
 const note: BaseballNoteV2 = {
   id: 1,
@@ -18,9 +23,23 @@ const note: BaseballNoteV2 = {
   media_attachments: [],
 };
 
+const noTags: FetchResult<NoteTag[]> = { status: "ok", data: [] };
+
+function renderList(
+  notes: BaseballNoteV2[],
+  tagsResult: FetchResult<NoteTag[]> = noTags,
+) {
+  return render(
+    <NoteListComponent
+      result={{ status: "ok", data: notes }}
+      tagsResult={tagsResult}
+    />,
+  );
+}
+
 describe("NoteListComponent", () => {
   it("ノートのタイトルと memo_preview を表示する", () => {
-    render(<NoteListComponent result={{ status: "ok", data: [note] }} />);
+    renderList([note]);
 
     expect(screen.getByText("気づき")).toBeInTheDocument();
     expect(screen.getByText("外角が詰まる")).toBeInTheDocument();
@@ -28,17 +47,13 @@ describe("NoteListComponent", () => {
   });
 
   it("タイトル未設定のノートは代替表記にする", () => {
-    render(
-      <NoteListComponent
-        result={{ status: "ok", data: [{ ...note, title: null }] }}
-      />,
-    );
+    renderList([{ ...note, title: null }]);
 
     expect(screen.getByText("無題のノート")).toBeInTheDocument();
   });
 
   it("0件は未作成メッセージを表示する", () => {
-    render(<NoteListComponent result={{ status: "ok", data: [] }} />);
+    renderList([]);
 
     expect(
       screen.getByText("まだ野球ノートが作成されていません。"),
@@ -46,7 +61,9 @@ describe("NoteListComponent", () => {
   });
 
   it("取得エラーは 0 件と区別してエラーメッセージを表示する", () => {
-    render(<NoteListComponent result={{ status: "error" }} />);
+    render(
+      <NoteListComponent result={{ status: "error" }} tagsResult={noTags} />,
+    );
 
     expect(
       screen.getByText("野球ノートの読み込みに失敗しました。"),
@@ -54,10 +71,16 @@ describe("NoteListComponent", () => {
     expect(
       screen.queryByText("まだ野球ノートが作成されていません。"),
     ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("ノートを検索")).not.toBeInTheDocument();
   });
 
   it("403 はエラーと区別して権限メッセージを表示する", () => {
-    render(<NoteListComponent result={{ status: "forbidden" }} />);
+    render(
+      <NoteListComponent
+        result={{ status: "forbidden" }}
+        tagsResult={noTags}
+      />,
+    );
 
     expect(
       screen.getByText("野球ノートを表示する権限がありません。"),
@@ -65,5 +88,150 @@ describe("NoteListComponent", () => {
     expect(
       screen.queryByText("野球ノートの読み込みに失敗しました。"),
     ).not.toBeInTheDocument();
+  });
+
+  it("タグと紐付けをチップで表示する（タグは # 付き）", () => {
+    renderList([
+      {
+        ...note,
+        tags: [battingTag],
+        game_result_ids: [10, 11],
+        improvement_theme_ids: [3],
+        practice_session_id: 5,
+      },
+    ]);
+
+    expect(screen.getByText("#打撃")).toBeInTheDocument();
+    expect(screen.getByText("試合 2件")).toBeInTheDocument();
+    expect(screen.getByText("課題 1件")).toBeInTheDocument();
+    expect(screen.getByText("練習記録")).toBeInTheDocument();
+  });
+});
+
+describe("NoteListComponent の検索・絞り込み・月次ページング", () => {
+  const notes: BaseballNoteV2[] = [
+    {
+      ...note,
+      id: 1,
+      title: "打撃の気づき",
+      date: "2026-08-20",
+      memo: buildMemoJson("体の開きが早い"),
+      memo_preview: "体の開きが早い",
+      tags: [battingTag],
+    },
+    {
+      ...note,
+      id: 2,
+      title: "守備の気づき",
+      date: "2026-08-05",
+      memo: buildMemoJson("一歩目が遅い"),
+      memo_preview: "一歩目が遅い",
+      tags: [mentalTag],
+    },
+    {
+      ...note,
+      id: 3,
+      title: "7月のノート",
+      date: "2026-07-10",
+      memo: buildMemoJson("打撃練習"),
+      memo_preview: "打撃練習",
+      tags: [],
+    },
+  ];
+
+  const tagsResult: FetchResult<NoteTag[]> = {
+    status: "ok",
+    data: [battingTag, mentalTag],
+  };
+
+  it("最新の月のノートだけを表示する", () => {
+    renderList(notes, tagsResult);
+
+    expect(screen.getByText("打撃の気づき")).toBeInTheDocument();
+    expect(screen.getByText("守備の気づき")).toBeInTheDocument();
+    expect(screen.queryByText("7月のノート")).not.toBeInTheDocument();
+    expect(screen.getByText("2026年8月（2件）")).toBeInTheDocument();
+  });
+
+  it("前の月へページ送りできる", () => {
+    renderList(notes, tagsResult);
+
+    fireEvent.click(screen.getByRole("button", { name: "前の月" }));
+
+    expect(screen.getByText("2026年7月（1件）")).toBeInTheDocument();
+    expect(screen.getByText("7月のノート")).toBeInTheDocument();
+    expect(screen.queryByText("打撃の気づき")).not.toBeInTheDocument();
+  });
+
+  it("キーワードでタイトル・本文を横断して絞り込む", () => {
+    renderList(notes, tagsResult);
+
+    fireEvent.change(screen.getByLabelText("ノートを検索"), {
+      target: { value: "一歩目" },
+    });
+
+    expect(screen.getByText("守備の気づき")).toBeInTheDocument();
+    expect(screen.queryByText("打撃の気づき")).not.toBeInTheDocument();
+  });
+
+  it("日付レンジで絞り込む（開始日・終了日を含む）", () => {
+    renderList(notes, tagsResult);
+
+    fireEvent.change(screen.getByLabelText("開始日"), {
+      target: { value: "2026-08-05" },
+    });
+    fireEvent.change(screen.getByLabelText("終了日"), {
+      target: { value: "2026-08-05" },
+    });
+
+    expect(screen.getByText("守備の気づき")).toBeInTheDocument();
+    expect(screen.queryByText("打撃の気づき")).not.toBeInTheDocument();
+    expect(screen.getByText("2026年8月（1件）")).toBeInTheDocument();
+  });
+
+  it("タグチップで絞り込む", () => {
+    renderList(notes, tagsResult);
+
+    fireEvent.click(screen.getByRole("button", { name: "#打撃" }));
+
+    expect(screen.getByText("打撃の気づき")).toBeInTheDocument();
+    expect(screen.queryByText("守備の気づき")).not.toBeInTheDocument();
+  });
+
+  it("絞り込みを変えると月のページが最新へ戻る", () => {
+    renderList(notes, tagsResult);
+    fireEvent.click(screen.getByRole("button", { name: "前の月" }));
+    expect(screen.getByText("2026年7月（1件）")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("ノートを検索"), {
+      target: { value: "気づき" },
+    });
+
+    expect(screen.getByText("2026年8月（2件）")).toBeInTheDocument();
+    expect(screen.getByText("打撃の気づき")).toBeInTheDocument();
+  });
+
+  it("条件に一致しない場合は未作成と区別したメッセージを出す", () => {
+    renderList(notes, tagsResult);
+
+    fireEvent.change(screen.getByLabelText("ノートを検索"), {
+      target: { value: "存在しない語" },
+    });
+
+    expect(
+      screen.getByText("条件に一致するノートがありません。"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("まだ野球ノートが作成されていません。"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("タグの取得に失敗した場合はタグチップを出さない", () => {
+    renderList(notes, { status: "error" });
+
+    expect(
+      screen.queryByRole("button", { name: "#打撃" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("ノートを検索")).toBeInTheDocument();
   });
 });

--- a/app/components/note/__tests__/NoteListComponent.test.tsx
+++ b/app/components/note/__tests__/NoteListComponent.test.tsx
@@ -198,17 +198,19 @@ describe("NoteListComponent の検索・絞り込み・月次ページング", (
     expect(screen.queryByText("守備の気づき")).not.toBeInTheDocument();
   });
 
-  it("絞り込みを変えると月のページが最新へ戻る", () => {
+  it("絞り込みを変えると、絞り込み後にも複数の月が残る場合でもページが最新へ戻る", () => {
     renderList(notes, tagsResult);
     fireEvent.click(screen.getByRole("button", { name: "前の月" }));
     expect(screen.getByText("2026年7月（1件）")).toBeInTheDocument();
 
+    // 絞り込み後も 8月・7月の2ヶ月が残る語を選び、古いページに留まらないことを見る。
     fireEvent.change(screen.getByLabelText("ノートを検索"), {
-      target: { value: "気づき" },
+      target: { value: "打撃" },
     });
 
-    expect(screen.getByText("2026年8月（2件）")).toBeInTheDocument();
+    expect(screen.getByText("2026年8月（1件）")).toBeInTheDocument();
     expect(screen.getByText("打撃の気づき")).toBeInTheDocument();
+    expect(screen.queryByText("7月のノート")).not.toBeInTheDocument();
   });
 
   it("条件に一致しない場合は未作成と区別したメッセージを出す", () => {

--- a/app/components/note/__tests__/NoteTagSection.test.tsx
+++ b/app/components/note/__tests__/NoteTagSection.test.tsx
@@ -1,0 +1,201 @@
+const mockHasEntitlement = jest.fn();
+const mockIsLoading = jest.fn(() => false);
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: () => ({
+    isPro: mockHasEntitlement("note_tags"),
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading: mockIsLoading(),
+    hasEntitlement: mockHasEntitlement,
+  }),
+}));
+
+jest.mock("@app/services/v2/noteTagService", () => ({
+  createNoteTag: jest.fn(),
+}));
+
+import type { NoteTag } from "@app/interface/baseballNoteV2";
+import type { FetchResult } from "@app/services/v2/requests";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createNoteTag } from "@app/services/v2/noteTagService";
+import NoteTagSection from "../NoteTagSection";
+
+const mockCreateNoteTag = createNoteTag as jest.MockedFunction<
+  typeof createNoteTag
+>;
+
+const tags: NoteTag[] = [
+  { id: 1, name: "打撃", is_preset: true },
+  { id: 2, name: "メンタル", is_preset: false },
+];
+
+function renderSection({
+  canEdit = true,
+  selectedIds = [] as number[],
+  onChange = jest.fn(),
+  tagsResult = { status: "ok", data: tags } as FetchResult<NoteTag[]>,
+} = {}) {
+  render(
+    <NoteTagSection
+      tagsResult={tagsResult}
+      selectedIds={selectedIds}
+      onChange={onChange}
+      canEdit={canEdit}
+    />,
+  );
+  return { onChange };
+}
+
+describe("NoteTagSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasEntitlement.mockReturnValue(true);
+    mockIsLoading.mockReturnValue(false);
+  });
+
+  it("タグ名は # 付きで表示する", () => {
+    renderSection();
+
+    expect(screen.getByRole("button", { name: "#打撃" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "#メンタル" }),
+    ).toBeInTheDocument();
+  });
+
+  it("未選択のチップを押すと選択に加わる", () => {
+    const { onChange } = renderSection({ selectedIds: [] });
+
+    fireEvent.click(screen.getByRole("button", { name: "#打撃" }));
+
+    expect(onChange).toHaveBeenCalledWith([1]);
+  });
+
+  it("選択中のチップを押すと選択から外れる", () => {
+    const { onChange } = renderSection({ selectedIds: [1, 2] });
+
+    fireEvent.click(screen.getByRole("button", { name: "#打撃" }));
+
+    expect(onChange).toHaveBeenCalledWith([2]);
+  });
+
+  it("選択中のチップは aria-pressed で分かる", () => {
+    renderSection({ selectedIds: [2] });
+
+    expect(screen.getByRole("button", { name: "#打撃" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "#メンタル" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("その場で作成したタグは保存名に # を含めず、選択に加わる", async () => {
+    mockCreateNoteTag.mockResolvedValue({
+      ok: true,
+      data: { id: 7, name: "走塁", is_preset: false },
+    });
+    const { onChange } = renderSection({ selectedIds: [1] });
+
+    fireEvent.change(screen.getByLabelText("新しいタグ"), {
+      target: { value: "#走塁" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "追加" }));
+
+    await waitFor(() =>
+      expect(mockCreateNoteTag).toHaveBeenCalledWith({ name: "走塁" }),
+    );
+    expect(onChange).toHaveBeenCalledWith([1, 7]);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "#走塁" })).toBeInTheDocument(),
+    );
+    expect(screen.getByLabelText("新しいタグ")).toHaveValue("");
+  });
+
+  it("作成に失敗しても入力は消えない", async () => {
+    mockCreateNoteTag.mockResolvedValue({
+      ok: false,
+      reason: "error",
+      errors: ["名前はすでに存在します"],
+    });
+    renderSection();
+
+    fireEvent.change(screen.getByLabelText("新しいタグ"), {
+      target: { value: "走塁" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "追加" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "名前はすでに存在します",
+      ),
+    );
+    expect(screen.getByLabelText("新しいタグ")).toHaveValue("走塁");
+  });
+
+  it("既にあるタグ名は作成せず選択に加えるだけ", async () => {
+    const { onChange } = renderSection({ selectedIds: [] });
+
+    fireEvent.change(screen.getByLabelText("新しいタグ"), {
+      target: { value: "打撃" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "追加" }));
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith([1]));
+    expect(mockCreateNoteTag).not.toHaveBeenCalled();
+  });
+
+  it("canEdit が false のときはチップを押しても選択が変わらない", () => {
+    const { onChange } = renderSection({ canEdit: false });
+
+    fireEvent.click(screen.getByRole("button", { name: "#打撃" }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("canEdit が false のときは新規作成も走らない", async () => {
+    renderSection({ canEdit: false });
+
+    fireEvent.change(screen.getByLabelText("新しいタグ"), {
+      target: { value: "走塁" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "追加" }));
+
+    await waitFor(() => expect(mockCreateNoteTag).not.toHaveBeenCalled());
+  });
+
+  it("note_tags を持たない無料ユーザーには Pro 訴求の暗幕を出す", () => {
+    mockHasEntitlement.mockReturnValue(false);
+    renderSection({ canEdit: false });
+
+    expect(screen.getByTestId("pro-upsell-scrim")).toBeInTheDocument();
+  });
+
+  it("note_tags を持つ Pro ユーザーには暗幕を出さない", () => {
+    mockHasEntitlement.mockReturnValue(true);
+    renderSection({ canEdit: true });
+
+    expect(screen.queryByTestId("pro-upsell-scrim")).not.toBeInTheDocument();
+  });
+
+  it("タグの取得に失敗したときは 0 件と区別してメッセージを出す", () => {
+    renderSection({ tagsResult: { status: "error" } });
+
+    expect(
+      screen.getByText(
+        "タグを取得できませんでした。メモはそのまま入力できます。",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("新しいタグ")).not.toBeInTheDocument();
+  });
+
+  it("タグが 0 件のときは作成を促す", () => {
+    renderSection({ tagsResult: { status: "ok", data: [] } });
+
+    expect(
+      screen.getByText("タグがまだありません。下の入力欄から作成できます。"),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/hooks/note/useNoteTagEditing.ts
+++ b/app/hooks/note/useNoteTagEditing.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+
+interface UseNoteTagEditingReturn {
+  /**
+   * タグを編集して送信してよいか。
+   * Pro 判定が未確定の間は false のままにする。未確定を「編集できる」と扱うと、
+   * 判定確定前に保存したノートへ `tag_ids` を送ってしまい、back 側で既存タグが消える。
+   */
+  canEditTags: boolean;
+  /** Pro 判定が未確定の間だけ true。 */
+  isLoading: boolean;
+}
+
+/** 野球ノートのタグ編集可否（`note_tags` entitlement）。 */
+export function useNoteTagEditing(): UseNoteTagEditingReturn {
+  const { hasEntitlement, isLoading } = useEntitlement();
+
+  return {
+    canEditTags: !isLoading && hasEntitlement("note_tags"),
+    isLoading,
+  };
+}

--- a/app/interface/baseballNoteV2.ts
+++ b/app/interface/baseballNoteV2.ts
@@ -7,7 +7,13 @@ export type MediaAttachmentStatus = "pending" | "ready" | "failed";
 export interface NoteTag {
   id: number;
   name: string;
+  /** 運営提供のプリセットタグ（全ユーザー共通）。false はそのユーザーの自作タグ。 */
   is_preset: boolean;
+}
+
+/** タグの作成パラメータ。`name` は `#` を含まない保存名で渡す（normalizeTagName を通すこと）。 */
+export interface NoteTagInput {
+  name: string;
 }
 
 /** 振り返りテンプレの問い→回答の1組。 */

--- a/app/services/v2/__tests__/noteTagService.test.ts
+++ b/app/services/v2/__tests__/noteTagService.test.ts
@@ -1,0 +1,114 @@
+const mockGet = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(() => Promise.resolve({ get: mockGet })),
+}));
+
+jest.mock("@app/constants/api", () => ({
+  RAILS_API_URL: "http://back:3000",
+}));
+
+jest.mock("../../../../lib/sentry-helpers", () => ({
+  captureServerActionError: jest.fn(),
+}));
+
+import { createNoteTag, getNoteTags } from "../noteTagService";
+
+function setupAuthCookies() {
+  mockGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: "test-uid" },
+    };
+    return values[key];
+  });
+}
+
+function mockResponse(status: number, body: unknown) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+function requestedUrl(): string {
+  return (global.fetch as jest.Mock).mock.calls[0][0] as string;
+}
+
+function requestedInit(): RequestInit {
+  return (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+}
+
+const presetTag = { id: 1, name: "打撃", is_preset: true };
+
+describe("ノートタグの v2 Server Actions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    setupAuthCookies();
+  });
+
+  describe("getNoteTags", () => {
+    it("GET /api/v2/note_tags を叩いて一覧を返す", async () => {
+      mockResponse(200, [presetTag]);
+
+      const result = await getNoteTags();
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/note_tags");
+      expect(requestedInit().method).toBeUndefined();
+      expect(result).toEqual({ status: "ok", data: [presetTag] });
+    });
+
+    it("0件は取得成功として空配列を返す", async () => {
+      mockResponse(200, []);
+
+      expect(await getNoteTags()).toEqual({ status: "ok", data: [] });
+    });
+
+    it("取得失敗は 0 件と区別して error を返す", async () => {
+      mockResponse(500, {});
+
+      expect(await getNoteTags()).toEqual({ status: "error" });
+    });
+  });
+
+  describe("createNoteTag", () => {
+    it("POST /api/v2/note_tags に note_tag でラップして送る", async () => {
+      mockResponse(201, { id: 5, name: "メンタル", is_preset: false });
+
+      const result = await createNoteTag({ name: "メンタル" });
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/note_tags");
+      expect(requestedInit().method).toBe("POST");
+      expect(JSON.parse(requestedInit().body as string)).toEqual({
+        note_tag: { name: "メンタル" },
+      });
+      expect(result).toEqual({
+        ok: true,
+        data: { id: 5, name: "メンタル", is_preset: false },
+      });
+    });
+
+    it("無料ユーザーの 403 は forbidden として理由を返す", async () => {
+      mockResponse(403, { error: "タグ機能は Pro プラン限定です" });
+
+      expect(await createNoteTag({ name: "メンタル" })).toEqual({
+        ok: false,
+        reason: "forbidden",
+        errors: ["タグ機能は Pro プラン限定です"],
+      });
+    });
+
+    it("同名の 422 はバリデーションエラーとして返す", async () => {
+      mockResponse(422, { errors: ["名前はすでに存在します"] });
+
+      expect(await createNoteTag({ name: "メンタル" })).toEqual({
+        ok: false,
+        reason: "error",
+        errors: ["名前はすでに存在します"],
+      });
+    });
+  });
+});

--- a/app/services/v2/noteTagService.ts
+++ b/app/services/v2/noteTagService.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import type { NoteTag, NoteTagInput } from "@app/interface/baseballNoteV2";
+import {
+  type FetchResult,
+  type MutationResult,
+  fetchV2,
+  mutateV2,
+} from "./requests";
+
+const BASE_PATH = "/api/v2/note_tags";
+
+/**
+ * ノートタグ一覧を取得する（GET /api/v2/note_tags）。
+ * 運営プリセットと自分の自作タグが混在して返る（`is_preset` で区別する）。
+ * 取得自体は無料ユーザーでも 200 で返り、付与だけが Pro 限定になる。
+ */
+export async function getNoteTags(): Promise<FetchResult<NoteTag[]>> {
+  return fetchV2<NoteTag[]>(BASE_PATH, "getNoteTags");
+}
+
+/**
+ * 自作タグを新規作成する（POST /api/v2/note_tags）。
+ * 無料ユーザーは 403（reason:"forbidden"）、同名が既にある場合は 422 が返る。
+ */
+export async function createNoteTag(
+  input: NoteTagInput,
+): Promise<MutationResult<NoteTag>> {
+  return mutateV2<NoteTag>(BASE_PATH, {
+    method: "POST",
+    body: { note_tag: input },
+    action: "createNoteTag",
+    fallbackMessage: "タグの作成に失敗しました",
+  });
+}

--- a/app/utils/__tests__/noteListFilter.test.ts
+++ b/app/utils/__tests__/noteListFilter.test.ts
@@ -1,0 +1,205 @@
+import type { BaseballNoteV2, NoteTag } from "@app/interface/baseballNoteV2";
+import {
+  EMPTY_NOTE_FILTERS,
+  collectNoteMonths,
+  filterNotes,
+  formatMonthLabel,
+  hasActiveNoteFilter,
+  notesInMonth,
+} from "@app/utils/noteListFilter";
+import { buildMemoJson } from "@app/utils/noteMemo";
+
+const battingTag: NoteTag = { id: 1, name: "打撃", is_preset: true };
+const mentalTag: NoteTag = { id: 2, name: "メンタル", is_preset: false };
+
+function buildNote(overrides: Partial<BaseballNoteV2> = {}): BaseballNoteV2 {
+  return {
+    id: 1,
+    title: "気づき",
+    date: "2026-08-10",
+    memo: buildMemoJson("外角が詰まる"),
+    memo_preview: "外角が詰まる",
+    game_result_ids: [],
+    practice_log_id: null,
+    practice_session_id: null,
+    improvement_theme_ids: [],
+    reflection_template_id: null,
+    reflection_answers: [],
+    tags: [],
+    media_attachments: [],
+    ...overrides,
+  };
+}
+
+describe("hasActiveNoteFilter", () => {
+  it("何も絞り込んでいなければ false", () => {
+    expect(hasActiveNoteFilter(EMPTY_NOTE_FILTERS)).toBe(false);
+  });
+
+  it("空白だけのキーワードは絞り込みとみなさない", () => {
+    expect(hasActiveNoteFilter({ ...EMPTY_NOTE_FILTERS, keyword: "   " })).toBe(
+      false,
+    );
+  });
+
+  it.each([
+    ["キーワード", { keyword: "外角" }],
+    ["開始日", { startDate: "2026-08-01" }],
+    ["終了日", { endDate: "2026-08-31" }],
+    ["タグ", { tagIds: [1] }],
+  ])("%s が入っていれば true", (_label, values) => {
+    expect(hasActiveNoteFilter({ ...EMPTY_NOTE_FILTERS, ...values })).toBe(
+      true,
+    );
+  });
+});
+
+describe("filterNotes（検索）", () => {
+  const notes = [
+    buildNote({
+      id: 1,
+      title: "打撃の気づき",
+      memo: buildMemoJson("体の開き"),
+    }),
+    buildNote({ id: 2, title: "守備", memo: buildMemoJson("一歩目が遅い") }),
+    buildNote({ id: 3, title: "メモなし", memo: null, tags: [mentalTag] }),
+  ];
+
+  it("タイトルを横断して検索する", () => {
+    const result = filterNotes(notes, {
+      ...EMPTY_NOTE_FILTERS,
+      keyword: "守備",
+    });
+
+    expect(result.map((note) => note.id)).toEqual([2]);
+  });
+
+  it("本文を横断して検索する", () => {
+    const result = filterNotes(notes, {
+      ...EMPTY_NOTE_FILTERS,
+      keyword: "一歩目",
+    });
+
+    expect(result.map((note) => note.id)).toEqual([2]);
+  });
+
+  it("タグ名を横断して検索する（# 付きでも引ける）", () => {
+    expect(
+      filterNotes(notes, { ...EMPTY_NOTE_FILTERS, keyword: "メンタル" }).map(
+        (note) => note.id,
+      ),
+    ).toEqual([3]);
+    expect(
+      filterNotes(notes, { ...EMPTY_NOTE_FILTERS, keyword: "#メンタル" }).map(
+        (note) => note.id,
+      ),
+    ).toEqual([3]);
+  });
+
+  it("memo_preview に載らない本文後半も検索できる", () => {
+    const longNote = buildNote({
+      id: 9,
+      title: "長文",
+      memo: buildMemoJson(`${"あ".repeat(200)}最後の一行`),
+      memo_preview: "あ".repeat(120),
+    });
+
+    expect(
+      filterNotes([longNote], {
+        ...EMPTY_NOTE_FILTERS,
+        keyword: "最後の一行",
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("一致しなければ空配列（0件）を返す", () => {
+    expect(
+      filterNotes(notes, { ...EMPTY_NOTE_FILTERS, keyword: "存在しない語" }),
+    ).toEqual([]);
+  });
+});
+
+describe("filterNotes（日付レンジ）", () => {
+  const notes = [
+    buildNote({ id: 1, date: "2026-07-31" }),
+    buildNote({ id: 2, date: "2026-08-01" }),
+    buildNote({ id: 3, date: "2026-08-31" }),
+    buildNote({ id: 4, date: "2026-09-01" }),
+  ];
+
+  it("開始日はその日を含む", () => {
+    const result = filterNotes(notes, {
+      ...EMPTY_NOTE_FILTERS,
+      startDate: "2026-08-01",
+    });
+
+    expect(result.map((note) => note.id)).toEqual([2, 3, 4]);
+  });
+
+  it("終了日はその日を含む", () => {
+    const result = filterNotes(notes, {
+      ...EMPTY_NOTE_FILTERS,
+      endDate: "2026-08-31",
+    });
+
+    expect(result.map((note) => note.id)).toEqual([1, 2, 3]);
+  });
+
+  it("開始日と終了日の両端を含んで絞り込む", () => {
+    const result = filterNotes(notes, {
+      ...EMPTY_NOTE_FILTERS,
+      startDate: "2026-08-01",
+      endDate: "2026-08-31",
+    });
+
+    expect(result.map((note) => note.id)).toEqual([2, 3]);
+  });
+});
+
+describe("filterNotes（タグ）", () => {
+  const notes = [
+    buildNote({ id: 1, tags: [battingTag] }),
+    buildNote({ id: 2, tags: [battingTag, mentalTag] }),
+    buildNote({ id: 3, tags: [] }),
+  ];
+
+  it("1つ選ぶとそのタグを持つノートに絞られる", () => {
+    const result = filterNotes(notes, {
+      ...EMPTY_NOTE_FILTERS,
+      tagIds: [battingTag.id],
+    });
+
+    expect(result.map((note) => note.id)).toEqual([1, 2]);
+  });
+
+  it("複数選ぶと全て持つノートだけに絞られる（AND）", () => {
+    const result = filterNotes(notes, {
+      ...EMPTY_NOTE_FILTERS,
+      tagIds: [battingTag.id, mentalTag.id],
+    });
+
+    expect(result.map((note) => note.id)).toEqual([2]);
+  });
+});
+
+describe("月次ページングの補助", () => {
+  const notes = [
+    buildNote({ id: 1, date: "2026-08-10" }),
+    buildNote({ id: 2, date: "2026-06-02" }),
+    buildNote({ id: 3, date: "2026-08-01" }),
+  ];
+
+  it("ノートのある年月を新しい順に重複なく並べる", () => {
+    expect(collectNoteMonths(notes)).toEqual(["2026-08", "2026-06"]);
+  });
+
+  it("指定した年月のノートだけを取り出す", () => {
+    expect(notesInMonth(notes, "2026-08").map((note) => note.id)).toEqual([
+      1, 3,
+    ]);
+  });
+
+  it("年月を日本語表記にする", () => {
+    expect(formatMonthLabel("2026-08")).toBe("2026年8月");
+  });
+});

--- a/app/utils/__tests__/noteTags.test.ts
+++ b/app/utils/__tests__/noteTags.test.ts
@@ -1,0 +1,128 @@
+import {
+  buildTagIdsPayload,
+  buildTagIdsUpdate,
+  normalizeTagName,
+  selectedTags,
+  tagLabel,
+} from "@app/utils/noteTags";
+
+describe("tagLabel", () => {
+  it("表示名には # を付ける", () => {
+    expect(tagLabel("打撃")).toBe("#打撃");
+  });
+
+  it("既に # が付いた名前でも ## にしない", () => {
+    expect(tagLabel("#打撃")).toBe("#打撃");
+  });
+});
+
+describe("normalizeTagName", () => {
+  it("保存名には # を含めない", () => {
+    expect(normalizeTagName("#打撃")).toBe("打撃");
+  });
+
+  it("複数の # と前後の空白を落とす", () => {
+    expect(normalizeTagName("  ##  打撃  ")).toBe("打撃");
+  });
+
+  it("名前の途中の # は残す", () => {
+    expect(normalizeTagName("打撃#メモ")).toBe("打撃#メモ");
+  });
+
+  it("# だけの入力は空になる", () => {
+    expect(normalizeTagName("###")).toBe("");
+  });
+});
+
+describe("selectedTags", () => {
+  const tags = [
+    { id: 1, name: "打撃", is_preset: true },
+    { id: 2, name: "守備", is_preset: true },
+  ];
+
+  it("選択された ID のタグだけを表示順のまま返す", () => {
+    expect(selectedTags(tags, [2])).toEqual([tags[1]]);
+  });
+});
+
+describe("buildTagIdsPayload（作成時）", () => {
+  it("編集できない（無料 / 判定未確定）ときは値があっても tag_ids キーを生やさない", () => {
+    const payload = buildTagIdsPayload({ canEditTags: false, tagIds: [1, 2] });
+
+    expect(payload).toEqual({});
+    expect("tag_ids" in payload).toBe(false);
+  });
+
+  it("編集できるときは選択したタグを送る", () => {
+    expect(buildTagIdsPayload({ canEditTags: true, tagIds: [1, 2] })).toEqual({
+      tag_ids: [1, 2],
+    });
+  });
+
+  it("編集できるなら未選択でも空配列を送る", () => {
+    const payload = buildTagIdsPayload({ canEditTags: true, tagIds: [] });
+
+    expect(payload).toEqual({ tag_ids: [] });
+    expect("tag_ids" in payload).toBe(true);
+  });
+
+  it("重複した ID は 1 つにまとめる", () => {
+    expect(
+      buildTagIdsPayload({ canEditTags: true, tagIds: [1, 1, 2] }),
+    ).toEqual({ tag_ids: [1, 2] });
+  });
+});
+
+describe("buildTagIdsUpdate（更新時）", () => {
+  it("編集できないときは選択が変わっていても tag_ids キーを生やさない", () => {
+    const payload = buildTagIdsUpdate({
+      canEditTags: false,
+      initialTagIds: [1],
+      tagIds: [1, 2],
+    });
+
+    expect(payload).toEqual({});
+    expect("tag_ids" in payload).toBe(false);
+  });
+
+  it("編集できないときは全解除の操作をしても tag_ids キーを生やさない", () => {
+    expect(
+      buildTagIdsUpdate({
+        canEditTags: false,
+        initialTagIds: [1, 2],
+        tagIds: [],
+      }),
+    ).toEqual({});
+  });
+
+  it("選択が変わっていなければキーを生やさない", () => {
+    expect(
+      buildTagIdsUpdate({
+        canEditTags: true,
+        initialTagIds: [1, 2],
+        tagIds: [2, 1],
+      }),
+    ).toEqual({});
+  });
+
+  it("選択を変えたら新しい ID を送る", () => {
+    expect(
+      buildTagIdsUpdate({
+        canEditTags: true,
+        initialTagIds: [1],
+        tagIds: [3],
+      }),
+    ).toEqual({ tag_ids: [3] });
+  });
+
+  it("全解除は空配列を明示して送る", () => {
+    const payload = buildTagIdsUpdate({
+      canEditTags: true,
+      initialTagIds: [1, 2],
+      tagIds: [],
+    });
+
+    expect(payload).toEqual({ tag_ids: [] });
+    expect("tag_ids" in payload).toBe(true);
+  });
+});

--- a/app/utils/noteListFilter.ts
+++ b/app/utils/noteListFilter.ts
@@ -1,0 +1,98 @@
+import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
+import { extractMemoText } from "@app/utils/noteMemo";
+import { tagLabel } from "@app/utils/noteTags";
+
+// back の GET /api/v2/baseball_notes は date / practice_log_id / practice_session_id /
+// game_result_id / improvement_theme_id しか絞り込めず、全文検索・日付レンジ・タグ絞り込み・
+// ページングのパラメータを持たない。そのため一覧側の検索と絞り込みは取得済みの
+// レスポンスに対してクライアントで行う。
+
+/** ノート一覧の絞り込み条件。すべて「空」が絞り込まないことを表す。 */
+export interface NoteListFilterValues {
+  /** タイトル / 本文 / タグを横断するフリーワード。 */
+  keyword: string;
+  /** 期間の開始日 `YYYY-MM-DD`。この日を含む。 */
+  startDate: string;
+  /** 期間の終了日 `YYYY-MM-DD`。この日を含む。 */
+  endDate: string;
+  /** 選択したタグ ID。複数選ぶと「すべて持つノート」に絞られる（AND）。 */
+  tagIds: number[];
+}
+
+export const EMPTY_NOTE_FILTERS: NoteListFilterValues = {
+  keyword: "",
+  startDate: "",
+  endDate: "",
+  tagIds: [],
+};
+
+/** 絞り込みが1つでも掛かっているか（クリアボタンの表示判定に使う）。 */
+export function hasActiveNoteFilter(values: NoteListFilterValues): boolean {
+  return (
+    values.keyword.trim() !== "" ||
+    values.startDate !== "" ||
+    values.endDate !== "" ||
+    values.tagIds.length > 0
+  );
+}
+
+/** `YYYY-MM-DD` 部分だけを取り出す（back が時刻付きで返した場合も比較できるようにする）。 */
+function noteDay(note: BaseballNoteV2): string {
+  return note.date.slice(0, 10);
+}
+
+/**
+ * 検索対象のテキスト。本文は memo_preview（120文字で切り詰め済み）ではなく
+ * memo 全文から抽出し、プレビューに載らない後半も検索できるようにする。
+ * タグは `#` 付きでも打てるよう両方の表記を含める。
+ */
+function searchHaystack(note: BaseballNoteV2): string {
+  const memoText = extractMemoText(note.memo) || note.memo_preview;
+  const tagTexts = note.tags.flatMap((tag) => [tag.name, tagLabel(tag.name)]);
+  return [note.title ?? "", memoText, ...tagTexts].join("\n").toLowerCase();
+}
+
+/**
+ * 検索・日付レンジ・タグで絞り込む。
+ *
+ * 日付レンジは開始日・終了日ともに **その日を含む**。
+ * タグは選択したものを **すべて** 持つノートだけを残す（AND）。
+ */
+export function filterNotes(
+  notes: BaseballNoteV2[],
+  values: NoteListFilterValues,
+): BaseballNoteV2[] {
+  const keyword = values.keyword.trim().toLowerCase();
+
+  return notes.filter((note) => {
+    if (keyword !== "" && !searchHaystack(note).includes(keyword)) return false;
+    const day = noteDay(note);
+    if (values.startDate !== "" && day < values.startDate) return false;
+    if (values.endDate !== "" && day > values.endDate) return false;
+    if (values.tagIds.length > 0) {
+      const noteTagIds = note.tags.map((tag) => tag.id);
+      if (!values.tagIds.every((id) => noteTagIds.includes(id))) return false;
+    }
+    return true;
+  });
+}
+
+/** ノートが存在する年月（`YYYY-MM`）を新しい順に重複なく並べる。 */
+export function collectNoteMonths(notes: BaseballNoteV2[]): string[] {
+  const months = new Set(notes.map((note) => noteDay(note).slice(0, 7)));
+  return Array.from(months).sort((a, b) => (a < b ? 1 : -1));
+}
+
+/** 指定した年月（`YYYY-MM`）のノートだけを取り出す。 */
+export function notesInMonth(
+  notes: BaseballNoteV2[],
+  month: string,
+): BaseballNoteV2[] {
+  return notes.filter((note) => noteDay(note).startsWith(month));
+}
+
+/** `YYYY-MM` を「2026年8月」形式にする。 */
+export function formatMonthLabel(month: string): string {
+  const [year, monthNumber] = month.split("-");
+  return `${Number(year)}年${Number(monthNumber)}月`;
+}

--- a/app/utils/noteTags.ts
+++ b/app/utils/noteTags.ts
@@ -1,0 +1,86 @@
+import type { BaseballNoteInput, NoteTag } from "@app/interface/baseballNoteV2";
+
+/**
+ * 表示用のタグ名。保存名には `#` を含めないため、表示のたびにここで付ける。
+ * 既に `#` が付いた名前を渡されても `##` にならないよう先頭の `#` は落とす。
+ */
+export function tagLabel(name: string): string {
+  return `#${stripHashPrefix(name)}`;
+}
+
+/**
+ * 入力されたタグ名を保存名へ正規化する。
+ * ユーザーが表示に合わせて `#` を打っても保存名には残さない（`#打撃` と `打撃` が
+ * 別タグとして増えるのを防ぐ）。
+ */
+export function normalizeTagName(input: string): string {
+  return stripHashPrefix(input.trim()).trim();
+}
+
+function stripHashPrefix(value: string): string {
+  return value.replace(/^#+/, "");
+}
+
+/** 選択済み ID の集合から、表示順を保ったタグを取り出す。 */
+export function selectedTags(tags: NoteTag[], ids: number[]): NoteTag[] {
+  return tags.filter((tag) => ids.includes(tag.id));
+}
+
+interface TagPayloadParams {
+  /**
+   * タグを編集できるか。`note_tags` entitlement を持ち、かつ Pro 判定が確定している場合だけ true。
+   * 判定中（未確定）に true を返してはならない。
+   */
+  canEditTags: boolean;
+  tagIds: number[];
+}
+
+/**
+ * 作成時に送る `tag_ids` を組み立てる。
+ *
+ * 無料ユーザー・Pro 判定が未確定のときは **キー自体を生やさない**。
+ * back はタグ付与を Pro 限定として扱い、`tag_ids` が届くと Pro 判定に入る。
+ * 空配列であっても送ってしまうと「タグを全解除する」意思表示になるため、
+ * `undefined` を入れるのではなくキーごと落とす。
+ */
+export function buildTagIdsPayload({
+  canEditTags,
+  tagIds,
+}: TagPayloadParams): Pick<BaseballNoteInput, "tag_ids"> {
+  if (!canEditTags) return {};
+  return { tag_ids: dedupe(tagIds) };
+}
+
+interface TagUpdateParams extends TagPayloadParams {
+  /** 更新前にノートへ付いていたタグ ID。 */
+  initialTagIds: number[];
+}
+
+/**
+ * 更新時に送る `tag_ids` を組み立てる。
+ *
+ * 編集していない・編集できないときはキーを生やさない（back は未送信を「変更なし」として扱う）。
+ * 全解除は `[]` を明示して送る。ここで `undefined` に丸めると解除が反映されない。
+ */
+export function buildTagIdsUpdate({
+  canEditTags,
+  initialTagIds,
+  tagIds,
+}: TagUpdateParams): Pick<BaseballNoteInput, "tag_ids"> {
+  if (!canEditTags) return {};
+  const next = dedupe(tagIds);
+  if (isSameIdSet(next, dedupe(initialTagIds))) return {};
+  return { tag_ids: next };
+}
+
+function dedupe(ids: number[]): number[] {
+  return Array.from(new Set(ids));
+}
+
+/** 並び順は保存時に意味を持たないため、集合として比較する。 */
+function isSameIdSet(a: number[], b: number[]): boolean {
+  if (a.length !== b.length) return false;
+  const left = [...a].sort((x, y) => x - y);
+  const right = [...b].sort((x, y) => x - y);
+  return left.every((value, index) => value === right[index]);
+}


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#476

## ⚠️ issue の前提が現状のコードと異なっていました

issue は「**mobile のノート一覧はタイトル・本文・タグ横断検索、日付レンジ、タグチップ絞り込み、月次ページングを備える**」としていますが、実際に確認したところ:

- **back の v2 ノート一覧に検索・日付レンジ・タグ絞り込み・ページングのパラメータは存在しません。** `FILTERABLE_COLUMNS = %i[date practice_log_id practice_session_id]`（完全一致）と `game_result_id` / `improvement_theme_id` のみで、並びは固定、`page` / `per_page` もありません。全文検索用の scope もモデルに無く、spec にも該当ケースが1件もありません
- **mobile にもこれらの機能はありません。** `app/(tabs)/(profile)/notes/index.tsx` は素の `FlatList` で、`getNotes` の params も back と同じ範囲です

そのため**フロントのクライアント側で実装**しました。詳細は下記「確認いただきたい点」を参照してください。

## ⚠️ 「無料では `tag_ids` を送らない」の実装

back の `valid_note_tags?` は**既存件数を見ない**ため、`game_result_ids` / `improvement_theme_ids` と違い**グランドファザリングがありません**。無料ユーザーが `tag_ids` を送ると即 403、または既存タグの全消しになります。

3段構えで防いでいます（UI を隠すだけにしていません）:

1. `useNoteTagEditing` — `canEditTags = !isLoading && hasEntitlement("note_tags")`。**Pro 判定未確定の間は必ず false**
2. `app/utils/noteTags.ts` — **送信ペイロード組み立ての時点で落とす**。`buildTagIdsPayload` / `buildTagIdsUpdate` が `{}`（キーごと無し）を返すため、`undefined` を経由せずキー自体が生えません。全解除は `{tag_ids: []}` を明示
3. `NoteTagSection` 側でも `canEdit` false でトグル・作成をガード（多重防御）

**`NoteFormTagPayload.test.tsx` ではタグ UI をスタブに差し替えて UI ガードを迂回し、それでもフォームが `tag_ids` を送らないことを固定しています。**

## タグの `#` の扱い（mobile 準拠）

表示は `#` 付き、**保存名には含めません**。ユーザーが `#` を入力しても `normalizeTagName` で除去します。同名が既にあれば作成せず選択に加えるだけ。作成失敗時は**入力をそのまま残します**。

## 既存フィルタ UI との関係

`app/components/filter/` に**部分的にのみ乗りました**。`FilterChipGroup`（チップ配置）は再利用していますが、`FilterBar` / `FilterValues` には乗れませんでした。

- `FilterValues` は固定キー（`year` / `matchType` / `seasonId` 等）で、フリーワード・**日単位**の開始/終了日・**複数選択**タグを表現できない
- `FilterChip` は HeroUI Dropdown の**単一選択**。タグはトグル複数選択が要件
- 日付レンジが**月粒度**（`monthOptionsFromRecorded` は `"YYYY-MM"`）。ノートは日単位の記録
- `FilterBar` は「年度と月レンジは排他」という成績画面固有ルールを内包

これらを `FilterValues` に足すと `FilterBar` を使う既存3画面（成績 / 試合一覧 / グループ詳細）に不要なチップと挙動が波及します。**「2種類のフィルタ UI」ではなく「共通プリミティブ上の2つのバー」**という位置づけです。方針の是非をご確認ください。

## 確認いただきたい点

1. **検索・日付レンジ・タグ絞り込み・月次ページングをクライアント側で実装しています（最重要）。** back に該当 API が無いためです。**ノート件数が増えると全件取得のコストが効いてきます。** 別途 back issue を起票しますので、サーバ側実装後に移行する想定です（front は `buildNotesQuery` に足すだけで移行できる形にしてあります）
2. **タグ絞り込みを AND（選択したタグを「すべて」持つ）にしました。** OR にする選択肢もあります。`filterNotes` の1箇所（`every`）で切り替え可能です
3. **月次ページングは「ノートが存在する月」だけを送ります**（記録の無い月を空ページとして挟まない）。カレンダー月を順に送る仕様が期待ならご指摘ください
4. **検索の本文は `memo_preview`（120文字切り詰め）ではなく `memo` 全文から抽出**しています。プレビューに載らない後半もヒットさせるためですが、Slate JSON のパースコストが件数分かかります
5. `NoteListItem` の紐付けチップの文言（「試合 2件」「課題 1件」等）は仮置きです

## チェックリスト

- [x] `yarn typecheck` / `yarn lint` / `yarn format:check` が通る
- [x] `yarn test` が通る（**132 suites / 1474 tests**）
- [x] `yarn build` が通る（**ローカルで実行済み**）
- [x] ミューテーションテスト **25 設計 / 25 KILLED / 0 SURVIVED**

### ルート表

**静的 87 / 動的 45** で、base（`e684b31`）を同一条件で実ビルドした結果と**完全一致**（追加・削除・分類変更すべてゼロ）。新規ルートはありません。

<details>
<summary>ミューテーションテスト詳細</summary>

隔離複製で実施（無改変で全 pass を確認後に実行、検証後に削除）。

無料でも `tag_ids` を送る4件 / Pro 判定未確定でも送る / `[]` を未送信扱い2件 / `#` の付け外し2件 / 日付レンジ境界2件 / タグ AND/OR 取り違え / 検索対象の改変2件 / フィルタ変更で月ページをリセットしない / 0件と取得失敗の取り違え2件 / オーバーレイ表示条件の反転 / API パス・メソッド・ボディ形状3件 / 作成失敗で入力が消える / 月送り方向・並び2件 / 同名タグの再作成。

**初回に2件が SURVIVED**（編集フォームが entitlement を無視 / 月ページのリセット）。前者は `NoteTagSection` のガードが冗長に効いて素通ししていたため**タグ UI をスタブ化してフォームの組み立てだけを検証するテストを追加**、後者は月インデックスの clamp が結果を覆い隠していたため**絞り込み後にも2ヶ月が残るケースに書き換え**て kill しました。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_