### PR TITLE
Add: 目標機能一式（設定・進捗・達成管理）を実装

### DIFF
--- a/app/(app)/goals/__tests__/GoalsContent.test.tsx
+++ b/app/(app)/goals/__tests__/GoalsContent.test.tsx
@@ -621,6 +621,39 @@ describe("GoalsContent", () => {
       expect(screen.getByLabelText(/期限/)).toBeInTheDocument();
     });
 
+    it("数値目標の達成条件は指標に応じて表示する", async () => {
+      const user = userEvent.setup();
+      renderContent();
+
+      await openCreateForm(user);
+      expect(screen.getByText("条件: 以上")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "防御率" }));
+      expect(screen.getByText("条件: 以下")).toBeInTheDocument();
+    });
+
+    it("自由指標で「以下」を選ぶと less_than を送る", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ features: ["manual_metric_goals"] });
+      mockCreate.mockResolvedValue({ ok: true, data: buildGoal({ id: 9 }) });
+      renderContent();
+
+      await openCreateForm(user);
+      await user.click(screen.getByRole("button", { name: "自由指標" }));
+      await user.type(screen.getByLabelText(/指標名/), "体重");
+      await user.click(screen.getByRole("button", { name: "以下" }));
+      await user.type(screen.getByLabelText(/目標値/), "70");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+      expect(mockCreate.mock.calls[0][0]).toMatchObject({
+        kind: "manual",
+        custom_metric_label: "体重",
+        target_value: 70,
+        comparison_type: "less_than",
+      });
+    });
+
     it("必須項目が未入力なら送信せずエラーを出す", async () => {
       const user = userEvent.setup();
       renderContent();

--- a/app/(app)/goals/__tests__/GoalsContent.test.tsx
+++ b/app/(app)/goals/__tests__/GoalsContent.test.tsx
@@ -1,0 +1,947 @@
+const mockOpenProUpgradeModal = jest.fn();
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({
+    open: mockOpenProUpgradeModal,
+    close: jest.fn(),
+  }),
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+jest.mock("@app/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@app/services/v2/goalService", () => ({
+  createGoal: jest.fn(),
+  updateGoal: jest.fn(),
+  deleteGoal: jest.fn(),
+  achieveGoal: jest.fn(),
+  unachieveGoal: jest.fn(),
+}));
+
+import type { Goal } from "@app/types/goal";
+import type { Feature } from "@app/types/pro";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import {
+  achieveGoal,
+  createGoal,
+  deleteGoal,
+  unachieveGoal,
+  updateGoal,
+} from "@app/services/v2/goalService";
+import GoalsContent from "../_components/GoalsContent";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+const mockCreate = createGoal as jest.MockedFunction<typeof createGoal>;
+const mockUpdate = updateGoal as jest.MockedFunction<typeof updateGoal>;
+const mockDelete = deleteGoal as jest.MockedFunction<typeof deleteGoal>;
+const mockAchieve = achieveGoal as jest.MockedFunction<typeof achieveGoal>;
+const mockUnachieve = unachieveGoal as jest.MockedFunction<
+  typeof unachieveGoal
+>;
+
+const TODAY = "2026-08-03";
+
+function buildGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: 1,
+    title: "月20日練習",
+    kind: "numeric",
+    period_type: "monthly",
+    season_id: null,
+    tournament_id: null,
+    month_start: "2026-08-01",
+    deadline: "2026-08-31",
+    metric_key: "practice_days",
+    target_value: 20,
+    comparison_type: "greater_than",
+    practice_menu_id: null,
+    practice_menu_name: null,
+    custom_metric_label: null,
+    custom_unit: null,
+    manual_current_value: 0,
+    is_achieved: false,
+    is_finalized: false,
+    achieved_value: null,
+    current_value: 5,
+    progress_percent: 25,
+    days_remaining: 28,
+    ...overrides,
+  };
+}
+
+function mockEntitlement({
+  features = [] as Feature[],
+  isLoading = false,
+}: { features?: Feature[]; isLoading?: boolean } = {}) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: features.length > 0,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading,
+    hasEntitlement: jest.fn((feature: Feature) => features.includes(feature)),
+  });
+}
+
+function renderContent(
+  props: Partial<Parameters<typeof GoalsContent>[0]> = {},
+) {
+  return render(
+    <GoalsContent
+      initialGoals={[]}
+      initialHistory={[]}
+      historyLoadFailed={false}
+      seasons={[{ id: 11, name: "2026年" }]}
+      tournaments={[{ id: 21, name: "夏の大会" }]}
+      menus={[
+        {
+          id: 31,
+          name: "素振り",
+          category: "batting",
+          unit: "count",
+          unit_label: "本",
+          default_value: "200.0",
+          is_favorite: false,
+          sort_order: 1,
+        },
+      ]}
+      today={TODAY}
+      {...props}
+    />,
+  );
+}
+
+async function openCreateForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "新しい目標を追加" }));
+}
+
+async function openEditForm(
+  user: ReturnType<typeof userEvent.setup>,
+  title: string,
+) {
+  await user.click(screen.getByRole("button", { name: `${title}の詳細` }));
+  await user.click(screen.getByRole("button", { name: "編集" }));
+  return screen.findByRole("dialog", { name: "目標を編集" });
+}
+
+describe("GoalsContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEntitlement();
+  });
+
+  describe("3タブの分類", () => {
+    const activeGoals = [
+      buildGoal({ id: 1, title: "進行中の目標" }),
+      buildGoal({
+        id: 2,
+        title: "手動達成した目標",
+        kind: "qualitative",
+        is_achieved: true,
+      }),
+    ];
+    const historyGoals = [
+      buildGoal({
+        id: 3,
+        title: "達成して確定した目標",
+        is_finalized: true,
+        is_achieved: true,
+      }),
+      buildGoal({ id: 4, title: "未達で確定した目標", is_finalized: true }),
+    ];
+
+    it("進行中タブには未達成・未確定の目標だけを出す", () => {
+      renderContent({
+        initialGoals: activeGoals,
+        initialHistory: historyGoals,
+      });
+
+      expect(screen.getByText("進行中の目標")).toBeVisible();
+      expect(screen.queryByText("手動達成した目標")).toBeNull();
+      expect(screen.queryByText("未達で確定した目標")).toBeNull();
+    });
+
+    it("達成タブには確定前に手動達成したものも含める", async () => {
+      const user = userEvent.setup();
+      renderContent({
+        initialGoals: activeGoals,
+        initialHistory: historyGoals,
+      });
+
+      await user.click(screen.getByRole("tab", { name: /達成/ }));
+
+      expect(screen.getByText("手動達成した目標")).toBeVisible();
+      expect(screen.getByText("達成して確定した目標")).toBeVisible();
+      expect(screen.queryByText("未達で確定した目標")).toBeNull();
+    });
+
+    it("未達タブには未達成のまま確定したものだけを出す", async () => {
+      const user = userEvent.setup();
+      renderContent({
+        initialGoals: activeGoals,
+        initialHistory: historyGoals,
+      });
+
+      await user.click(screen.getByRole("tab", { name: /未達/ }));
+
+      expect(screen.getByText("未達で確定した目標")).toBeVisible();
+      expect(screen.queryByText("進行中の目標")).toBeNull();
+      expect(screen.queryByText("達成して確定した目標")).toBeNull();
+    });
+
+    it("タブの件数バッジが分類と一致する", () => {
+      renderContent({
+        initialGoals: activeGoals,
+        initialHistory: historyGoals,
+      });
+
+      expect(screen.getByRole("tab", { name: "進行中 1" })).toBeVisible();
+      expect(screen.getByRole("tab", { name: "達成 2" })).toBeVisible();
+      expect(screen.getByRole("tab", { name: "未達 1" })).toBeVisible();
+    });
+
+    it("期間タイプごとに見出しを付けて並べる", () => {
+      renderContent({
+        initialGoals: [
+          buildGoal({ id: 1, title: "月次の目標", period_type: "monthly" }),
+          buildGoal({ id: 2, title: "週次の目標", period_type: "weekly" }),
+        ],
+      });
+
+      const weekly = screen.getByRole("region", { name: "週次" });
+      expect(within(weekly).getByText("週次の目標")).toBeVisible();
+      const monthly = screen.getByRole("region", { name: "月次" });
+      expect(within(monthly).getByText("月次の目標")).toBeVisible();
+    });
+  });
+
+  describe("進捗バー", () => {
+    it("back の進捗率をバーの幅として反映する", () => {
+      renderContent({
+        initialGoals: [buildGoal({ progress_percent: 42.5 })],
+      });
+
+      const bar = screen.getByRole("progressbar", { name: "月20日練習の進捗" });
+      expect(bar).toHaveAttribute("aria-valuenow", "42.5");
+      expect(bar.firstChild).toHaveStyle({ width: "42.5%" });
+      expect(screen.getByText("43%")).toBeVisible();
+    });
+
+    it("進捗率が 100 を超えてもバーは 100% で止める", () => {
+      renderContent({
+        initialGoals: [buildGoal({ progress_percent: 150 })],
+      });
+
+      const bar = screen.getByRole("progressbar", { name: "月20日練習の進捗" });
+      expect(bar.firstChild).toHaveStyle({ width: "100%" });
+    });
+
+    it("現在値と目標値をこの順で表示する", () => {
+      renderContent({
+        initialGoals: [buildGoal({ current_value: 5, target_value: 20 })],
+      });
+
+      const card = screen.getByRole("button", { name: "月20日練習の詳細" });
+      expect(card.textContent).toContain("現在5→目標20");
+    });
+
+    it("以下条件の指標は目標値に「以下」を添える", () => {
+      renderContent({
+        initialGoals: [
+          buildGoal({
+            metric_key: "era",
+            comparison_type: "less_than",
+            current_value: 3.2,
+            target_value: 2.5,
+          }),
+        ],
+      });
+
+      expect(screen.getByText("2.50 以下")).toBeVisible();
+      expect(screen.getByText("3.20")).toBeVisible();
+    });
+
+    it("back が数値を文字列で返しても整形して表示する", () => {
+      renderContent({
+        initialGoals: [
+          buildGoal({
+            metric_key: "batting_average",
+            current_value: "0.28",
+            target_value: "0.3",
+          }),
+        ],
+      });
+
+      expect(screen.getByText(".280")).toBeVisible();
+      expect(screen.getByText(".300")).toBeVisible();
+    });
+
+    it("定性目標は進捗バーではなく達成状態のチップを出す", () => {
+      renderContent({
+        initialGoals: [
+          buildGoal({ kind: "qualitative", title: "大会で優勝する" }),
+        ],
+      });
+
+      expect(screen.queryByRole("progressbar")).toBeNull();
+      expect(screen.getByText("未達成")).toBeVisible();
+    });
+  });
+
+  describe("達成トグル", () => {
+    it("数値目標には達成トグルを出さない（back が 422 を返すため）", () => {
+      renderContent({ initialGoals: [buildGoal({ kind: "numeric" })] });
+
+      expect(screen.queryByRole("button", { name: /達成にする/ })).toBeNull();
+    });
+
+    it("自由指標にも達成トグルを出さない", () => {
+      renderContent({
+        initialGoals: [
+          buildGoal({
+            kind: "manual",
+            custom_metric_label: "球速",
+            title: "球速アップ",
+          }),
+        ],
+      });
+
+      expect(screen.queryByRole("button", { name: /達成にする/ })).toBeNull();
+    });
+
+    it("確定済みの定性目標には達成トグルを出さない", async () => {
+      const user = userEvent.setup();
+      renderContent({
+        initialHistory: [
+          buildGoal({
+            kind: "qualitative",
+            title: "去年の目標",
+            is_finalized: true,
+          }),
+        ],
+      });
+
+      await user.click(screen.getByRole("tab", { name: /未達/ }));
+
+      expect(screen.queryByRole("button", { name: /達成にする/ })).toBeNull();
+    });
+
+    it("定性目標の達成トグルで達成にできる", async () => {
+      const user = userEvent.setup();
+      const goal = buildGoal({ kind: "qualitative", title: "大会で優勝する" });
+      mockAchieve.mockResolvedValue({
+        ok: true,
+        data: { ...goal, is_achieved: true, progress_percent: 100 },
+      });
+      renderContent({ initialGoals: [goal] });
+
+      await user.click(
+        screen.getByRole("button", { name: "大会で優勝するを達成にする" }),
+      );
+
+      await waitFor(() => expect(mockAchieve).toHaveBeenCalledWith(1));
+      expect(mockUnachieve).not.toHaveBeenCalled();
+      // 達成済みになったので進行中タブから消え、達成タブへ移る。
+      expect(await screen.findByRole("tab", { name: "達成 1" })).toBeVisible();
+      expect(screen.getByRole("tab", { name: "進行中 0" })).toBeVisible();
+    });
+
+    it("達成済みの定性目標はトグルで取り消せる", async () => {
+      const user = userEvent.setup();
+      const goal = buildGoal({
+        kind: "qualitative",
+        title: "大会で優勝する",
+        is_achieved: true,
+      });
+      mockUnachieve.mockResolvedValue({
+        ok: true,
+        data: { ...goal, is_achieved: false, progress_percent: 0 },
+      });
+      renderContent({ initialGoals: [goal] });
+
+      await user.click(screen.getByRole("tab", { name: /達成/ }));
+      await user.click(
+        screen.getByRole("button", { name: "大会で優勝するの達成を取り消す" }),
+      );
+
+      await waitFor(() => expect(mockUnachieve).toHaveBeenCalledWith(1));
+      expect(mockAchieve).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("編集（変更不可属性の固定）", () => {
+    const editableGoal = buildGoal({
+      id: 5,
+      title: "月20日練習",
+      metric_key: "practice_days",
+      target_value: 20,
+    });
+
+    it("種類・期間・指標・条件の選択肢をすべて操作不能にする", async () => {
+      const user = userEvent.setup();
+      renderContent({ initialGoals: [editableGoal] });
+
+      await openEditForm(user, "月20日練習");
+
+      expect(screen.getByRole("button", { name: "数値目標" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "達成目標" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "自由指標" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "月次" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "シーズン" })).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "カスタム期間" }),
+      ).toBeDisabled();
+      expect(screen.getByRole("button", { name: "練習日数" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "防御率" })).toBeDisabled();
+    });
+
+    it("変更できない理由を画面で伝える", async () => {
+      const user = userEvent.setup();
+      renderContent({ initialGoals: [editableGoal] });
+
+      await openEditForm(user, "月20日練習");
+
+      expect(
+        screen.getByText(
+          "目標タイプ・期間・指標・条件は作成後に変更できません。変更したい場合は削除して作り直してください。",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("更新では変更不可の属性を一切送らない", async () => {
+      const user = userEvent.setup();
+      mockUpdate.mockResolvedValue({
+        ok: true,
+        data: { ...editableGoal, target_value: 25 },
+      });
+      renderContent({ initialGoals: [editableGoal] });
+
+      await openEditForm(user, "月20日練習");
+      await user.clear(screen.getByLabelText(/目標値/));
+      await user.type(screen.getByLabelText(/目標値/), "25");
+      await user.click(screen.getByRole("button", { name: "更新" }));
+
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      const [id, payload] = mockUpdate.mock.calls[0];
+      expect(id).toBe(5);
+      expect(payload).toEqual({
+        title: "月20日練習",
+        month_start: "2026-08-01",
+        deadline: "2026-08-31",
+        target_value: 25,
+      });
+      [
+        "kind",
+        "period_type",
+        "season_id",
+        "tournament_id",
+        "metric_key",
+        "comparison_type",
+        "practice_menu_id",
+      ].forEach((key) => expect(payload).not.toHaveProperty(key));
+    });
+
+    it("シーズン目標の編集ではシーズンの選択肢も操作不能にする", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ features: ["season_goals"] });
+      renderContent({
+        initialGoals: [
+          buildGoal({
+            id: 6,
+            title: "シーズン打率3割",
+            period_type: "season",
+            season_id: 11,
+            month_start: null,
+            metric_key: "batting_average",
+            target_value: 0.3,
+          }),
+        ],
+      });
+
+      await openEditForm(user, "シーズン打率3割");
+
+      expect(screen.getByRole("button", { name: "2026年" })).toBeDisabled();
+    });
+
+    it("自由指標の編集では条件（以上・以下）も操作不能にする", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ features: ["manual_metric_goals"] });
+      renderContent({
+        initialGoals: [
+          buildGoal({
+            id: 7,
+            title: "球速アップ",
+            kind: "manual",
+            metric_key: null,
+            custom_metric_label: "球速",
+            custom_unit: "km/h",
+            target_value: 130,
+            manual_current_value: 125,
+          }),
+        ],
+      });
+
+      await openEditForm(user, "球速アップ");
+
+      expect(screen.getByRole("button", { name: "以上" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "以下" })).toBeDisabled();
+    });
+
+    it("確定済みの目標は詳細から編集できない", async () => {
+      const user = userEvent.setup();
+      renderContent({
+        initialHistory: [
+          buildGoal({ id: 8, title: "去年の目標", is_finalized: true }),
+        ],
+      });
+
+      await user.click(screen.getByRole("tab", { name: /未達/ }));
+      await user.click(
+        screen.getByRole("button", { name: "去年の目標の詳細" }),
+      );
+
+      expect(screen.queryByRole("button", { name: "編集" })).toBeNull();
+    });
+  });
+
+  describe("作成フォームの出し分け", () => {
+    it("数値目標では指標と目標値を出し、指標名・現在値は出さない", async () => {
+      const user = userEvent.setup();
+      renderContent();
+
+      await openCreateForm(user);
+
+      expect(screen.getByRole("group", { name: "打撃" })).toBeInTheDocument();
+      expect(screen.getByLabelText(/目標値/)).toBeInTheDocument();
+      expect(screen.queryByLabelText(/指標名/)).toBeNull();
+      expect(screen.queryByLabelText(/現在値/)).toBeNull();
+    });
+
+    it("定性目標では指標も目標値も出さない", async () => {
+      const user = userEvent.setup();
+      renderContent();
+
+      await openCreateForm(user);
+      await user.click(screen.getByRole("button", { name: "達成目標" }));
+
+      expect(screen.queryByRole("group", { name: "打撃" })).toBeNull();
+      expect(screen.queryByLabelText(/目標値/)).toBeNull();
+      expect(screen.getByLabelText("目標")).toBeInTheDocument();
+    });
+
+    it("自由指標では指標名・単位・条件・現在値を出し、指標カテゴリは出さない", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ features: ["manual_metric_goals"] });
+      renderContent();
+
+      await openCreateForm(user);
+      await user.click(screen.getByRole("button", { name: "自由指標" }));
+
+      expect(screen.getByLabelText(/指標名/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/単位/)).toBeInTheDocument();
+      expect(screen.getByRole("group", { name: "条件" })).toBeInTheDocument();
+      expect(screen.getByLabelText(/現在値/)).toBeInTheDocument();
+      expect(screen.queryByRole("group", { name: "打撃" })).toBeNull();
+    });
+
+    it("メニュー継続日数を選ぶと対象メニューの選択欄が出る", async () => {
+      const user = userEvent.setup();
+      renderContent();
+
+      await openCreateForm(user);
+      expect(
+        screen.queryByRole("group", { name: "対象の練習メニュー" }),
+      ).toBeNull();
+
+      await user.click(
+        screen.getByRole("button", { name: "メニュー継続日数" }),
+      );
+
+      const group = screen.getByRole("group", { name: "対象の練習メニュー" });
+      expect(
+        within(group).getByRole("button", { name: "素振り" }),
+      ).toBeInTheDocument();
+    });
+
+    it("週次・月次・年間は期間が自動設定であることを伝え、日付入力を出さない", async () => {
+      const user = userEvent.setup();
+      renderContent();
+
+      await openCreateForm(user);
+
+      expect(
+        screen.getByText("対象期間: 今月（自動設定）"),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText(/期限/)).toBeNull();
+
+      await user.click(screen.getByRole("button", { name: "週次" }));
+      expect(
+        screen.getByText("対象期間: 今週 月〜日（自動設定）"),
+      ).toBeInTheDocument();
+    });
+
+    it("カスタム期間では開始日と期限を入力させる", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ features: ["custom_period_goals"] });
+      renderContent();
+
+      await openCreateForm(user);
+      await user.click(screen.getByRole("button", { name: "カスタム期間" }));
+
+      expect(screen.getByLabelText(/開始日/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/期限/)).toBeInTheDocument();
+    });
+
+    it("シーズン・大会では対象の選択欄と期限を出す", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ features: ["season_goals", "tournament_goals"] });
+      renderContent();
+
+      await openCreateForm(user);
+      await user.click(screen.getByRole("button", { name: "シーズン" }));
+      expect(
+        screen.getByRole("group", { name: "シーズン" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText(/開始日/)).toBeNull();
+
+      await user.click(screen.getByRole("button", { name: "大会" }));
+      expect(screen.getByRole("group", { name: "大会" })).toBeInTheDocument();
+      expect(screen.getByLabelText(/期限/)).toBeInTheDocument();
+    });
+
+    it("必須項目が未入力なら送信せずエラーを出す", async () => {
+      const user = userEvent.setup();
+      renderContent();
+
+      await openCreateForm(user);
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      expect(
+        await screen.findByText("目標値を入力してください"),
+      ).toBeInTheDocument();
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("入力した内容で作成できる", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({
+        ok: true,
+        data: buildGoal({ id: 9, title: "今月20日練習" }),
+      });
+      renderContent();
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText(/目標値/), "20");
+      await user.type(screen.getByLabelText(/タイトル/), "今月20日練習");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+      expect(mockCreate).toHaveBeenCalledWith({
+        title: "今月20日練習",
+        kind: "numeric",
+        period_type: "monthly",
+        season_id: null,
+        tournament_id: null,
+        month_start: "2026-08-01",
+        deadline: "2026-08-31",
+        metric_key: "practice_days",
+        target_value: 20,
+        comparison_type: "greater_than",
+        practice_menu_id: null,
+      });
+      expect(await screen.findByText("今月20日練習")).toBeVisible();
+    });
+  });
+
+  describe("Pro ゲート", () => {
+    it.each([
+      ["シーズン", "season_goals", "シーズン目標を設定"],
+      ["大会", "tournament_goals", "大会目標を設定"],
+      ["カスタム期間", "custom_period_goals", "カスタム期間で目標を設定"],
+    ] as const)(
+      "%s は無料だと訴求を出して保存させない",
+      async (chipLabel, feature, upsellTitle) => {
+        const user = userEvent.setup();
+        renderContent();
+
+        await openCreateForm(user);
+        await user.click(screen.getByRole("button", { name: chipLabel }));
+
+        expect(screen.getByText(upsellTitle)).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "保存" })).toBeDisabled();
+
+        mockEntitlement({ features: [feature] });
+      },
+    );
+
+    it("自由指標は無料だと訴求を出して保存させない", async () => {
+      const user = userEvent.setup();
+      renderContent();
+
+      await openCreateForm(user);
+      await user.click(screen.getByRole("button", { name: "自由指標" }));
+
+      expect(screen.getByText("自由指標で目標を設定")).toBeInTheDocument();
+      expect(screen.queryByLabelText(/指標名/)).toBeNull();
+      expect(screen.getByRole("button", { name: "保存" })).toBeDisabled();
+    });
+
+    it.each([
+      ["シーズン", "season_goals"],
+      ["大会", "tournament_goals"],
+      ["カスタム期間", "custom_period_goals"],
+    ] as const)(
+      "%s は対応する entitlement があれば訴求を出さない",
+      async (chipLabel, feature) => {
+        const user = userEvent.setup();
+        mockEntitlement({ features: [feature] });
+        renderContent();
+
+        await openCreateForm(user);
+        await user.click(screen.getByRole("button", { name: chipLabel }));
+
+        expect(screen.queryByText(/Pro プランを見る/)).toBeNull();
+      },
+    );
+
+    it("別の Pro 機能の entitlement では解放されない", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ features: ["season_goals"] });
+      renderContent();
+
+      await openCreateForm(user);
+      await user.click(screen.getByRole("button", { name: "大会" }));
+
+      expect(screen.getByText("大会目標を設定")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "保存" })).toBeDisabled();
+    });
+
+    it("Pro 判定が未確定の間は追加ボタン自体を押せなくする", () => {
+      mockEntitlement({ isLoading: true });
+      renderContent();
+
+      expect(
+        screen.getByRole("button", { name: "新しい目標を追加" }),
+      ).toBeDisabled();
+    });
+
+    it("作成が 403 になったら back の文言を出して該当機能のペイウォールを開く", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ features: ["season_goals"] });
+      mockCreate.mockResolvedValue({
+        ok: false,
+        reason: "forbidden",
+        errors: ["シーズン目標は Pro プラン限定です"],
+      });
+      renderContent();
+
+      await openCreateForm(user);
+      await user.click(screen.getByRole("button", { name: "シーズン" }));
+      await user.click(screen.getByRole("button", { name: "2026年" }));
+      await user.type(screen.getByLabelText(/目標値/), "0.3");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      expect(
+        await screen.findByText("シーズン目標は Pro プラン限定です"),
+      ).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "season_goals",
+      });
+    });
+  });
+
+  describe("無料枠の上限", () => {
+    const twoPersonalGoals = [
+      buildGoal({ id: 1, title: "月次目標", period_type: "monthly" }),
+      buildGoal({ id: 2, title: "週次目標", period_type: "weekly" }),
+    ];
+
+    it("無料で3件目を作ろうとするとフォームではなくペイウォールが出る", async () => {
+      const user = userEvent.setup();
+      renderContent({ initialGoals: twoPersonalGoals });
+
+      await openCreateForm(user);
+
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "unlimited_monthly_goals",
+      });
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    it("上限に達すると Pro 限定ではなく件数上限として案内する", () => {
+      renderContent({ initialGoals: twoPersonalGoals });
+
+      expect(
+        screen.getByText("無料プランで同時に設定できる目標は2件までです"),
+      ).toBeVisible();
+    });
+
+    it("シーズン・大会目標は無料枠を消費しない", () => {
+      renderContent({
+        initialGoals: [
+          buildGoal({ id: 1, period_type: "season" }),
+          buildGoal({ id: 2, period_type: "tournament" }),
+          buildGoal({ id: 3, period_type: "monthly" }),
+        ],
+      });
+
+      expect(
+        screen.queryByText("無料プランで同時に設定できる目標は2件までです"),
+      ).toBeNull();
+    });
+
+    it("確定済みの目標は無料枠を消費しない", () => {
+      renderContent({
+        initialGoals: [buildGoal({ id: 1, period_type: "monthly" })],
+        initialHistory: [
+          buildGoal({ id: 2, period_type: "monthly", is_finalized: true }),
+          buildGoal({ id: 3, period_type: "weekly", is_finalized: true }),
+        ],
+      });
+
+      expect(
+        screen.queryByText("無料プランで同時に設定できる目標は2件までです"),
+      ).toBeNull();
+    });
+
+    it("Pro なら3件目以降も作成フォームを開ける", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ features: ["unlimited_monthly_goals"] });
+      renderContent({ initialGoals: twoPersonalGoals });
+
+      await openCreateForm(user);
+
+      expect(
+        screen.getByRole("dialog", { name: "新しい目標" }),
+      ).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+
+    it("Pro 判定が未確定の間は上限の案内を出さない", () => {
+      mockEntitlement({ isLoading: true });
+      renderContent({ initialGoals: twoPersonalGoals });
+
+      expect(
+        screen.queryByText("無料プランで同時に設定できる目標は2件までです"),
+      ).toBeNull();
+    });
+
+    it("上限を超えて保有していても既存目標は編集・削除できる（グランドファザリング）", async () => {
+      const user = userEvent.setup();
+      mockUpdate.mockResolvedValue({
+        ok: true,
+        data: buildGoal({ id: 1, title: "月次目標" }),
+      });
+      renderContent({
+        initialGoals: [
+          ...twoPersonalGoals,
+          buildGoal({ id: 3, title: "年間目標", period_type: "yearly" }),
+          buildGoal({ id: 4, title: "カスタム目標", period_type: "custom" }),
+        ],
+      });
+
+      const dialog = await openEditForm(user, "月次目標");
+
+      expect(dialog).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole("button", { name: "更新" }));
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    });
+
+    it("作成が 403 になったら件数上限として案内する", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({
+        ok: false,
+        reason: "forbidden",
+        errors: ["Pro プランで期間目標を無制限に設定できます"],
+      });
+      renderContent();
+
+      await openCreateForm(user);
+      await user.type(screen.getByLabelText(/目標値/), "20");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      expect(
+        await screen.findByText(
+          /無料プランで同時に設定できる目標は2件までです。/,
+        ),
+      ).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "unlimited_monthly_goals",
+      });
+    });
+  });
+
+  describe("詳細・削除", () => {
+    it("詳細で進捗・残り日数・期限を出す", async () => {
+      const user = userEvent.setup();
+      renderContent({
+        initialGoals: [buildGoal({ progress_percent: 25, days_remaining: 28 })],
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: "月20日練習の詳細" }),
+      );
+
+      const dialog = screen.getByRole("dialog", { name: "目標の詳細" });
+      // 進捗率はバーと数値サマリーの2箇所に出る。
+      expect(within(dialog).getAllByText("25%")).toHaveLength(2);
+      expect(within(dialog).getByText("28日")).toBeInTheDocument();
+      expect(within(dialog).getByText("2026/8/31")).toBeInTheDocument();
+    });
+
+    it("確認を経てから削除する", async () => {
+      const user = userEvent.setup();
+      mockDelete.mockResolvedValue({
+        ok: true,
+        data: { message: "削除しました" },
+      });
+      renderContent({ initialGoals: [buildGoal({ id: 3 })] });
+
+      await user.click(
+        screen.getByRole("button", { name: "月20日練習の詳細" }),
+      );
+      await user.click(screen.getByRole("button", { name: "削除" }));
+
+      expect(
+        screen.getByText("「月20日練習」を削除しますか？"),
+      ).toBeInTheDocument();
+      expect(mockDelete).not.toHaveBeenCalled();
+
+      await user.click(
+        within(screen.getByRole("dialog", { name: "目標の削除" })).getByRole(
+          "button",
+          { name: "削除" },
+        ),
+      );
+
+      await waitFor(() => expect(mockDelete).toHaveBeenCalledWith(3));
+      await waitFor(() => expect(screen.queryByText("月20日練習")).toBeNull());
+    });
+  });
+
+  describe("取得失敗", () => {
+    it("履歴の取得に失敗したら未達0件と誤認させない", () => {
+      renderContent({ historyLoadFailed: true });
+
+      expect(
+        screen.getByText(
+          "達成・未達の履歴を取得できませんでした。進行中の目標のみ表示しています。",
+        ),
+      ).toBeVisible();
+    });
+  });
+});

