### PR TITLE
Add: 練習スケジュール（予定）の登録・編集・削除を実装

### DIFF
--- a/app/(app)/practice/schedules/[id]/__tests__/ScheduleDetailContent.test.tsx
+++ b/app/(app)/practice/schedules/[id]/__tests__/ScheduleDetailContent.test.tsx
@@ -1,0 +1,240 @@
+const mockPush = jest.fn();
+const mockRefresh = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@app/services/v2/practiceLogService", () => ({
+  createPracticeLog: jest.fn(),
+  deletePracticeLog: jest.fn(),
+}));
+
+jest.mock("@app/services/v2/scheduleService", () => ({
+  deleteSchedule: jest.fn(),
+}));
+
+import type { Schedule } from "@app/types/schedule";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  createPracticeLog,
+  deletePracticeLog,
+} from "@app/services/v2/practiceLogService";
+import { deleteSchedule } from "@app/services/v2/scheduleService";
+import ScheduleDetailContent from "../_components/ScheduleDetailContent";
+
+const mockCreateLog = createPracticeLog as jest.MockedFunction<
+  typeof createPracticeLog
+>;
+const mockDeleteLog = deletePracticeLog as jest.MockedFunction<
+  typeof deletePracticeLog
+>;
+const mockDeleteSchedule = deleteSchedule as jest.MockedFunction<
+  typeof deleteSchedule
+>;
+
+function buildSchedule(overrides: Partial<Schedule> = {}): Schedule {
+  return {
+    id: 10,
+    title: "朝の素振り",
+    days_of_week: "1,3,5",
+    planned_on: null,
+    scheduled_time: "06:00",
+    event_type: "self_practice",
+    recurring: true,
+    menu_set_id: null,
+    game_result_id: null,
+    note: null,
+    notification_enabled: true,
+    active: true,
+    notification_message: null,
+    menus: [
+      {
+        practice_menu_id: 1,
+        name: "素振り",
+        unit_label: "本",
+        target_value: 200,
+      },
+      {
+        practice_menu_id: 2,
+        name: "ランニング",
+        unit_label: "km",
+        target_value: 5,
+      },
+    ],
+    logged_practice_menu_ids: [],
+    ...overrides,
+  };
+}
+
+function renderDetail({
+  schedule = buildSchedule(),
+  initialDoneLogIds = {},
+  logsLoadFailed = false,
+}: {
+  schedule?: Schedule;
+  initialDoneLogIds?: Record<number, number[]>;
+  logsLoadFailed?: boolean;
+} = {}) {
+  render(
+    <ScheduleDetailContent
+      schedule={schedule}
+      contextDate="2026-08-03"
+      initialDoneLogIds={initialDoneLogIds}
+      logsLoadFailed={logsLoadFailed}
+    />,
+  );
+}
+
+function recordHrefParams(): URLSearchParams {
+  const href = screen
+    .getByRole("link", { name: "練習記録をつける" })
+    .getAttribute("href") as string;
+  return new URLSearchParams(href.split("?")[1]);
+}
+
+describe("ScheduleDetailContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("「済」トグル", () => {
+    it("未完了のメニューをチェックするとその日の練習ログを作る", async () => {
+      const user = userEvent.setup();
+      mockCreateLog.mockResolvedValue({
+        ok: true,
+        data: { id: 99 },
+      } as Awaited<ReturnType<typeof createPracticeLog>>);
+      renderDetail();
+
+      await user.click(screen.getByRole("checkbox", { name: /素振り/ }));
+
+      expect(mockCreateLog).toHaveBeenCalledWith({
+        practice_menu_id: 1,
+        schedule_id: 10,
+        logged_on: "2026-08-03",
+      });
+      await waitFor(() =>
+        expect(screen.getByRole("checkbox", { name: /素振り/ })).toBeChecked(),
+      );
+    });
+
+    it("済のメニューを外すとその予定の練習ログを削除する", async () => {
+      const user = userEvent.setup();
+      mockDeleteLog.mockResolvedValue({
+        ok: true,
+        data: { message: "削除しました" },
+      });
+      renderDetail({ initialDoneLogIds: { 1: [99] } });
+
+      expect(screen.getByRole("checkbox", { name: /素振り/ })).toBeChecked();
+      await user.click(screen.getByRole("checkbox", { name: /素振り/ }));
+
+      expect(mockDeleteLog).toHaveBeenCalledWith(99);
+      await waitFor(() =>
+        expect(
+          screen.getByRole("checkbox", { name: /素振り/ }),
+        ).not.toBeChecked(),
+      );
+    });
+
+    it("当日ログの取得に失敗したときは済の状態を触らせない", () => {
+      renderDetail({ logsLoadFailed: true });
+
+      expect(screen.getByRole("checkbox", { name: /素振り/ })).toBeDisabled();
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+
+  describe("練習記録への引き継ぎ", () => {
+    it("済メニューを date と presetMenus の両方で渡す", () => {
+      renderDetail({ initialDoneLogIds: { 2: [98] } });
+
+      const params = recordHrefParams();
+      expect(params.get("date")).toBe("2026-08-03");
+      expect(JSON.parse(params.get("presetMenus") as string)).toEqual([
+        { practice_menu_id: 2, target_value: 5 },
+      ]);
+    });
+
+    it("済メニューが無くても date は渡す", () => {
+      renderDetail();
+
+      const params = recordHrefParams();
+      expect(params.get("date")).toBe("2026-08-03");
+      expect(params.get("presetMenus")).toBeNull();
+    });
+
+    it("トグルした結果が引き継ぎ内容に反映される", async () => {
+      const user = userEvent.setup();
+      mockCreateLog.mockResolvedValue({
+        ok: true,
+        data: { id: 99 },
+      } as Awaited<ReturnType<typeof createPracticeLog>>);
+      renderDetail();
+
+      await user.click(screen.getByRole("checkbox", { name: /素振り/ }));
+
+      await waitFor(() =>
+        expect(
+          JSON.parse(recordHrefParams().get("presetMenus") as string),
+        ).toEqual([{ practice_menu_id: 1, target_value: 200 }]),
+      );
+    });
+  });
+
+  describe("記録画面への導線", () => {
+    it("試合の予定では試合記録への導線を出す", () => {
+      renderDetail({ schedule: buildSchedule({ event_type: "game" }) });
+
+      expect(
+        screen.getByRole("link", { name: "試合記録をつける" }),
+      ).toHaveAttribute("href", "/game-result/record");
+      expect(
+        screen.queryByRole("link", { name: "練習記録をつける" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("試合以外では練習記録への導線を出す", () => {
+      renderDetail();
+
+      expect(
+        screen.queryByRole("link", { name: "試合記録をつける" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "練習記録をつける" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("編集への導線を持つ", () => {
+    renderDetail();
+
+    expect(screen.getByRole("button", { name: "編集" })).toHaveAttribute(
+      "href",
+      "/practice/schedules/10/edit",
+    );
+  });
+
+  it("削除すると一覧へ戻る", async () => {
+    const user = userEvent.setup();
+    mockDeleteSchedule.mockResolvedValue({
+      ok: true,
+      data: { message: "削除しました" },
+    });
+    renderDetail();
+
+    await user.click(screen.getByRole("button", { name: "削除" }));
+    await user.click(
+      screen.getAllByRole("button", { name: "削除" }).slice(-1)[0],
+    );
+
+    await waitFor(() => expect(mockDeleteSchedule).toHaveBeenCalledWith(10));
+    expect(mockPush).toHaveBeenCalledWith("/practice/schedules");
+  });
+});

--- a/app/(app)/practice/schedules/[id]/_components/ScheduleDetailContent.tsx
+++ b/app/(app)/practice/schedules/[id]/_components/ScheduleDetailContent.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+import type { Schedule } from "@app/types/schedule";
+import BellAlertIcon from "@heroicons/react/24/outline/BellAlertIcon";
+import BellSlashIcon from "@heroicons/react/24/outline/BellSlashIcon";
+import CalendarDaysIcon from "@heroicons/react/24/outline/CalendarDaysIcon";
+import ChatBubbleLeftEllipsisIcon from "@heroicons/react/24/outline/ChatBubbleLeftEllipsisIcon";
+import ClockIcon from "@heroicons/react/24/outline/ClockIcon";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import { dayLabels, eventTypeMeta } from "@app/constants/schedule";
+import {
+  createPracticeLog,
+  deletePracticeLog,
+} from "@app/services/v2/practiceLogService";
+import { deleteSchedule } from "@app/services/v2/scheduleService";
+import {
+  DELETE_CONFIRM_TITLE,
+  DELETE_KEEPS_LOGS_NOTICE,
+  DELETE_LABEL,
+  DONE_LOAD_ERROR,
+  DONE_SECTION_TITLE,
+  EDIT_LABEL,
+  RECORD_GAME_LABEL,
+  RECORD_PRACTICE_HELPER,
+  RECORD_PRACTICE_LABEL,
+} from "../../_components/scheduleCopy";
+import {
+  buildPracticeRecordHref,
+  doneMenusAsPresets,
+} from "../../_utils/scheduleRecord";
+
+interface ScheduleDetailContentProps {
+  schedule: Schedule;
+  /** 「済」を判定する日付（YYYY-MM-DD）。練習記録への引き継ぎにもこの日付を使う。 */
+  contextDate: string;
+  /** practice_menu_id → その日この予定で作られた練習ログの ID 一覧。 */
+  initialDoneLogIds: Record<number, number[]>;
+  /** 当日ログの取得に失敗したか。「済が無い」と取り違えないためフラグで分ける。 */
+  logsLoadFailed: boolean;
+}
+
+const ICON_CLASS = "h-4.5 w-4.5 shrink-0 text-zinc-400";
+
+function InfoRow({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <li className="flex items-center gap-2.5 border-b-1 border-zinc-700 py-2.5 text-sm text-white">
+      {icon}
+      <span className="min-w-0 flex-1 break-words">{label}</span>
+    </li>
+  );
+}
+
+/**
+ * 予定詳細の Container。
+ * メニューの「済」トグル（練習ログの作成／削除）と、済メニューを引き継いだ記録画面への導線を担う。
+ */
+export default function ScheduleDetailContent({
+  schedule,
+  contextDate,
+  initialDoneLogIds,
+  logsLoadFailed,
+}: ScheduleDetailContentProps) {
+  const router = useRouter();
+  const [doneLogIds, setDoneLogIds] =
+    useState<Record<number, number[]>>(initialDoneLogIds);
+  const [togglingMenuId, setTogglingMenuId] = useState<number | null>(null);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const meta = eventTypeMeta(schedule.event_type);
+  const whenLabel = schedule.days_of_week
+    ? `毎週 ${dayLabels(schedule.days_of_week)}`
+    : (schedule.planned_on ?? contextDate);
+
+  const isDone = (menuId: number) => (doneLogIds[menuId]?.length ?? 0) > 0;
+
+  const handleToggle = async (menuId: number) => {
+    setTogglingMenuId(menuId);
+    const logIds = doneLogIds[menuId] ?? [];
+
+    if (logIds.length > 0) {
+      const results = await Promise.all(
+        logIds.map((logId) => deletePracticeLog(logId)),
+      );
+      setTogglingMenuId(null);
+      if (results.some((result) => !result.ok)) {
+        toast.error("「済」の解除に失敗しました");
+        return;
+      }
+      setDoneLogIds((prev) => {
+        const next = { ...prev };
+        delete next[menuId];
+        return next;
+      });
+      router.refresh();
+      return;
+    }
+
+    // 量を伴わない完了マークなので amount は送らない（練習記録画面で後から入力できる）。
+    const result = await createPracticeLog({
+      practice_menu_id: menuId,
+      schedule_id: schedule.id,
+      logged_on: contextDate,
+    });
+    setTogglingMenuId(null);
+    if (!result.ok) {
+      toast.error(result.errors[0]);
+      return;
+    }
+    setDoneLogIds((prev) => ({ ...prev, [menuId]: [result.data.id] }));
+    router.refresh();
+  };
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    const result = await deleteSchedule(schedule.id);
+    setIsDeleting(false);
+
+    if (!result.ok) {
+      toast.error(result.errors[0]);
+      return;
+    }
+    toast.success("予定を削除しました");
+    router.push("/practice/schedules");
+    router.refresh();
+  };
+
+  const practiceRecordHref = buildPracticeRecordHref(
+    contextDate,
+    doneMenusAsPresets(schedule.menus, doneLogIds),
+  );
+
+  return (
+    <>
+      <div className="flex items-start gap-3">
+        <span
+          aria-hidden
+          className="mt-1 h-10 w-1 shrink-0 rounded-full"
+          style={{ backgroundColor: meta.color }}
+        />
+        <div className="min-w-0 flex-1">
+          <h2 className="break-words text-xl font-bold text-white">
+            {schedule.title ?? meta.label}
+          </h2>
+          <span
+            className="mt-2 inline-block rounded-full px-2 py-0.5 text-[11px] font-bold"
+            style={{ backgroundColor: `${meta.color}22`, color: meta.color }}
+          >
+            {meta.label}
+          </span>
+        </div>
+      </div>
+
+      <ul className="mt-5">
+        <InfoRow
+          icon={<CalendarDaysIcon className={ICON_CLASS} aria-hidden />}
+          label={whenLabel}
+        />
+        {schedule.scheduled_time ? (
+          <InfoRow
+            icon={<ClockIcon className={ICON_CLASS} aria-hidden />}
+            label={schedule.scheduled_time}
+          />
+        ) : null}
+        <InfoRow
+          icon={
+            schedule.notification_enabled ? (
+              <BellAlertIcon className={ICON_CLASS} aria-hidden />
+            ) : (
+              <BellSlashIcon className={ICON_CLASS} aria-hidden />
+            )
+          }
+          label={
+            schedule.notification_enabled
+              ? "リマインド通知 オン（アプリ版で届きます）"
+              : "リマインド通知 オフ"
+          }
+        />
+        {schedule.notification_message ? (
+          <InfoRow
+            icon={
+              <ChatBubbleLeftEllipsisIcon className={ICON_CLASS} aria-hidden />
+            }
+            label={schedule.notification_message}
+          />
+        ) : null}
+      </ul>
+
+      {schedule.menus.length > 0 ? (
+        <section className="mt-6">
+          <h3 className="mb-2 text-sm font-bold text-zinc-400">
+            {DONE_SECTION_TITLE}（{contextDate}）
+          </h3>
+          {logsLoadFailed ? (
+            <p role="alert" className="mb-2 text-xs text-zinc-400">
+              {DONE_LOAD_ERROR}
+            </p>
+          ) : null}
+          <ul className="flex flex-col gap-2">
+            {schedule.menus.map((menu) => {
+              const done = isDone(menu.practice_menu_id);
+              return (
+                <li key={menu.practice_menu_id}>
+                  <label className="flex items-center gap-2.5 rounded-[10px] bg-sub px-3.5 py-3 text-sm text-white">
+                    <input
+                      type="checkbox"
+                      checked={done}
+                      disabled={
+                        logsLoadFailed ||
+                        togglingMenuId === menu.practice_menu_id
+                      }
+                      onChange={() => handleToggle(menu.practice_menu_id)}
+                      className="h-4 w-4 accent-[#d08000] disabled:opacity-50"
+                    />
+                    <span className={done ? "text-zinc-400 line-through" : ""}>
+                      {menu.name ?? "メニュー"}
+                      {menu.target_value !== null
+                        ? ` ${menu.target_value}${menu.unit_label ?? ""}`
+                        : ""}
+                    </span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : null}
+
+      {schedule.note ? (
+        <section className="mt-6">
+          <h3 className="mb-2 text-sm font-bold text-zinc-400">メモ</h3>
+          <p className="whitespace-pre-wrap text-sm text-white">
+            {schedule.note}
+          </p>
+        </section>
+      ) : null}
+
+      <div className="mt-8 flex flex-col gap-2">
+        {schedule.event_type === "game" ? (
+          <Link
+            href="/game-result/record"
+            className="flex w-full items-center justify-center rounded-[10px] bg-[#d08000] px-5 py-3 text-sm font-bold text-white transition-opacity hover:opacity-90"
+          >
+            {RECORD_GAME_LABEL}
+          </Link>
+        ) : (
+          <>
+            <Link
+              href={practiceRecordHref}
+              className="flex w-full items-center justify-center rounded-[10px] bg-[#d08000] px-5 py-3 text-sm font-bold text-white transition-opacity hover:opacity-90"
+            >
+              {RECORD_PRACTICE_LABEL}
+            </Link>
+            <p className="text-xs text-zinc-400">{RECORD_PRACTICE_HELPER}</p>
+          </>
+        )}
+      </div>
+
+      <div className="mt-4 flex gap-3">
+        <Button
+          as={Link}
+          href={`/practice/schedules/${schedule.id}/edit`}
+          variant="flat"
+          radius="sm"
+          className="flex-1"
+        >
+          {EDIT_LABEL}
+        </Button>
+        <Button
+          color="danger"
+          variant="flat"
+          radius="sm"
+          className="flex-1"
+          onPress={() => setIsDeleteOpen(true)}
+        >
+          {DELETE_LABEL}
+        </Button>
+      </div>
+
+      <Modal
+        isOpen={isDeleteOpen}
+        onClose={() => setIsDeleteOpen(false)}
+        placement="center"
+        className="buzz-dark"
+      >
+        <ModalContent>
+          <ModalHeader className="text-white">
+            {DELETE_CONFIRM_TITLE}
+          </ModalHeader>
+          <ModalBody>
+            <p className="text-sm text-white">
+              「{schedule.title ?? meta.label}」を削除しますか？
+            </p>
+            <p className="text-xs text-zinc-400">{DELETE_KEEPS_LOGS_NOTICE}</p>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="flat"
+              onPress={() => setIsDeleteOpen(false)}
+              isDisabled={isDeleting}
+            >
+              キャンセル
+            </Button>
+            <Button
+              color="danger"
+              onPress={handleDelete}
+              isDisabled={isDeleting}
+              isLoading={isDeleting}
+            >
+              {DELETE_LABEL}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/app/(app)/practice/schedules/[id]/edit/page.tsx
+++ b/app/(app)/practice/schedules/[id]/edit/page.tsx
@@ -1,0 +1,68 @@
+import { cookies } from "next/headers";
+import { notFound, redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getMenuSets } from "@app/services/v2/menuSetService";
+import { getPracticeMenus } from "@app/services/v2/practiceMenuService";
+import { getSchedules } from "@app/services/v2/scheduleService";
+import { todayString } from "../../../record/_utils/practiceRecordDraft";
+import { LOAD_ERROR } from "../../_components/scheduleCopy";
+import ScheduleFormContent from "../../_components/ScheduleFormContent";
+
+export const metadata = {
+  title: "予定を編集",
+};
+
+export default async function EditSchedulePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const { id } = await params;
+  const scheduleId = Number(id);
+  if (!Number.isInteger(scheduleId)) notFound();
+
+  const [schedulesResult, menusResult, menuSetsResult] = await Promise.all([
+    getSchedules(),
+    getPracticeMenus(),
+    getMenuSets(),
+  ]);
+
+  const schedule =
+    schedulesResult.status === "ok"
+      ? (schedulesResult.data.find((item) => item.id === scheduleId) ?? null)
+      : null;
+  if (schedulesResult.status === "ok" && schedule === null) notFound();
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            <h2 className="mb-6 text-2xl font-bold">予定を編集</h2>
+            {schedule ? (
+              <ScheduleFormContent
+                schedule={schedule}
+                menus={menusResult.status === "ok" ? menusResult.data : []}
+                menuSets={
+                  menuSetsResult.status === "ok" ? menuSetsResult.data : []
+                }
+                today={todayString()}
+              />
+            ) : (
+              // 取得失敗を「予定なし」に丸めると、空のフォームで既存の予定を上書きしてしまう。
+              <p className="py-8 text-center text-sm text-zinc-400">
+                {LOAD_ERROR}
+              </p>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/(app)/practice/schedules/[id]/page.tsx
+++ b/app/(app)/practice/schedules/[id]/page.tsx
@@ -1,0 +1,81 @@
+import { cookies } from "next/headers";
+import { notFound, redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getPracticeLogs } from "@app/services/v2/practiceLogService";
+import { getSchedules } from "@app/services/v2/scheduleService";
+import { todayString } from "../../record/_utils/practiceRecordDraft";
+import { LOAD_ERROR } from "../_components/scheduleCopy";
+import { buildDoneLogIds, resolveContextDate } from "../_utils/scheduleRecord";
+import ScheduleDetailContent from "./_components/ScheduleDetailContent";
+
+export const metadata = {
+  title: "予定の詳細",
+};
+
+interface ScheduleDetailSearchParams {
+  /** 「済」を判定する日（YYYY-MM-DD）。毎週の予定をカレンダー等から開くときに使う。 */
+  date?: string;
+}
+
+export default async function ScheduleDetailPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<ScheduleDetailSearchParams>;
+}) {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const [{ id }, query] = await Promise.all([params, searchParams]);
+  const scheduleId = Number(id);
+  if (!Number.isInteger(scheduleId)) notFound();
+
+  const schedulesResult = await getSchedules();
+  if (schedulesResult.status !== "ok") {
+    return (
+      <PageShell>
+        <p className="py-8 text-center text-sm text-zinc-400">{LOAD_ERROR}</p>
+      </PageShell>
+    );
+  }
+
+  const schedule = schedulesResult.data.find((item) => item.id === scheduleId);
+  if (!schedule) notFound();
+
+  const contextDate = resolveContextDate(query.date, schedule, todayString());
+  const logsResult = await getPracticeLogs({
+    from: contextDate,
+    to: contextDate,
+  });
+
+  return (
+    <PageShell>
+      <ScheduleDetailContent
+        schedule={schedule}
+        contextDate={contextDate}
+        initialDoneLogIds={
+          logsResult.status === "ok"
+            ? buildDoneLogIds(logsResult.data, schedule.id)
+            : {}
+        }
+        logsLoadFailed={logsResult.status !== "ok"}
+      />
+    </PageShell>
+  );
+}
+
+function PageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">{children}</div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/(app)/practice/schedules/__tests__/ScheduleForm.test.tsx
+++ b/app/(app)/practice/schedules/__tests__/ScheduleForm.test.tsx
@@ -1,0 +1,302 @@
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: jest.fn(), close: jest.fn() }),
+}));
+
+jest.mock("@app/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+import type { MenuSet } from "@app/types/menuSet";
+import type { PracticeMenu } from "@app/types/practice";
+import type { Schedule, ScheduleInput } from "@app/types/schedule";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import ScheduleForm from "../_components/ScheduleForm";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+
+function mockEntitlement(granted: boolean) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: granted,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading: false,
+    hasEntitlement: jest.fn(() => granted),
+  });
+}
+
+const menus: PracticeMenu[] = [
+  {
+    id: 1,
+    name: "素振り",
+    category: "batting",
+    unit: "count",
+    unit_label: "本",
+    default_value: "200.0",
+    is_favorite: false,
+    sort_order: 1,
+  },
+  {
+    id: 2,
+    name: "ランニング",
+    category: "training",
+    unit: "distance",
+    unit_label: "km",
+    default_value: null,
+    is_favorite: false,
+    sort_order: 2,
+  },
+];
+
+const menuSets: MenuSet[] = [
+  { id: 3, name: "オフ日ルーティン", note: null, sort_order: 1, items: [] },
+];
+
+function buildSchedule(overrides: Partial<Schedule> = {}): Schedule {
+  return {
+    id: 10,
+    title: "朝の素振り",
+    days_of_week: null,
+    planned_on: "2026-08-10",
+    scheduled_time: "06:00",
+    event_type: "self_practice",
+    recurring: false,
+    menu_set_id: null,
+    game_result_id: null,
+    note: null,
+    notification_enabled: true,
+    active: true,
+    notification_message: null,
+    menus: [],
+    logged_practice_menu_ids: [],
+    ...overrides,
+  };
+}
+
+function renderForm({
+  schedule = null,
+  onSubmit = jest.fn(),
+}: {
+  schedule?: Schedule | null;
+  onSubmit?: jest.Mock;
+} = {}) {
+  render(
+    <ScheduleForm
+      schedule={schedule}
+      menus={menus}
+      menuSets={menuSets}
+      today="2026-08-03"
+      isSaving={false}
+      serverErrors={[]}
+      onSubmit={onSubmit}
+      onCancel={jest.fn()}
+    />,
+  );
+  return { onSubmit };
+}
+
+function submittedInput(onSubmit: jest.Mock): ScheduleInput {
+  return onSubmit.mock.calls[0][0] as ScheduleInput;
+}
+
+const save = (user: ReturnType<typeof userEvent.setup>) =>
+  user.click(screen.getByRole("button", { name: /登録する|更新する/ }));
+
+describe("ScheduleForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEntitlement(false);
+  });
+
+  describe("繰り返し種別の切り替え", () => {
+    it("既定はこの日だけで、日付入力を出す", () => {
+      renderForm();
+
+      expect(screen.getByLabelText("日付")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "月" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("毎週に切り替えると曜日の選択に変わる", async () => {
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.click(screen.getByRole("button", { name: "毎週" }));
+
+      expect(screen.getByRole("button", { name: "月" })).toBeInTheDocument();
+      expect(screen.queryByLabelText("日付")).not.toBeInTheDocument();
+    });
+
+    it("毎週で選んだ曜日を days_of_week として送り、planned_on は送らない", async () => {
+      const user = userEvent.setup();
+      const { onSubmit } = renderForm();
+
+      await user.click(screen.getByRole("button", { name: "毎週" }));
+      await user.click(screen.getByRole("button", { name: "水" }));
+      await user.click(screen.getByRole("button", { name: "月" }));
+      await user.type(screen.getByLabelText(/タイトル/), "朝練");
+      await save(user);
+
+      const input = submittedInput(onSubmit);
+      expect(input.days_of_week).toBe("1,3");
+      expect(input.planned_on).toBeNull();
+    });
+  });
+
+  describe("バリデーション", () => {
+    it("毎週で曜日を選ばないと保存できない", async () => {
+      const user = userEvent.setup();
+      const { onSubmit } = renderForm();
+
+      await user.click(screen.getByRole("button", { name: "毎週" }));
+      await user.type(screen.getByLabelText(/タイトル/), "朝練");
+      await save(user);
+
+      expect(
+        screen.getByText("曜日または日付のいずれかを指定してください"),
+      ).toBeInTheDocument();
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("メニューセット未指定でタイトルが空なら保存できない", async () => {
+      const user = userEvent.setup();
+      const { onSubmit } = renderForm();
+
+      await save(user);
+
+      expect(
+        screen.getByText(
+          "タイトルを入力してください（メニューセットを選ぶと省略できます）",
+        ),
+      ).toBeInTheDocument();
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("メニューセットを選べばタイトル無しでも保存できる", async () => {
+      const user = userEvent.setup();
+      const { onSubmit } = renderForm();
+
+      await user.click(screen.getByRole("button", { name: "セットから" }));
+      await user.click(
+        screen.getByRole("button", { name: "オフ日ルーティン" }),
+      );
+      await save(user);
+
+      expect(submittedInput(onSubmit).menu_set_id).toBe(3);
+    });
+
+    it("タイトルは50文字を超えて入力できない", () => {
+      renderForm();
+
+      expect(screen.getByLabelText(/タイトル/)).toHaveAttribute(
+        "maxlength",
+        "50",
+      );
+    });
+  });
+
+  describe("メニューの編集ロック", () => {
+    const lockedSchedule = buildSchedule({
+      menus: [
+        {
+          practice_menu_id: 1,
+          name: "素振り",
+          unit_label: "本",
+          target_value: 200,
+        },
+      ],
+      logged_practice_menu_ids: [1],
+    });
+
+    it("記録済みメニューのチェックと目標量を操作できない", () => {
+      renderForm({ schedule: lockedSchedule });
+
+      expect(screen.getByRole("checkbox", { name: /素振り/ })).toBeDisabled();
+      expect(screen.getByLabelText("素振りの目標量")).toBeDisabled();
+      expect(
+        screen.getByRole("checkbox", { name: "ランニング" }),
+      ).toBeEnabled();
+    });
+
+    it("記録済みメニューを外そうとしても保存内容から消えない", async () => {
+      const user = userEvent.setup();
+      const { onSubmit } = renderForm({ schedule: lockedSchedule });
+
+      await user.click(screen.getByRole("checkbox", { name: /素振り/ }));
+      await save(user);
+
+      expect(submittedInput(onSubmit).menus).toContainEqual({
+        practice_menu_id: 1,
+        target_value: 200,
+      });
+    });
+
+    it("記録済みメニューがあるとメニューセットへ切り替えられない", () => {
+      renderForm({ schedule: lockedSchedule });
+
+      expect(screen.getByRole("button", { name: "セットから" })).toBeDisabled();
+    });
+
+    it("記録済みメニューが無ければメニューの選択を解除できる", async () => {
+      const user = userEvent.setup();
+      const { onSubmit } = renderForm({
+        schedule: buildSchedule({
+          menus: [
+            {
+              practice_menu_id: 1,
+              name: "素振り",
+              unit_label: "本",
+              target_value: 200,
+            },
+          ],
+        }),
+      });
+
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+      await save(user);
+
+      expect(submittedInput(onSubmit).menus).toEqual([]);
+    });
+  });
+
+  describe("カスタム通知文の Pro ゲート", () => {
+    it("無料プランでは入力欄を出さず訴求カードを見せる", () => {
+      renderForm();
+
+      expect(screen.queryByLabelText("カスタム通知文")).not.toBeInTheDocument();
+      expect(
+        screen.getByText("通知メッセージをカスタマイズ"),
+      ).toBeInTheDocument();
+    });
+
+    it("Pro なら入力した文言を送信する", async () => {
+      mockEntitlement(true);
+      const user = userEvent.setup();
+      const { onSubmit } = renderForm();
+
+      await user.type(screen.getByLabelText(/タイトル/), "朝練");
+      await user.type(screen.getByLabelText("カスタム通知文"), "頑張れ");
+      await save(user);
+
+      expect(submittedInput(onSubmit).notification_message).toBe("頑張れ");
+    });
+  });
+
+  it("Web では通知が届かないことを明示する", () => {
+    renderForm();
+
+    expect(
+      screen.getByText(
+        "通知は iOS / Android アプリ版でのみ届きます。ブラウザには通知されません（設定はアプリと共通です）。",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/(app)/practice/schedules/__tests__/ScheduleForm.test.tsx
+++ b/app/(app)/practice/schedules/__tests__/ScheduleForm.test.tsx
@@ -288,6 +288,26 @@ describe("ScheduleForm", () => {
 
       expect(submittedInput(onSubmit).notification_message).toBe("頑張れ");
     });
+
+    // 自主練スケジュールは無料でも無制限に作れるため、件数上限の訴求を出してはいけない。
+    it("無料プランでも件数上限の訴求は出さない", () => {
+      renderForm();
+
+      const ctas = screen.getAllByRole("button", { name: /Pro プランを見る/ });
+      expect(ctas).toHaveLength(1);
+      expect(ctas[0]).toHaveAccessibleName(/通知メッセージをカスタマイズ/);
+    });
+  });
+
+  it("選んだ種別を back の enum のまま送る", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderForm();
+
+    await user.click(screen.getByRole("button", { name: "試合" }));
+    await user.type(screen.getByLabelText(/タイトル/), "vs 港南高");
+    await save(user);
+
+    expect(submittedInput(onSubmit).event_type).toBe("game");
   });
 
   it("Web では通知が届かないことを明示する", () => {

--- a/app/(app)/practice/schedules/_components/ScheduleForm.tsx
+++ b/app/(app)/practice/schedules/_components/ScheduleForm.tsx
@@ -70,13 +70,26 @@ const SEGMENT_BASE =
 const CHIP_BASE =
   "rounded-full px-3.5 py-2 text-xs font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000]";
 
-/** 目標量の初期値。back の decimal は文字列で返るため数値化してから入力欄へ流す。 */
-function initialMenuAmounts(schedule: Schedule | null): Record<number, string> {
+/** 目標量の表示用文字列。back の decimal は文字列で返るため数値化してから入力欄へ流す。 */
+function toAmountText(value: number | null): string {
+  const parsed = parseDecimal(value);
+  return parsed === null ? "" : String(parsed);
+}
+
+/**
+ * 編集可能なメニューの目標量の初期値。
+ * 記録済み（ロック）メニューは入力状態として持たず、送信時にサーバー由来の値をそのまま
+ * 足し戻す。ユーザー操作の状態に混ぜると、UI の無効化を外しただけで紐付けを失いうる。
+ */
+function initialMenuAmounts(
+  schedule: Schedule | null,
+  lockedIds: Set<number>,
+): Record<number, string> {
   if (!schedule || schedule.menu_set_id !== null) return {};
   const amounts: Record<number, string> = {};
   schedule.menus.forEach((menu) => {
-    const parsed = parseDecimal(menu.target_value);
-    amounts[menu.practice_menu_id] = parsed === null ? "" : String(parsed);
+    if (lockedIds.has(menu.practice_menu_id)) return;
+    amounts[menu.practice_menu_id] = toAmountText(menu.target_value);
   });
   return amounts;
 }
@@ -107,6 +120,9 @@ export default function ScheduleForm({
     lockedIds.has(menu.practice_menu_id),
   );
   const hasLockedMenu = lockedMenus.length > 0;
+  const lockedAmounts = new Map(
+    lockedMenus.map((menu) => [menu.practice_menu_id, menu.target_value]),
+  );
 
   const [recurrence, setRecurrence] = useState<ScheduleRecurrence>(
     schedule?.days_of_week ? "weekly" : "single",
@@ -129,7 +145,7 @@ export default function ScheduleForm({
     schedule?.menu_set_id ?? null,
   );
   const [menuAmounts, setMenuAmounts] = useState<Record<number, string>>(() =>
-    initialMenuAmounts(schedule),
+    initialMenuAmounts(schedule, lockedIds),
   );
   const [notificationEnabled, setNotificationEnabled] = useState(
     schedule?.notification_enabled ?? true,
@@ -406,8 +422,8 @@ export default function ScheduleForm({
             ) : (
               <ul className="flex flex-col gap-2">
                 {menus.map((menu) => {
-                  const isSelected = menu.id in menuAmounts;
                   const isLocked = lockedIds.has(menu.id);
+                  const isSelected = isLocked || menu.id in menuAmounts;
                   const defaultValue = parseDecimal(menu.default_value);
                   return (
                     <li
@@ -442,7 +458,13 @@ export default function ScheduleForm({
                           <input
                             type="number"
                             aria-label={`${menu.name}の目標量`}
-                            value={menuAmounts[menu.id] ?? ""}
+                            value={
+                              isLocked
+                                ? toAmountText(
+                                    lockedAmounts.get(menu.id) ?? null,
+                                  )
+                                : (menuAmounts[menu.id] ?? "")
+                            }
                             disabled={isLocked}
                             onChange={(event) =>
                               changeMenuAmount(menu.id, event.target.value)

--- a/app/(app)/practice/schedules/_components/ScheduleForm.tsx
+++ b/app/(app)/practice/schedules/_components/ScheduleForm.tsx
@@ -1,0 +1,526 @@
+"use client";
+
+import type { MenuSet } from "@app/types/menuSet";
+import type { PracticeMenu } from "@app/types/practice";
+import type {
+  Schedule,
+  ScheduleEventType,
+  ScheduleInput,
+} from "@app/types/schedule";
+import LockClosedIcon from "@heroicons/react/24/solid/LockClosedIcon";
+import { Button, Input, Switch } from "@heroui/react";
+import { useState } from "react";
+import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
+import { parseDecimal } from "@app/constants/practice";
+import {
+  EVENT_TYPES,
+  SCHEDULE_TITLE_MAX_LENGTH,
+  WEEK_DAYS,
+} from "@app/constants/schedule";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import {
+  type ScheduleMenuSource,
+  type ScheduleRecurrence,
+  buildScheduleInput,
+  validateScheduleInput,
+} from "../_utils/scheduleForm";
+import {
+  CANCEL_LABEL,
+  DATE_LABEL,
+  EVENT_TYPE_LABEL,
+  LOCKED_MENU_BADGE,
+  LOCKED_MENU_NOTICE,
+  LOCKED_MENU_SOURCE_NOTICE,
+  MENUS_EMPTY,
+  MENU_LABEL,
+  MENU_SETS_EMPTY,
+  MENU_SOURCE_INDIVIDUAL_LABEL,
+  MENU_SOURCE_SET_LABEL,
+  NOTIFICATION_LABEL,
+  NOTIFICATION_MESSAGE_LABEL,
+  NOTIFICATION_MESSAGE_PLACEHOLDER,
+  NOTIFICATION_WEB_NOTICE,
+  RECURRENCE_LABEL,
+  RECURRENCE_SINGLE_LABEL,
+  RECURRENCE_WEEKLY_LABEL,
+  SAVE_LABEL,
+  TIME_LABEL,
+  TITLE_HELPER,
+  TITLE_LABEL,
+  TITLE_OPTIONAL_LABEL,
+  UPDATE_LABEL,
+} from "./scheduleCopy";
+
+interface ScheduleFormProps {
+  /** 編集対象。null なら新規作成。 */
+  schedule: Schedule | null;
+  menus: PracticeMenu[];
+  menuSets: MenuSet[];
+  /** 新規作成時に初期表示する日付（Asia/Tokyo の今日）。 */
+  today: string;
+  isSaving: boolean;
+  /** 保存に失敗したときに出すサーバー由来のメッセージ。 */
+  serverErrors: string[];
+  onSubmit: (input: ScheduleInput) => void;
+  onCancel: () => void;
+}
+
+const SEGMENT_BASE =
+  "flex-1 py-2.5 text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000]";
+const CHIP_BASE =
+  "rounded-full px-3.5 py-2 text-xs font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000]";
+
+/** 目標量の初期値。back の decimal は文字列で返るため数値化してから入力欄へ流す。 */
+function initialMenuAmounts(schedule: Schedule | null): Record<number, string> {
+  if (!schedule || schedule.menu_set_id !== null) return {};
+  const amounts: Record<number, string> = {};
+  schedule.menus.forEach((menu) => {
+    const parsed = parseDecimal(menu.target_value);
+    amounts[menu.practice_menu_id] = parsed === null ? "" : String(parsed);
+  });
+  return amounts;
+}
+
+/**
+ * 予定の作成・編集フォーム。
+ *
+ * 入力値の保持とクライアント側バリデーションだけを担い、
+ * API 呼び出しと画面遷移は呼び出し元（Container）に委ねる。
+ * 初期値は props からマウント時に一度だけ組み立てる（useEffect での同期はしない）。
+ */
+export default function ScheduleForm({
+  schedule,
+  menus,
+  menuSets,
+  today,
+  isSaving,
+  serverErrors,
+  onSubmit,
+  onCancel,
+}: ScheduleFormProps) {
+  const { hasEntitlement, isLoading: isEntitlementLoading } = useEntitlement();
+  const canCustomizeMessage = hasEntitlement("custom_notification_messages");
+
+  // 記録済みメニューは「済」判定の整合が壊れるため、選択解除も目標量の変更もさせない。
+  const lockedIds = new Set(schedule?.logged_practice_menu_ids ?? []);
+  const lockedMenus = (schedule?.menus ?? []).filter((menu) =>
+    lockedIds.has(menu.practice_menu_id),
+  );
+  const hasLockedMenu = lockedMenus.length > 0;
+
+  const [recurrence, setRecurrence] = useState<ScheduleRecurrence>(
+    schedule?.days_of_week ? "weekly" : "single",
+  );
+  const [eventType, setEventType] = useState<ScheduleEventType>(
+    schedule?.event_type ?? "self_practice",
+  );
+  const [title, setTitle] = useState(schedule?.title ?? "");
+  const [days, setDays] = useState<number[]>(
+    schedule?.days_of_week ? schedule.days_of_week.split(",").map(Number) : [],
+  );
+  const [plannedOn, setPlannedOn] = useState(schedule?.planned_on ?? today);
+  const [scheduledTime, setScheduledTime] = useState(
+    schedule?.scheduled_time ?? "06:00",
+  );
+  const [menuSource, setMenuSource] = useState<ScheduleMenuSource>(
+    schedule?.menu_set_id ? "set" : "individual",
+  );
+  const [menuSetId, setMenuSetId] = useState<number | null>(
+    schedule?.menu_set_id ?? null,
+  );
+  const [menuAmounts, setMenuAmounts] = useState<Record<number, string>>(() =>
+    initialMenuAmounts(schedule),
+  );
+  const [notificationEnabled, setNotificationEnabled] = useState(
+    schedule?.notification_enabled ?? true,
+  );
+  const [notificationMessage, setNotificationMessage] = useState(
+    schedule?.notification_message ?? "",
+  );
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const usingSet = menuSource === "set" && menuSetId !== null;
+
+  const toggleDay = (num: number) =>
+    setDays((prev) =>
+      prev.includes(num) ? prev.filter((day) => day !== num) : [...prev, num],
+    );
+
+  const toggleMenu = (menuId: number, defaultValue: string) => {
+    if (lockedIds.has(menuId)) return;
+    setMenuAmounts((prev) => {
+      if (menuId in prev) {
+        const next = { ...prev };
+        delete next[menuId];
+        return next;
+      }
+      return { ...prev, [menuId]: defaultValue };
+    });
+  };
+
+  const changeMenuAmount = (menuId: number, amount: string) => {
+    if (lockedIds.has(menuId)) return;
+    setMenuAmounts((prev) => ({ ...prev, [menuId]: amount }));
+  };
+
+  const handleMenuSourceChange = (next: ScheduleMenuSource) => {
+    // セットへ切り替えると個別紐付けが全置換され、ロック対象が外れてしまう。
+    if (next === "set" && hasLockedMenu) return;
+    setMenuSource(next);
+  };
+
+  const handleSubmit = () => {
+    const input = buildScheduleInput(
+      {
+        recurrence,
+        eventType,
+        title,
+        days,
+        plannedOn,
+        scheduledTime,
+        menuSource,
+        menuSetId,
+        menuAmounts,
+        notificationEnabled,
+        notificationMessage,
+      },
+      { canCustomizeMessage, lockedMenus },
+    );
+
+    const validationErrors = validateScheduleInput(input);
+    if (validationErrors.length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+    setErrors([]);
+    onSubmit(input);
+  };
+
+  const messages = errors.length > 0 ? errors : serverErrors;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <p className="mb-1.5 text-sm text-white">{RECURRENCE_LABEL}</p>
+        <div
+          className="flex overflow-hidden rounded-lg border-1 border-zinc-600"
+          role="group"
+          aria-label={RECURRENCE_LABEL}
+        >
+          {(
+            [
+              ["single", RECURRENCE_SINGLE_LABEL],
+              ["weekly", RECURRENCE_WEEKLY_LABEL],
+            ] as const
+          ).map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              aria-pressed={recurrence === value}
+              onClick={() => setRecurrence(value)}
+              className={`${SEGMENT_BASE} ${
+                recurrence === value
+                  ? "bg-[#d08000] text-white"
+                  : "bg-sub text-zinc-400"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {recurrence === "weekly" ? (
+          <div
+            className="mt-3 flex flex-wrap gap-2"
+            role="group"
+            aria-label="曜日"
+          >
+            {WEEK_DAYS.map((day) => {
+              const isActive = days.includes(day.num);
+              return (
+                <button
+                  key={day.num}
+                  type="button"
+                  aria-pressed={isActive}
+                  onClick={() => toggleDay(day.num)}
+                  className={`h-10 w-10 rounded-full text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000] ${
+                    isActive
+                      ? "bg-[#d08000] text-white"
+                      : "bg-sub text-zinc-400"
+                  }`}
+                >
+                  {day.label}
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="mt-3">
+            <Input
+              type="date"
+              variant="bordered"
+              size="sm"
+              radius="sm"
+              className="w-48"
+              label={DATE_LABEL}
+              labelPlacement="outside"
+              value={plannedOn}
+              onChange={(event) => setPlannedOn(event.target.value)}
+            />
+          </div>
+        )}
+      </div>
+
+      <div>
+        <p className="mb-1.5 text-sm text-white">{EVENT_TYPE_LABEL}</p>
+        <div
+          className="flex flex-wrap gap-2"
+          role="group"
+          aria-label={EVENT_TYPE_LABEL}
+        >
+          {EVENT_TYPES.map((item) => {
+            const isActive = item.value === eventType;
+            return (
+              <button
+                key={item.value}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => setEventType(item.value)}
+                className={`${CHIP_BASE} ${
+                  isActive
+                    ? "text-white"
+                    : "bg-sub text-zinc-400 hover:text-white"
+                }`}
+                style={isActive ? { backgroundColor: item.color } : undefined}
+              >
+                {item.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <Input
+        type="text"
+        variant="bordered"
+        label={usingSet ? TITLE_OPTIONAL_LABEL : TITLE_LABEL}
+        labelPlacement="outside"
+        isRequired={!usingSet}
+        maxLength={SCHEDULE_TITLE_MAX_LENGTH}
+        placeholder={eventType === "game" ? "vs 港南高" : "例: 朝の素振り"}
+        description={TITLE_HELPER}
+        value={title}
+        onChange={(event) => setTitle(event.target.value)}
+      />
+
+      <Input
+        type="time"
+        variant="bordered"
+        size="sm"
+        radius="sm"
+        className="w-40"
+        label={TIME_LABEL}
+        labelPlacement="outside"
+        value={scheduledTime}
+        onChange={(event) => setScheduledTime(event.target.value)}
+      />
+
+      <div>
+        <p className="mb-1.5 text-sm text-white">{MENU_LABEL}</p>
+        <div
+          className="flex overflow-hidden rounded-lg border-1 border-zinc-600"
+          role="group"
+          aria-label={MENU_LABEL}
+        >
+          {(
+            [
+              ["individual", MENU_SOURCE_INDIVIDUAL_LABEL],
+              ["set", MENU_SOURCE_SET_LABEL],
+            ] as const
+          ).map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              aria-pressed={menuSource === value}
+              disabled={value === "set" && hasLockedMenu}
+              onClick={() => handleMenuSourceChange(value)}
+              className={`${SEGMENT_BASE} disabled:opacity-40 ${
+                menuSource === value
+                  ? "bg-[#d08000] text-white"
+                  : "bg-sub text-zinc-400"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {hasLockedMenu ? (
+          <p className="mt-2 text-xs text-zinc-400">
+            {LOCKED_MENU_SOURCE_NOTICE}
+          </p>
+        ) : null}
+
+        {menuSource === "set" ? (
+          <div className="mt-3">
+            {menuSets.length === 0 ? (
+              <p className="text-xs text-zinc-400">{MENU_SETS_EMPTY}</p>
+            ) : (
+              <div
+                className="flex flex-wrap gap-2"
+                role="group"
+                aria-label={MENU_SOURCE_SET_LABEL}
+              >
+                {menuSets.map((set) => {
+                  const isActive = menuSetId === set.id;
+                  return (
+                    <button
+                      key={set.id}
+                      type="button"
+                      aria-pressed={isActive}
+                      onClick={() =>
+                        setMenuSetId((prev) =>
+                          prev === set.id ? null : set.id,
+                        )
+                      }
+                      className={`${CHIP_BASE} ${
+                        isActive
+                          ? "bg-[#d08000] text-white"
+                          : "bg-sub text-zinc-400 hover:text-white"
+                      }`}
+                    >
+                      {set.name}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="mt-3">
+            {hasLockedMenu ? (
+              <p className="mb-2 text-xs text-zinc-400">{LOCKED_MENU_NOTICE}</p>
+            ) : null}
+            {menus.length === 0 ? (
+              <p className="text-xs text-zinc-400">{MENUS_EMPTY}</p>
+            ) : (
+              <ul className="flex flex-col gap-2">
+                {menus.map((menu) => {
+                  const isSelected = menu.id in menuAmounts;
+                  const isLocked = lockedIds.has(menu.id);
+                  const defaultValue = parseDecimal(menu.default_value);
+                  return (
+                    <li
+                      key={menu.id}
+                      className="rounded-[10px] bg-sub px-3.5 py-3"
+                    >
+                      <label className="flex items-center gap-2.5 text-sm text-white">
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          disabled={isLocked}
+                          onChange={() =>
+                            toggleMenu(
+                              menu.id,
+                              defaultValue === null ? "" : String(defaultValue),
+                            )
+                          }
+                          className="h-4 w-4 accent-[#d08000] disabled:opacity-50"
+                        />
+                        <span className={isLocked ? "text-zinc-400" : ""}>
+                          {menu.name}
+                        </span>
+                        {isLocked ? (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-[#2E2E2E] px-2 py-0.5 text-[11px] font-bold text-zinc-400">
+                            <LockClosedIcon className="h-3 w-3" aria-hidden />
+                            {LOCKED_MENU_BADGE}
+                          </span>
+                        ) : null}
+                      </label>
+                      {isSelected ? (
+                        <div className="mt-2.5 flex items-center gap-2 pl-6">
+                          <input
+                            type="number"
+                            aria-label={`${menu.name}の目標量`}
+                            value={menuAmounts[menu.id] ?? ""}
+                            disabled={isLocked}
+                            onChange={(event) =>
+                              changeMenuAmount(menu.id, event.target.value)
+                            }
+                            className="w-28 rounded-lg bg-main px-3 py-2 text-sm font-bold text-white disabled:opacity-50"
+                          />
+                          <span className="text-sm text-zinc-400">
+                            {menu.unit_label ?? ""}
+                          </span>
+                        </div>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div>
+        <Switch
+          isSelected={notificationEnabled}
+          onValueChange={setNotificationEnabled}
+          color="primary"
+          size="sm"
+          classNames={{ label: "text-sm text-white" }}
+        >
+          {NOTIFICATION_LABEL}
+        </Switch>
+        <p className="mt-1.5 text-xs text-zinc-400">
+          {NOTIFICATION_WEB_NOTICE}
+        </p>
+      </div>
+
+      {isEntitlementLoading ? null : canCustomizeMessage ? (
+        <Input
+          type="text"
+          variant="bordered"
+          label={NOTIFICATION_MESSAGE_LABEL}
+          labelPlacement="outside"
+          placeholder={NOTIFICATION_MESSAGE_PLACEHOLDER}
+          value={notificationMessage}
+          onChange={(event) => setNotificationMessage(event.target.value)}
+        />
+      ) : (
+        <ProUpsellCard feature="custom_notification_messages" />
+      )}
+
+      {messages.length > 0 ? (
+        <ul role="alert" className="space-y-1 text-sm text-danger">
+          {messages.map((message) => (
+            <li key={message}>{message}</li>
+          ))}
+        </ul>
+      ) : null}
+
+      <div className="flex gap-3">
+        <Button
+          variant="flat"
+          radius="sm"
+          className="flex-1"
+          onPress={onCancel}
+          isDisabled={isSaving}
+        >
+          {CANCEL_LABEL}
+        </Button>
+        <Button
+          color="primary"
+          radius="sm"
+          className="flex-1 font-bold"
+          onPress={handleSubmit}
+          isDisabled={isSaving}
+          isLoading={isSaving}
+        >
+          {schedule ? UPDATE_LABEL : SAVE_LABEL}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/practice/schedules/_components/ScheduleFormContent.tsx
+++ b/app/(app)/practice/schedules/_components/ScheduleFormContent.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { MenuSet } from "@app/types/menuSet";
+import type { PracticeMenu } from "@app/types/practice";
+import type { Schedule, ScheduleInput } from "@app/types/schedule";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  createSchedule,
+  updateSchedule,
+} from "@app/services/v2/scheduleService";
+import ScheduleForm from "./ScheduleForm";
+
+interface ScheduleFormContentProps {
+  /** 編集対象。null なら新規作成。 */
+  schedule: Schedule | null;
+  menus: PracticeMenu[];
+  menuSets: MenuSet[];
+  today: string;
+}
+
+/**
+ * 予定フォーム画面の Container。
+ * Server Action の呼び出しと保存後の遷移を担い、入力 UI は ScheduleForm に委ねる。
+ */
+export default function ScheduleFormContent({
+  schedule,
+  menus,
+  menuSets,
+  today,
+}: ScheduleFormContentProps) {
+  const router = useRouter();
+  const [isSaving, setIsSaving] = useState(false);
+  const [serverErrors, setServerErrors] = useState<string[]>([]);
+
+  const handleSubmit = async (input: ScheduleInput) => {
+    setIsSaving(true);
+    setServerErrors([]);
+
+    const result = schedule
+      ? await updateSchedule(schedule.id, input)
+      : await createSchedule(input);
+    setIsSaving(false);
+
+    if (!result.ok) {
+      setServerErrors(result.errors);
+      return;
+    }
+
+    toast.success(schedule ? "予定を更新しました" : "予定を登録しました");
+    router.push(`/practice/schedules/${result.data.id}`);
+    router.refresh();
+  };
+
+  return (
+    <ScheduleForm
+      schedule={schedule}
+      menus={menus}
+      menuSets={menuSets}
+      today={today}
+      isSaving={isSaving}
+      serverErrors={serverErrors}
+      onSubmit={handleSubmit}
+      onCancel={() => router.back()}
+    />
+  );
+}

--- a/app/(app)/practice/schedules/_components/ScheduleList.tsx
+++ b/app/(app)/practice/schedules/_components/ScheduleList.tsx
@@ -1,0 +1,96 @@
+import type { Schedule } from "@app/types/schedule";
+import Link from "next/link";
+import { dayLabels, eventTypeMeta } from "@app/constants/schedule";
+import {
+  EMPTY_MESSAGE,
+  RECURRING_SECTION_TITLE,
+  SINGLE_SECTION_TITLE,
+} from "./scheduleCopy";
+
+interface ScheduleListProps {
+  schedules: Schedule[];
+}
+
+/** 予定の「いつ」を1行で表す。毎週は曜日、単発は日付。 */
+function whenLabel(schedule: Schedule): string {
+  if (schedule.days_of_week) return `毎週 ${dayLabels(schedule.days_of_week)}`;
+  return schedule.planned_on ?? "";
+}
+
+function ScheduleRow({ schedule }: { schedule: Schedule }) {
+  const meta = eventTypeMeta(schedule.event_type);
+
+  return (
+    <li>
+      <Link
+        href={`/practice/schedules/${schedule.id}`}
+        className="flex items-center gap-3 rounded-[10px] bg-sub px-3.5 py-3 transition-opacity hover:opacity-90"
+      >
+        <span
+          aria-hidden
+          className="h-9 w-1 shrink-0 rounded-full"
+          style={{ backgroundColor: meta.color }}
+        />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm font-bold text-white">
+            {schedule.title ?? meta.label}
+          </span>
+          <span className="mt-0.5 block text-xs text-zinc-400">
+            {whenLabel(schedule)}
+            {schedule.scheduled_time ? ` ${schedule.scheduled_time}` : ""}
+          </span>
+        </span>
+        <span
+          className="shrink-0 rounded-full px-2 py-0.5 text-[11px] font-bold"
+          style={{ backgroundColor: `${meta.color}22`, color: meta.color }}
+        >
+          {meta.label}
+        </span>
+      </Link>
+    </li>
+  );
+}
+
+function Section({
+  title,
+  schedules,
+}: {
+  title: string;
+  schedules: Schedule[];
+}) {
+  if (schedules.length === 0) return null;
+  return (
+    <section>
+      <h3 className="mb-2 text-sm font-bold text-zinc-400">{title}</h3>
+      <ul className="flex flex-col gap-2">
+        {schedules.map((schedule) => (
+          <ScheduleRow key={schedule.id} schedule={schedule} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+/**
+ * 予定一覧の Presentational。
+ * 繰り返しと単発は意味が違う（毎週続く／その日限り）ため節を分けて並べる。
+ */
+export default function ScheduleList({ schedules }: ScheduleListProps) {
+  if (schedules.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-zinc-400">{EMPTY_MESSAGE}</p>
+    );
+  }
+
+  const recurring = schedules.filter((schedule) => schedule.recurring);
+  const single = schedules
+    .filter((schedule) => !schedule.recurring)
+    .sort((a, b) => (a.planned_on ?? "").localeCompare(b.planned_on ?? ""));
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Section title={SINGLE_SECTION_TITLE} schedules={single} />
+      <Section title={RECURRING_SECTION_TITLE} schedules={recurring} />
+    </div>
+  );
+}

--- a/app/(app)/practice/schedules/_components/scheduleCopy.ts
+++ b/app/(app)/practice/schedules/_components/scheduleCopy.ts
@@ -1,0 +1,73 @@
+import { SCHEDULE_TITLE_MAX_LENGTH } from "@app/constants/schedule";
+
+/** 練習スケジュール画面の文言。表示のゆれを避けるため 1 箇所に集約する。 */
+
+export const PAGE_TITLE = "練習スケジュール";
+export const PAGE_DESCRIPTION =
+  "この日だけの予定と、毎週くり返す予定を登録できます。メニューを紐付けておくと、その日の練習記録にそのまま引き継げます。";
+
+export const CREATE_LABEL = "予定を作る";
+export const EMPTY_MESSAGE = "まだ予定がありません";
+export const RECURRING_SECTION_TITLE = "毎週の予定";
+export const SINGLE_SECTION_TITLE = "この日だけの予定";
+export const LOAD_ERROR =
+  "予定を取得できませんでした。時間を置いて再度お試しください。";
+
+export const RECURRENCE_LABEL = "いつ";
+export const RECURRENCE_SINGLE_LABEL = "この日だけ";
+export const RECURRENCE_WEEKLY_LABEL = "毎週";
+export const EVENT_TYPE_LABEL = "種別";
+export const TITLE_LABEL = "タイトル";
+export const TITLE_OPTIONAL_LABEL = "タイトル（任意）";
+export const TITLE_HELPER = `${SCHEDULE_TITLE_MAX_LENGTH}文字以内。メニューセットを選んだ場合は省略するとセット名が使われます。`;
+export const TIME_LABEL = "時刻";
+export const DATE_LABEL = "日付";
+export const MENU_LABEL = "メニュー（任意）";
+export const MENU_SOURCE_INDIVIDUAL_LABEL = "個別に選ぶ";
+export const MENU_SOURCE_SET_LABEL = "セットから";
+export const MENU_SETS_EMPTY =
+  "メニューセットがありません。先にメニューセットを作ると、まとめて紐付けられます。";
+export const MENUS_EMPTY =
+  "練習メニューがありません。先に練習メニューを登録すると、予定に紐付けられます。";
+
+/** 記録済みメニューを触らせない理由を、操作できない事実とセットで伝える。 */
+export const LOCKED_MENU_NOTICE =
+  "練習記録が「済」になっているメニューは、記録との対応が崩れるため変更できません。";
+export const LOCKED_MENU_BADGE = "変更不可";
+export const LOCKED_MENU_SOURCE_NOTICE =
+  "「済」のメニューがあるため、メニューセットへの切り替えはできません。";
+
+export const NOTIFICATION_LABEL = "リマインド通知";
+
+/**
+ * Web にはプッシュ通知の配信基盤が無く、この設定は端末（アプリ版）のローカル通知にだけ効く。
+ * 「設定したのに通知が来ない」と誤解させないため、保存先と配信先が違うことを明示する。
+ */
+export const NOTIFICATION_WEB_NOTICE =
+  "通知は iOS / Android アプリ版でのみ届きます。ブラウザには通知されません（設定はアプリと共通です）。";
+
+export const NOTIFICATION_MESSAGE_LABEL = "カスタム通知文";
+export const NOTIFICATION_MESSAGE_PLACEHOLDER = "おはよう！今日も素振りしよう";
+
+export const SAVE_LABEL = "登録する";
+export const UPDATE_LABEL = "更新する";
+export const CANCEL_LABEL = "キャンセル";
+
+export const DELETE_LABEL = "削除";
+export const EDIT_LABEL = "編集";
+export const DELETE_CONFIRM_TITLE = "予定の削除";
+
+/** 削除してもログは残る（back が schedule_id を nullify する）ことを伝える。 */
+export const DELETE_KEEPS_LOGS_NOTICE =
+  "この予定でつけた練習記録は削除されず、そのまま残ります。";
+
+export const DETAIL_NOT_FOUND = "予定が見つかりません";
+export const DONE_SECTION_TITLE = "メニュー";
+export const DONE_LOAD_ERROR =
+  "この日の練習記録を取得できませんでした。「済」の状態は表示できません。";
+export const RECORD_PRACTICE_LABEL = "練習記録をつける";
+export const RECORD_GAME_LABEL = "試合記録をつける";
+
+/** 済メニューの引き継ぎ先が「その日」であることを明示する。 */
+export const RECORD_PRACTICE_HELPER =
+  "「済」にしたメニューを選択済みの状態で練習記録画面を開きます。";

--- a/app/(app)/practice/schedules/_utils/__tests__/scheduleForm.test.ts
+++ b/app/(app)/practice/schedules/_utils/__tests__/scheduleForm.test.ts
@@ -1,0 +1,182 @@
+import type { ScheduleMenu } from "@app/types/schedule";
+import {
+  RECURRENCE_CONFLICT_ERROR,
+  RECURRENCE_MISSING_ERROR,
+  type ScheduleFormValues,
+  TITLE_REQUIRED_ERROR,
+  TITLE_TOO_LONG_ERROR,
+  buildScheduleInput,
+  buildScheduleMenuItems,
+  validateScheduleInput,
+} from "../scheduleForm";
+
+function buildValues(
+  overrides: Partial<ScheduleFormValues> = {},
+): ScheduleFormValues {
+  return {
+    recurrence: "single",
+    eventType: "self_practice",
+    title: "朝の素振り",
+    days: [],
+    plannedOn: "2026-08-10",
+    scheduledTime: "06:00",
+    menuSource: "individual",
+    menuSetId: null,
+    menuAmounts: {},
+    notificationEnabled: true,
+    notificationMessage: "",
+    ...overrides,
+  };
+}
+
+const lockedMenu: ScheduleMenu = {
+  practice_menu_id: 1,
+  name: "素振り",
+  unit_label: "本",
+  target_value: 200,
+};
+
+describe("buildScheduleInput", () => {
+  it("この日だけの予定は planned_on だけを送り、days_of_week は null にする", () => {
+    const input = buildScheduleInput(buildValues(), {
+      canCustomizeMessage: false,
+      lockedMenus: [],
+    });
+
+    expect(input.planned_on).toBe("2026-08-10");
+    expect(input.days_of_week).toBeNull();
+  });
+
+  it("毎週の予定は days_of_week だけを送り、planned_on は null にする", () => {
+    const input = buildScheduleInput(
+      buildValues({ recurrence: "weekly", days: [5, 1, 3] }),
+      { canCustomizeMessage: false, lockedMenus: [] },
+    );
+
+    expect(input.days_of_week).toBe("1,3,5");
+    expect(input.planned_on).toBeNull();
+  });
+
+  it("曜日は月=1〜日=7 の番号で送る", () => {
+    const input = buildScheduleInput(
+      buildValues({ recurrence: "weekly", days: [7, 6] }),
+      { canCustomizeMessage: false, lockedMenus: [] },
+    );
+
+    expect(input.days_of_week).toBe("6,7");
+  });
+
+  it("メニューセットを選ぶと menu_set_id を送り、個別メニューは空にする", () => {
+    const input = buildScheduleInput(
+      buildValues({
+        menuSource: "set",
+        menuSetId: 3,
+        menuAmounts: { 1: "100" },
+      }),
+      { canCustomizeMessage: false, lockedMenus: [] },
+    );
+
+    expect(input.menu_set_id).toBe(3);
+    expect(input.menus).toEqual([]);
+  });
+
+  it("カスタム通知文は Pro を持たないと送らない", () => {
+    const values = buildValues({ notificationMessage: "頑張れ" });
+
+    expect(
+      buildScheduleInput(values, {
+        canCustomizeMessage: false,
+        lockedMenus: [],
+      }).notification_message,
+    ).toBeNull();
+    expect(
+      buildScheduleInput(values, { canCustomizeMessage: true, lockedMenus: [] })
+        .notification_message,
+    ).toBe("頑張れ");
+  });
+});
+
+describe("buildScheduleMenuItems（編集ロック）", () => {
+  it("記録済みメニューは選択から外れていても必ず送る", () => {
+    const items = buildScheduleMenuItems({ 2: "50" }, [lockedMenu]);
+
+    expect(items).toContainEqual({ practice_menu_id: 1, target_value: 200 });
+    expect(items).toContainEqual({ practice_menu_id: 2, target_value: 50 });
+  });
+
+  it("記録済みメニューの目標量は入力値ではなく元の値を送る", () => {
+    const items = buildScheduleMenuItems({ 1: "9999" }, [lockedMenu]);
+
+    expect(items).toEqual([{ practice_menu_id: 1, target_value: 200 }]);
+  });
+});
+
+describe("validateScheduleInput", () => {
+  it("曜日と日付を両方指定するとエラーになる", () => {
+    expect(
+      validateScheduleInput({
+        title: "x",
+        days_of_week: "1",
+        planned_on: "2026-08-10",
+      }),
+    ).toContain(RECURRENCE_CONFLICT_ERROR);
+  });
+
+  it("曜日も日付も無いとエラーになる", () => {
+    expect(
+      validateScheduleInput({
+        title: "x",
+        days_of_week: null,
+        planned_on: null,
+      }),
+    ).toContain(RECURRENCE_MISSING_ERROR);
+  });
+
+  it("どちらか一方だけならエラーにならない", () => {
+    expect(
+      validateScheduleInput({
+        title: "x",
+        days_of_week: "1",
+        planned_on: null,
+      }),
+    ).toEqual([]);
+    expect(
+      validateScheduleInput({
+        title: "x",
+        days_of_week: null,
+        planned_on: "2026-08-10",
+      }),
+    ).toEqual([]);
+  });
+
+  it("メニューセット未指定ならタイトルが必須", () => {
+    expect(
+      validateScheduleInput({ title: "", planned_on: "2026-08-10" }),
+    ).toContain(TITLE_REQUIRED_ERROR);
+  });
+
+  it("メニューセットを指定すればタイトルは省略できる", () => {
+    expect(
+      validateScheduleInput({
+        title: null,
+        menu_set_id: 3,
+        planned_on: "2026-08-10",
+      }),
+    ).toEqual([]);
+  });
+
+  it("タイトルは50文字までは通り、51文字でエラーになる", () => {
+    expect(
+      validateScheduleInput({
+        title: "あ".repeat(50),
+        planned_on: "2026-08-10",
+      }),
+    ).toEqual([]);
+    expect(
+      validateScheduleInput({
+        title: "あ".repeat(51),
+        planned_on: "2026-08-10",
+      }),
+    ).toContain(TITLE_TOO_LONG_ERROR);
+  });
+});

--- a/app/(app)/practice/schedules/_utils/__tests__/scheduleRecord.test.ts
+++ b/app/(app)/practice/schedules/_utils/__tests__/scheduleRecord.test.ts
@@ -1,0 +1,144 @@
+import type { PracticeLog } from "@app/types/practice";
+import type { Schedule } from "@app/types/schedule";
+import {
+  buildDoneLogIds,
+  buildPracticeRecordHref,
+  doneMenusAsPresets,
+  resolveContextDate,
+} from "../scheduleRecord";
+
+function buildLog(overrides: Partial<PracticeLog> = {}): PracticeLog {
+  return {
+    id: 1,
+    practice_menu_id: 1,
+    schedule_id: 10,
+    logged_on: "2026-08-03",
+    amount: null,
+    weight: null,
+    menu_name: "素振り",
+    unit_label: "本",
+    source: "manual",
+    memo: null,
+    created_at: "2026-08-03T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function buildSchedule(overrides: Partial<Schedule> = {}): Schedule {
+  return {
+    id: 10,
+    title: "朝の素振り",
+    days_of_week: "1,3,5",
+    planned_on: null,
+    scheduled_time: "06:00",
+    event_type: "self_practice",
+    recurring: true,
+    menu_set_id: null,
+    game_result_id: null,
+    note: null,
+    notification_enabled: true,
+    active: true,
+    notification_message: null,
+    menus: [],
+    logged_practice_menu_ids: [],
+    ...overrides,
+  };
+}
+
+describe("resolveContextDate", () => {
+  it("クエリの日付を優先する", () => {
+    expect(
+      resolveContextDate("2026-08-05", buildSchedule(), "2026-08-03"),
+    ).toBe("2026-08-05");
+  });
+
+  it("クエリが無ければ単発予定の日付を使う", () => {
+    expect(
+      resolveContextDate(
+        undefined,
+        buildSchedule({ days_of_week: null, planned_on: "2026-08-09" }),
+        "2026-08-03",
+      ),
+    ).toBe("2026-08-09");
+  });
+
+  it("毎週の予定を直接開いたときは今日を使う", () => {
+    expect(resolveContextDate(undefined, buildSchedule(), "2026-08-03")).toBe(
+      "2026-08-03",
+    );
+  });
+
+  it("形式が不正なクエリは無視する", () => {
+    expect(resolveContextDate("yesterday", buildSchedule(), "2026-08-03")).toBe(
+      "2026-08-03",
+    );
+  });
+});
+
+describe("buildDoneLogIds", () => {
+  it("その予定のログだけを practice_menu_id 別に集める", () => {
+    const logs = [
+      buildLog({ id: 1, practice_menu_id: 1 }),
+      buildLog({ id: 2, practice_menu_id: 2 }),
+      buildLog({ id: 3, practice_menu_id: 1, schedule_id: 99 }),
+      buildLog({ id: 4, practice_menu_id: 1, schedule_id: null }),
+    ];
+
+    expect(buildDoneLogIds(logs, 10)).toEqual({ 1: [1], 2: [2] });
+  });
+
+  it("同じメニューに複数ログがあれば全ての ID を持つ", () => {
+    const logs = [
+      buildLog({ id: 1, practice_menu_id: 1 }),
+      buildLog({ id: 5, practice_menu_id: 1 }),
+    ];
+
+    expect(buildDoneLogIds(logs, 10)).toEqual({ 1: [1, 5] });
+  });
+});
+
+describe("doneMenusAsPresets", () => {
+  it("済のメニューだけを目標量つきで返す", () => {
+    const menus = [
+      {
+        practice_menu_id: 1,
+        name: "素振り",
+        unit_label: "本",
+        target_value: 200,
+      },
+      {
+        practice_menu_id: 2,
+        name: "ランニング",
+        unit_label: "km",
+        target_value: 5,
+      },
+    ];
+
+    expect(doneMenusAsPresets(menus, { 1: [1] })).toEqual([
+      { practice_menu_id: 1, target_value: 200 },
+    ]);
+  });
+});
+
+describe("buildPracticeRecordHref", () => {
+  it("date と presetMenus の両方を渡す", () => {
+    const href = buildPracticeRecordHref("2026-08-03", [
+      { practice_menu_id: 1, target_value: 200 },
+    ]);
+    const params = new URLSearchParams(href.split("?")[1]);
+
+    expect(href.startsWith("/practice/record?")).toBe(true);
+    expect(params.get("date")).toBe("2026-08-03");
+    expect(JSON.parse(params.get("presetMenus") as string)).toEqual([
+      { practice_menu_id: 1, target_value: 200 },
+    ]);
+  });
+
+  it("済メニューが無くても date は必ず渡す", () => {
+    const href = buildPracticeRecordHref("2026-08-03", []);
+    const params = new URLSearchParams(href.split("?")[1]);
+
+    expect(params.get("date")).toBe("2026-08-03");
+    expect(params.get("presetMenus")).toBeNull();
+  });
+});

--- a/app/(app)/practice/schedules/_utils/scheduleForm.ts
+++ b/app/(app)/practice/schedules/_utils/scheduleForm.ts
@@ -1,0 +1,139 @@
+import type {
+  ScheduleEventType,
+  ScheduleInput,
+  ScheduleMenu,
+} from "@app/types/schedule";
+import { SCHEDULE_TITLE_MAX_LENGTH } from "@app/constants/schedule";
+
+/** 繰り返し種別。single = この日だけ（planned_on）／weekly = 毎週（days_of_week）。 */
+export type ScheduleRecurrence = "single" | "weekly";
+
+/** メニューの指定方法。set = メニューセットから／individual = 個別に選ぶ。 */
+export type ScheduleMenuSource = "individual" | "set";
+
+export interface ScheduleFormValues {
+  recurrence: ScheduleRecurrence;
+  eventType: ScheduleEventType;
+  title: string;
+  /** 選択中の曜日番号（月=1〜日=7）。 */
+  days: number[];
+  /** YYYY-MM-DD。 */
+  plannedOn: string;
+  /** HH:MM。空文字は終日（時刻未設定）。 */
+  scheduledTime: string;
+  menuSource: ScheduleMenuSource;
+  menuSetId: number | null;
+  /** practice_menu_id → 目標量の入力文字列。キーの存在が「選択中」を意味する。 */
+  menuAmounts: Record<number, string>;
+  notificationEnabled: boolean;
+  notificationMessage: string;
+}
+
+export interface BuildScheduleInputOptions {
+  /** Pro（custom_notification_messages）を持つか。無い場合は送っても back に捨てられる。 */
+  canCustomizeMessage: boolean;
+  /** 練習ログ記録済みで編集ロックされたメニュー。入力値に関わらず元の内容を維持する。 */
+  lockedMenus: ScheduleMenu[];
+}
+
+export const RECURRENCE_CONFLICT_ERROR = "曜日と日付は同時に指定できません";
+export const RECURRENCE_MISSING_ERROR =
+  "曜日または日付のいずれかを指定してください";
+export const TITLE_REQUIRED_ERROR =
+  "タイトルを入力してください（メニューセットを選ぶと省略できます）";
+export const TITLE_TOO_LONG_ERROR = `タイトルは${SCHEDULE_TITLE_MAX_LENGTH}文字以内で入力してください`;
+
+/** 入力欄の文字列を送信値へ変換する。空文字・非数は null（未指定）として送る。 */
+function toNumberOrNull(value: string | undefined): number | null {
+  if (value === undefined || value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/** メニューセットを使う指定になっているか。セット未選択なら個別扱いに倒す。 */
+function usesMenuSet(values: ScheduleFormValues): boolean {
+  return values.menuSource === "set" && values.menuSetId !== null;
+}
+
+/**
+ * 送信するメニュー項目を組み立てる。
+ *
+ * 編集ロックされたメニュー（logged_practice_menu_ids）は必ず元の目標量のまま含める。
+ * back は menus を渡すと全置換するため、ロック対象を落とすと記録済みログとの紐付けが
+ * 壊れて「済」判定が不整合になる。入力側の値は採用せず、サーバーから来た値を返す。
+ */
+export function buildScheduleMenuItems(
+  menuAmounts: Record<number, string>,
+  lockedMenus: ScheduleMenu[],
+): { practice_menu_id: number; target_value: number | null }[] {
+  const lockedIds = new Set(lockedMenus.map((menu) => menu.practice_menu_id));
+  const locked = lockedMenus.map((menu) => ({
+    practice_menu_id: menu.practice_menu_id,
+    target_value: menu.target_value,
+  }));
+  const selected = Object.entries(menuAmounts)
+    .map(([menuId, amount]) => ({
+      practice_menu_id: Number(menuId),
+      target_value: toNumberOrNull(amount),
+    }))
+    .filter((item) => !lockedIds.has(item.practice_menu_id));
+
+  return [...locked, ...selected];
+}
+
+/**
+ * フォームの状態を back の schedule パラメータへ変換する。
+ * 排他制約に合わせ、選ばれていない側（days_of_week / planned_on）は必ず null で送る。
+ */
+export function buildScheduleInput(
+  values: ScheduleFormValues,
+  { canCustomizeMessage, lockedMenus }: BuildScheduleInputOptions,
+): ScheduleInput {
+  const usingSet = usesMenuSet(values);
+  const message = values.notificationMessage.trim();
+
+  return {
+    title: values.title.trim() || null,
+    event_type: values.eventType,
+    days_of_week:
+      values.recurrence === "weekly" && values.days.length > 0
+        ? Array.from(new Set(values.days))
+            .sort((a, b) => a - b)
+            .join(",")
+        : null,
+    planned_on:
+      values.recurrence === "single" ? values.plannedOn || null : null,
+    scheduled_time: values.scheduledTime || null,
+    menu_set_id: usingSet ? values.menuSetId : null,
+    notification_enabled: values.notificationEnabled,
+    notification_message: canCustomizeMessage && message ? message : null,
+    // セット指定時は個別紐付けを空にして、表示元（menu_set）と実データを一致させる。
+    menus: usingSet
+      ? []
+      : buildScheduleMenuItems(values.menuAmounts, lockedMenus),
+  };
+}
+
+/**
+ * 送信前のクライアント側バリデーション。
+ * back のモデルバリデーション（排他必須・タイトル必須・50文字以内）と同じ条件を先に検査し、
+ * 422 まで往復せずその場でエラーを返す。
+ */
+export function validateScheduleInput(input: ScheduleInput): string[] {
+  const errors: string[] = [];
+  const hasDays = Boolean(input.days_of_week);
+  const hasDate = Boolean(input.planned_on);
+
+  if (hasDays && hasDate) {
+    errors.push(RECURRENCE_CONFLICT_ERROR);
+  } else if (!hasDays && !hasDate) {
+    errors.push(RECURRENCE_MISSING_ERROR);
+  }
+
+  const title = (input.title ?? "").trim();
+  if (!input.menu_set_id && title === "") errors.push(TITLE_REQUIRED_ERROR);
+  if (title.length > SCHEDULE_TITLE_MAX_LENGTH)
+    errors.push(TITLE_TOO_LONG_ERROR);
+
+  return errors;
+}

--- a/app/(app)/practice/schedules/_utils/scheduleRecord.ts
+++ b/app/(app)/practice/schedules/_utils/scheduleRecord.ts
@@ -1,0 +1,67 @@
+import type { PracticeLog, PresetMenu } from "@app/types/practice";
+import type { Schedule, ScheduleMenu } from "@app/types/schedule";
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * 「済」を判定する日付を決める。
+ * 明示的な `?date=` があればそれを使い、無ければ単発予定の日付、
+ * どちらも無い（毎週の予定を直接開いた）場合は今日を対象にする。
+ */
+export function resolveContextDate(
+  raw: string | undefined,
+  schedule: Schedule,
+  today: string,
+): string {
+  if (raw && DATE_PATTERN.test(raw)) return raw;
+  return schedule.planned_on ?? today;
+}
+
+/**
+ * その日の練習ログを practice_menu_id → ログ ID 配列へ畳み込む。
+ * 「済」は予定（schedule）単位で判定するため、他の予定やフル記録のログ（schedule_id 違い）は除く。
+ * 解除時に削除する対象を特定できるよう、件数ではなく ID を保持する。
+ */
+export function buildDoneLogIds(
+  logs: PracticeLog[],
+  scheduleId: number,
+): Record<number, number[]> {
+  return logs.reduce<Record<number, number[]>>((acc, log) => {
+    if (log.schedule_id !== scheduleId || log.practice_menu_id === null) {
+      return acc;
+    }
+    const menuId = log.practice_menu_id;
+    acc[menuId] = [...(acc[menuId] ?? []), log.id];
+    return acc;
+  }, {});
+}
+
+/** 「済」になっているメニューだけをプリセット形式へ変換する。 */
+export function doneMenusAsPresets(
+  menus: ScheduleMenu[],
+  doneLogIds: Record<number, number[]>,
+): PresetMenu[] {
+  return menus
+    .filter((menu) => (doneLogIds[menu.practice_menu_id]?.length ?? 0) > 0)
+    .map((menu) => ({
+      practice_menu_id: menu.practice_menu_id,
+      target_value: menu.target_value,
+    }));
+}
+
+/**
+ * 済メニューを引き継いで練習記録画面を開く URL を組み立てる。
+ *
+ * 練習記録側は「URL の date と画面で選択中の日付が一致するとき」だけプリセットを適用するため、
+ * date を必ず添える。省略するとプリセットが無効化されて引き継ぎが効かない。
+ */
+export function buildPracticeRecordHref(
+  date: string,
+  presetMenus: PresetMenu[],
+): string {
+  const query = new URLSearchParams({ date });
+  if (presetMenus.length > 0) {
+    query.set("presetMenus", JSON.stringify(presetMenus));
+  }
+  return `/practice/record?${query.toString()}`;
+}

--- a/app/(app)/practice/schedules/new/page.tsx
+++ b/app/(app)/practice/schedules/new/page.tsx
@@ -1,0 +1,58 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getMenuSets } from "@app/services/v2/menuSetService";
+import { getPracticeMenus } from "@app/services/v2/practiceMenuService";
+import { todayString } from "../../record/_utils/practiceRecordDraft";
+import ScheduleFormContent from "../_components/ScheduleFormContent";
+
+export const metadata = {
+  title: "予定を作る",
+};
+
+interface NewSchedulePageSearchParams {
+  /** 単発予定の初期日付（YYYY-MM-DD）。カレンダーなど日付が確定した文脈からの遷移で使う。 */
+  date?: string;
+}
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export default async function NewSchedulePage({
+  searchParams,
+}: {
+  searchParams: Promise<NewSchedulePageSearchParams>;
+}) {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const params = await searchParams;
+  const [menusResult, menuSetsResult] = await Promise.all([
+    getPracticeMenus(),
+    getMenuSets(),
+  ]);
+  const initialDate =
+    params.date && DATE_PATTERN.test(params.date) ? params.date : todayString();
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            <h2 className="mb-6 text-2xl font-bold">予定を作る</h2>
+            <ScheduleFormContent
+              schedule={null}
+              menus={menusResult.status === "ok" ? menusResult.data : []}
+              menuSets={
+                menuSetsResult.status === "ok" ? menuSetsResult.data : []
+              }
+              today={initialDate}
+            />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/(app)/practice/schedules/page.tsx
+++ b/app/(app)/practice/schedules/page.tsx
@@ -1,0 +1,59 @@
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import { cookies } from "next/headers";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getSchedules } from "@app/services/v2/scheduleService";
+import {
+  CREATE_LABEL,
+  LOAD_ERROR,
+  PAGE_DESCRIPTION,
+  PAGE_TITLE,
+} from "./_components/scheduleCopy";
+import ScheduleList from "./_components/ScheduleList";
+
+export const metadata = {
+  title: "練習スケジュール",
+};
+
+export default async function SchedulesPage() {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const result = await getSchedules();
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            <h2 className="text-2xl font-bold">{PAGE_TITLE}</h2>
+            <p className="mt-2 text-sm text-zinc-300">{PAGE_DESCRIPTION}</p>
+
+            <div className="my-6">
+              {result.status === "ok" ? (
+                <ScheduleList schedules={result.data} />
+              ) : (
+                // 取得失敗を空配列に丸めると「予定なし」と誤表示し、重複登録を招く。
+                <p className="py-8 text-center text-sm text-zinc-400">
+                  {LOAD_ERROR}
+                </p>
+              )}
+            </div>
+
+            <Link
+              href="/practice/schedules/new"
+              className="flex w-full items-center justify-center gap-1.5 rounded-[10px] bg-[#d08000] px-5 py-3 text-sm font-bold text-white transition-opacity hover:opacity-90"
+            >
+              <PlusIcon className="h-5 w-5" aria-hidden />
+              {CREATE_LABEL}
+            </Link>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/components/header/HeaderRight.tsx
+++ b/app/components/header/HeaderRight.tsx
@@ -76,6 +76,16 @@ export default function HeaderRight() {
                   練習メニュー
                 </DropdownItem>
                 <DropdownItem
+                  key="practice-schedules"
+                  as={Link}
+                  href="/practice/schedules"
+                  startContent={
+                    <CalendarIcon fill="currentColor" width="18" height="18" />
+                  }
+                >
+                  練習スケジュール
+                </DropdownItem>
+                <DropdownItem
                   key="seasons"
                   as={Link}
                   href="/seasons"

--- a/app/components/header/__tests__/HeaderRight.test.tsx
+++ b/app/components/header/__tests__/HeaderRight.test.tsx
@@ -42,6 +42,14 @@ describe("HeaderRight のメニュー", () => {
     ).toHaveAttribute("href", "/practice/menus");
   });
 
+  it("練習スケジュールへの導線を持つ", async () => {
+    await openMenu();
+
+    expect(
+      screen.getByRole("menuitem", { name: /練習スケジュール/ }),
+    ).toHaveAttribute("href", "/practice/schedules");
+  });
+
   it("振り返りテンプレへの導線を持つ", async () => {
     await openMenu();
 

--- a/app/constants/schedule.ts
+++ b/app/constants/schedule.ts
@@ -1,0 +1,45 @@
+import type { ScheduleEventType } from "@app/types/schedule";
+
+// back/app/models/schedule.rb の `validates :title, length: { maximum: 50 }` と一致させる。
+export const SCHEDULE_TITLE_MAX_LENGTH = 50;
+
+/**
+ * 曜日マスタ。num は back の Schedule#day_numbers と同じ「月=1〜日=7」。
+ * JavaScript の Date#getDay（日=0〜土=6）とはずれるため、変換せずこの番号だけを使う。
+ */
+export const WEEK_DAYS: ReadonlyArray<{ num: number; label: string }> = [
+  { num: 1, label: "月" },
+  { num: 2, label: "火" },
+  { num: 3, label: "水" },
+  { num: 4, label: "木" },
+  { num: 5, label: "金" },
+  { num: 6, label: "土" },
+  { num: 7, label: "日" },
+];
+
+/** "1,3,5" を「月・水・金」へ整形する。未知の番号は無視する。 */
+export const dayLabels = (daysOfWeek: string): string =>
+  daysOfWeek
+    .split(",")
+    .map((value) => WEEK_DAYS.find((day) => day.num === Number(value))?.label)
+    .filter((label): label is string => label !== undefined)
+    .join("・");
+
+/**
+ * 種別マスタ。value は back の Schedule::EVENT_TYPES と完全一致させる。
+ * color は mobile の @constants/schedule と同じ値を使い、種別の見た目を揃える。
+ */
+export const EVENT_TYPES: ReadonlyArray<{
+  value: ScheduleEventType;
+  label: string;
+  color: string;
+}> = [
+  { value: "self_practice", label: "自主練", color: "#4a8e32" },
+  { value: "practice", label: "チーム練習", color: "#3B82F6" },
+  { value: "game", label: "試合", color: "#EF4444" },
+  { value: "other", label: "その他", color: "#52525B" },
+];
+
+/** 種別のメタ情報を返す。未知の値は自主練にフォールバックする。 */
+export const eventTypeMeta = (value: ScheduleEventType) =>
+  EVENT_TYPES.find((event) => event.value === value) ?? EVENT_TYPES[0];

--- a/app/services/v2/__tests__/scheduleService.test.ts
+++ b/app/services/v2/__tests__/scheduleService.test.ts
@@ -1,0 +1,136 @@
+const mockGet = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(() => Promise.resolve({ get: mockGet })),
+}));
+
+jest.mock("@app/constants/api", () => ({
+  RAILS_API_URL: "http://back:3000",
+}));
+
+jest.mock("../../../../lib/sentry-helpers", () => ({
+  captureServerActionError: jest.fn(),
+}));
+
+import type { Schedule } from "@app/types/schedule";
+import {
+  createSchedule,
+  deleteSchedule,
+  getSchedules,
+  updateSchedule,
+} from "../scheduleService";
+
+function setupAuthCookies() {
+  mockGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: "test-uid" },
+    };
+    return values[key];
+  });
+}
+
+function mockResponse(status: number, body: unknown) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+function requestedUrl(callIndex = 0): string {
+  return (global.fetch as jest.Mock).mock.calls[callIndex][0] as string;
+}
+
+function requestedInit(callIndex = 0): RequestInit {
+  return (global.fetch as jest.Mock).mock.calls[callIndex][1] as RequestInit;
+}
+
+const schedule: Schedule = {
+  id: 10,
+  title: "朝の素振り",
+  days_of_week: "1,3,5",
+  planned_on: null,
+  scheduled_time: "06:00",
+  event_type: "self_practice",
+  recurring: true,
+  menu_set_id: null,
+  game_result_id: null,
+  note: null,
+  notification_enabled: true,
+  active: true,
+  notification_message: null,
+  menus: [],
+  logged_practice_menu_ids: [],
+};
+
+describe("scheduleService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    setupAuthCookies();
+  });
+
+  it("一覧は GET /api/v2/schedules を叩く", async () => {
+    mockResponse(200, [schedule]);
+
+    const result = await getSchedules();
+
+    expect(requestedUrl()).toBe("http://back:3000/api/v2/schedules");
+    expect(result).toEqual({ status: "ok", data: [schedule] });
+  });
+
+  it("作成は POST /api/v2/schedules に schedule でラップして送る", async () => {
+    mockResponse(201, schedule);
+
+    const result = await createSchedule({
+      title: "朝の素振り",
+      days_of_week: "1,3,5",
+      planned_on: null,
+    });
+
+    expect(requestedUrl()).toBe("http://back:3000/api/v2/schedules");
+    const init = requestedInit();
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      schedule: {
+        title: "朝の素振り",
+        days_of_week: "1,3,5",
+        planned_on: null,
+      },
+    });
+    expect(result).toEqual({ ok: true, data: schedule });
+  });
+
+  it("更新は PATCH /api/v2/schedules/:id を叩く", async () => {
+    mockResponse(200, schedule);
+
+    await updateSchedule(10, { title: "朝練" });
+
+    expect(requestedUrl()).toBe("http://back:3000/api/v2/schedules/10");
+    expect(requestedInit().method).toBe("PATCH");
+  });
+
+  it("削除は DELETE /api/v2/schedules/:id を叩く", async () => {
+    mockResponse(200, { message: "削除しました" });
+
+    const result = await deleteSchedule(10);
+
+    expect(requestedUrl()).toBe("http://back:3000/api/v2/schedules/10");
+    expect(requestedInit().method).toBe("DELETE");
+    expect(result).toEqual({ ok: true, data: { message: "削除しました" } });
+  });
+
+  it("422 のバリデーションエラーはメッセージを取り出して返す", async () => {
+    mockResponse(422, { errors: ["曜日と日付は同時に指定できません"] });
+
+    const result = await createSchedule({ title: "x" });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "error",
+      errors: ["曜日と日付は同時に指定できません"],
+    });
+  });
+});

--- a/app/services/v2/scheduleService.ts
+++ b/app/services/v2/scheduleService.ts
@@ -1,0 +1,67 @@
+"use server";
+
+import type { Schedule, ScheduleInput } from "@app/types/schedule";
+import {
+  type DeletedResponse,
+  type FetchResult,
+  type MutationResult,
+  fetchV2,
+  mutateV2,
+} from "./requests";
+
+const BASE_PATH = "/api/v2/schedules";
+
+/**
+ * 予定一覧を取得する（GET /api/v2/schedules）。
+ * back は active な予定だけを時刻順で返す。繰り返し・単発は混在するため、
+ * 画面側で days_of_week / planned_on を見て振り分ける。
+ */
+export async function getSchedules(): Promise<FetchResult<Schedule[]>> {
+  return fetchV2<Schedule[]>(BASE_PATH, "getSchedules");
+}
+
+/**
+ * 予定を新規作成する（POST /api/v2/schedules）。
+ * 自主練スケジュールは無料プランでも件数上限が無いため、403 を「無料枠の超過」として扱わない。
+ * notification_message は Pro（custom_notification_messages）以外では back 側で捨てられる。
+ */
+export async function createSchedule(
+  input: ScheduleInput,
+): Promise<MutationResult<Schedule>> {
+  return mutateV2<Schedule>(BASE_PATH, {
+    method: "POST",
+    body: { schedule: input },
+    action: "createSchedule",
+    fallbackMessage: "予定の作成に失敗しました",
+  });
+}
+
+/**
+ * 予定を更新する（PATCH /api/v2/schedules/:id）。
+ * menus を渡すと紐付けメニューを全置換し、省略すると既存のまま維持される。
+ */
+export async function updateSchedule(
+  id: number,
+  input: ScheduleInput,
+): Promise<MutationResult<Schedule>> {
+  return mutateV2<Schedule>(`${BASE_PATH}/${id}`, {
+    method: "PATCH",
+    body: { schedule: input },
+    action: "updateSchedule",
+    fallbackMessage: "予定の更新に失敗しました",
+  });
+}
+
+/**
+ * 予定を削除する（DELETE /api/v2/schedules/:id）。
+ * 予定に紐づいた練習ログは実績として残り、schedule_id だけが外れる。
+ */
+export async function deleteSchedule(
+  id: number,
+): Promise<MutationResult<DeletedResponse>> {
+  return mutateV2<DeletedResponse>(`${BASE_PATH}/${id}`, {
+    method: "DELETE",
+    action: "deleteSchedule",
+    fallbackMessage: "予定の削除に失敗しました",
+  });
+}

--- a/app/types/schedule.ts
+++ b/app/types/schedule.ts
@@ -1,0 +1,71 @@
+/**
+ * 練習スケジュール（予定）の型定義。
+ * back/app/serializers/v2/schedule_serializer.rb のレスポンスに対応する。
+ * キー名は back の JSON をそのまま使う（snake_case のまま扱い、変換しない）。
+ */
+
+/** 予定の種別。back の Schedule::EVENT_TYPES と完全一致させる。 */
+export type ScheduleEventType = "self_practice" | "practice" | "game" | "other";
+
+/**
+ * 予定に紐づく練習メニュー1件。
+ * name / unit_label は practice_menu から都度引く表示用の値で、
+ * メニューが削除されている場合は null になる。
+ */
+export interface ScheduleMenu {
+  practice_menu_id: number;
+  name: string | null;
+  unit_label: string | null;
+  /** back は float カラムのため文字列化されず number で返る。 */
+  target_value: number | null;
+}
+
+export interface Schedule {
+  id: number;
+  /** back は未設定時にメニューセット名へフォールバックした表示用タイトルを返す。 */
+  title: string | null;
+  /** "1,3,5"（月=1〜日=7）。単発予定は null。 */
+  days_of_week: string | null;
+  /** "2026-07-11"。繰り返し予定は null。 */
+  planned_on: string | null;
+  /** "06:00"。時刻未設定（終日）は null。 */
+  scheduled_time: string | null;
+  event_type: ScheduleEventType;
+  /** days_of_week を持つ（毎週繰り返し）か。 */
+  recurring: boolean;
+  menu_set_id: number | null;
+  game_result_id: number | null;
+  note: string | null;
+  notification_enabled: boolean;
+  active: boolean;
+  /** カスタム通知文。Pro 以外が送っても back 側で無視されるため null で返る。 */
+  notification_message: string | null;
+  /** menu_set_id があればセット内メニュー、無ければ個別紐付けを展開したもの。 */
+  menus: ScheduleMenu[];
+  /**
+   * この予定に対して練習ログが記録済みの practice_menu_id 一覧。
+   * 変更すると記録済みログとの「済」判定の整合が壊れるため、編集画面では操作不可にする。
+   */
+  logged_practice_menu_ids: number[];
+}
+
+/**
+ * 予定の作成・更新パラメータ（back の schedule_params に対応）。
+ * days_of_week と planned_on はどちらか一方のみ指定できる（back のモデルバリデーション）。
+ */
+export interface ScheduleInput {
+  title?: string | null;
+  days_of_week?: string | null;
+  planned_on?: string | null;
+  scheduled_time?: string | null;
+  event_type?: ScheduleEventType;
+  menu_set_id?: number | null;
+  note?: string | null;
+  notification_enabled?: boolean;
+  notification_message?: string | null;
+  /**
+   * 個別に紐付ける練習メニュー。渡すと既存の紐付けを全置換し、省略すると維持される。
+   * 他ユーザーの practice_menu_id は back 側でエラーにならず黙って除外される。
+   */
+  menus?: { practice_menu_id: number; target_value?: number | null }[];
+}


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#482

## 概要

単発（`planned_on`）／毎週繰り返し（`days_of_week`）の予定を登録・編集・削除する画面です。front に `schedules` を参照するコードが一切ありませんでした。

## ⚠️ 編集ロックを構造的に担保しました（実装をやり直しています）

`logged_practice_menu_ids`（記録済みのメニュー）を編集できてしまうと、back の済判定が壊れます。当初は UI の `disabled` と操作ハンドラのガードだけでしたが、**「送信ペイロードにロック対象を混ぜる」ミューテーションが生き残った**ため、3層目を作り直しました。

1. **UI** — チェックボックスと目標量入力を `disabled`、鍵アイコン＋「変更不可」バッジ
2. **操作ハンドラ** — ロック ID なら即 return。ロックがあるときは「セットから」への切替も禁止（切り替えると `menus: []` で全置換されロックが消えるため）
3. **送信ペイロード（構造的な担保）** — ロック対象は `menuAmounts`（ユーザー操作の state）に**一切入れず**、送信時に `lockedMenus`（サーバー由来の値）をそのまま足し戻す。**入力側に同じ ID があっても除外されるため、UI の disabled を外しただけでは紐付けが失われません**

## 通知の扱い（判断が必要だった点）

**トグルとカスタム通知文は出しますが、「アプリ版でのみ届く」ことを明示しています。**

- back のコメントどおり、リマインドは**端末側のローカル通知**で行われ、サーバーは設定を保管するだけです（mobile が `expo-notifications` で貼っている）
- **front には Service Worker / PushManager / web-push の基盤が一切ありません**（grep で0件）。Web だけでは通知は絶対に届きません
- しかし `notification_enabled` は DB default `true` なので、**Web で作った予定は既定で通知 ON になります**。UI を出さないと「アプリで勝手に通知が鳴るのに Web からは止められない」状態になり、かえって悪い

そのため「出すが配信先が違うことを明示」を選びました（「通知は iOS / Android アプリ版でのみ届きます。ブラウザには通知されません（設定はアプリと共通です）。」）。**文言含めてご確認ください。**

## back の契約で判明した点

**「済」トグルは schedule 側ではなく practice_log 側**でした。済にするのは `POST /api/v2/practice_logs`（`practice_menu_id` + `schedule_id` + `logged_on`、量なし）、解除は該当ログの `DELETE`。**`schedule_id` を必ず送る必要があります**（back の `done_menu_ids_by_schedule_on` が schedule_id 単位で判定するため、送らないと済になりません）。

**スケジュールの CRUD 自体は無料で無制限**です（spec に「無料ユーザーでも件数上限なく作成できる」と明記）。403 を返すのは `week_copy` と `plans#calendar` のみ。**上限ペイウォールを出すのは誤り**なので、それを検出するミューテーションも入れています。

**`custom_notification_messages` は 403 ではなく「permit から黙って削除」**という挙動なので、front も entitlement が無ければ送らない実装にしています。

**バリデーション**: `days_of_week` と `planned_on` は排他必須、`menu_set_id` 未指定時はタイトル必須（50文字以内）、曜日は**月=1〜日=7**。

## 変更内容

- `app/types/schedule.ts` / `app/constants/schedule.ts` — mobile と同じ構造・色・曜日番号
- `app/services/v2/scheduleService.ts`
- `_utils/scheduleForm.ts` — `buildScheduleMenuItems`（編集ロック）/ `validateScheduleInput`
- `_utils/scheduleRecord.ts` — 済判定・プリセット組み立て・遷移先
- `practice/schedules/` の4ルート（一覧 / 新規 / 詳細 / 編集）
- `HeaderRight.tsx` に導線を追加

**プリセット引き継ぎ**は mobile と同形式（`?date=YYYY-MM-DD&presetMenus=[{"practice_menu_id":1,"target_value":200}]`）。`date` は常に付与しています（#469 は `date === initialDate` のときだけプリセットを適用するため）。

## スコープ外（別 issue 想定）

issue が「登録・編集・削除」+「予定詳細」だったため、**週プラン・カレンダー俯瞰（`plans#calendar`、`schedule_calendar_full_history`）と「来週へコピー」（`schedules/week_copy`）は実装していません**。別 issue の想定で良いかご確認ください。

## レビューで確認いただきたい点

1. **通知の扱いと文言**（上記）
2. **「済」判定に `plans#by_date` を使わず `practice_logs?from=&to=` から畳み込んでいます。** 詳細1画面のために予定展開 API を叩くより依存が少ないと判断しました（back の `done_menu_ids_by_schedule_on` と同じロジック）。将来カレンダー画面を作るときは `planService` に寄せるのが自然です
3. **毎週の予定を直接開いたときの「済」対象日**は Asia/Tokyo の今日にフォールバックしています（`?date=` があれば優先）。カレンダー導線が未実装なので現状は「今日」が唯一の入口です
4. **試合記録への導線はパラメータ無しで遷移**しています。mobile は store に日付を積んでから遷移しますが、front の記録画面は `searchParams` を受け取らないため渡す口がありません。日付プリフィルが欲しければ受け口側の改修が必要です
5. **`menu_set_id` を選んだとき `menus: []` を送って個別紐付けを明示的に空にしています。** mobile は省略するため `schedule_menus` が孤児として残ります。表示と実データを一致させる意図ですが、mobile と挙動が微妙に違います

## チェックリスト

- [x] `yarn typecheck` / `yarn lint` / `yarn format:check` が通る
- [x] `yarn test` が通る（**132 suites / 1448 tests**。新規 4 suites / 48 tests）
- [x] `yarn build` が通る（**ローカルで実行済み**）
- [x] ミューテーションテスト **35 設計 / 35 KILLED / 0 SURVIVED**

### ルート表

**静的 87 / 動的 49**。新規4ルート（一覧 / 新規 / 詳細 / 編集）はすべて `cookies()` を読むため動的です。**静的は 87 で不変＝既存ルートの分類変更なし**。

複製環境で新規ディレクトリだけを削除して同条件でビルドし、ベースが 静的 87 / 動的 45 であることも確認しています（差分は動的 +4 のみ）。

<details>
<summary>ミューテーションテスト詳細</summary>

隔離複製で実施（無改変で全通過を確認後に開始、検証後に削除）。

排他バリデーション5件 / タイトル必須・50文字境界5件 / **編集ロック6件** / 曜日インデックス2件 / Pro ゲート反転2件 / 種別 enum / **上限ペイウォールの誤表示** / プリセット引き継ぎ3件 / 済トグル5件（他予定のログ混入・`schedule_id` 欠落等）/ 試合導線反転 / API パス・メソッド・ペイロード3件 / ヘッダー導線。

**初回に1件 SURVIVED**（`buildScheduleInput` に `lockedMenus: []` を渡す）。ロック対象を入力 state に入れていたため UI の disabled だけが実質の防御になっていたのが原因で、**設計を作り直して構造的に担保**し KILLED になりました。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_