--- a/app/(app)/goals/__tests__/goalForm.test.ts
+++ b/app/(app)/goals/__tests__/goalForm.test.ts
@@ -1,0 +1,557 @@
+import type { Goal } from "@app/types/goal";
+import {
+  type GoalFormValues,
+  addDays,
+  buildGoalCreatePayload,
+  buildGoalUpdatePayload,
+  hasAutoRange,
+  initialGoalFormValues,
+  isMenuMetric,
+  monthRange,
+  resolveGoalPeriod,
+  todayString,
+  validateGoalForm,
+  weekRange,
+  yearRange,
+} from "../_utils/goalForm";
+
+const TODAY = "2026-08-03";
+
+function buildGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: 1,
+    title: "月20日練習",
+    kind: "numeric",
+    period_type: "monthly",
+    season_id: null,
+    tournament_id: null,
+    month_start: "2026-08-01",
+    deadline: "2026-08-31",
+    metric_key: "practice_days",
+    target_value: 20,
+    comparison_type: "greater_than",
+    practice_menu_id: null,
+    practice_menu_name: null,
+    custom_metric_label: null,
+    custom_unit: null,
+    manual_current_value: 0,
+    is_achieved: false,
+    is_finalized: false,
+    achieved_value: null,
+    current_value: 5,
+    progress_percent: 25,
+    days_remaining: 28,
+    ...overrides,
+  };
+}
+
+function buildValues(overrides: Partial<GoalFormValues> = {}): GoalFormValues {
+  return { ...initialGoalFormValues(null, TODAY), ...overrides };
+}
+
+describe("日付ユーティリティ", () => {
+  it("todayString は Asia/Tokyo の日付を YYYY-MM-DD で返す", () => {
+    // JST では翌日の 08:30。UTC 基準で計算すると 1 日ずれる。
+    expect(todayString(new Date("2026-08-02T23:30:00Z"))).toBe("2026-08-03");
+  });
+
+  it("addDays は月をまたいでも正しく加算する", () => {
+    expect(addDays("2026-08-31", 1)).toBe("2026-09-01");
+    expect(addDays("2026-03-01", -1)).toBe("2026-02-28");
+  });
+
+  it("monthRange は当月の初日と末日を返す", () => {
+    expect(monthRange("2026-08-03")).toEqual({
+      start: "2026-08-01",
+      end: "2026-08-31",
+    });
+    expect(monthRange("2026-02-15")).toEqual({
+      start: "2026-02-01",
+      end: "2026-02-28",
+    });
+  });
+
+  it("weekRange は月曜始まり・日曜終わりの週を返す", () => {
+    // 2026-08-03 は月曜。
+    expect(weekRange("2026-08-03")).toEqual({
+      start: "2026-08-03",
+      end: "2026-08-09",
+    });
+    // 2026-08-09 は日曜。前週の月曜まで戻る。
+    expect(weekRange("2026-08-09")).toEqual({
+      start: "2026-08-03",
+      end: "2026-08-09",
+    });
+  });
+
+  it("yearRange は 1月1日〜12月31日を返す", () => {
+    expect(yearRange("2026-08-03")).toEqual({
+      start: "2026-01-01",
+      end: "2026-12-31",
+    });
+  });
+
+  it("期間が自動算出されるのは週次・月次・年間だけ", () => {
+    expect(hasAutoRange("weekly")).toBe(true);
+    expect(hasAutoRange("monthly")).toBe(true);
+    expect(hasAutoRange("yearly")).toBe(true);
+    expect(hasAutoRange("custom")).toBe(false);
+    expect(hasAutoRange("season")).toBe(false);
+    expect(hasAutoRange("tournament")).toBe(false);
+  });
+});
+
+describe("initialGoalFormValues", () => {
+  it("新規は数値目標・月次・先頭の指標を既定にする", () => {
+    const values = initialGoalFormValues(null, TODAY);
+    expect(values.kind).toBe("numeric");
+    expect(values.periodType).toBe("monthly");
+    expect(values.metricKey).toBe("practice_days");
+    expect(values.targetValue).toBe("");
+    expect(values.deadline).toBe(addDays(TODAY, 90));
+  });
+
+  it("編集は既存の目標から復元する", () => {
+    const values = initialGoalFormValues(
+      buildGoal({
+        kind: "manual",
+        period_type: "custom",
+        custom_metric_label: "球速",
+        custom_unit: "km/h",
+        comparison_type: "less_than",
+        target_value: 130,
+        manual_current_value: 125,
+        month_start: "2026-07-01",
+        deadline: "2026-09-30",
+      }),
+      TODAY,
+    );
+
+    expect(values.kind).toBe("manual");
+    expect(values.periodType).toBe("custom");
+    expect(values.customMetricLabel).toBe("球速");
+    expect(values.customUnit).toBe("km/h");
+    expect(values.comparison).toBe("less_than");
+    expect(values.targetValue).toBe("130");
+    expect(values.manualCurrentValue).toBe("125");
+    expect(values.startDate).toBe("2026-07-01");
+    expect(values.deadline).toBe("2026-09-30");
+  });
+
+  it("back が数値を文字列で返しても入力欄には数値として流し込む", () => {
+    const values = initialGoalFormValues(
+      buildGoal({ kind: "manual", target_value: "130.0" }),
+      TODAY,
+    );
+    expect(values.targetValue).toBe("130");
+  });
+});
+
+describe("isMenuMetric", () => {
+  it("数値目標でメニュー継続日数を選んだときだけ true", () => {
+    expect(isMenuMetric(buildValues({ metricKey: "menu_practice_days" }))).toBe(
+      true,
+    );
+    expect(isMenuMetric(buildValues({ metricKey: "practice_days" }))).toBe(
+      false,
+    );
+    // 定性目標は指標を持たないため、metricKey が残っていても対象外。
+    expect(
+      isMenuMetric(
+        buildValues({ kind: "qualitative", metricKey: "menu_practice_days" }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("resolveGoalPeriod", () => {
+  it.each([
+    ["monthly", "2026-08-01", "2026-08-31"],
+    ["weekly", "2026-08-03", "2026-08-09"],
+    ["yearly", "2026-01-01", "2026-12-31"],
+  ] as const)(
+    "%s は今日を基準に期間を自動算出する",
+    (periodType, start, end) => {
+      expect(
+        resolveGoalPeriod(buildValues({ periodType }), null, TODAY),
+      ).toEqual({ month_start: start, deadline: end });
+    },
+  );
+
+  it("カスタム期間は入力した開始日・期限を使う", () => {
+    expect(
+      resolveGoalPeriod(
+        buildValues({
+          periodType: "custom",
+          startDate: "2026-08-10",
+          deadline: "2026-08-31",
+        }),
+        null,
+        TODAY,
+      ),
+    ).toEqual({ month_start: "2026-08-10", deadline: "2026-08-31" });
+  });
+
+  it.each(["season", "tournament"] as const)(
+    "%s は開始日を持たない",
+    (periodType) => {
+      expect(
+        resolveGoalPeriod(
+          buildValues({ periodType, deadline: "2026-10-01" }),
+          null,
+          TODAY,
+        ),
+      ).toEqual({ month_start: null, deadline: "2026-10-01" });
+    },
+  );
+
+  it("編集では月次の対象期間を今日基準で振り直さない", () => {
+    const editing = buildGoal({
+      period_type: "monthly",
+      month_start: "2026-06-01",
+      deadline: "2026-06-30",
+    });
+    expect(
+      resolveGoalPeriod(initialGoalFormValues(editing, TODAY), editing, TODAY),
+    ).toEqual({ month_start: "2026-06-01", deadline: "2026-06-30" });
+  });
+});
+
+describe("validateGoalForm", () => {
+  it("数値目標は目標値が必須", () => {
+    expect(validateGoalForm(buildValues({ targetValue: "" }))).toContain(
+      "目標値を入力してください",
+    );
+    expect(validateGoalForm(buildValues({ targetValue: "20" }))).toEqual([]);
+  });
+
+  it("目標値 0 は未入力として扱わない", () => {
+    expect(validateGoalForm(buildValues({ targetValue: "0" }))).toEqual([]);
+  });
+
+  it("定性目標は目標（タイトル）が必須で、目標値は不要", () => {
+    expect(
+      validateGoalForm(buildValues({ kind: "qualitative", title: "" })),
+    ).toEqual(["目標を入力してください"]);
+    expect(
+      validateGoalForm(buildValues({ kind: "qualitative", title: "優勝する" })),
+    ).toEqual([]);
+  });
+
+  it("自由指標は指標名が必須", () => {
+    expect(
+      validateGoalForm(
+        buildValues({
+          kind: "manual",
+          customMetricLabel: "",
+          targetValue: "130",
+        }),
+      ),
+    ).toEqual(["指標名を入力してください"]);
+  });
+
+  it("メニュー継続日数は対象メニューが必須", () => {
+    expect(
+      validateGoalForm(
+        buildValues({
+          metricKey: "menu_practice_days",
+          targetValue: "20",
+          practiceMenuId: null,
+        }),
+      ),
+    ).toEqual(["対象の練習メニューを選択してください"]);
+  });
+
+  it("シーズン目標はシーズン、大会目標は大会が必須", () => {
+    expect(
+      validateGoalForm(
+        buildValues({ periodType: "season", targetValue: "0.3" }),
+      ),
+    ).toEqual(["シーズンを選択してください"]);
+    expect(
+      validateGoalForm(
+        buildValues({ periodType: "tournament", targetValue: "0.3" }),
+      ),
+    ).toEqual(["大会を選択してください"]);
+  });
+
+  it("カスタム期間は終了日が開始日以降であること", () => {
+    expect(
+      validateGoalForm(
+        buildValues({
+          periodType: "custom",
+          targetValue: "20",
+          startDate: "2026-08-10",
+          deadline: "2026-08-09",
+        }),
+      ),
+    ).toEqual(["終了日は開始日以降にしてください"]);
+    expect(
+      validateGoalForm(
+        buildValues({
+          periodType: "custom",
+          targetValue: "20",
+          startDate: "2026-08-10",
+          deadline: "2026-08-10",
+        }),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("buildGoalCreatePayload", () => {
+  it("数値目標は指標と指標固定の達成条件を送る", () => {
+    const payload = buildGoalCreatePayload(
+      buildValues({ metricKey: "era", targetValue: "2.5", title: "防御率" }),
+      TODAY,
+    );
+    expect(payload).toEqual({
+      title: "防御率",
+      kind: "numeric",
+      period_type: "monthly",
+      season_id: null,
+      tournament_id: null,
+      month_start: "2026-08-01",
+      deadline: "2026-08-31",
+      metric_key: "era",
+      target_value: 2.5,
+      comparison_type: "less_than",
+      practice_menu_id: null,
+    });
+  });
+
+  it("達成条件は指標ごとの定義に従い、フォームの条件では上書きされない", () => {
+    const payload = buildGoalCreatePayload(
+      buildValues({
+        metricKey: "batting_average",
+        targetValue: "0.3",
+        comparison: "less_than",
+      }),
+      TODAY,
+    );
+    expect(payload.comparison_type).toBe("greater_than");
+  });
+
+  it("定性目標は指標・目標値・達成条件を一切送らない", () => {
+    const payload = buildGoalCreatePayload(
+      buildValues({
+        kind: "qualitative",
+        periodType: "tournament",
+        tournamentId: 7,
+        title: "優勝する",
+      }),
+      TODAY,
+    );
+    expect(payload).toEqual({
+      title: "優勝する",
+      kind: "qualitative",
+      period_type: "tournament",
+      season_id: null,
+      tournament_id: 7,
+      month_start: null,
+      deadline: payload.deadline,
+    });
+    expect(payload).not.toHaveProperty("metric_key");
+    expect(payload).not.toHaveProperty("target_value");
+  });
+
+  it("自由指標は指標名・単位・現在値とユーザーが選んだ条件を送る", () => {
+    const payload = buildGoalCreatePayload(
+      buildValues({
+        kind: "manual",
+        customMetricLabel: " 球速 ",
+        customUnit: " km/h ",
+        targetValue: "130",
+        manualCurrentValue: "125",
+        comparison: "greater_than",
+        title: "",
+      }),
+      TODAY,
+    );
+    expect(payload).toMatchObject({
+      title: "球速",
+      kind: "manual",
+      custom_metric_label: "球速",
+      custom_unit: "km/h",
+      target_value: 130,
+      comparison_type: "greater_than",
+      manual_current_value: 125,
+    });
+    expect(payload).not.toHaveProperty("metric_key");
+  });
+
+  it("自由指標の現在値が未入力なら 0 を送る", () => {
+    const payload = buildGoalCreatePayload(
+      buildValues({
+        kind: "manual",
+        customMetricLabel: "体重",
+        targetValue: "70",
+        manualCurrentValue: "",
+      }),
+      TODAY,
+    );
+    expect(payload.manual_current_value).toBe(0);
+    expect(payload.custom_unit).toBeNull();
+  });
+
+  it("メニュー継続日数のときだけ practice_menu_id を送る", () => {
+    expect(
+      buildGoalCreatePayload(
+        buildValues({
+          metricKey: "menu_practice_days",
+          practiceMenuId: 3,
+          targetValue: "20",
+        }),
+        TODAY,
+      ).practice_menu_id,
+    ).toBe(3);
+
+    expect(
+      buildGoalCreatePayload(
+        buildValues({
+          metricKey: "practice_days",
+          practiceMenuId: 3,
+          targetValue: "20",
+        }),
+        TODAY,
+      ).practice_menu_id,
+    ).toBeNull();
+  });
+
+  it("シーズン以外では season_id を、大会以外では tournament_id を送らない", () => {
+    const payload = buildGoalCreatePayload(
+      buildValues({
+        periodType: "monthly",
+        seasonId: 5,
+        tournamentId: 6,
+        targetValue: "20",
+      }),
+      TODAY,
+    );
+    expect(payload.season_id).toBeNull();
+    expect(payload.tournament_id).toBeNull();
+  });
+
+  it("タイトル未入力なら指標名から補う", () => {
+    expect(
+      buildGoalCreatePayload(
+        buildValues({ metricKey: "home_runs", targetValue: "10", title: "" }),
+        TODAY,
+      ).title,
+    ).toBe("本塁打目標");
+  });
+});
+
+describe("buildGoalUpdatePayload", () => {
+  const IMMUTABLE_KEYS = [
+    "kind",
+    "period_type",
+    "season_id",
+    "tournament_id",
+    "metric_key",
+    "comparison_type",
+    "practice_menu_id",
+  ];
+
+  it("back が更新を許可しない属性を一切含めない", () => {
+    const editing = buildGoal({
+      period_type: "custom",
+      month_start: "2026-08-01",
+      metric_key: "batting_average",
+      comparison_type: "greater_than",
+      practice_menu_id: 3,
+      season_id: 2,
+      tournament_id: 4,
+    });
+    const payload = buildGoalUpdatePayload(
+      {
+        ...initialGoalFormValues(editing, TODAY),
+        // 万一 UI 側で変更されても送信対象にならないこと。
+        kind: "manual",
+        periodType: "season",
+        metricKey: "era",
+        comparison: "less_than",
+        practiceMenuId: 99,
+        seasonId: 99,
+        tournamentId: 99,
+        title: "更新後",
+        targetValue: "0.35",
+      },
+      editing,
+      TODAY,
+    );
+
+    IMMUTABLE_KEYS.forEach((key) => expect(payload).not.toHaveProperty(key));
+    expect(Object.keys(payload).sort()).toEqual([
+      "custom_metric_label",
+      "custom_unit",
+      "deadline",
+      "manual_current_value",
+      "month_start",
+      "target_value",
+      "title",
+    ]);
+  });
+
+  it("数値目標の更新はタイトル・期間・目標値だけを送る", () => {
+    const editing = buildGoal();
+    const payload = buildGoalUpdatePayload(
+      {
+        ...initialGoalFormValues(editing, TODAY),
+        title: "月25日練習",
+        targetValue: "25",
+      },
+      editing,
+      TODAY,
+    );
+    expect(payload).toEqual({
+      title: "月25日練習",
+      month_start: "2026-08-01",
+      deadline: "2026-08-31",
+      target_value: 25,
+    });
+  });
+
+  it("定性目標の更新は目標値を送らない", () => {
+    const editing = buildGoal({
+      kind: "qualitative",
+      metric_key: null,
+      target_value: null,
+      period_type: "tournament",
+      tournament_id: 7,
+      month_start: null,
+    });
+    const payload = buildGoalUpdatePayload(
+      { ...initialGoalFormValues(editing, TODAY), title: "全国大会で優勝" },
+      editing,
+      TODAY,
+    );
+    expect(payload).toEqual({
+      title: "全国大会で優勝",
+      month_start: null,
+      deadline: editing.deadline,
+    });
+  });
+
+  it("自由指標の更新は指標名・単位・現在値も送る", () => {
+    const editing = buildGoal({
+      kind: "manual",
+      metric_key: null,
+      custom_metric_label: "球速",
+      custom_unit: "km/h",
+      target_value: 130,
+      manual_current_value: 125,
+    });
+    const payload = buildGoalUpdatePayload(
+      { ...initialGoalFormValues(editing, TODAY), manualCurrentValue: "128" },
+      editing,
+      TODAY,
+    );
+    expect(payload).toMatchObject({
+      custom_metric_label: "球速",
+      custom_unit: "km/h",
+      target_value: 130,
+      manual_current_value: 128,
+    });
+  });
+});

--- a/app/(app)/goals/__tests__/goalList.test.ts
+++ b/app/(app)/goals/__tests__/goalList.test.ts
@@ -1,0 +1,349 @@
+import type { Goal } from "@app/types/goal";
+import {
+  goalForbiddenFeature,
+  lockedGoalFeature,
+} from "../_utils/goalEntitlement";
+import {
+  canToggleAchievement,
+  categorizeGoal,
+  countPersonalPeriodGoals,
+  groupGoalsByPeriod,
+  groupGoalsByTab,
+  isAtGoalFreeLimit,
+  isGoalEditable,
+  progressBarWidth,
+} from "../_utils/goalList";
+
+function buildGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: 1,
+    title: "月20日練習",
+    kind: "numeric",
+    period_type: "monthly",
+    season_id: null,
+    tournament_id: null,
+    month_start: "2026-08-01",
+    deadline: "2026-08-31",
+    metric_key: "practice_days",
+    target_value: 20,
+    comparison_type: "greater_than",
+    practice_menu_id: null,
+    practice_menu_name: null,
+    custom_metric_label: null,
+    custom_unit: null,
+    manual_current_value: 0,
+    is_achieved: false,
+    is_finalized: false,
+    achieved_value: null,
+    current_value: 5,
+    progress_percent: 25,
+    days_remaining: 28,
+    ...overrides,
+  };
+}
+
+describe("categorizeGoal", () => {
+  it("未達成・未確定は進行中", () => {
+    expect(
+      categorizeGoal(buildGoal({ is_achieved: false, is_finalized: false })),
+    ).toBe("in_progress");
+  });
+
+  it("達成済みは確定前でも達成タブに入る", () => {
+    expect(
+      categorizeGoal(buildGoal({ is_achieved: true, is_finalized: false })),
+    ).toBe("achieved");
+  });
+
+  it("達成して確定したものも達成タブに入る", () => {
+    expect(
+      categorizeGoal(buildGoal({ is_achieved: true, is_finalized: true })),
+    ).toBe("achieved");
+  });
+
+  it("未達成のまま確定したものだけが未達タブに入る", () => {
+    expect(
+      categorizeGoal(buildGoal({ is_achieved: false, is_finalized: true })),
+    ).toBe("unachieved");
+  });
+});
+
+describe("groupGoalsByTab", () => {
+  it("進行中と履歴をまとめて3タブへ分類する", () => {
+    const buckets = groupGoalsByTab(
+      [
+        buildGoal({ id: 1 }),
+        buildGoal({ id: 2, is_achieved: true }),
+        buildGoal({ id: 3 }),
+      ],
+      [
+        buildGoal({ id: 4, is_finalized: true, is_achieved: true }),
+        buildGoal({ id: 5, is_finalized: true }),
+      ],
+    );
+
+    expect(buckets.in_progress.map((goal) => goal.id)).toEqual([1, 3]);
+    expect(buckets.achieved.map((goal) => goal.id)).toEqual([2, 4]);
+    expect(buckets.unachieved.map((goal) => goal.id)).toEqual([5]);
+  });
+});
+
+describe("groupGoalsByPeriod", () => {
+  it("期間タイプ順に並べ、0件の期間は返さない", () => {
+    const groups = groupGoalsByPeriod([
+      buildGoal({ id: 1, period_type: "season" }),
+      buildGoal({ id: 2, period_type: "weekly" }),
+      buildGoal({ id: 3, period_type: "monthly" }),
+      buildGoal({ id: 4, period_type: "weekly" }),
+    ]);
+
+    expect(groups.map((group) => group.periodType)).toEqual([
+      "weekly",
+      "monthly",
+      "season",
+    ]);
+    expect(groups[0].goals.map((goal) => goal.id)).toEqual([2, 4]);
+  });
+});
+
+describe("progressBarWidth", () => {
+  it("0〜100 はそのまま使う", () => {
+    expect(progressBarWidth(0)).toBe(0);
+    expect(progressBarWidth(42.5)).toBe(42.5);
+    expect(progressBarWidth(100)).toBe(100);
+  });
+
+  it("範囲外は枠から溢れないよう丸める", () => {
+    expect(progressBarWidth(140)).toBe(100);
+    expect(progressBarWidth(-10)).toBe(0);
+  });
+
+  it("不正な値は 0 にする", () => {
+    expect(progressBarWidth(Number.NaN)).toBe(0);
+    expect(progressBarWidth(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe("canToggleAchievement", () => {
+  it("進行中の定性目標だけ達成トグルを出す", () => {
+    expect(canToggleAchievement(buildGoal({ kind: "qualitative" }))).toBe(true);
+  });
+
+  it.each(["numeric", "manual"] as const)(
+    "%s 目標には出さない（back が 422 を返すため）",
+    (kind) => {
+      expect(canToggleAchievement(buildGoal({ kind }))).toBe(false);
+    },
+  );
+
+  it("確定済みの定性目標には出さない", () => {
+    expect(
+      canToggleAchievement(
+        buildGoal({ kind: "qualitative", is_finalized: true }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isGoalEditable", () => {
+  it("確定済みは編集できない", () => {
+    expect(isGoalEditable(buildGoal())).toBe(true);
+    expect(isGoalEditable(buildGoal({ is_finalized: true }))).toBe(false);
+  });
+});
+
+describe("countPersonalPeriodGoals", () => {
+  it("週次・月次・年間・カスタム期間だけを数える", () => {
+    expect(
+      countPersonalPeriodGoals([
+        buildGoal({ id: 1, period_type: "weekly" }),
+        buildGoal({ id: 2, period_type: "monthly" }),
+        buildGoal({ id: 3, period_type: "yearly" }),
+        buildGoal({ id: 4, period_type: "custom" }),
+        buildGoal({ id: 5, period_type: "season" }),
+        buildGoal({ id: 6, period_type: "tournament" }),
+      ]),
+    ).toBe(4);
+  });
+});
+
+describe("isAtGoalFreeLimit", () => {
+  const twoPersonalGoals = [
+    buildGoal({ id: 1, period_type: "monthly" }),
+    buildGoal({ id: 2, period_type: "weekly" }),
+  ];
+
+  it("無料で個人の期間目標が2件あれば上限", () => {
+    expect(
+      isAtGoalFreeLimit({
+        activeGoals: twoPersonalGoals,
+        hasUnlimited: false,
+        isEntitlementLoading: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("1件なら上限ではない", () => {
+    expect(
+      isAtGoalFreeLimit({
+        activeGoals: twoPersonalGoals.slice(0, 1),
+        hasUnlimited: false,
+        isEntitlementLoading: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("シーズン・大会目標は無料枠を消費しない", () => {
+    expect(
+      isAtGoalFreeLimit({
+        activeGoals: [
+          buildGoal({ id: 1, period_type: "season" }),
+          buildGoal({ id: 2, period_type: "tournament" }),
+        ],
+        hasUnlimited: false,
+        isEntitlementLoading: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("Pro なら件数に関係なく上限にしない", () => {
+    expect(
+      isAtGoalFreeLimit({
+        activeGoals: twoPersonalGoals,
+        hasUnlimited: true,
+        isEntitlementLoading: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("Pro 判定が未確定の間は上限扱いにしない", () => {
+    expect(
+      isAtGoalFreeLimit({
+        activeGoals: twoPersonalGoals,
+        hasUnlimited: false,
+        isEntitlementLoading: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("上限を超えて保有していても既存分は数えるだけで、削除は要求しない", () => {
+    // Pro 解約後（グランドファザリング）を想定。新規作成だけがブロックされる。
+    const overLimit = [
+      ...twoPersonalGoals,
+      buildGoal({ id: 3, period_type: "yearly" }),
+      buildGoal({ id: 4, period_type: "custom" }),
+    ];
+    expect(
+      isAtGoalFreeLimit({
+        activeGoals: overLimit,
+        hasUnlimited: false,
+        isEntitlementLoading: false,
+      }),
+    ).toBe(true);
+    expect(overLimit.every(isGoalEditable)).toBe(true);
+  });
+
+  it("確定済みの目標は無料枠を消費しない（active のみ渡す前提）", () => {
+    expect(
+      isAtGoalFreeLimit({
+        activeGoals: [buildGoal({ id: 1, period_type: "monthly" })],
+        hasUnlimited: false,
+        isEntitlementLoading: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("lockedGoalFeature", () => {
+  const denyAll = () => false;
+  const allowAll = () => true;
+
+  it.each([
+    ["season", "season_goals"],
+    ["tournament", "tournament_goals"],
+    ["custom", "custom_period_goals"],
+  ] as const)("%s は %s でゲートする", (periodType, feature) => {
+    expect(lockedGoalFeature({ kind: "numeric", periodType }, denyAll)).toBe(
+      feature,
+    );
+    expect(
+      lockedGoalFeature({ kind: "numeric", periodType }, allowAll),
+    ).toBeNull();
+  });
+
+  it("自由指標は manual_metric_goals でゲートする", () => {
+    expect(
+      lockedGoalFeature({ kind: "manual", periodType: "monthly" }, denyAll),
+    ).toBe("manual_metric_goals");
+  });
+
+  it("自由指標×カスタム期間は back と同じく自由指標を先に案内する", () => {
+    expect(
+      lockedGoalFeature({ kind: "manual", periodType: "custom" }, denyAll),
+    ).toBe("manual_metric_goals");
+  });
+
+  it("個人の期間目標（週次・月次・年間）は Pro 限定ではない", () => {
+    (["weekly", "monthly", "yearly"] as const).forEach((periodType) => {
+      expect(
+        lockedGoalFeature({ kind: "numeric", periodType }, denyAll),
+      ).toBeNull();
+    });
+  });
+
+  it("対象の entitlement だけを見る（別の Pro 機能では解放されない）", () => {
+    const onlySeason = (feature: string) => feature === "season_goals";
+    expect(
+      lockedGoalFeature({ kind: "numeric", periodType: "season" }, onlySeason),
+    ).toBeNull();
+    expect(
+      lockedGoalFeature(
+        { kind: "numeric", periodType: "tournament" },
+        onlySeason,
+      ),
+    ).toBe("tournament_goals");
+    expect(
+      lockedGoalFeature({ kind: "numeric", periodType: "custom" }, onlySeason),
+    ).toBe("custom_period_goals");
+    expect(
+      lockedGoalFeature({ kind: "manual", periodType: "monthly" }, onlySeason),
+    ).toBe("manual_metric_goals");
+  });
+});
+
+describe("goalForbiddenFeature", () => {
+  it.each([
+    ["season", "season_goals"],
+    ["tournament", "tournament_goals"],
+    ["custom", "custom_period_goals"],
+  ] as const)("%s の 403 は %s が原因", (periodType, feature) => {
+    expect(goalForbiddenFeature({ kind: "numeric", periodType })).toBe(feature);
+  });
+
+  it.each(["weekly", "monthly", "yearly"] as const)(
+    "%s の 403 は件数上限が原因",
+    (periodType) => {
+      expect(goalForbiddenFeature({ kind: "numeric", periodType })).toBe(
+        "unlimited_monthly_goals",
+      );
+    },
+  );
+
+  it("自由指標は期間タイプより先に判定する（back の render_limit_error と同順）", () => {
+    expect(goalForbiddenFeature({ kind: "manual", periodType: "custom" })).toBe(
+      "manual_metric_goals",
+    );
+    expect(
+      goalForbiddenFeature({ kind: "manual", periodType: "monthly" }),
+    ).toBe("manual_metric_goals");
+  });
+
+  it("定性目標は種類でゲートされない（期間タイプで決まる）", () => {
+    expect(
+      goalForbiddenFeature({ kind: "qualitative", periodType: "tournament" }),
+    ).toBe("tournament_goals");
+    expect(
+      goalForbiddenFeature({ kind: "qualitative", periodType: "monthly" }),
+    ).toBe("unlimited_monthly_goals");
+  });
+});

--- a/app/(app)/goals/_components/GoalDetailModal.tsx
+++ b/app/(app)/goals/_components/GoalDetailModal.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import type { Goal } from "@app/types/goal";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import { GOAL_PERIOD_LABELS } from "@app/constants/goal";
+import { canToggleAchievement, isGoalEditable } from "../_utils/goalList";
+import GoalProgressBar from "./GoalProgressBar";
+
+interface GoalDetailModalProps {
+  goal: Goal;
+  isToggling: boolean;
+  onClose: () => void;
+  onEdit: (goal: Goal) => void;
+  onDelete: (goal: Goal) => void;
+  onToggleAchievement: (goal: Goal) => void;
+}
+
+/** "YYYY-MM-DD" を "YYYY/M/D" へ整形する。 */
+function formatDeadline(iso: string): string {
+  const [year, month, day] = iso.split("-").map(Number);
+  return `${year}/${month}/${day}`;
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex-1 rounded-xl bg-sub px-2 py-3 text-center">
+      <p className="text-base font-bold text-[#d08000]">{value}</p>
+      <p className="mt-1 text-xs text-zinc-400">{label}</p>
+    </div>
+  );
+}
+
+/** 目標の詳細（進捗・編集・削除）。 */
+export default function GoalDetailModal({
+  goal,
+  isToggling,
+  onClose,
+  onEdit,
+  onDelete,
+  onToggleAchievement,
+}: GoalDetailModalProps) {
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      placement="center"
+      scrollBehavior="inside"
+      className="buzz-dark"
+    >
+      <ModalContent>
+        <ModalHeader className="text-white">目標の詳細</ModalHeader>
+        <ModalBody className="gap-4">
+          <p className="text-xs font-bold text-zinc-400">
+            {GOAL_PERIOD_LABELS[goal.period_type]}
+          </p>
+
+          <div className="rounded-[10px] bg-sub px-3.5 py-3">
+            <GoalProgressBar goal={goal} />
+          </div>
+
+          <div className="flex gap-2">
+            <Stat
+              label="進捗"
+              value={`${Math.round(goal.progress_percent)}%`}
+            />
+            <Stat
+              label="残り"
+              value={
+                goal.is_finalized ? "確定済み" : `${goal.days_remaining}日`
+              }
+            />
+            <Stat label="期限" value={formatDeadline(goal.deadline)} />
+          </div>
+
+          {canToggleAchievement(goal) ? (
+            <Button
+              variant={goal.is_achieved ? "flat" : "bordered"}
+              className={
+                goal.is_achieved
+                  ? "font-bold"
+                  : "border-[#d08000] font-bold text-[#d08000]"
+              }
+              isDisabled={isToggling}
+              isLoading={isToggling}
+              onPress={() => onToggleAchievement(goal)}
+            >
+              {goal.is_achieved ? "達成を取り消す" : "達成にする"}
+            </Button>
+          ) : null}
+        </ModalBody>
+        <ModalFooter className="justify-between">
+          <Button color="danger" variant="flat" onPress={() => onDelete(goal)}>
+            削除
+          </Button>
+          <div className="flex gap-2">
+            <Button variant="flat" onPress={onClose}>
+              閉じる
+            </Button>
+            {isGoalEditable(goal) ? (
+              <Button
+                color="primary"
+                className="font-bold"
+                onPress={() => onEdit(goal)}
+              >
+                編集
+              </Button>
+            ) : null}
+          </div>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/app/(app)/goals/_components/GoalFormModal.tsx
+++ b/app/(app)/goals/_components/GoalFormModal.tsx
@@ -1,0 +1,519 @@
+"use client";
+
+import type { SeasonData, TournamentData } from "@app/interface";
+import type { Goal, GoalKind, GoalPeriodType } from "@app/types/goal";
+import type { PracticeMenu } from "@app/types/practice";
+import LockClosedIcon from "@heroicons/react/24/solid/LockClosedIcon";
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import { useState } from "react";
+import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
+import {
+  GOAL_COMPARISON_LABELS,
+  GOAL_KIND_DESCRIPTIONS,
+  GOAL_KIND_LABELS,
+  GOAL_METRIC_CATEGORIES,
+  GOAL_PERIOD_LABELS,
+  GOAL_PERIOD_ORDER,
+  metricExample,
+  metricFor,
+  metricsInCategory,
+} from "@app/constants/goal";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import {
+  goalPeriodGateFeature,
+  lockedGoalFeature,
+} from "../_utils/goalEntitlement";
+import {
+  type GoalFormValues,
+  hasAutoRange,
+  initialGoalFormValues,
+  isMenuMetric,
+  validateGoalForm,
+} from "../_utils/goalForm";
+import {
+  AUTO_RANGE_HINTS,
+  IMMUTABLE_FIELDS_NOTICE,
+  MANUAL_CURRENT_VALUE_HINT,
+  MENU_METRIC_HINT,
+  NO_PRACTICE_MENU_MESSAGE,
+  NO_SEASON_MESSAGE,
+  NO_TOURNAMENT_MESSAGE,
+} from "./goalCopy";
+
+const KIND_ORDER: readonly GoalKind[] = ["numeric", "qualitative", "manual"];
+
+interface GoalFormModalProps {
+  /** 編集対象。null なら新規作成。 */
+  goal: Goal | null;
+  seasons: SeasonData[];
+  tournaments: TournamentData[];
+  menus: PracticeMenu[];
+  today: string;
+  isSaving: boolean;
+  serverErrors: string[];
+  onClose: () => void;
+  onSubmit: (values: GoalFormValues) => void;
+}
+
+function ChoiceChip({
+  label,
+  isActive,
+  isDisabled,
+  onSelect,
+}: {
+  label: string;
+  isActive: boolean;
+  isDisabled: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={isActive}
+      disabled={isDisabled}
+      onClick={onSelect}
+      className={`rounded-full px-3.5 py-2 text-xs font-bold transition-colors disabled:cursor-not-allowed ${
+        isActive
+          ? "bg-[#d08000] text-white"
+          : "bg-sub text-zinc-400 hover:text-white disabled:opacity-40"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+/**
+ * 目標の作成・編集フォーム。
+ *
+ * 入力値の保持と必須チェックだけを担い、API 呼び出しは呼び出し元（Container）に委ねる。
+ * 開くたびに呼び出し元が key を変えて再マウントするため、初期値の同期に useEffect は使わない。
+ *
+ * 編集では back が更新を許可しない属性（種類・期間・シーズン・大会・指標・条件・対象メニュー）を
+ * すべて disabled にする。触れてしまうと「変更できたのに保存されない」状態になるため。
+ */
+export default function GoalFormModal({
+  goal,
+  seasons,
+  tournaments,
+  menus,
+  today,
+  isSaving,
+  serverErrors,
+  onClose,
+  onSubmit,
+}: GoalFormModalProps) {
+  const [values, setValues] = useState<GoalFormValues>(() =>
+    initialGoalFormValues(goal, today),
+  );
+  const [errors, setErrors] = useState<string[]>([]);
+  const { hasEntitlement, isLoading: isEntitlementLoading } = useEntitlement();
+
+  const isEditing = goal !== null;
+  const update = (patch: Partial<GoalFormValues>) =>
+    setValues((prev) => ({ ...prev, ...patch }));
+
+  // Pro 判定が未確定の間はロック表示を出さない（Pro 加入者にロックが一瞬見える方が実害が大きい）。
+  // 代わりに保存を無効化するので、誤った entitlement のまま送信されることはない。
+  const grantedWhileLoading = (feature: Parameters<typeof hasEntitlement>[0]) =>
+    isEntitlementLoading || hasEntitlement(feature);
+
+  // 編集では種類も期間も変更できないため、既存の目標に鍵をかけない
+  // （Pro 解約後も既存目標のタイトル・目標値は編集できる必要がある）。
+  const lockedFeature = isEditing
+    ? null
+    : lockedGoalFeature(
+        { kind: values.kind, periodType: values.periodType },
+        grantedWhileLoading,
+      );
+
+  const metric = metricFor(values.metricKey);
+  const isQualitative = values.kind === "qualitative";
+  const isManual = values.kind === "manual";
+  const menuMetricSelected = isMenuMetric(values);
+  const periodGate = goalPeriodGateFeature(values.periodType);
+  const showPeriodUpsell =
+    !isEditing && periodGate !== null && !grantedWhileLoading(periodGate);
+  const showManualUpsell =
+    !isEditing && isManual && !grantedWhileLoading("manual_metric_goals");
+
+  const handleSubmit = () => {
+    const validationErrors = validateGoalForm(values);
+    setErrors(validationErrors);
+    if (validationErrors.length > 0) return;
+    onSubmit(values);
+  };
+
+  const renderDeadline = () => (
+    <Input
+      type="date"
+      variant="bordered"
+      label="期限"
+      labelPlacement="outside"
+      value={values.deadline}
+      onChange={(event) => update({ deadline: event.target.value })}
+    />
+  );
+
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      placement="center"
+      scrollBehavior="inside"
+      className="buzz-dark"
+      size="lg"
+    >
+      <ModalContent>
+        <ModalHeader className="text-white">
+          {isEditing ? "目標を編集" : "新しい目標"}
+        </ModalHeader>
+        <ModalBody className="gap-4">
+          {isEditing ? (
+            <p className="rounded-lg bg-sub p-3 text-xs leading-5 text-zinc-300">
+              {IMMUTABLE_FIELDS_NOTICE}
+            </p>
+          ) : null}
+
+          <div>
+            <p className="mb-1.5 text-sm text-white">目標タイプ</p>
+            <div className="flex gap-2" role="group" aria-label="目標タイプ">
+              {KIND_ORDER.map((kind) => {
+                const isActive = values.kind === kind;
+                const showLock =
+                  !isEditing &&
+                  kind === "manual" &&
+                  !grantedWhileLoading("manual_metric_goals");
+                return (
+                  <button
+                    key={kind}
+                    type="button"
+                    aria-pressed={isActive}
+                    disabled={isEditing}
+                    onClick={() => update({ kind })}
+                    className={`flex flex-1 items-center justify-center gap-1 rounded-lg py-2.5 text-sm font-bold transition-colors disabled:cursor-not-allowed ${
+                      isActive
+                        ? "bg-[#d08000] text-white"
+                        : "bg-sub text-zinc-400 disabled:opacity-40"
+                    }`}
+                  >
+                    {showLock ? (
+                      <LockClosedIcon className="h-3.5 w-3.5" aria-hidden />
+                    ) : null}
+                    {GOAL_KIND_LABELS[kind]}
+                  </button>
+                );
+              })}
+            </div>
+            <p className="mt-2 rounded-lg bg-sub px-3 py-2.5 text-xs leading-5 text-zinc-300">
+              {GOAL_KIND_DESCRIPTIONS[values.kind]}
+            </p>
+          </div>
+
+          <div>
+            <p className="mb-1.5 text-sm text-white">期間</p>
+            <div
+              className="flex flex-wrap gap-2"
+              role="group"
+              aria-label="期間"
+            >
+              {GOAL_PERIOD_ORDER.map((periodType: GoalPeriodType) => (
+                <ChoiceChip
+                  key={periodType}
+                  label={GOAL_PERIOD_LABELS[periodType]}
+                  isActive={values.periodType === periodType}
+                  isDisabled={isEditing}
+                  onSelect={() => update({ periodType })}
+                />
+              ))}
+            </div>
+          </div>
+
+          {showPeriodUpsell && periodGate !== null ? (
+            <ProUpsellCard feature={periodGate} />
+          ) : null}
+
+          {hasAutoRange(values.periodType) ? (
+            <p className="text-xs text-zinc-500">
+              {
+                AUTO_RANGE_HINTS[
+                  values.periodType as keyof typeof AUTO_RANGE_HINTS
+                ]
+              }
+            </p>
+          ) : null}
+
+          {values.periodType === "custom" ? (
+            <>
+              <Input
+                type="date"
+                variant="bordered"
+                label="開始日"
+                labelPlacement="outside"
+                value={values.startDate}
+                onChange={(event) => update({ startDate: event.target.value })}
+              />
+              {renderDeadline()}
+            </>
+          ) : null}
+
+          {values.periodType === "season" ? (
+            <>
+              <div>
+                <p className="mb-1.5 text-sm text-white">シーズン</p>
+                {seasons.length === 0 ? (
+                  <p className="rounded-lg bg-sub p-3 text-xs text-zinc-400">
+                    {NO_SEASON_MESSAGE}
+                  </p>
+                ) : (
+                  <div
+                    className="flex flex-wrap gap-2"
+                    role="group"
+                    aria-label="シーズン"
+                  >
+                    {seasons.map((season) => (
+                      <ChoiceChip
+                        key={season.id}
+                        label={season.name}
+                        isActive={values.seasonId === season.id}
+                        isDisabled={isEditing}
+                        onSelect={() => update({ seasonId: season.id })}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+              {renderDeadline()}
+            </>
+          ) : null}
+
+          {values.periodType === "tournament" ? (
+            <>
+              <div>
+                <p className="mb-1.5 text-sm text-white">大会</p>
+                {tournaments.length === 0 ? (
+                  <p className="rounded-lg bg-sub p-3 text-xs text-zinc-400">
+                    {NO_TOURNAMENT_MESSAGE}
+                  </p>
+                ) : (
+                  <div
+                    className="flex flex-wrap gap-2"
+                    role="group"
+                    aria-label="大会"
+                  >
+                    {tournaments.map((tournament) => (
+                      <ChoiceChip
+                        key={tournament.id}
+                        label={tournament.name}
+                        isActive={values.tournamentId === tournament.id}
+                        isDisabled={isEditing}
+                        onSelect={() => update({ tournamentId: tournament.id })}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+              {renderDeadline()}
+            </>
+          ) : null}
+
+          {values.kind === "numeric" ? (
+            <>
+              <div>
+                <p className="mb-1.5 text-sm text-white">指標</p>
+                <div className="space-y-3">
+                  {GOAL_METRIC_CATEGORIES.map((category) => (
+                    <div key={category.key}>
+                      <p className="mb-1.5 text-xs font-bold text-zinc-500">
+                        {category.label}
+                      </p>
+                      <div
+                        className="flex flex-wrap gap-2"
+                        role="group"
+                        aria-label={category.label}
+                      >
+                        {metricsInCategory(category.keys).map((item) => (
+                          <ChoiceChip
+                            key={item.key}
+                            label={item.label}
+                            isActive={values.metricKey === item.key}
+                            isDisabled={isEditing}
+                            onSelect={() => update({ metricKey: item.key })}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {menuMetricSelected ? (
+                <div>
+                  <p className="mb-1.5 text-sm text-white">
+                    対象の練習メニュー
+                  </p>
+                  {menus.length === 0 ? (
+                    <p className="rounded-lg bg-sub p-3 text-xs text-zinc-400">
+                      {NO_PRACTICE_MENU_MESSAGE}
+                    </p>
+                  ) : (
+                    <div
+                      className="flex flex-wrap gap-2"
+                      role="group"
+                      aria-label="対象の練習メニュー"
+                    >
+                      {menus.map((menu) => (
+                        <ChoiceChip
+                          key={menu.id}
+                          label={menu.name}
+                          isActive={values.practiceMenuId === menu.id}
+                          isDisabled={isEditing}
+                          onSelect={() => update({ practiceMenuId: menu.id })}
+                        />
+                      ))}
+                    </div>
+                  )}
+                  <p className="mt-2 text-xs text-zinc-500">
+                    {MENU_METRIC_HINT}
+                  </p>
+                </div>
+              ) : (
+                <p className="text-xs text-zinc-500">
+                  条件: {GOAL_COMPARISON_LABELS[metric.comparison]}
+                </p>
+              )}
+            </>
+          ) : null}
+
+          {showManualUpsell ? (
+            <ProUpsellCard feature="manual_metric_goals" />
+          ) : null}
+
+          {isManual && !showManualUpsell ? (
+            <>
+              <Input
+                type="text"
+                variant="bordered"
+                label="指標名"
+                labelPlacement="outside"
+                isRequired
+                placeholder="例: 球速 / 遠投距離 / 体重"
+                value={values.customMetricLabel}
+                onChange={(event) =>
+                  update({ customMetricLabel: event.target.value })
+                }
+              />
+              <Input
+                type="text"
+                variant="bordered"
+                label="単位（任意）"
+                labelPlacement="outside"
+                placeholder="例: km/h"
+                value={values.customUnit}
+                onChange={(event) => update({ customUnit: event.target.value })}
+              />
+              <div>
+                <p className="mb-1.5 text-sm text-white">条件</p>
+                <div className="flex gap-2" role="group" aria-label="条件">
+                  {(["greater_than", "less_than"] as const).map(
+                    (comparison) => (
+                      <ChoiceChip
+                        key={comparison}
+                        label={GOAL_COMPARISON_LABELS[comparison]}
+                        isActive={values.comparison === comparison}
+                        isDisabled={isEditing}
+                        onSelect={() => update({ comparison })}
+                      />
+                    ),
+                  )}
+                </div>
+                <p className="mt-2 text-xs text-zinc-500">
+                  {MANUAL_CURRENT_VALUE_HINT}
+                </p>
+              </div>
+            </>
+          ) : null}
+
+          {isQualitative ? null : (
+            <>
+              <Input
+                type="number"
+                variant="bordered"
+                label="目標値"
+                labelPlacement="outside"
+                isRequired
+                placeholder={metric.decimal ? "例: 0.300" : "例: 20"}
+                value={values.targetValue}
+                onChange={(event) =>
+                  update({ targetValue: event.target.value })
+                }
+              />
+              {isManual && !showManualUpsell ? (
+                <Input
+                  type="number"
+                  variant="bordered"
+                  label="現在値"
+                  labelPlacement="outside"
+                  placeholder="例: 125"
+                  value={values.manualCurrentValue}
+                  onChange={(event) =>
+                    update({ manualCurrentValue: event.target.value })
+                  }
+                />
+              ) : null}
+            </>
+          )}
+
+          <Input
+            type="text"
+            variant="bordered"
+            label={isQualitative ? "目標" : "タイトル（任意）"}
+            labelPlacement="outside"
+            isRequired={isQualitative}
+            placeholder={
+              isQualitative
+                ? "例: この大会で優勝する"
+                : isManual
+                  ? values.customMetricLabel.trim() || "指標名の目標"
+                  : metricExample(values.metricKey)
+            }
+            value={values.title}
+            onChange={(event) => update({ title: event.target.value })}
+          />
+
+          {errors.length > 0 || serverErrors.length > 0 ? (
+            <ul role="alert" className="space-y-1 text-sm text-danger">
+              {[...errors, ...serverErrors].map((message) => (
+                <li key={message}>{message}</li>
+              ))}
+            </ul>
+          ) : null}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="flat" onPress={onClose} isDisabled={isSaving}>
+            キャンセル
+          </Button>
+          <Button
+            color="primary"
+            className="font-bold"
+            onPress={handleSubmit}
+            isDisabled={
+              isSaving || isEntitlementLoading || lockedFeature !== null
+            }
+            isLoading={isSaving}
+          >
+            {isEditing ? "更新" : "保存"}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/app/(app)/goals/_components/GoalList.tsx
+++ b/app/(app)/goals/_components/GoalList.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import type { Goal } from "@app/types/goal";
+import CheckCircleIcon from "@heroicons/react/24/outline/CheckCircleIcon";
+import SolidCheckCircleIcon from "@heroicons/react/24/solid/CheckCircleIcon";
+import { GOAL_PERIOD_LABELS } from "@app/constants/goal";
+import { canToggleAchievement, groupGoalsByPeriod } from "../_utils/goalList";
+import GoalProgressBar from "./GoalProgressBar";
+
+interface GoalListProps {
+  goals: Goal[];
+  emptyMessage: string;
+  /** 達成トグルの処理中で操作を止めたい目標の id。 */
+  togglingId: number | null;
+  onSelect: (goal: Goal) => void;
+  onToggleAchievement: (goal: Goal) => void;
+}
+
+/**
+ * 目標一覧（Presentational）。期間タイプごとに見出しを付けて並べる。
+ * 達成トグルは定性目標にだけ出す。数値目標・自由指標は back が手動達成を 422 で拒否するため。
+ */
+export default function GoalList({
+  goals,
+  emptyMessage,
+  togglingId,
+  onSelect,
+  onToggleAchievement,
+}: GoalListProps) {
+  if (goals.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-zinc-400">{emptyMessage}</p>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {groupGoalsByPeriod(goals).map((group) => (
+        <section
+          key={group.periodType}
+          aria-label={GOAL_PERIOD_LABELS[group.periodType]}
+        >
+          <h3 className="mb-2 text-xs font-bold text-zinc-400">
+            {GOAL_PERIOD_LABELS[group.periodType]}
+          </h3>
+          <ul className="space-y-2">
+            {group.goals.map((goal) => (
+              <li
+                key={goal.id}
+                className="flex items-center gap-3 rounded-[10px] bg-sub px-3.5 py-3"
+              >
+                <button
+                  type="button"
+                  className="flex-1 text-left"
+                  aria-label={`${goal.title}の詳細`}
+                  onClick={() => onSelect(goal)}
+                >
+                  <GoalProgressBar goal={goal} />
+                </button>
+                {canToggleAchievement(goal) ? (
+                  <button
+                    type="button"
+                    className="shrink-0 text-zinc-500 transition-colors hover:text-[#d08000] disabled:opacity-50"
+                    aria-label={
+                      goal.is_achieved
+                        ? `${goal.title}の達成を取り消す`
+                        : `${goal.title}を達成にする`
+                    }
+                    aria-pressed={goal.is_achieved}
+                    disabled={togglingId === goal.id}
+                    onClick={() => onToggleAchievement(goal)}
+                  >
+                    {goal.is_achieved ? (
+                      <SolidCheckCircleIcon className="h-7 w-7 text-[#d08000]" />
+                    ) : (
+                      <CheckCircleIcon className="h-7 w-7" />
+                    )}
+                  </button>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/app/(app)/goals/_components/GoalProgressBar.tsx
+++ b/app/(app)/goals/_components/GoalProgressBar.tsx
@@ -1,0 +1,102 @@
+import type { Goal } from "@app/types/goal";
+import { formatMetricValue, metricLabel } from "@app/constants/goal";
+import { progressBarWidth } from "../_utils/goalList";
+
+/**
+ * 進捗の表示に使う値。
+ * 現在値・目標値は back が返す文字列/数値どちらでも同じ見た目になるよう整形して返す。
+ */
+export function goalDisplayValues(goal: Goal): {
+  metricText: string;
+  currentText: string;
+  targetText: string;
+  remainingText: string;
+} {
+  const isManual = goal.kind === "manual";
+  // 単位はユーザーが定義した自由指標だけが持つ。自動集計の指標は指標名（meta 行）で判別できる。
+  const unit = isManual ? (goal.custom_unit ?? "") : "";
+
+  const metricText = isManual
+    ? (goal.custom_metric_label ?? "")
+    : goal.metric_key === "menu_practice_days" && goal.practice_menu_name
+      ? `${goal.practice_menu_name} 継続日数`
+      : metricLabel(goal.metric_key);
+
+  return {
+    metricText,
+    currentText: `${formatMetricValue(goal.metric_key, goal.current_value)}${unit}`,
+    targetText: `${formatMetricValue(goal.metric_key, goal.target_value)}${unit}${
+      goal.comparison_type === "less_than" ? " 以下" : ""
+    }`,
+    remainingText: goal.is_finalized
+      ? "確定済み"
+      : `残り${goal.days_remaining}日`,
+  };
+}
+
+/**
+ * 目標1件の進捗表示（Presentational）。
+ * 定性目標は数値を持たないため、バーではなく達成/未達成のチップで表す。
+ */
+export default function GoalProgressBar({ goal }: { goal: Goal }) {
+  const { metricText, currentText, targetText, remainingText } =
+    goalDisplayValues(goal);
+
+  if (goal.kind === "qualitative") {
+    return (
+      <div className="w-full">
+        <div className="flex items-start justify-between gap-2">
+          <p className="text-sm font-semibold text-white">{goal.title}</p>
+          <span
+            className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-bold ${
+              goal.is_achieved
+                ? "bg-[#d08000] text-white"
+                : "bg-main text-zinc-400"
+            }`}
+          >
+            {goal.is_achieved ? "達成" : "未達成"}
+          </span>
+        </div>
+        <p className="mt-1.5 text-xs text-zinc-400">{remainingText}</p>
+      </div>
+    );
+  }
+
+  const width = progressBarWidth(goal.progress_percent);
+
+  return (
+    <div className="w-full">
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-sm font-semibold text-white">{goal.title}</p>
+        <span className="shrink-0 text-sm font-bold text-[#d08000]">
+          {Math.round(goal.progress_percent)}%
+        </span>
+      </div>
+      <div
+        className="mt-2 h-2 w-full overflow-hidden rounded-full bg-[#424242]"
+        role="progressbar"
+        aria-label={`${goal.title}の進捗`}
+        aria-valuenow={width}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div
+          className="h-2 rounded-full bg-[#d08000]"
+          style={{ width: `${width}%` }}
+        />
+      </div>
+      <div className="mt-2 flex items-baseline gap-2 text-sm">
+        <span className="text-xs text-zinc-400">現在</span>
+        <span className="font-bold text-white">{currentText}</span>
+        <span aria-hidden className="text-zinc-500">
+          →
+        </span>
+        <span className="text-xs text-zinc-400">目標</span>
+        <span className="font-extrabold text-[#d08000]">{targetText}</span>
+      </div>
+      <p className="mt-1.5 text-xs text-zinc-400">
+        {metricText} ・ {remainingText}
+      </p>
+    </div>
+  );
+}

--- a/app/(app)/goals/_components/GoalsContent.tsx
+++ b/app/(app)/goals/_components/GoalsContent.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import type { SeasonData, TournamentData } from "@app/interface";
+import type { Goal } from "@app/types/goal";
+import type { PracticeMenu } from "@app/types/practice";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import {
+  achieveGoal,
+  createGoal,
+  deleteGoal,
+  unachieveGoal,
+  updateGoal,
+} from "@app/services/v2/goalService";
+import { goalForbiddenFeature } from "../_utils/goalEntitlement";
+import {
+  type GoalFormValues,
+  buildGoalCreatePayload,
+  buildGoalUpdatePayload,
+} from "../_utils/goalForm";
+import {
+  GOAL_TABS,
+  type GoalTab,
+  groupGoalsByTab,
+  isAtGoalFreeLimit,
+} from "../_utils/goalList";
+import {
+  DELETE_CONFIRM_NOTICE,
+  EMPTY_MESSAGE,
+  FREE_LIMIT_DESCRIPTION,
+  FREE_LIMIT_SERVER_ERROR,
+  FREE_LIMIT_TITLE,
+  HISTORY_LOAD_ERROR_MESSAGE,
+} from "./goalCopy";
+import GoalDetailModal from "./GoalDetailModal";
+import GoalFormModal from "./GoalFormModal";
+import GoalList from "./GoalList";
+
+interface GoalsContentProps {
+  initialGoals: Goal[];
+  initialHistory: Goal[];
+  /** 履歴の取得に失敗したか。空配列と区別して「未達が0件」の誤表示を避ける。 */
+  historyLoadFailed: boolean;
+  seasons: SeasonData[];
+  tournaments: TournamentData[];
+  menus: PracticeMenu[];
+  today: string;
+}
+
+/** フォームを開くたびに増やし、key の付け替えで入力状態を初期化するための識別子。 */
+interface FormTarget {
+  goal: Goal | null;
+  token: number;
+}
+
+/**
+ * 目標画面の Container。
+ * 一覧の状態保持・Server Action 呼び出し・Pro / 無料枠の判定を担い、表示は子コンポーネントへ委ねる。
+ */
+export default function GoalsContent({
+  initialGoals,
+  initialHistory,
+  historyLoadFailed,
+  seasons,
+  tournaments,
+  menus,
+  today,
+}: GoalsContentProps) {
+  const [goals, setGoals] = useState<Goal[]>(initialGoals);
+  const [history, setHistory] = useState<Goal[]>(initialHistory);
+  const [tab, setTab] = useState<GoalTab>("in_progress");
+  const [form, setForm] = useState<FormTarget | null>(null);
+  const [formErrors, setFormErrors] = useState<string[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const [detailId, setDetailId] = useState<number | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Goal | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [togglingId, setTogglingId] = useState<number | null>(null);
+  const { hasEntitlement, isLoading: isEntitlementLoading } = useEntitlement();
+  const { open: openProUpgradeModal } = useProUpgradeModal();
+
+  const goalsByTab = groupGoalsByTab(goals, history);
+  const detailGoal =
+    [...goals, ...history].find((goal) => goal.id === detailId) ?? null;
+  const isAtFreeLimit = isAtGoalFreeLimit({
+    activeGoals: goals,
+    hasUnlimited: hasEntitlement("unlimited_monthly_goals"),
+    isEntitlementLoading,
+  });
+
+  const replaceGoal = (updated: Goal) => {
+    setGoals((prev) =>
+      prev.map((goal) => (goal.id === updated.id ? updated : goal)),
+    );
+    setHistory((prev) =>
+      prev.map((goal) => (goal.id === updated.id ? updated : goal)),
+    );
+  };
+
+  const openForm = (goal: Goal | null) => {
+    setFormErrors([]);
+    setForm({ goal, token: Date.now() + goals.length });
+  };
+
+  const handleAdd = () => {
+    if (isAtFreeLimit) {
+      openProUpgradeModal({ trigger: "unlimited_monthly_goals" });
+      return;
+    }
+    openForm(null);
+  };
+
+  const handleSubmit = async (values: GoalFormValues) => {
+    const editing = form?.goal ?? null;
+    setIsSaving(true);
+    setFormErrors([]);
+
+    const result = editing
+      ? await updateGoal(
+          editing.id,
+          buildGoalUpdatePayload(values, editing, today),
+        )
+      : await createGoal(buildGoalCreatePayload(values, today));
+    setIsSaving(false);
+
+    if (result.ok) {
+      if (editing) {
+        replaceGoal(result.data);
+      } else {
+        setGoals((prev) => [...prev, result.data]);
+      }
+      setForm(null);
+      toast.success(editing ? "目標を更新しました" : "目標を作成しました");
+      return;
+    }
+
+    if (result.reason === "forbidden") {
+      // back は Pro 限定機能も無料枠超過も 403 で返す。どちらだったかは送った内容から判定する。
+      const feature = goalForbiddenFeature({
+        kind: values.kind,
+        periodType: values.periodType,
+      });
+      // 件数上限のときの back の文言は「Pro プランで期間目標を無制限に設定できます」で、
+      // 何件までなのかが伝わらないため、上限を明示した文言へ置き換える。
+      setFormErrors(
+        feature === "unlimited_monthly_goals"
+          ? [FREE_LIMIT_SERVER_ERROR]
+          : result.errors,
+      );
+      openProUpgradeModal({ trigger: feature });
+      return;
+    }
+    setFormErrors(result.errors);
+  };
+
+  const handleToggleAchievement = async (goal: Goal) => {
+    setTogglingId(goal.id);
+    const result = goal.is_achieved
+      ? await unachieveGoal(goal.id)
+      : await achieveGoal(goal.id);
+    setTogglingId(null);
+
+    if (!result.ok) {
+      toast.error(result.errors[0]);
+      return;
+    }
+    replaceGoal(result.data);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    const result = await deleteGoal(deleteTarget.id);
+    setIsDeleting(false);
+
+    if (!result.ok) {
+      toast.error(result.errors[0]);
+      return;
+    }
+    setGoals((prev) => prev.filter((goal) => goal.id !== deleteTarget.id));
+    setHistory((prev) => prev.filter((goal) => goal.id !== deleteTarget.id));
+    setDetailId(null);
+    setDeleteTarget(null);
+    toast.success("目標を削除しました");
+  };
+
+  return (
+    <>
+      <h2 className="text-2xl font-bold">目標</h2>
+      <p className="mt-2 text-sm text-zinc-300">
+        練習量や成績の目標を決めると、記録した内容から進み具合を自動で計算します。数字にできない目標は達成ボタンで管理できます。
+      </p>
+
+      {historyLoadFailed ? (
+        <p className="mt-4 rounded-lg bg-sub p-3 text-xs text-zinc-300">
+          {HISTORY_LOAD_ERROR_MESSAGE}
+        </p>
+      ) : null}
+
+      <div className="my-5 flex gap-2" role="tablist" aria-label="目標の状態">
+        {GOAL_TABS.map((item) => {
+          const isActive = item.key === tab;
+          return (
+            <button
+              key={item.key}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => setTab(item.key)}
+              className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg py-2.5 text-sm font-bold transition-colors ${
+                isActive ? "bg-[#d08000] text-white" : "bg-sub text-zinc-400"
+              }`}
+            >
+              {item.label}
+              <span className="text-xs">{goalsByTab[item.key].length}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mb-6">
+        <GoalList
+          goals={goalsByTab[tab]}
+          emptyMessage={EMPTY_MESSAGE[tab]}
+          togglingId={togglingId}
+          onSelect={(goal) => setDetailId(goal.id)}
+          onToggleAchievement={handleToggleAchievement}
+        />
+      </div>
+
+      {isAtFreeLimit ? (
+        <ProUpsellCard
+          feature="unlimited_monthly_goals"
+          title={FREE_LIMIT_TITLE}
+          description={FREE_LIMIT_DESCRIPTION}
+          className="mb-4"
+        />
+      ) : null}
+
+      <Button
+        color="primary"
+        fullWidth
+        radius="sm"
+        className="font-bold"
+        startContent={<PlusIcon className="h-5 w-5" aria-hidden />}
+        isDisabled={isEntitlementLoading}
+        onPress={handleAdd}
+      >
+        新しい目標を追加
+      </Button>
+
+      {form ? (
+        <GoalFormModal
+          key={form.token}
+          goal={form.goal}
+          seasons={seasons}
+          tournaments={tournaments}
+          menus={menus}
+          today={today}
+          isSaving={isSaving}
+          serverErrors={formErrors}
+          onClose={() => setForm(null)}
+          onSubmit={handleSubmit}
+        />
+      ) : null}
+
+      {detailGoal ? (
+        <GoalDetailModal
+          goal={detailGoal}
+          isToggling={togglingId === detailGoal.id}
+          onClose={() => setDetailId(null)}
+          onEdit={(goal) => {
+            setDetailId(null);
+            openForm(goal);
+          }}
+          onDelete={(goal) => {
+            // 詳細の上に確認モーダルを重ねると背面が aria-hidden になり読み上げが届かないため、
+            // 詳細を閉じてから確認へ切り替える。
+            setDetailId(null);
+            setDeleteTarget(goal);
+          }}
+          onToggleAchievement={handleToggleAchievement}
+        />
+      ) : null}
+
+      <Modal
+        isOpen={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        placement="center"
+        className="buzz-dark"
+      >
+        <ModalContent>
+          <ModalHeader className="text-white">目標の削除</ModalHeader>
+          <ModalBody>
+            <p className="text-sm text-white">
+              「{deleteTarget?.title}」を削除しますか？
+            </p>
+            <p className="text-xs text-zinc-400">{DELETE_CONFIRM_NOTICE}</p>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="flat"
+              onPress={() => setDeleteTarget(null)}
+              isDisabled={isDeleting}
+            >
+              キャンセル
+            </Button>
+            <Button
+              color="danger"
+              onPress={handleDelete}
+              isDisabled={isDeleting}
+              isLoading={isDeleting}
+            >
+              削除
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/app/(app)/goals/_components/goalCopy.ts
+++ b/app/(app)/goals/_components/goalCopy.ts
@@ -1,0 +1,54 @@
+import type { GoalTab } from "../_utils/goalList";
+import { MONTHLY_GOAL_FREE_LIMIT } from "@app/constants/goal";
+
+export const FREE_LIMIT_TITLE = `無料プランで同時に設定できる目標は${MONTHLY_GOAL_FREE_LIMIT}件までです`;
+
+export const FREE_LIMIT_DESCRIPTION =
+  "週次・月次・年間・カスタム期間の目標は合わせて2件までです。Pro プランなら3つ目以降も同時に管理できます。";
+
+/**
+ * 作成が 403 で弾かれたときにフォームへ出す文言。
+ * back の「Pro プランで期間目標を無制限に設定できます」は Pro 限定機能ではなく件数上限を指すため、
+ * 別端末での追加などで件数判定がずれた場合も上限として案内する。
+ */
+export const FREE_LIMIT_SERVER_ERROR = `${FREE_LIMIT_TITLE}。${FREE_LIMIT_DESCRIPTION}`;
+
+export const EMPTY_MESSAGE: Record<GoalTab, string> = {
+  in_progress: "進行中の目標はありません",
+  achieved: "達成した目標はまだありません",
+  unachieved: "未達で終わった目標はありません",
+};
+
+export const LOAD_ERROR_MESSAGE =
+  "目標を取得できませんでした。時間を置いて再度お試しください。";
+
+export const HISTORY_LOAD_ERROR_MESSAGE =
+  "達成・未達の履歴を取得できませんでした。進行中の目標のみ表示しています。";
+
+export const DELETE_CONFIRM_NOTICE =
+  "削除すると進捗の記録も失われます。達成バッジは残ります。";
+
+/** 編集で変更できない項目の理由。UI の disabled とセットで必ず伝える。 */
+export const IMMUTABLE_FIELDS_NOTICE =
+  "目標タイプ・期間・指標・条件は作成後に変更できません。変更したい場合は削除して作り直してください。";
+
+export const MENU_METRIC_HINT =
+  "期間内にこのメニューを実施した「日数」を数えます。";
+
+export const MANUAL_CURRENT_VALUE_HINT =
+  "現在値は手入力で更新します（自動集計はしません）。";
+
+export const NO_SEASON_MESSAGE =
+  "シーズンがありません。シーズン管理から登録してください。";
+
+export const NO_TOURNAMENT_MESSAGE =
+  "大会がありません。試合記録で大会を登録してください。";
+
+export const NO_PRACTICE_MENU_MESSAGE =
+  "練習メニューがありません。練習メニュー画面で登録してください。";
+
+export const AUTO_RANGE_HINTS = {
+  monthly: "対象期間: 今月（自動設定）",
+  weekly: "対象期間: 今週 月〜日（自動設定）",
+  yearly: "対象期間: 今年 1月〜12月（自動設定）",
+} as const;

--- a/app/(app)/goals/_utils/goalEntitlement.ts
+++ b/app/(app)/goals/_utils/goalEntitlement.ts
@@ -1,0 +1,57 @@
+import type { GoalKind, GoalPeriodType } from "@app/types/goal";
+import type { Feature, ProFeature } from "@app/types/pro";
+
+/**
+ * Pro 限定になる期間タイプ → entitlement キー。
+ * back/app/controllers/api/v2/goals_controller.rb の allowed_to_create? と対応させる。
+ * ここに無い期間タイプ（monthly / weekly / yearly）は無料でも作成でき、件数だけが制限される。
+ */
+const PERIOD_GATE_FEATURES: Partial<Record<GoalPeriodType, ProFeature>> = {
+  season: "season_goals",
+  tournament: "tournament_goals",
+  custom: "custom_period_goals",
+};
+
+/** その期間タイプが Pro 限定なら entitlement キー、無料で作れるなら null。 */
+export function goalPeriodGateFeature(
+  periodType: GoalPeriodType,
+): ProFeature | null {
+  return PERIOD_GATE_FEATURES[periodType] ?? null;
+}
+
+/**
+ * 作成が 403 になったとき、back がどのゲートで弾いたか。
+ *
+ * back/app/controllers/api/v2/goals_controller.rb の render_limit_error と同じ優先順で決める
+ * （自由指標 → 期間タイプ → 個人の期間目標の件数上限）。
+ * クライアントの entitlement は参照しない。手元の Pro 状態が古いまま 403 を受けたときこそ、
+ * 送った内容から原因を特定する必要があるため。
+ */
+export function goalForbiddenFeature(target: {
+  kind: GoalKind;
+  periodType: GoalPeriodType;
+}): ProFeature {
+  if (target.kind === "manual") return "manual_metric_goals";
+  return goalPeriodGateFeature(target.periodType) ?? "unlimited_monthly_goals";
+}
+
+/**
+ * 新規作成をブロックしている Pro 機能。作成できるなら null。
+ *
+ * 自由指標（manual）を先に見るのは back の allowed_to_create? と同じ順序にするため。
+ * 例えば「自由指標 × カスタム期間」を無料で作ろうとしたとき、back が返す 403 は
+ * 自由指標の文言なので、フロントの訴求もそれに合わせる。
+ *
+ * 個人の期間目標の件数上限はここでは扱わない（entitlement ではなく保有件数で決まるため）。
+ */
+export function lockedGoalFeature(
+  target: { kind: GoalKind; periodType: GoalPeriodType },
+  hasEntitlement: (feature: Feature) => boolean,
+): ProFeature | null {
+  if (target.kind === "manual" && !hasEntitlement("manual_metric_goals")) {
+    return "manual_metric_goals";
+  }
+  const periodGate = goalPeriodGateFeature(target.periodType);
+  if (periodGate !== null && !hasEntitlement(periodGate)) return periodGate;
+  return null;
+}

--- a/app/(app)/goals/_utils/goalForm.ts
+++ b/app/(app)/goals/_utils/goalForm.ts
@@ -1,0 +1,320 @@
+import type {
+  Goal,
+  GoalComparison,
+  GoalInput,
+  GoalKind,
+  GoalMetricKey,
+  GoalPeriodType,
+  GoalUpdateInput,
+} from "@app/types/goal";
+import { GOAL_METRICS, MENU_METRIC_KEY, metricFor } from "@app/constants/goal";
+import { parseDecimal } from "@app/constants/practice";
+
+/**
+ * 「今日」の基準は back の集計（Asia/Tokyo）に合わせる。
+ * 実行環境のタイムゾーンに任せると、月次目標の対象期間が SSR と CSR でずれる。
+ */
+const TIME_ZONE = "Asia/Tokyo";
+
+const DATE_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  timeZone: TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+/** 今日の日付を `YYYY-MM-DD` で返す。 */
+export function todayString(now: Date = new Date()): string {
+  return DATE_FORMATTER.format(now);
+}
+
+// 日付演算は UTC 固定の Date で行う。ローカルタイムゾーンで計算すると
+// 夏時間や UTC+X の環境で 1 日ずれることがある。
+const toDate = (iso: string): Date => new Date(`${iso}T00:00:00Z`);
+const toIso = (date: Date): string => date.toISOString().slice(0, 10);
+
+/** `YYYY-MM-DD` に日数を加算する。 */
+export function addDays(iso: string, days: number): string {
+  const date = toDate(iso);
+  date.setUTCDate(date.getUTCDate() + days);
+  return toIso(date);
+}
+
+export interface DateRange {
+  start: string;
+  end: string;
+}
+
+/** その日を含む月の初日・末日。 */
+export function monthRange(iso: string): DateRange {
+  const date = toDate(iso);
+  const year = date.getUTCFullYear();
+  const month = date.getUTCMonth();
+  return {
+    start: toIso(new Date(Date.UTC(year, month, 1))),
+    end: toIso(new Date(Date.UTC(year, month + 1, 0))),
+  };
+}
+
+/** その日を含む週（月曜〜日曜）の初日・末日。 */
+export function weekRange(iso: string): DateRange {
+  const date = toDate(iso);
+  const weekday = date.getUTCDay();
+  const start = addDays(iso, -(weekday === 0 ? 6 : weekday - 1));
+  return { start, end: addDays(start, 6) };
+}
+
+/** その日を含む年の初日・末日。 */
+export function yearRange(iso: string): DateRange {
+  const year = toDate(iso).getUTCFullYear();
+  return { start: `${year}-01-01`, end: `${year}-12-31` };
+}
+
+/** 対象期間を自動算出する期間タイプ。ユーザーに開始日・期限を入力させない。 */
+const AUTO_RANGE_PERIOD_TYPES: readonly GoalPeriodType[] = [
+  "monthly",
+  "weekly",
+  "yearly",
+];
+
+/** 対象期間が自動算出される期間タイプか。 */
+export function hasAutoRange(periodType: GoalPeriodType): boolean {
+  return AUTO_RANGE_PERIOD_TYPES.includes(periodType);
+}
+
+/** 新規作成時の既定の期限（今日から90日後）。 */
+const DEFAULT_DEADLINE_OFFSET_DAYS = 90;
+
+export interface GoalFormValues {
+  kind: GoalKind;
+  periodType: GoalPeriodType;
+  metricKey: GoalMetricKey;
+  practiceMenuId: number | null;
+  targetValue: string;
+  customMetricLabel: string;
+  customUnit: string;
+  manualCurrentValue: string;
+  comparison: GoalComparison;
+  title: string;
+  seasonId: number | null;
+  tournamentId: number | null;
+  /** カスタム期間の開始日（`YYYY-MM-DD`）。 */
+  startDate: string;
+  /** カスタム期間・シーズン・大会の期限（`YYYY-MM-DD`）。 */
+  deadline: string;
+}
+
+/** 数値入力欄へ流し込む文字列。未入力（null）と 0 を取り違えないよう空文字を返す。 */
+function toInputValue(value: Goal["target_value"]): string {
+  const parsed = parseDecimal(value);
+  return parsed === null ? "" : String(parsed);
+}
+
+/** フォームの初期値。編集時は既存の目標から復元する。 */
+export function initialGoalFormValues(
+  goal: Goal | null,
+  today: string,
+): GoalFormValues {
+  if (!goal) {
+    return {
+      kind: "numeric",
+      periodType: "monthly",
+      metricKey: GOAL_METRICS[0].key,
+      practiceMenuId: null,
+      targetValue: "",
+      customMetricLabel: "",
+      customUnit: "",
+      manualCurrentValue: "",
+      comparison: "greater_than",
+      title: "",
+      seasonId: null,
+      tournamentId: null,
+      startDate: today,
+      deadline: addDays(today, DEFAULT_DEADLINE_OFFSET_DAYS),
+    };
+  }
+
+  return {
+    kind: goal.kind,
+    periodType: goal.period_type,
+    metricKey: goal.metric_key ?? GOAL_METRICS[0].key,
+    practiceMenuId: goal.practice_menu_id,
+    targetValue: toInputValue(goal.target_value),
+    customMetricLabel: goal.custom_metric_label ?? "",
+    customUnit: goal.custom_unit ?? "",
+    manualCurrentValue:
+      goal.kind === "manual" ? toInputValue(goal.manual_current_value) : "",
+    comparison: goal.comparison_type,
+    title: goal.title,
+    seasonId: goal.season_id,
+    tournamentId: goal.tournament_id,
+    startDate: goal.month_start ?? today,
+    deadline: goal.deadline,
+  };
+}
+
+/** 継続日数（対象メニューの指定が必須）の指標を選んでいるか。 */
+export function isMenuMetric(values: GoalFormValues): boolean {
+  return values.kind === "numeric" && values.metricKey === MENU_METRIC_KEY;
+}
+
+/**
+ * 対象期間（month_start / deadline）を決める。
+ *
+ * 編集では monthly / weekly / yearly の期間を再計算しない。
+ * 保存のたびに「今日」を基準に振り直すと、先月作った月次目標が今月へ移ってしまうため。
+ */
+export function resolveGoalPeriod(
+  values: GoalFormValues,
+  editing: Goal | null,
+  today: string,
+): { month_start: string | null; deadline: string } {
+  if (editing && hasAutoRange(values.periodType)) {
+    return { month_start: editing.month_start, deadline: editing.deadline };
+  }
+
+  switch (values.periodType) {
+    case "monthly": {
+      const range = monthRange(today);
+      return { month_start: range.start, deadline: range.end };
+    }
+    case "weekly": {
+      const range = weekRange(today);
+      return { month_start: range.start, deadline: range.end };
+    }
+    case "yearly": {
+      const range = yearRange(today);
+      return { month_start: range.start, deadline: range.end };
+    }
+    case "custom":
+      return { month_start: values.startDate, deadline: values.deadline };
+    default:
+      // シーズン・大会は対象試合から期間を求めるため開始日を持たない。
+      return { month_start: null, deadline: values.deadline };
+  }
+}
+
+/**
+ * 入力値を検証し、エラーメッセージを返す（空配列なら送信可）。
+ * back の 422 を待たずに気づけるよう、必須項目と日付の前後関係だけを見る。
+ */
+export function validateGoalForm(values: GoalFormValues): string[] {
+  const errors: string[] = [];
+  const isQualitative = values.kind === "qualitative";
+  const isManual = values.kind === "manual";
+
+  if (isQualitative && values.title.trim() === "") {
+    errors.push("目標を入力してください");
+  }
+  if (isManual && values.customMetricLabel.trim() === "") {
+    errors.push("指標名を入力してください");
+  }
+  if (!isQualitative && parseDecimal(values.targetValue) === null) {
+    errors.push("目標値を入力してください");
+  }
+  if (isMenuMetric(values) && values.practiceMenuId === null) {
+    errors.push("対象の練習メニューを選択してください");
+  }
+  if (values.periodType === "season" && values.seasonId === null) {
+    errors.push("シーズンを選択してください");
+  }
+  if (values.periodType === "tournament" && values.tournamentId === null) {
+    errors.push("大会を選択してください");
+  }
+  if (values.periodType === "custom" && values.startDate > values.deadline) {
+    errors.push("終了日は開始日以降にしてください");
+  }
+  return errors;
+}
+
+/** タイトル未入力時のフォールバック。一覧で「無題」が並ばないよう指標名から補う。 */
+function resolveTitle(values: GoalFormValues): string {
+  const title = values.title.trim();
+  if (title !== "") return title;
+  if (values.kind === "manual") return values.customMetricLabel.trim();
+  return `${metricFor(values.metricKey).label}目標`;
+}
+
+/** 数値・自由指標で共通の目標値。検証済み前提で数値化する。 */
+function targetValueOf(values: GoalFormValues): number {
+  return parseDecimal(values.targetValue) ?? 0;
+}
+
+/**
+ * 新規作成の送信ペイロードを組み立てる。
+ * 定性目標は指標・目標値を持たないため、それらのキー自体を送らない。
+ */
+export function buildGoalCreatePayload(
+  values: GoalFormValues,
+  today: string,
+): GoalInput {
+  const period = resolveGoalPeriod(values, null, today);
+  const base: GoalInput = {
+    title: resolveTitle(values),
+    kind: values.kind,
+    period_type: values.periodType,
+    season_id: values.periodType === "season" ? values.seasonId : null,
+    tournament_id:
+      values.periodType === "tournament" ? values.tournamentId : null,
+    month_start: period.month_start,
+    deadline: period.deadline,
+  };
+
+  if (values.kind === "qualitative") return base;
+
+  if (values.kind === "manual") {
+    return {
+      ...base,
+      custom_metric_label: values.customMetricLabel.trim(),
+      custom_unit: values.customUnit.trim() || null,
+      target_value: targetValueOf(values),
+      // 自由指標は自動集計できないため、達成条件をユーザーに選ばせる。
+      comparison_type: values.comparison,
+      manual_current_value: parseDecimal(values.manualCurrentValue) ?? 0,
+    };
+  }
+
+  return {
+    ...base,
+    metric_key: values.metricKey,
+    target_value: targetValueOf(values),
+    // 数値目標の達成条件は指標ごとに決まる（防御率は以下、打率は以上）。
+    comparison_type: metricFor(values.metricKey).comparison,
+    practice_menu_id: isMenuMetric(values) ? values.practiceMenuId : null,
+  };
+}
+
+/**
+ * 更新の送信ペイロードを組み立てる。
+ *
+ * back が更新を許可するのは title / month_start / deadline / target_value /
+ * custom_metric_label / custom_unit / manual_current_value だけ。
+ * 種類・期間タイプ・シーズン・大会・指標・達成条件・対象メニューは含めない
+ * （送っても無視され、「編集できたのに反映されない」状態になるため）。
+ */
+export function buildGoalUpdatePayload(
+  values: GoalFormValues,
+  editing: Goal,
+  today: string,
+): GoalUpdateInput {
+  const period = resolveGoalPeriod(values, editing, today);
+  const base: GoalUpdateInput = {
+    title: resolveTitle(values),
+    month_start: period.month_start,
+    deadline: period.deadline,
+  };
+
+  if (values.kind === "qualitative") return base;
+
+  if (values.kind === "manual") {
+    return {
+      ...base,
+      custom_metric_label: values.customMetricLabel.trim(),
+      custom_unit: values.customUnit.trim() || null,
+      target_value: targetValueOf(values),
+      manual_current_value: parseDecimal(values.manualCurrentValue) ?? 0,
+    };
+  }
+
+  return { ...base, target_value: targetValueOf(values) };
+}

--- a/app/(app)/goals/_utils/goalList.ts
+++ b/app/(app)/goals/_utils/goalList.ts
@@ -1,0 +1,111 @@
+import type { Goal, GoalPeriodType } from "@app/types/goal";
+import {
+  GOAL_PERIOD_ORDER,
+  MONTHLY_GOAL_FREE_LIMIT,
+  PERSONAL_GOAL_PERIOD_TYPES,
+} from "@app/constants/goal";
+
+export type GoalTab = "in_progress" | "achieved" | "unachieved";
+
+export const GOAL_TABS: ReadonlyArray<{ key: GoalTab; label: string }> = [
+  { key: "in_progress", label: "進行中" },
+  { key: "achieved", label: "達成" },
+  { key: "unachieved", label: "未達" },
+];
+
+/**
+ * 目標をタブへ振り分ける。
+ * 達成は「期限前に手動達成した進行中の定性目標」も含み、
+ * 未達は「期限到来後に未達のまま確定したもの」だけを指す。
+ */
+export function categorizeGoal(goal: Goal): GoalTab {
+  if (goal.is_achieved) return "achieved";
+  if (goal.is_finalized) return "unachieved";
+  return "in_progress";
+}
+
+/**
+ * 進行中（index）と確定済み（history）をまとめてタブ別に分類する。
+ * back が is_finalized で排他的に返すため、2つのリストに重複は無い。
+ */
+export function groupGoalsByTab(
+  activeGoals: Goal[],
+  historyGoals: Goal[],
+): Record<GoalTab, Goal[]> {
+  const buckets: Record<GoalTab, Goal[]> = {
+    in_progress: [],
+    achieved: [],
+    unachieved: [],
+  };
+  [...activeGoals, ...historyGoals].forEach((goal) => {
+    buckets[categorizeGoal(goal)].push(goal);
+  });
+  return buckets;
+}
+
+/** 期間タイプ別に GOAL_PERIOD_ORDER の順で並べ、0件の期間タイプは返さない。 */
+export function groupGoalsByPeriod(
+  goals: Goal[],
+): Array<{ periodType: GoalPeriodType; goals: Goal[] }> {
+  return GOAL_PERIOD_ORDER.map((periodType) => ({
+    periodType,
+    goals: goals.filter((goal) => goal.period_type === periodType),
+  })).filter((group) => group.goals.length > 0);
+}
+
+/**
+ * 進捗バーの塗り幅（%）。
+ * back の progress_percent をそのまま使い、不正値・範囲外だけを丸める
+ * （0〜100 の外に出ると帯が枠から溢れる）。
+ */
+export function progressBarWidth(percent: number): number {
+  if (!Number.isFinite(percent)) return 0;
+  return Math.min(100, Math.max(0, percent));
+}
+
+/**
+ * 達成トグルを出してよい目標か。
+ * 定性目標だけが achievement API の対象で、数値目標・自由指標は back が 422 を返す。
+ * 確定済みの目標は結果が固定されるため操作させない。
+ */
+export function canToggleAchievement(goal: Goal): boolean {
+  return goal.kind === "qualitative" && !goal.is_finalized;
+}
+
+/** 確定済みの目標は編集できない（期間も結果も固定されるため）。 */
+export function isGoalEditable(goal: Goal): boolean {
+  return !goal.is_finalized;
+}
+
+/**
+ * 無料枠を消費している目標の件数。
+ * back の PlanLimits#active_monthly_goals_count と同じく、進行中かつ個人の期間目標だけを数える
+ * （シーズン・大会は件数ではなく Pro 限定機能として別に判定される）。
+ */
+export function countPersonalPeriodGoals(activeGoals: Goal[]): number {
+  return activeGoals.filter((goal) =>
+    PERSONAL_GOAL_PERIOD_TYPES.includes(goal.period_type),
+  ).length;
+}
+
+interface FreeLimitParams {
+  activeGoals: Goal[];
+  hasUnlimited: boolean;
+  isEntitlementLoading: boolean;
+}
+
+/**
+ * 個人の期間目標を新規作成できないか（無料枠が埋まっているか）。
+ *
+ * back は「上限以上でも既存分は維持できる」グランドファザリング実装（新規作成だけを弾く）なので、
+ * ここでも判定するのは新規作成の可否だけ。既存目標の編集・削除は件数に関係なく許可する。
+ * Pro 判定が未確定の間は上限扱いにしない（Pro 加入者へ誤って上限を告知しないため）。
+ */
+export function isAtGoalFreeLimit({
+  activeGoals,
+  hasUnlimited,
+  isEntitlementLoading,
+}: FreeLimitParams): boolean {
+  if (isEntitlementLoading || hasUnlimited) return false;
+  return countPersonalPeriodGoals(activeGoals) >= MONTHLY_GOAL_FREE_LIMIT;
+}

--- a/app/(app)/goals/actions.ts
+++ b/app/(app)/goals/actions.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import type { SeasonData, TournamentData } from "@app/interface";
+import { type FetchResult, fetchV2 } from "@app/services/v2/requests";
+
+/**
+ * 目標フォームのシーズン候補を取得する。
+ *
+ * シーズン・大会には v2 エンドポイントがまだ無いため v1 を叩く。
+ * fetchV2 は「認証ヘッダー付き GET + 403 の判別」を担うだけなので、パスの API バージョンには依存しない。
+ */
+export async function getGoalSeasonOptions(): Promise<
+  FetchResult<SeasonData[]>
+> {
+  return fetchV2<SeasonData[]>("/api/v1/seasons", "getGoalSeasonOptions");
+}
+
+/**
+ * 目標フォームの大会候補を取得する。
+ *
+ * 全大会ではなく自分の試合に紐づく大会だけを返すエンドポイントを使う。
+ * 出場していない大会を目標に選んでも集計対象の試合が無く、進捗が常に 0 になってしまうため。
+ */
+export async function getGoalTournamentOptions(): Promise<
+  FetchResult<TournamentData[]>
+> {
+  return fetchV2<TournamentData[]>(
+    "/api/v1/tournaments/user_tournaments",
+    "getGoalTournamentOptions",
+  );
+}

--- a/app/(app)/goals/page.tsx
+++ b/app/(app)/goals/page.tsx
@@ -1,0 +1,65 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getGoalHistory, getGoals } from "@app/services/v2/goalService";
+import { getPracticeMenus } from "@app/services/v2/practiceMenuService";
+import { LOAD_ERROR_MESSAGE } from "./_components/goalCopy";
+import GoalsContent from "./_components/GoalsContent";
+import { todayString } from "./_utils/goalForm";
+import { getGoalSeasonOptions, getGoalTournamentOptions } from "./actions";
+
+export const metadata = {
+  title: "目標",
+};
+
+export default async function GoalsPage() {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const [goalsResult, historyResult, seasonsResult, tournamentsResult, menus] =
+    await Promise.all([
+      getGoals(),
+      getGoalHistory(),
+      getGoalSeasonOptions(),
+      getGoalTournamentOptions(),
+      getPracticeMenus(),
+    ]);
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            {goalsResult.status === "ok" ? (
+              <GoalsContent
+                initialGoals={goalsResult.data}
+                initialHistory={
+                  historyResult.status === "ok" ? historyResult.data : []
+                }
+                historyLoadFailed={historyResult.status !== "ok"}
+                seasons={
+                  seasonsResult.status === "ok" ? seasonsResult.data : []
+                }
+                tournaments={
+                  tournamentsResult.status === "ok"
+                    ? tournamentsResult.data
+                    : []
+                }
+                menus={menus.status === "ok" ? menus.data : []}
+                today={todayString()}
+              />
+            ) : (
+              // 取得失敗を空配列に丸めると「目標が未設定」と誤表示し、同じ目標の重複作成を招く。
+              <p className="py-8 text-center text-sm text-zinc-400">
+                {LOAD_ERROR_MESSAGE}
+              </p>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/components/header/HeaderRight.tsx
+++ b/app/components/header/HeaderRight.tsx
@@ -14,6 +14,7 @@ import { CalendarIcon } from "@app/components/icon/CalendarIcon";
 import { MailIcon } from "@app/components/icon/MailIcon";
 import { MenuIcon } from "@app/components/icon/MenuIcon";
 import { NoteIcon } from "@app/components/icon/NoteIcon";
+import { RankingIcon } from "@app/components/icon/RankingIcon";
 import NotificationBadge from "@app/components/notification/NotificationBadge";
 import UserSearch from "@app/components/user/UserSearch";
 import { useAuthContext } from "@app/contexts/useAuthContext";
@@ -64,6 +65,16 @@ export default function HeaderRight() {
                   }
                 >
                   振り返りテンプレ
+                </DropdownItem>
+                <DropdownItem
+                  key="goals"
+                  as={Link}
+                  href="/goals"
+                  startContent={
+                    <RankingIcon fill="currentColor" width="18" height="18" />
+                  }
+                >
+                  目標
                 </DropdownItem>
                 <DropdownItem
                   key="practice-menus"

--- a/app/constants/goal.ts
+++ b/app/constants/goal.ts
@@ -1,0 +1,271 @@
+import type {
+  GoalComparison,
+  GoalKind,
+  GoalMetricKey,
+  GoalPeriodType,
+} from "@app/types/goal";
+import type { DecimalValue } from "@app/types/practice";
+import { parseDecimal } from "@app/constants/practice";
+
+// back/app/models/concerns/plan_limits.rb の MONTHLY_GOAL_FREE_LIMIT と一致させる。
+export const MONTHLY_GOAL_FREE_LIMIT = 2;
+
+/**
+ * 無料枠を共有する個人の期間目標。back の Goal::PERSONAL_PERIOD_TYPES と一致させる。
+ * season / tournament は件数ではなく Pro 限定機能として別に判定される。
+ */
+export const PERSONAL_GOAL_PERIOD_TYPES: readonly GoalPeriodType[] = [
+  "monthly",
+  "weekly",
+  "yearly",
+  "custom",
+];
+
+/** 目標の期間タイプの表示ラベル。 */
+export const GOAL_PERIOD_LABELS: Record<GoalPeriodType, string> = {
+  weekly: "週次",
+  monthly: "月次",
+  yearly: "年間",
+  custom: "カスタム期間",
+  tournament: "大会",
+  season: "シーズン",
+};
+
+/** 期間タイプの選択肢・一覧のグルーピングで使う表示順。mobile と揃える。 */
+export const GOAL_PERIOD_ORDER: readonly GoalPeriodType[] = [
+  "weekly",
+  "monthly",
+  "yearly",
+  "custom",
+  "tournament",
+  "season",
+];
+
+/** 目標の種類（kind）の表示ラベル。 */
+export const GOAL_KIND_LABELS: Record<GoalKind, string> = {
+  numeric: "数値目標",
+  qualitative: "達成目標",
+  manual: "自由指標",
+};
+
+/** 種類ごとの説明。何ができるかを選択前に伝えるため、mobile と同じ文言を使う。 */
+export const GOAL_KIND_DESCRIPTIONS: Record<GoalKind, string> = {
+  numeric:
+    "「打率3割」「今月20日練習」のように数字で決めると、記録した成績や練習からアプリが今の数字を自動で計算して、達成までの進み具合を出してくれます。",
+  qualitative:
+    "「大会で優勝」「レギュラーになる」など数字にできない目標向け。叶ったら「達成」を押すだけで管理できます（数字の入力は不要）。",
+  manual:
+    "「球速130km/h」「体重を増やす」など、アプリが測れない自分だけの目標を作れます。測った値を入力するたびに、目標までの進み具合が更新されます。",
+};
+
+/** 達成条件の表示ラベル。 */
+export const GOAL_COMPARISON_LABELS: Record<GoalComparison, string> = {
+  greater_than: "以上",
+  less_than: "以下",
+};
+
+export interface GoalMetric {
+  key: GoalMetricKey;
+  label: string;
+  unit: string;
+  /** 達成条件。指標ごとに固定で、ユーザーには選ばせない（防御率は「以下」など）。 */
+  comparison: GoalComparison;
+  /** 小数で扱う指標か。目標値の入力例と表示桁数の切り替えに使う。 */
+  decimal?: boolean;
+}
+
+// back の Goal::METRIC_KEYS / Goals::MetricCalculator と対応（自動集計できる指標）。
+export const GOAL_METRICS: readonly GoalMetric[] = [
+  {
+    key: "practice_days",
+    label: "練習日数",
+    unit: "日",
+    comparison: "greater_than",
+  },
+  {
+    key: "total_swing_count",
+    label: "素振り本数",
+    unit: "本",
+    comparison: "greater_than",
+  },
+  {
+    key: "game_count",
+    label: "出場試合数",
+    unit: "試合",
+    comparison: "greater_than",
+  },
+  {
+    key: "menu_practice_days",
+    label: "メニュー継続日数",
+    unit: "日",
+    comparison: "greater_than",
+  },
+  {
+    key: "batting_average",
+    label: "打率",
+    unit: "",
+    comparison: "greater_than",
+    decimal: true,
+  },
+  {
+    key: "on_base_percentage",
+    label: "出塁率",
+    unit: "",
+    comparison: "greater_than",
+    decimal: true,
+  },
+  {
+    key: "slugging_percentage",
+    label: "長打率",
+    unit: "",
+    comparison: "greater_than",
+    decimal: true,
+  },
+  {
+    key: "ops",
+    label: "OPS",
+    unit: "",
+    comparison: "greater_than",
+    decimal: true,
+  },
+  { key: "hits", label: "安打", unit: "本", comparison: "greater_than" },
+  { key: "home_runs", label: "本塁打", unit: "本", comparison: "greater_than" },
+  {
+    key: "runs_batted_in",
+    label: "打点",
+    unit: "点",
+    comparison: "greater_than",
+  },
+  { key: "runs_scored", label: "得点", unit: "点", comparison: "greater_than" },
+  {
+    key: "stolen_bases",
+    label: "盗塁",
+    unit: "個",
+    comparison: "greater_than",
+  },
+  {
+    key: "era",
+    label: "防御率",
+    unit: "",
+    comparison: "less_than",
+    decimal: true,
+  },
+  {
+    key: "whip",
+    label: "WHIP",
+    unit: "",
+    comparison: "less_than",
+    decimal: true,
+  },
+  {
+    key: "strikeouts",
+    label: "奪三振",
+    unit: "個",
+    comparison: "greater_than",
+  },
+  { key: "wins", label: "勝利", unit: "勝", comparison: "greater_than" },
+  { key: "saves", label: "セーブ", unit: "個", comparison: "greater_than" },
+];
+
+export type GoalMetricCategory = "practice" | "batting" | "pitching";
+
+/** 指標選択のカテゴリ（表示順・見出し・所属キー）。mobile の並び順と揃える。 */
+export const GOAL_METRIC_CATEGORIES: ReadonlyArray<{
+  key: GoalMetricCategory;
+  label: string;
+  keys: readonly GoalMetricKey[];
+}> = [
+  {
+    key: "practice",
+    label: "練習・試合",
+    keys: [
+      "practice_days",
+      "total_swing_count",
+      "game_count",
+      "menu_practice_days",
+    ],
+  },
+  {
+    key: "batting",
+    label: "打撃",
+    keys: [
+      "batting_average",
+      "on_base_percentage",
+      "slugging_percentage",
+      "ops",
+      "hits",
+      "home_runs",
+      "runs_batted_in",
+      "runs_scored",
+      "stolen_bases",
+    ],
+  },
+  {
+    key: "pitching",
+    label: "投手",
+    keys: ["era", "whip", "strikeouts", "wins", "saves"],
+  },
+];
+
+/** 継続日数を数える対象メニューの指定が必須になる指標。back の validates と一致させる。 */
+export const MENU_METRIC_KEY: GoalMetricKey = "menu_practice_days";
+
+/** 数値目標タイトルのプレースホルダー例（指標別）。 */
+const GOAL_METRIC_EXAMPLES: Partial<Record<GoalMetricKey, string>> = {
+  practice_days: "例: 今月20日練習する",
+  total_swing_count: "例: 今月2000本素振り",
+  game_count: "例: 今シーズン15試合出場",
+  menu_practice_days: "例: このメニューを20日継続",
+  batting_average: "例: 打率.320を目指す",
+  on_base_percentage: "例: 出塁率.400を目指す",
+  slugging_percentage: "例: 長打率.500を目指す",
+  ops: "例: OPS.850を目指す",
+  hits: "例: 安打30本",
+  home_runs: "例: 本塁打10本",
+  runs_batted_in: "例: 打点20点",
+  runs_scored: "例: 得点20点",
+  stolen_bases: "例: 盗塁10個",
+  era: "例: 防御率2.50以下",
+  whip: "例: WHIP1.20以下",
+  strikeouts: "例: 奪三振50個",
+  wins: "例: 今シーズン5勝",
+  saves: "例: 10セーブ",
+};
+
+export const metricExample = (key: GoalMetricKey): string =>
+  GOAL_METRIC_EXAMPLES[key] ?? "";
+
+/** カテゴリの所属キーに対応する指標を GOAL_METRICS の定義順で返す。 */
+export const metricsInCategory = (
+  keys: readonly GoalMetricKey[],
+): GoalMetric[] => GOAL_METRICS.filter((metric) => keys.includes(metric.key));
+
+/** 指標定義。未知のキーが来ても画面を落とさないよう先頭の指標へフォールバックする。 */
+export const metricFor = (key: GoalMetricKey | null): GoalMetric =>
+  GOAL_METRICS.find((metric) => metric.key === key) ?? GOAL_METRICS[0];
+
+export const metricLabel = (key: GoalMetricKey | null): string =>
+  GOAL_METRICS.find((metric) => metric.key === key)?.label ?? key ?? "";
+
+// 防御率・WHIP は 1 以上でも小数第2位まで見せたい（打率系と違い ".XXX" 表記の慣習が無いため）。
+const TWO_DECIMAL_METRIC_KEYS: readonly GoalMetricKey[] = ["era", "whip"];
+
+/**
+ * 指標の値を表示用に整形する。
+ * 小数指標でない場合は整数へ丸め、打率系は 1 未満なら先頭の 0 を落として ".320" と見せる。
+ */
+export const formatMetricValue = (
+  key: GoalMetricKey | null,
+  value: DecimalValue | null | undefined,
+): string => {
+  const parsed = parseDecimal(value) ?? 0;
+  const metric = GOAL_METRICS.find((item) => item.key === key);
+  if (!metric?.decimal) return String(Math.round(parsed));
+
+  if (key !== null && TWO_DECIMAL_METRIC_KEYS.includes(key)) {
+    return parsed.toFixed(2);
+  }
+  return Math.abs(parsed) < 1
+    ? parsed.toFixed(3).replace(/^(-?)0\./, "$1.")
+    : parsed.toFixed(3);
+};

--- a/app/services/v2/__tests__/goalService.test.ts
+++ b/app/services/v2/__tests__/goalService.test.ts
@@ -1,0 +1,261 @@
+const mockGet = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(() => Promise.resolve({ get: mockGet })),
+}));
+
+jest.mock("@app/constants/api", () => ({
+  RAILS_API_URL: "http://back:3000",
+}));
+
+jest.mock("../../../../lib/sentry-helpers", () => ({
+  captureServerActionError: jest.fn(),
+}));
+
+import type { Goal } from "@app/types/goal";
+import {
+  getGoalSeasonOptions,
+  getGoalTournamentOptions,
+} from "@app/(app)/goals/actions";
+import {
+  achieveGoal,
+  createGoal,
+  deleteGoal,
+  getGoalHistory,
+  getGoals,
+  unachieveGoal,
+  updateGoal,
+} from "../goalService";
+
+function setupAuthCookies() {
+  mockGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: "test-uid" },
+    };
+    return values[key];
+  });
+}
+
+function requestedUrl(callIndex = 0): string {
+  return (global.fetch as jest.Mock).mock.calls[callIndex][0] as string;
+}
+
+function requestedInit(callIndex = 0): RequestInit {
+  return (global.fetch as jest.Mock).mock.calls[callIndex][1] as RequestInit;
+}
+
+function sentGoalPayload(callIndex = 0): Record<string, unknown> {
+  const body = JSON.parse(requestedInit(callIndex).body as string) as {
+    goal: Record<string, unknown>;
+  };
+  return body.goal;
+}
+
+function mockJsonResponse(body: unknown, status = 200) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+const goal = {
+  id: 1,
+  title: "月20日練習",
+  kind: "numeric",
+  period_type: "monthly",
+  season_id: null,
+  tournament_id: null,
+  month_start: "2026-08-01",
+  deadline: "2026-08-31",
+  metric_key: "practice_days",
+  target_value: 20,
+  comparison_type: "greater_than",
+  practice_menu_id: null,
+  practice_menu_name: null,
+  custom_metric_label: null,
+  custom_unit: null,
+  manual_current_value: 0,
+  is_achieved: false,
+  is_finalized: false,
+  achieved_value: null,
+  current_value: 5,
+  progress_percent: 25,
+  days_remaining: 28,
+} satisfies Goal;
+
+describe("v2 目標 Server Actions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    setupAuthCookies();
+  });
+
+  it("getGoals は進行中一覧のエンドポイントを叩く", async () => {
+    mockJsonResponse([goal]);
+
+    const result = await getGoals();
+
+    expect(result).toEqual({ status: "ok", data: [goal] });
+    expect(requestedUrl()).toBe("http://back:3000/api/v2/goals");
+    expect(requestedInit()).toEqual(
+      expect.objectContaining({
+        cache: "no-store",
+        headers: expect.objectContaining({
+          "access-token": "test-access-token",
+          client: "test-client",
+          uid: "test-uid",
+        }),
+      }),
+    );
+  });
+
+  it("getGoalHistory は履歴のエンドポイントを叩く", async () => {
+    mockJsonResponse([]);
+
+    await getGoalHistory();
+
+    expect(requestedUrl()).toBe("http://back:3000/api/v2/goals/history");
+  });
+
+  it("createGoal は POST で goal キーに包んで送る", async () => {
+    mockJsonResponse(goal, 201);
+
+    const result = await createGoal({
+      title: "月20日練習",
+      kind: "numeric",
+      period_type: "monthly",
+      month_start: "2026-08-01",
+      deadline: "2026-08-31",
+      metric_key: "practice_days",
+      target_value: 20,
+      comparison_type: "greater_than",
+    });
+
+    expect(result).toEqual({ ok: true, data: goal });
+    expect(requestedUrl()).toBe("http://back:3000/api/v2/goals");
+    expect(requestedInit().method).toBe("POST");
+    expect(sentGoalPayload()).toMatchObject({
+      period_type: "monthly",
+      metric_key: "practice_days",
+      target_value: 20,
+    });
+  });
+
+  it("updateGoal は PATCH で id 付きのパスを叩く", async () => {
+    mockJsonResponse(goal);
+
+    await updateGoal(7, {
+      title: "月25日練習",
+      month_start: "2026-08-01",
+      deadline: "2026-08-31",
+      target_value: 25,
+    });
+
+    expect(requestedUrl()).toBe("http://back:3000/api/v2/goals/7");
+    expect(requestedInit().method).toBe("PATCH");
+    expect(sentGoalPayload()).toEqual({
+      title: "月25日練習",
+      month_start: "2026-08-01",
+      deadline: "2026-08-31",
+      target_value: 25,
+    });
+  });
+
+  it("deleteGoal は DELETE で id 付きのパスを叩く", async () => {
+    mockJsonResponse({ message: "削除しました" });
+
+    await deleteGoal(7);
+
+    expect(requestedUrl()).toBe("http://back:3000/api/v2/goals/7");
+    expect(requestedInit().method).toBe("DELETE");
+  });
+
+  it("achieveGoal は achievement へ POST する", async () => {
+    mockJsonResponse({ ...goal, is_achieved: true });
+
+    await achieveGoal(7);
+
+    expect(requestedUrl()).toBe("http://back:3000/api/v2/goals/7/achievement");
+    expect(requestedInit().method).toBe("POST");
+  });
+
+  it("unachieveGoal は achievement へ DELETE する", async () => {
+    mockJsonResponse(goal);
+
+    await unachieveGoal(7);
+
+    expect(requestedUrl()).toBe("http://back:3000/api/v2/goals/7/achievement");
+    expect(requestedInit().method).toBe("DELETE");
+  });
+
+  it("403 は forbidden として返し、back のメッセージを保つ", async () => {
+    mockJsonResponse({ error: "シーズン目標は Pro プラン限定です" }, 403);
+
+    const result = await createGoal({
+      title: "シーズン打率",
+      kind: "numeric",
+      period_type: "season",
+      deadline: "2026-12-31",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "forbidden",
+      errors: ["シーズン目標は Pro プラン限定です"],
+    });
+  });
+
+  it("422 は error として返す（403 と取り違えない）", async () => {
+    mockJsonResponse({ errors: ["目標値を入力してください"] }, 422);
+
+    const result = await createGoal({
+      title: "月20日練習",
+      kind: "numeric",
+      period_type: "monthly",
+      deadline: "2026-08-31",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "error",
+      errors: ["目標値を入力してください"],
+    });
+  });
+
+  it("数値目標の手動達成が 422 になったらエラーとして返す", async () => {
+    mockJsonResponse(
+      { error: "数値目標は自動判定のため手動で達成にできません" },
+      422,
+    );
+
+    const result = await achieveGoal(7);
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "error",
+      errors: ["数値目標は自動判定のため手動で達成にできません"],
+    });
+  });
+
+  it("目標フォームのシーズン候補は自分のシーズン一覧を取得する", async () => {
+    mockJsonResponse([{ id: 1, name: "2026年" }]);
+
+    const result = await getGoalSeasonOptions();
+
+    expect(result).toEqual({ status: "ok", data: [{ id: 1, name: "2026年" }] });
+    expect(requestedUrl()).toBe("http://back:3000/api/v1/seasons");
+  });
+
+  it("目標フォームの大会候補は自分の試合に紐づく大会だけを取得する", async () => {
+    mockJsonResponse([{ id: 2, name: "夏の大会" }]);
+
+    await getGoalTournamentOptions();
+
+    expect(requestedUrl()).toBe(
+      "http://back:3000/api/v1/tournaments/user_tournaments",
+    );
+  });
+});

--- a/app/services/v2/goalService.ts
+++ b/app/services/v2/goalService.ts
@@ -1,0 +1,97 @@
+"use server";
+
+import type { Goal, GoalInput, GoalUpdateInput } from "@app/types/goal";
+import {
+  type DeletedResponse,
+  type FetchResult,
+  type MutationResult,
+  fetchV2,
+  mutateV2,
+} from "./requests";
+
+const BASE_PATH = "/api/v2/goals";
+
+/**
+ * 進行中（未確定）の目標一覧を取得する（GET /api/v2/goals）。
+ * back は is_finalized = false のものだけを期限の昇順で返す。
+ */
+export async function getGoals(): Promise<FetchResult<Goal[]>> {
+  return fetchV2<Goal[]>(BASE_PATH, "getGoals");
+}
+
+/**
+ * 確定済み（期限到来後に FinalizeGoalsJob が確定させた）目標の履歴を取得する
+ * （GET /api/v2/goals/history）。達成・未達タブの表示に使う。
+ */
+export async function getGoalHistory(): Promise<FetchResult<Goal[]>> {
+  return fetchV2<Goal[]>(`${BASE_PATH}/history`, "getGoalHistory");
+}
+
+/**
+ * 目標を新規作成する（POST /api/v2/goals）。
+ *
+ * back は Pro 限定（シーズン / 大会 / カスタム期間 / 自由指標）と
+ * 無料枠超過（個人の期間目標が合算 2 件）をどちらも 403 で返すため、
+ * reason:"forbidden" の文言は back のメッセージをそのまま使って取り違えを防ぐ。
+ */
+export async function createGoal(
+  input: GoalInput,
+): Promise<MutationResult<Goal>> {
+  return mutateV2<Goal>(BASE_PATH, {
+    method: "POST",
+    body: { goal: input },
+    action: "createGoal",
+    fallbackMessage: "目標の作成に失敗しました",
+  });
+}
+
+/**
+ * 目標を更新する（PATCH /api/v2/goals/:id）。
+ *
+ * back が許可するのは title / month_start / deadline / target_value /
+ * custom_metric_label / custom_unit / manual_current_value のみ。
+ * 変更不可の属性は GoalUpdateInput が持たないため、送信されることはない。
+ */
+export async function updateGoal(
+  id: number,
+  input: GoalUpdateInput,
+): Promise<MutationResult<Goal>> {
+  return mutateV2<Goal>(`${BASE_PATH}/${id}`, {
+    method: "PATCH",
+    body: { goal: input },
+    action: "updateGoal",
+    fallbackMessage: "目標の更新に失敗しました",
+  });
+}
+
+/** 目標を削除する（DELETE /api/v2/goals/:id）。自分の目標のみ削除可。 */
+export async function deleteGoal(
+  id: number,
+): Promise<MutationResult<DeletedResponse>> {
+  return mutateV2<DeletedResponse>(`${BASE_PATH}/${id}`, {
+    method: "DELETE",
+    action: "deleteGoal",
+    fallbackMessage: "目標の削除に失敗しました",
+  });
+}
+
+/**
+ * 定性目標を達成にする（POST /api/v2/goals/:id/achievement）。
+ * 数値目標・自由指標は指標から自動判定するため back が 422 を返す。UI 側でも操作を出さない。
+ */
+export async function achieveGoal(id: number): Promise<MutationResult<Goal>> {
+  return mutateV2<Goal>(`${BASE_PATH}/${id}/achievement`, {
+    method: "POST",
+    action: "achieveGoal",
+    fallbackMessage: "達成の記録に失敗しました",
+  });
+}
+
+/** 定性目標の達成を取り消す（DELETE /api/v2/goals/:id/achievement）。 */
+export async function unachieveGoal(id: number): Promise<MutationResult<Goal>> {
+  return mutateV2<Goal>(`${BASE_PATH}/${id}/achievement`, {
+    method: "DELETE",
+    action: "unachieveGoal",
+    fallbackMessage: "達成の取り消しに失敗しました",
+  });
+}

--- a/app/types/goal.ts
+++ b/app/types/goal.ts
@@ -1,0 +1,119 @@
+/**
+ * 目標ドメインの型定義。
+ * back/app/serializers/v2/goal_serializer.rb と back/app/models/goal.rb に対応する。
+ * キー名は back の JSON をそのまま使う（snake_case のまま扱い、変換しない）。
+ */
+
+import type { DecimalValue } from "@app/types/practice";
+
+/** 目標の対象期間。back の Goal::PERIOD_TYPES と完全一致させる。 */
+export type GoalPeriodType =
+  | "season"
+  | "monthly"
+  | "tournament"
+  | "weekly"
+  | "yearly"
+  | "custom";
+
+/** 達成条件。back の Goal::COMPARISON_TYPES と完全一致させる。 */
+export type GoalComparison = "greater_than" | "less_than";
+
+/**
+ * 目標の種類。back の Goal::KINDS と完全一致させる。
+ * numeric: 指標を自動集計する数値目標 / qualitative: 達成・未達で管理する定性目標 /
+ * manual: 指標名・現在値をユーザーが手入力する自由指標。
+ */
+export type GoalKind = "numeric" | "qualitative" | "manual";
+
+/** 自動集計できる指標。back の Goal::METRIC_KEYS と完全一致させる。 */
+export type GoalMetricKey =
+  | "practice_days"
+  | "total_swing_count"
+  | "game_count"
+  | "menu_practice_days"
+  | "batting_average"
+  | "on_base_percentage"
+  | "slugging_percentage"
+  | "ops"
+  | "hits"
+  | "home_runs"
+  | "runs_batted_in"
+  | "runs_scored"
+  | "stolen_bases"
+  | "era"
+  | "whip"
+  | "strikeouts"
+  | "wins"
+  | "saves";
+
+/**
+ * 目標1件。
+ *
+ * 数値項目を DecimalValue で受けるのは、back のカラム型が float から decimal へ変わると
+ * JSON が文字列（"0.3"）になり、素の number 型では `"0.3" * 100` のような事故が起きるため。
+ * 表示・計算の前に必ず parseDecimal を通す。
+ */
+export interface Goal {
+  id: number;
+  title: string;
+  kind: GoalKind;
+  period_type: GoalPeriodType;
+  season_id: number | null;
+  tournament_id: number | null;
+  /** 集計対象期間の開始日（YYYY-MM-DD）。season / tournament は持たない。 */
+  month_start: string | null;
+  deadline: string;
+  metric_key: GoalMetricKey | null;
+  target_value: DecimalValue | null;
+  comparison_type: GoalComparison;
+  practice_menu_id: number | null;
+  practice_menu_name: string | null;
+  custom_metric_label: string | null;
+  custom_unit: string | null;
+  manual_current_value: DecimalValue;
+  is_achieved: boolean;
+  /** 期限到来後に FinalizeGoalsJob が確定させたか。確定後は編集・達成操作をさせない。 */
+  is_finalized: boolean;
+  achieved_value: DecimalValue | null;
+  current_value: DecimalValue;
+  progress_percent: number;
+  days_remaining: number;
+}
+
+/**
+ * 新規作成で送る属性。back の GoalsController#goal_params と一致させる。
+ */
+export interface GoalInput {
+  title: string;
+  kind: GoalKind;
+  period_type: GoalPeriodType;
+  season_id?: number | null;
+  tournament_id?: number | null;
+  month_start?: string | null;
+  deadline: string;
+  metric_key?: GoalMetricKey | null;
+  target_value?: number | null;
+  comparison_type?: GoalComparison;
+  practice_menu_id?: number | null;
+  custom_metric_label?: string | null;
+  custom_unit?: string | null;
+  manual_current_value?: number;
+}
+
+/**
+ * 更新で送れる属性。back の GoalsController#update_params と一致させる。
+ *
+ * kind / period_type / season_id / tournament_id / metric_key / comparison_type /
+ * practice_menu_id は作成後に変更できず（Pro 制限の回避防止と集計整合のため back が
+ * 許可パラメータから外している）、送っても黙って無視される。
+ * 「編集できたのに保存されない」を型レベルで防ぐため、更新の入力型からは持たない。
+ */
+export interface GoalUpdateInput {
+  title: string;
+  month_start?: string | null;
+  deadline: string;
+  target_value?: number | null;
+  custom_metric_label?: string | null;
+  custom_unit?: string | null;
+  manual_current_value?: number;
+}


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#479

## 概要

数値/定性/自由指標 × 週次/月次/年間/カスタム/大会/シーズン の目標を設定し、進捗を表示します。mobile では最大規模の画面（作成フォームだけで807行）で、front には `goal` ディレクトリ自体が存在しませんでした。

## ⚠️ issue の「変更不可属性」の記載に漏れがありました

issue は `period_type` / `season_id` / `metric_key` / `comparison_type` / `practice_menu_id` の5つを挙げていますが、back の `update_params` を確認したところ:

```ruby
params.require(:goal).permit(:title, :month_start, :deadline,
                             :target_value, :custom_metric_label, :custom_unit, :manual_current_value)
```

許可されるのは**7属性のみ**で、**`kind` と `tournament_id` も変更不可**でした。issue に記載がない2つも含めて固定しています。

### 三重防御で固定しました

1. **型で防ぐ** — `GoalUpdateInput` が7つの可変属性しか持たない。`buildGoalUpdatePayload` の返り値型がこれなので、変更不可属性を書こうとすると型エラーになります
2. **ペイロードで防ぐ** — `buildGoalUpdatePayload` が `kind` に応じて必要なキーだけを組み立て。ユニットテストで `Object.keys(payload)` を完全一致検証
3. **UI で防ぐ** — 編集時は目標タイプ・期間タイプ・シーズン・大会・指標・対象メニュー・条件をすべて `disabled` に。加えて「作成後に変更できない」旨をモーダル冒頭に明示

これを守らないと「**編集画面で変更できるのに保存すると反映されない**」という最悪の UX になります。

## back の契約で判明した点

**achievement の 422 は `manual`（自由指標）も対象です。** issue は「数値目標は 422」としていますが、条件は `@goal.qualitative?` でないこと。つまり `numeric` だけでなく `manual` も 422 になります。

**Pro ゲート4種は評価順が重要です。** back の `allowed_to_create?` は `manual` を**期間タイプより先に**評価します（manual → season → tournament → custom → 件数上限）。front も同じ優先順で判定し、順序を変えるミューテーションで検証しています。

**グランドファザリング**: `can_create_monthly_goal?` は**新規作成のみをブロック**するため、上限超過状態でも既存目標の編集・削除は可能です。front も上限判定を「追加」導線だけに適用しています。また件数に数えるのは **active かつ個人期間タイプ（monthly/weekly/yearly/custom）のみ**で、シーズン・大会目標は枠を消費しません。

## 403 の扱い

作成が 403 になったとき、`goalForbiddenFeature` が**クライアントの entitlement を見ずに送信内容から**原因を特定します（手元の Pro 状態が古い場合に対応）。

- Pro 限定なら back の文言をそのまま表示
- **件数上限なら「無料プランで同時に設定できる目標は2件までです…」に置換**（back の「Pro プランで期間目標を無制限に…」では上限件数が伝わらないため）

## 変更内容

- `app/types/goal.ts` — `Goal` / `GoalInput` / **`GoalUpdateInput`（変更可能属性のみ）**
- `app/constants/goal.ts` — 指標カタログ（3カテゴリ）・期間ラベル・値整形
- `app/services/v2/goalService.ts` — index / history / create / update / destroy / achievement(POST/DELETE)
- `app/(app)/goals/` — 一覧・フォーム・詳細（`_utils/` に純粋関数を切り出し）
- `HeaderRight.tsx` に「目標」導線を追加

## レビューで確認いただきたい点

1. **画面構成をモーダル方式にしました。** back に `show` エンドポイントが無い（index / history のみ）ため、詳細を `/goals/[id]` の独立ルートにすると一覧を再取得して探す形になります。既存の `practice/menus` に倣い `/goals` 1ルートに収めました。mobile は画面分割なので構成は異なります
2. **進捗バーは back の `progress_percent` に一本化**しています。フロントで `Goals::ProgressCalculator` を再実装すると drift するためで、純粋関数化したのは clamp のみです
3. **数値目標に単位を付けていません**（「5 → 20」と表示）。mobile の `GoalProgressBar` がそうなっているためです。「5日 → 20日」にする方が親切ですが、**両プラットフォームで揃えるべき変更**だと思います
4. **シーズン／大会の選択を必須にしました。** back は `season_id` 未指定でも作成できますが、未指定だと `period_range` が nil で進捗が計算できないためです（mobile も必須）
5. **シーズン／大会の候補取得は v1 エンドポイント**を使っています（v2 が無いため）。`user_tournaments`（自分の試合に紐づく大会）を使うのは、出場していない大会を選ぶと進捗が常に0になるためです
6. **`FEATURE_COMPARISONS` の `availability` は触っていません。** 目標4機能は Web でも提供されるようになりましたが、`unlimited_practice_menus` 等の先行 PR でも未更新のまま溜まっています。**別途まとめて更新します**

## チェックリスト

- [x] `yarn typecheck` / `yarn lint` / `yarn format:check` が通る
- [x] `yarn test` が通る（**131 suites / 1533 tests**。+4 suites / +139 tests）
- [x] `yarn build` が通る（**ローカルで実行済み**）
- [x] ミューテーションテスト **41 設計 / 41 KILLED / 0 SURVIVED**

### ルート表

base（`e684b31`）を `git archive` した独立ツリーでも実ビルドして比較しました。

- base: **静的 87 / 動的 45**
- head: 静的 87 / 動的 46
- **差分は `/goals`（動的）の1件のみ。既存ルートの分類変更なし**

<details>
<summary>ミューテーションテスト詳細</summary>

隔離複製で実施（無改変で 4 suites / 139 tests 全通過を確認後に開始、検証後に削除）。

変更不可属性を送る3件 / 編集時の disabled 解除5件 / 数値目標に達成トグル2件 / **Pro ゲート4種の反転・判定順序変更6件** / 無料枠上限5件 / グランドファザリング無視 / 3タブ分類2件 / 進捗計算3件 / 比較（以上/以下）反転4件 / 期間 enum 3件 / `parseDecimal` 2件 / API パス・メソッド5件。

**初回に1件 SURVIVED**（以上/以下ラベルの入れ替え）。「指標に応じた条件表示」と「自由指標で『以下』を選ぶと `less_than` を送る」の2テストを追加して KILLED を確認しています。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_