### PR TITLE
Add: 練習記録の一覧・検索・詳細画面を実装

### DIFF
--- a/app/(app)/practice/records/[id]/__tests__/PracticeSessionDetail.test.tsx
+++ b/app/(app)/practice/records/[id]/__tests__/PracticeSessionDetail.test.tsx
@@ -1,0 +1,328 @@
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: jest.fn(), close: jest.fn() }),
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@app/services/v2/practiceSessionService", () => ({
+  deletePracticeSession: jest.fn(),
+}));
+
+import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
+import type {
+  PracticeLog,
+  PracticeMenu,
+  PracticeSession,
+} from "@app/types/practice";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { deletePracticeSession } from "@app/services/v2/practiceSessionService";
+import PracticeSessionDetail from "../_components/PracticeSessionDetail";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+const mockDelete = deletePracticeSession as jest.MockedFunction<
+  typeof deletePracticeSession
+>;
+
+function setEntitlement(hasCondition: boolean, isLoading = false) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: hasCondition,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading,
+    hasEntitlement: (feature) =>
+      feature === "detailed_condition_log" ? hasCondition : false,
+  });
+}
+
+function buildLog(overrides: Partial<PracticeLog> = {}): PracticeLog {
+  return {
+    id: 1,
+    practice_menu_id: 1,
+    schedule_id: null,
+    logged_on: "2026-07-14",
+    amount: "200.0",
+    weight: null,
+    menu_name: "素振り",
+    unit_label: "本",
+    source: "manual",
+    memo: null,
+    created_at: "2026-07-14T10:00:00+09:00",
+    ...overrides,
+  };
+}
+
+function buildSession(
+  overrides: Partial<PracticeSession> = {},
+): PracticeSession {
+  return {
+    id: 7,
+    logged_on: "2026-07-14",
+    memo: null,
+    improvement_theme_ids: [],
+    practice_logs: [],
+    condition: null,
+    created_at: "2026-07-14T10:00:00+09:00",
+    ...overrides,
+  };
+}
+
+const menu: PracticeMenu = {
+  id: 1,
+  name: "素振り",
+  category: "batting",
+  unit: "count",
+  unit_label: "本",
+  default_value: "200.0",
+  is_favorite: false,
+  sort_order: 1,
+};
+
+const note: BaseballNoteV2 = {
+  id: 100,
+  title: "気づき",
+  date: "2026-07-14",
+  memo: null,
+  memo_preview: "外角が詰まる",
+  game_result_ids: [],
+  practice_log_id: null,
+  practice_session_id: 7,
+  improvement_theme_ids: [],
+  reflection_template_id: null,
+  reflection_answers: [],
+  tags: [],
+  media_attachments: [],
+};
+
+function renderDetail(
+  overrides: Partial<React.ComponentProps<typeof PracticeSessionDetail>> = {},
+) {
+  return render(
+    <PracticeSessionDetail
+      session={buildSession()}
+      menus={[menu]}
+      notes={[]}
+      {...overrides}
+    />,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setEntitlement(true);
+});
+
+describe("PracticeSessionDetail の表示", () => {
+  it("練習日を「7月14日(火)」形式で見出しに出す", () => {
+    renderDetail();
+
+    expect(
+      screen.getByRole("heading", { name: "7月14日(火)" }),
+    ).toBeInTheDocument();
+  });
+
+  it("メニューごとの量を formatPracticeValue の表記で出す", () => {
+    renderDetail({
+      session: buildSession({
+        practice_logs: [
+          buildLog({ id: 1, menu_name: "素振り", amount: "200.0" }),
+          buildLog({
+            id: 2,
+            menu_name: "ベンチプレス",
+            amount: "10.0",
+            weight: "60.0",
+            unit_label: "回",
+          }),
+        ],
+      }),
+    });
+
+    expect(screen.getByText("200本")).toBeInTheDocument();
+    expect(screen.getByText("60kg × 10回")).toBeInTheDocument();
+  });
+
+  it("ログ個別のメモを出す", () => {
+    renderDetail({
+      session: buildSession({
+        practice_logs: [buildLog({ memo: "外角を意識した" })],
+      }),
+    });
+
+    expect(screen.getByText("外角を意識した")).toBeInTheDocument();
+  });
+
+  it("その日のメモを出す", () => {
+    renderDetail({ session: buildSession({ memo: "全体的に振り遅れ気味" }) });
+
+    expect(screen.getByText("全体的に振り遅れ気味")).toBeInTheDocument();
+  });
+
+  it("編集導線は記録画面へ日付付きで遷移する", () => {
+    renderDetail();
+
+    expect(screen.getByRole("link", { name: "編集する" })).toHaveAttribute(
+      "href",
+      "/practice/record?date=2026-07-14",
+    );
+  });
+});
+
+describe("PracticeSessionDetail のコンディション", () => {
+  const withCondition = buildSession({
+    condition: {
+      id: 1,
+      logged_on: "2026-07-14",
+      fatigue_level: 2,
+      physical_level: 3,
+      sleep_hours: "7.5",
+      mood: "普通",
+      memo: "後半は集中が切れた",
+      injuries: [{ part: "肩", memo: "軽い張り" }],
+    },
+  });
+
+  it("Pro ユーザーには記録したコンディションをそのまま出す", () => {
+    setEntitlement(true);
+    renderDetail({ session: withCondition });
+
+    expect(screen.getByText("睡眠 7.5時間")).toBeInTheDocument();
+    expect(screen.getByText("後半は集中が切れた")).toBeInTheDocument();
+    expect(screen.queryByTestId("pro-upsell-scrim")).not.toBeInTheDocument();
+  });
+
+  it("無料ユーザーにはオーバーレイを重ねる", () => {
+    setEntitlement(false);
+    renderDetail({ session: withCondition });
+
+    expect(screen.getByTestId("pro-upsell-scrim")).toBeInTheDocument();
+  });
+
+  it("Pro ユーザーで記録が無ければサンプルではなく未記録として案内する", () => {
+    setEntitlement(true);
+    renderDetail();
+
+    expect(
+      screen.getByText("この日のコンディションは記録されていません。"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("睡眠 7.5時間")).not.toBeInTheDocument();
+  });
+
+  it("無料ユーザーで記録が無ければサンプルであることを明示する", () => {
+    setEntitlement(false);
+    renderDetail();
+
+    expect(
+      screen.getByText("サンプルデータ（実際の記録ではありません）"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("pro-upsell-scrim")).toBeInTheDocument();
+  });
+});
+
+describe("PracticeSessionDetail の紐づくノート", () => {
+  it("紐づくノートを一覧表示する", () => {
+    renderDetail({ notes: [note] });
+
+    expect(screen.getByText("気づき")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /気づき/ })).toHaveAttribute(
+      "href",
+      "/note/100",
+    );
+  });
+
+  it("0件は未作成メッセージを出す", () => {
+    renderDetail({ notes: [] });
+
+    expect(
+      screen.getByText("この練習記録に紐づく野球ノートはありません。"),
+    ).toBeInTheDocument();
+  });
+
+  it("取得失敗は0件と区別してエラーメッセージを出す", () => {
+    renderDetail({ notes: null });
+
+    expect(
+      screen.getByText("紐づく野球ノートを読み込めませんでした。"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("この練習記録に紐づく野球ノートはありません。"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("PracticeSessionDetail の削除", () => {
+  it("確認を挟まずには削除しない", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+
+    expect(mockDelete).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText("7月14日(火)の練習記録を削除しますか？"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "この日に記録した練習メニューのログもすべて削除されます。紐づく野球ノートとコンディションの記録は削除されず、練習記録との紐付けだけが外れます。",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("確認して削除すると一覧へ戻る", async () => {
+    const user = userEvent.setup();
+    mockDelete.mockResolvedValue({
+      ok: true,
+      data: { message: "削除しました" },
+    });
+    renderDetail();
+
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+    await user.click(await screen.findByRole("button", { name: "削除" }));
+
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith(7));
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith("/practice/records"),
+    );
+  });
+
+  it("キャンセルすると削除しない", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+    await user.click(await screen.findByRole("button", { name: "キャンセル" }));
+
+    expect(mockDelete).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("削除に失敗したら一覧へ遷移しない", async () => {
+    const user = userEvent.setup();
+    mockDelete.mockResolvedValue({
+      ok: false,
+      reason: "error",
+      errors: ["練習記録の削除に失敗しました"],
+    });
+    renderDetail();
+
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+    await user.click(await screen.findByRole("button", { name: "削除" }));
+
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith(7));
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/app/(app)/practice/records/[id]/__tests__/PracticeSessionDetail.test.tsx
+++ b/app/(app)/practice/records/[id]/__tests__/PracticeSessionDetail.test.tsx
@@ -189,7 +189,7 @@ describe("PracticeSessionDetail のコンディション", () => {
       logged_on: "2026-07-14",
       fatigue_level: 2,
       physical_level: 3,
-      sleep_hours: "7.5",
+      sleep_hours: "7.0",
       mood: "普通",
       memo: "後半は集中が切れた",
       injuries: [{ part: "肩", memo: "軽い張り" }],
@@ -200,7 +200,8 @@ describe("PracticeSessionDetail のコンディション", () => {
     setEntitlement(true);
     renderDetail({ session: withCondition });
 
-    expect(screen.getByText("睡眠 7.5時間")).toBeInTheDocument();
+    // back の decimal は "7.0" のような文字列で返るため、数値化した表記になる。
+    expect(screen.getByText("睡眠 7時間")).toBeInTheDocument();
     expect(screen.getByText("後半は集中が切れた")).toBeInTheDocument();
     expect(screen.queryByTestId("pro-upsell-scrim")).not.toBeInTheDocument();
   });
@@ -219,7 +220,7 @@ describe("PracticeSessionDetail のコンディション", () => {
     expect(
       screen.getByText("この日のコンディションは記録されていません。"),
     ).toBeInTheDocument();
-    expect(screen.queryByText("睡眠 7.5時間")).not.toBeInTheDocument();
+    expect(screen.queryByText("睡眠 7時間")).not.toBeInTheDocument();
   });
 
   it("無料ユーザーで記録が無ければサンプルであることを明示する", () => {

--- a/app/(app)/practice/records/[id]/_components/PracticeSessionDetail.tsx
+++ b/app/(app)/practice/records/[id]/_components/PracticeSessionDetail.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
+import type { PracticeMenu, PracticeSession } from "@app/types/practice";
+import ArrowLeftIcon from "@heroicons/react/24/outline/ArrowLeftIcon";
+import PencilSquareIcon from "@heroicons/react/24/outline/PencilSquareIcon";
+import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import { SAMPLE_CONDITION } from "@app/(app)/practice/record/_components/conditionSample";
+import NoteListItem from "@app/components/note/NoteListItem";
+import ConditionCard from "@app/components/practice/ConditionCard";
+import { ProUpsellOverlay } from "@app/components/pro/ProUpsellOverlay";
+import { SampleDataLabel } from "@app/components/pro/SampleDataLabel";
+import {
+  formatPracticeValue,
+  practiceIconForLog,
+} from "@app/constants/practice";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { deletePracticeSession } from "@app/services/v2/practiceSessionService";
+import {
+  BACK_TO_LIST_LABEL,
+  DELETE_CANCEL_LABEL,
+  DELETE_CONFIRM_DESCRIPTION,
+  DELETE_CONFIRM_LABEL,
+  DELETE_LABEL,
+  DELETE_MODAL_TITLE,
+  DELETE_SUCCESS_MESSAGE,
+  DETAIL_MEMO_SECTION_TITLE,
+  DETAIL_MENU_SECTION_TITLE,
+  DETAIL_NOTES_EMPTY_MESSAGE,
+  DETAIL_NOTES_LOAD_ERROR,
+  DETAIL_NOTES_SECTION_TITLE,
+  EDIT_LABEL,
+  MENUS_EMPTY_LOG_MESSAGE,
+  deleteConfirmQuestion,
+} from "../../_components/practiceRecordsCopy";
+import { formatPracticeDate } from "../../_utils/practiceRecordDate";
+
+interface PracticeSessionDetailProps {
+  session: PracticeSession;
+  /** アイコンのカテゴリ判定用。取得に失敗した場合は空配列で既定アイコンに倒す。 */
+  menus: PracticeMenu[];
+  /** 紐づく野球ノート。取得に失敗した場合は null（0件と区別する）。 */
+  notes: BaseballNoteV2[] | null;
+}
+
+const CONDITION_SECTION_TITLE = "コンディション";
+
+const CONDITION_EMPTY_MESSAGE = "この日のコンディションは記録されていません。";
+
+/** 練習記録詳細の Container。表示・削除・編集導線をまとめて受け持つ。 */
+export default function PracticeSessionDetail({
+  session,
+  menus,
+  notes,
+}: PracticeSessionDetailProps) {
+  const router = useRouter();
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const { hasEntitlement, isLoading: isEntitlementLoading } = useEntitlement();
+
+  const categoryById = new Map(menus.map((menu) => [menu.id, menu.category]));
+  const practiceDate = formatPracticeDate(session.logged_on);
+  const canSeeCondition = hasEntitlement("detailed_condition_log");
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    const result = await deletePracticeSession(session.id);
+    if (!result.ok) {
+      setIsDeleting(false);
+      toast.error(result.errors[0]);
+      return;
+    }
+    toast.success(DELETE_SUCCESS_MESSAGE);
+    router.push("/practice/records");
+  };
+
+  return (
+    <div>
+      <Link
+        href="/practice/records"
+        className="inline-flex items-center gap-1.5 text-[13px] font-semibold text-zinc-400"
+      >
+        <ArrowLeftIcon className="h-4 w-4 shrink-0" aria-hidden />
+        {BACK_TO_LIST_LABEL}
+      </Link>
+
+      <h2 className="mt-3 text-2xl font-bold text-white">{practiceDate}</h2>
+
+      <div className="mt-4 flex gap-2">
+        <Link
+          href={`/practice/record?date=${session.logged_on}`}
+          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-zinc-600 py-2.5 text-[13px] font-bold text-white"
+        >
+          <PencilSquareIcon className="h-4 w-4 shrink-0" aria-hidden />
+          {EDIT_LABEL}
+        </Link>
+        <button
+          type="button"
+          onClick={() => setIsConfirmOpen(true)}
+          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-danger/60 py-2.5 text-[13px] font-bold text-danger"
+        >
+          <TrashIcon className="h-4 w-4 shrink-0" aria-hidden />
+          {DELETE_LABEL}
+        </button>
+      </div>
+
+      <h3 className="mt-8 text-sm font-bold text-white">
+        {DETAIL_MENU_SECTION_TITLE}
+      </h3>
+      {session.practice_logs.length > 0 ? (
+        <ul className="mt-3 space-y-2">
+          {session.practice_logs.map((log) => {
+            const MenuIcon = practiceIconForLog(
+              log.source,
+              log.practice_menu_id === null
+                ? undefined
+                : categoryById.get(log.practice_menu_id),
+            );
+            const value = formatPracticeValue(log);
+            return (
+              <li key={log.id} className="rounded-xl bg-sub p-3">
+                <div className="flex items-center gap-2">
+                  <MenuIcon
+                    className="h-4 w-4 shrink-0 text-[#d08000]"
+                    aria-hidden
+                  />
+                  <p className="flex-1 text-sm font-bold text-white">
+                    {log.menu_name}
+                  </p>
+                  {value ? (
+                    <p className="text-sm font-extrabold text-[#d08000]">
+                      {value}
+                    </p>
+                  ) : null}
+                </div>
+                {log.memo ? (
+                  <p className="mt-1.5 text-[13px] leading-5 text-zinc-300">
+                    {log.memo}
+                  </p>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <p className="mt-3 text-sm text-zinc-400">{MENUS_EMPTY_LOG_MESSAGE}</p>
+      )}
+
+      {session.memo ? (
+        <>
+          <h3 className="mt-8 text-sm font-bold text-white">
+            {DETAIL_MEMO_SECTION_TITLE}
+          </h3>
+          <p className="mt-3 whitespace-pre-wrap rounded-xl bg-sub p-3 text-[13px] leading-5 text-zinc-200">
+            {session.memo}
+          </p>
+        </>
+      ) : null}
+
+      <h3 className="mt-8 text-sm font-bold text-white">
+        {CONDITION_SECTION_TITLE}
+      </h3>
+      <div className="mt-3">
+        {canSeeCondition ? (
+          session.condition ? (
+            <ConditionCard
+              condition={session.condition}
+              showTitle={false}
+              className="rounded-xl bg-sub p-3"
+            />
+          ) : (
+            <p className="text-sm text-zinc-400">{CONDITION_EMPTY_MESSAGE}</p>
+          )
+        ) : (
+          <div className="flex flex-col gap-y-2">
+            {/* 記録済みのコンディションがあるときは、それを暗幕越しのプレビューにする。 */}
+            {isEntitlementLoading || session.condition ? null : (
+              <SampleDataLabel />
+            )}
+            <ProUpsellOverlay feature="detailed_condition_log">
+              <ConditionCard
+                condition={session.condition ?? SAMPLE_CONDITION}
+                showTitle={false}
+                className="p-1"
+              />
+            </ProUpsellOverlay>
+          </div>
+        )}
+      </div>
+
+      <h3 className="mt-8 text-sm font-bold text-white">
+        {DETAIL_NOTES_SECTION_TITLE}
+      </h3>
+      <div className="mt-1">
+        {notes === null ? (
+          <p className="mt-2 text-sm text-zinc-400">
+            {DETAIL_NOTES_LOAD_ERROR}
+          </p>
+        ) : notes.length > 0 ? (
+          notes.map((note) => <NoteListItem key={note.id} note={note} />)
+        ) : (
+          <p className="mt-2 text-sm text-zinc-400">
+            {DETAIL_NOTES_EMPTY_MESSAGE}
+          </p>
+        )}
+      </div>
+
+      <Modal
+        isOpen={isConfirmOpen}
+        onClose={() => setIsConfirmOpen(false)}
+        placement="center"
+        className="buzz-dark"
+      >
+        <ModalContent>
+          <ModalHeader className="text-white">{DELETE_MODAL_TITLE}</ModalHeader>
+          <ModalBody>
+            <p className="text-sm text-white">
+              {deleteConfirmQuestion(practiceDate)}
+            </p>
+            <p className="text-xs text-zinc-400">
+              {DELETE_CONFIRM_DESCRIPTION}
+            </p>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="flat"
+              onPress={() => setIsConfirmOpen(false)}
+              isDisabled={isDeleting}
+            >
+              {DELETE_CANCEL_LABEL}
+            </Button>
+            <Button
+              color="danger"
+              onPress={handleDelete}
+              isDisabled={isDeleting}
+              isLoading={isDeleting}
+            >
+              {DELETE_CONFIRM_LABEL}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+}

--- a/app/(app)/practice/records/[id]/page.tsx
+++ b/app/(app)/practice/records/[id]/page.tsx
@@ -1,0 +1,83 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getBaseballNotes } from "@app/services/v2/baseballNoteService";
+import { getPracticeMenus } from "@app/services/v2/practiceMenuService";
+import { getPracticeSession } from "@app/services/v2/practiceSessionService";
+import {
+  DETAIL_FORBIDDEN,
+  DETAIL_LOAD_ERROR,
+  DETAIL_NOT_FOUND,
+} from "../_components/practiceRecordsCopy";
+import PracticeSessionDetail from "./_components/PracticeSessionDetail";
+
+export const metadata = {
+  title: "練習記録の詳細",
+};
+
+function DetailShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">{children}</div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default async function PracticeSessionDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const { id } = await params;
+  const sessionId = Number(id);
+  if (!Number.isInteger(sessionId) || sessionId <= 0) {
+    return (
+      <DetailShell>
+        <p className="py-8 text-center text-sm text-zinc-400">
+          {DETAIL_NOT_FOUND}
+        </p>
+      </DetailShell>
+    );
+  }
+
+  // 互いに依存しない取得なので並列で待つ。
+  const [sessionResult, notesResult, menusResult] = await Promise.all([
+    getPracticeSession(sessionId),
+    getBaseballNotes({ practiceSessionId: sessionId }),
+    getPracticeMenus(),
+  ]);
+
+  if (sessionResult.status !== "ok") {
+    const message =
+      sessionResult.status === "not_found"
+        ? DETAIL_NOT_FOUND
+        : sessionResult.status === "forbidden"
+          ? DETAIL_FORBIDDEN
+          : DETAIL_LOAD_ERROR;
+    return (
+      <DetailShell>
+        <p className="py-8 text-center text-sm text-zinc-400">{message}</p>
+      </DetailShell>
+    );
+  }
+
+  return (
+    <DetailShell>
+      <PracticeSessionDetail
+        session={sessionResult.data}
+        menus={menusResult.status === "ok" ? menusResult.data : []}
+        notes={notesResult.status === "ok" ? notesResult.data : null}
+      />
+    </DetailShell>
+  );
+}

--- a/app/(app)/practice/records/__tests__/PracticeRecordsSection.test.tsx
+++ b/app/(app)/practice/records/__tests__/PracticeRecordsSection.test.tsx
@@ -1,0 +1,351 @@
+import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
+import type {
+  PracticeLog,
+  PracticeMenu,
+  PracticeSession,
+} from "@app/types/practice";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import PracticeRecordsSection from "../_components/PracticeRecordsSection";
+
+function buildLog(overrides: Partial<PracticeLog> = {}): PracticeLog {
+  return {
+    id: 1,
+    practice_menu_id: 1,
+    schedule_id: null,
+    logged_on: "2026-07-14",
+    amount: "200.0",
+    weight: null,
+    menu_name: "素振り",
+    unit_label: "本",
+    source: "manual",
+    memo: null,
+    created_at: "2026-07-14T10:00:00+09:00",
+    ...overrides,
+  };
+}
+
+function buildSession(
+  overrides: Partial<PracticeSession> = {},
+): PracticeSession {
+  return {
+    id: 1,
+    logged_on: "2026-07-14",
+    memo: null,
+    improvement_theme_ids: [],
+    practice_logs: [],
+    condition: null,
+    created_at: "2026-07-14T10:00:00+09:00",
+    ...overrides,
+  };
+}
+
+const menu: PracticeMenu = {
+  id: 1,
+  name: "素振り",
+  category: "batting",
+  unit: "count",
+  unit_label: "本",
+  default_value: "200.0",
+  is_favorite: false,
+  sort_order: 1,
+};
+
+const note: BaseballNoteV2 = {
+  id: 100,
+  title: "気づき",
+  date: "2026-07-14",
+  memo: null,
+  memo_preview: "外角が詰まる",
+  game_result_ids: [],
+  practice_log_id: null,
+  practice_session_id: 1,
+  improvement_theme_ids: [],
+  reflection_template_id: null,
+  reflection_answers: [],
+  tags: [],
+  media_attachments: [],
+};
+
+// back は logged_on の新しい順で返すため、テストデータもその順で用意する。
+const sessions: PracticeSession[] = [
+  buildSession({
+    id: 1,
+    logged_on: "2026-08-20",
+    practice_logs: [buildLog({ id: 11, menu_name: "素振り", amount: "300.0" })],
+  }),
+  buildSession({
+    id: 2,
+    logged_on: "2026-08-05",
+    memo: "全体的に振り遅れ気味",
+    practice_logs: [
+      buildLog({
+        id: 12,
+        menu_name: "ベンチプレス",
+        amount: "10.0",
+        weight: "60.0",
+        unit_label: "回",
+      }),
+    ],
+  }),
+  buildSession({
+    id: 3,
+    logged_on: "2026-07-14",
+    practice_logs: [
+      buildLog({ id: 13, menu_name: "ロングティー", amount: "150.0" }),
+    ],
+  }),
+];
+
+function renderSection(
+  overrides: Partial<React.ComponentProps<typeof PracticeRecordsSection>> = {},
+) {
+  return render(
+    <PracticeRecordsSection
+      sessionsResult={{ status: "ok", data: sessions }}
+      menusResult={{ status: "ok", data: [menu] }}
+      notesResult={{ status: "ok", data: [] }}
+      {...overrides}
+    />,
+  );
+}
+
+describe("PracticeRecordsSection の導線", () => {
+  it("メニュー管理・練習の記録・積み上げの導線を出す", () => {
+    renderSection();
+
+    expect(
+      screen.getByRole("link", { name: "練習メニューを管理" }),
+    ).toHaveAttribute("href", "/practice/menus");
+    expect(screen.getByRole("link", { name: "練習を記録" })).toHaveAttribute(
+      "href",
+      "/practice/record",
+    );
+    expect(
+      screen.getByRole("link", { name: "メニュー別の積み上げを見る" }),
+    ).toHaveAttribute("href", "/practice/summary");
+  });
+});
+
+describe("PracticeRecordsSection の月ページング", () => {
+  it("未絞り込みでは最新の月だけを件数付きで表示する", () => {
+    renderSection();
+
+    expect(screen.getByText("2026年8月（2件）")).toBeInTheDocument();
+    expect(screen.getByText("素振り")).toBeInTheDocument();
+    expect(screen.getByText("ベンチプレス")).toBeInTheDocument();
+    expect(screen.queryByText("ロングティー")).not.toBeInTheDocument();
+  });
+
+  it("前の月・次の月に移動できる", () => {
+    renderSection();
+
+    fireEvent.click(screen.getByRole("button", { name: "前の月" }));
+
+    expect(screen.getByText("2026年7月（1件）")).toBeInTheDocument();
+    expect(screen.getByText("ロングティー")).toBeInTheDocument();
+    expect(screen.queryByText("素振り")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "次の月" }));
+
+    expect(screen.getByText("2026年8月（2件）")).toBeInTheDocument();
+  });
+
+  it("両端では月送りを止める", () => {
+    renderSection();
+
+    expect(screen.getByRole("button", { name: "次の月" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "前の月" }));
+
+    expect(screen.getByRole("button", { name: "前の月" })).toBeDisabled();
+  });
+
+  it("練習日と曜日を一覧の左側に出す", () => {
+    renderSection();
+
+    expect(screen.getByText("20")).toBeInTheDocument();
+    expect(screen.getAllByText("木").length).toBeGreaterThan(0);
+  });
+
+  it("メニューの量を formatPracticeValue の表記で出す", () => {
+    renderSection();
+
+    expect(screen.getByText("300本")).toBeInTheDocument();
+    expect(screen.getByText("60kg × 10回")).toBeInTheDocument();
+  });
+
+  it("ノートが紐付く記録にはバッジを出す", () => {
+    renderSection({ notesResult: { status: "ok", data: [note] } });
+
+    // ノートが紐付くのは 7月の記録なので、その月まで送ってから確認する。
+    fireEvent.click(screen.getByRole("button", { name: "前の月" }));
+    expect(screen.queryByText("ノート")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "次の月" }));
+    expect(screen.getByText("ノート")).toBeInTheDocument();
+  });
+
+  it("詳細画面へのリンクを張る", () => {
+    renderSection();
+
+    expect(
+      screen.getAllByRole("link").map((link) => link.getAttribute("href")),
+    ).toEqual(
+      expect.arrayContaining(["/practice/records/1", "/practice/records/2"]),
+    );
+  });
+});
+
+describe("PracticeRecordsSection の絞り込み", () => {
+  it("絞り込み中は月ページングをやめ、全期間を月見出し付きで表示する", () => {
+    renderSection();
+
+    fireEvent.change(screen.getByLabelText("練習記録を検索"), {
+      target: { value: "ティー" },
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "前の月" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("ロングティー")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("練習記録を検索"), {
+      target: { value: "" },
+    });
+    fireEvent.change(screen.getByLabelText("開始日"), {
+      target: { value: "2026-07-01" },
+    });
+
+    // 8月・7月の両方が残る条件では、月見出しを挟んで全期間が並ぶ。
+    expect(
+      screen.getByRole("heading", { name: "2026年8月" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "2026年7月" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("素振り")).toBeInTheDocument();
+    expect(screen.getByText("ロングティー")).toBeInTheDocument();
+  });
+
+  it("日付レンジは開始日・終了日を含めて絞り込む", () => {
+    renderSection();
+
+    fireEvent.change(screen.getByLabelText("開始日"), {
+      target: { value: "2026-08-05" },
+    });
+    fireEvent.change(screen.getByLabelText("終了日"), {
+      target: { value: "2026-08-05" },
+    });
+
+    expect(screen.getByText("ベンチプレス")).toBeInTheDocument();
+    expect(screen.queryByText("素振り")).not.toBeInTheDocument();
+    expect(screen.queryByText("ロングティー")).not.toBeInTheDocument();
+  });
+
+  it("セッションメモも検索対象にする", () => {
+    renderSection();
+
+    fireEvent.change(screen.getByLabelText("練習記録を検索"), {
+      target: { value: "振り遅れ" },
+    });
+
+    expect(screen.getByText("ベンチプレス")).toBeInTheDocument();
+    expect(screen.queryByText("ロングティー")).not.toBeInTheDocument();
+  });
+
+  it("絞り込みを解除すると最新の月へ戻る", () => {
+    renderSection();
+
+    fireEvent.click(screen.getByRole("button", { name: "前の月" }));
+    expect(screen.getByText("2026年7月（1件）")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("練習記録を検索"), {
+      target: { value: "素振り" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "クリア" }));
+
+    expect(screen.getByText("2026年8月（2件）")).toBeInTheDocument();
+    expect(screen.getByText("素振り")).toBeInTheDocument();
+  });
+
+  it("検索語を消して絞り込みを外したときも最新の月へ戻る", () => {
+    renderSection();
+
+    fireEvent.click(screen.getByRole("button", { name: "前の月" }));
+    expect(screen.getByText("2026年7月（1件）")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("練習記録を検索"), {
+      target: { value: "素振り" },
+    });
+    fireEvent.change(screen.getByLabelText("練習記録を検索"), {
+      target: { value: "" },
+    });
+
+    expect(screen.getByText("2026年8月（2件）")).toBeInTheDocument();
+  });
+
+  it("条件に一致しない場合は未記録と区別したメッセージを出す", () => {
+    renderSection();
+
+    fireEvent.change(screen.getByLabelText("練習記録を検索"), {
+      target: { value: "存在しない語" },
+    });
+
+    expect(
+      screen.getByText("条件に一致する練習記録がありません。"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("まだ練習記録がありません。"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("PracticeRecordsSection の空状態とエラー", () => {
+  it("0件は未記録メッセージを出す", () => {
+    renderSection({ sessionsResult: { status: "ok", data: [] } });
+
+    expect(screen.getByText("まだ練習記録がありません。")).toBeInTheDocument();
+    expect(screen.getByLabelText("練習記録を検索")).toBeInTheDocument();
+  });
+
+  it("取得失敗は0件と区別してエラーメッセージを出す", () => {
+    renderSection({ sessionsResult: { status: "error" } });
+
+    expect(
+      screen.getByText(
+        "練習記録を読み込めませんでした。時間を置いて再度お試しください。",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("まだ練習記録がありません。"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("練習記録を検索")).not.toBeInTheDocument();
+  });
+
+  it("403 は取得失敗と区別して権限メッセージを出す", () => {
+    renderSection({ sessionsResult: { status: "forbidden" } });
+
+    expect(
+      screen.getByText("練習記録を表示する権限がありません。"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "練習記録を読み込めませんでした。時間を置いて再度お試しください。",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("メニュー取得に失敗しても一覧自体は表示する", () => {
+    renderSection({ menusResult: { status: "error" } });
+
+    expect(screen.getByText("素振り")).toBeInTheDocument();
+  });
+
+  it("ノート取得に失敗してもバッジだけ落として一覧を表示する", () => {
+    renderSection({ notesResult: { status: "error" } });
+
+    const list = screen.getByText("素振り");
+    expect(list).toBeInTheDocument();
+    expect(within(document.body).queryByText("ノート")).not.toBeInTheDocument();
+  });
+});

--- a/app/(app)/practice/records/__tests__/RecordsTabBar.test.tsx
+++ b/app/(app)/practice/records/__tests__/RecordsTabBar.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import RecordsTabBar from "../_components/RecordsTabBar";
+
+describe("RecordsTabBar", () => {
+  it("練習記録タブと野球ノートタブを ?tab= で切り替えるリンクにする", () => {
+    render(<RecordsTabBar active="practice" />);
+
+    expect(screen.getByRole("link", { name: "練習記録" })).toHaveAttribute(
+      "href",
+      "/practice/records",
+    );
+    expect(screen.getByRole("link", { name: "野球ノート" })).toHaveAttribute(
+      "href",
+      "/practice/records?tab=note",
+    );
+  });
+
+  it("表示中のタブを aria-current で示す", () => {
+    render(<RecordsTabBar active="note" />);
+
+    expect(screen.getByRole("link", { name: "野球ノート" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("link", { name: "練習記録" })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+});

--- a/app/(app)/practice/records/__tests__/practiceRecordDate.test.ts
+++ b/app/(app)/practice/records/__tests__/practiceRecordDate.test.ts
@@ -1,0 +1,27 @@
+import {
+  formatPracticeDate,
+  practiceDayOfMonth,
+  practiceWeekday,
+} from "../_utils/practiceRecordDate";
+
+describe("formatPracticeDate", () => {
+  it("練習日を「7月14日(火)」形式で返す", () => {
+    expect(formatPracticeDate("2026-07-14")).toBe("7月14日(火)");
+  });
+
+  it("月末・月初でも日付がずれない", () => {
+    expect(formatPracticeDate("2026-08-01")).toBe("8月1日(土)");
+    expect(formatPracticeDate("2026-12-31")).toBe("12月31日(木)");
+  });
+
+  it("時刻付きで返ってきても日付部分だけを見る", () => {
+    expect(formatPracticeDate("2026-07-14T23:30:00+09:00")).toBe("7月14日(火)");
+  });
+});
+
+describe("一覧のタイムライン表記", () => {
+  it("日と曜日を分けて返す", () => {
+    expect(practiceDayOfMonth("2026-07-14")).toBe(14);
+    expect(practiceWeekday("2026-07-14")).toBe("火");
+  });
+});

--- a/app/(app)/practice/records/__tests__/practiceSessionFilter.test.ts
+++ b/app/(app)/practice/records/__tests__/practiceSessionFilter.test.ts
@@ -1,0 +1,167 @@
+import type { PracticeLog, PracticeSession } from "@app/types/practice";
+import { EMPTY_RECORD_SEARCH } from "@app/utils/recordListFilter";
+import {
+  filterPracticeSessions,
+  practiceSessionDate,
+} from "../_utils/practiceSessionFilter";
+
+function buildLog(overrides: Partial<PracticeLog> = {}): PracticeLog {
+  return {
+    id: 1,
+    practice_menu_id: 1,
+    schedule_id: null,
+    logged_on: "2026-07-14",
+    amount: "200.0",
+    weight: null,
+    menu_name: "素振り",
+    unit_label: "本",
+    source: "manual",
+    memo: null,
+    created_at: "2026-07-14T10:00:00+09:00",
+    ...overrides,
+  };
+}
+
+function buildSession(
+  overrides: Partial<PracticeSession> = {},
+): PracticeSession {
+  return {
+    id: 1,
+    logged_on: "2026-07-14",
+    memo: null,
+    improvement_theme_ids: [],
+    practice_logs: [],
+    condition: null,
+    created_at: "2026-07-14T10:00:00+09:00",
+    ...overrides,
+  };
+}
+
+function buildCondition(
+  overrides: Partial<NonNullable<PracticeSession["condition"]>> = {},
+): NonNullable<PracticeSession["condition"]> {
+  return {
+    id: 1,
+    logged_on: "2026-07-14",
+    fatigue_level: null,
+    physical_level: null,
+    sleep_hours: null,
+    mood: null,
+    memo: null,
+    injuries: [],
+    ...overrides,
+  };
+}
+
+function search(sessions: PracticeSession[], keyword: string): number[] {
+  return filterPracticeSessions(sessions, {
+    ...EMPTY_RECORD_SEARCH,
+    keyword,
+  }).map((session) => session.id);
+}
+
+describe("filterPracticeSessions（横断検索）", () => {
+  const target = buildSession({ id: 1 });
+  const other = buildSession({ id: 2, logged_on: "2026-06-01" });
+
+  it("日付を検索対象にする", () => {
+    expect(search([target, other], "2026-07-14")).toEqual([1]);
+  });
+
+  it("日付は「7月14日」のような和暦表記でも引ける", () => {
+    expect(search([target, other], "7月14日")).toEqual([1]);
+  });
+
+  it("セッションメモを検索対象にする", () => {
+    const withMemo = buildSession({ id: 1, memo: "全体的に振り遅れ気味" });
+
+    expect(search([withMemo, other], "振り遅れ")).toEqual([1]);
+  });
+
+  it("コンディションメモを検索対象にする", () => {
+    const withConditionMemo = buildSession({
+      id: 1,
+      condition: buildCondition({ memo: "後半は集中が切れた" }),
+    });
+
+    expect(search([withConditionMemo, other], "集中が切れた")).toEqual([1]);
+  });
+
+  it("気分を検索対象にする", () => {
+    const withMood = buildSession({
+      id: 1,
+      condition: buildCondition({ mood: "好調" }),
+    });
+
+    expect(search([withMood, other], "好調")).toEqual([1]);
+  });
+
+  it("怪我の部位を検索対象にする", () => {
+    const withInjury = buildSession({
+      id: 1,
+      condition: buildCondition({ injuries: [{ part: "肘", memo: "違和感" }] }),
+    });
+
+    expect(search([withInjury, other], "肘")).toEqual([1]);
+  });
+
+  it("メニュー名を検索対象にする", () => {
+    const withLogs = buildSession({
+      id: 1,
+      practice_logs: [buildLog({ menu_name: "ロングティー" })],
+    });
+
+    expect(search([withLogs, other], "ロングティー")).toEqual([1]);
+  });
+
+  it("一致しなければ空配列（0件）を返す", () => {
+    expect(search([target, other], "存在しない語")).toEqual([]);
+  });
+});
+
+describe("filterPracticeSessions（日付レンジ）", () => {
+  const sessions = [
+    buildSession({ id: 1, logged_on: "2026-06-30" }),
+    buildSession({ id: 2, logged_on: "2026-07-01" }),
+    buildSession({ id: 3, logged_on: "2026-07-31" }),
+    buildSession({ id: 4, logged_on: "2026-08-01" }),
+  ];
+
+  it("開始日はその日を含む", () => {
+    expect(
+      filterPracticeSessions(sessions, {
+        ...EMPTY_RECORD_SEARCH,
+        startDate: "2026-07-01",
+      }).map((session) => session.id),
+    ).toEqual([2, 3, 4]);
+  });
+
+  it("終了日はその日を含む", () => {
+    expect(
+      filterPracticeSessions(sessions, {
+        ...EMPTY_RECORD_SEARCH,
+        endDate: "2026-07-31",
+      }).map((session) => session.id),
+    ).toEqual([1, 2, 3]);
+  });
+
+  it("両端を含んで絞り込む", () => {
+    expect(
+      filterPracticeSessions(sessions, {
+        ...EMPTY_RECORD_SEARCH,
+        startDate: "2026-07-01",
+        endDate: "2026-07-31",
+      }).map((session) => session.id),
+    ).toEqual([2, 3]);
+  });
+});
+
+describe("practiceSessionDate", () => {
+  it("月の集計に渡せるよう日付だけを返す", () => {
+    expect(
+      practiceSessionDate(
+        buildSession({ logged_on: "2026-07-14T10:00:00+09:00" }),
+      ),
+    ).toBe("2026-07-14");
+  });
+});

--- a/app/(app)/practice/records/_components/PracticeRecordsBoard.tsx
+++ b/app/(app)/practice/records/_components/PracticeRecordsBoard.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import type { PracticeMenu, PracticeSession } from "@app/types/practice";
+import type { RecordSearchValues } from "@app/utils/recordListFilter";
+import { useState } from "react";
+import MonthPaginator from "@app/components/filter/MonthPaginator";
+import RecordSearchFilterBar from "@app/components/filter/RecordSearchFilterBar";
+import { useMonthPager } from "@app/hooks/records/useMonthPager";
+import {
+  EMPTY_RECORD_SEARCH,
+  formatMonthLabel,
+  groupByMonth,
+  hasActiveRecordSearch,
+} from "@app/utils/recordListFilter";
+import {
+  filterPracticeSessions,
+  practiceSessionDate,
+} from "../_utils/practiceSessionFilter";
+import {
+  SEARCH_LABEL,
+  SEARCH_PLACEHOLDER,
+  SESSIONS_EMPTY_MESSAGE,
+  SESSIONS_NO_MATCH_MESSAGE,
+} from "./practiceRecordsCopy";
+import PracticeSessionListItem from "./PracticeSessionListItem";
+
+interface PracticeRecordsBoardProps {
+  sessions: PracticeSession[];
+  /** アイコンのカテゴリ判定に使う。取得に失敗した場合は空配列で既定アイコンに倒す。 */
+  menus: PracticeMenu[];
+  /** 野球ノートが紐付いているセッションの ID。取得に失敗した場合は空配列。 */
+  sessionIdsWithNote: number[];
+}
+
+/**
+ * 練習記録一覧の Container。
+ * 絞り込み状態と月ページを保持し、未絞り込みなら1ヶ月ずつ、絞り込み中は全期間を
+ * 月見出し付きで表示する。back に検索・ページングの API が無いため計算はすべてここで行う。
+ */
+export default function PracticeRecordsBoard({
+  sessions,
+  menus,
+  sessionIdsWithNote,
+}: PracticeRecordsBoardProps) {
+  const [filters, setFilters] = useState<RecordSearchValues>(
+    () => EMPTY_RECORD_SEARCH,
+  );
+
+  const categoryById = new Map(menus.map((menu) => [menu.id, menu.category]));
+  const noteSessionIds = new Set(sessionIdsWithNote);
+
+  const isFiltered = hasActiveRecordSearch(filters);
+  const filtered = filterPracticeSessions(sessions, filters);
+  const monthGroups = groupByMonth(filtered, practiceSessionDate);
+  const pager = useMonthPager(sessions, practiceSessionDate);
+
+  // 絞り込みを変えたら必ず最新の月へ戻す。古いページ番号のまま絞り込みを解除すると
+  // 該当する記録があるのに「結果なし」に見えてしまう。
+  const handleFilterChange = (next: RecordSearchValues) => {
+    setFilters(next);
+    pager.reset();
+  };
+
+  const renderItem = (session: PracticeSession) => (
+    <PracticeSessionListItem
+      key={session.id}
+      session={session}
+      hasNote={noteSessionIds.has(session.id)}
+      categoryById={categoryById}
+    />
+  );
+
+  const visibleCount = isFiltered ? filtered.length : pager.items.length;
+
+  return (
+    <div className="space-y-4">
+      <RecordSearchFilterBar
+        values={filters}
+        onChange={handleFilterChange}
+        onClear={() => handleFilterChange({ ...EMPTY_RECORD_SEARCH })}
+        showClear={isFiltered}
+        searchLabel={SEARCH_LABEL}
+        searchPlaceholder={SEARCH_PLACEHOLDER}
+      />
+      {isFiltered ? (
+        <div className="space-y-5">
+          {monthGroups.map((group) => (
+            <section key={group.month}>
+              <h3 className="mb-2 text-[13px] font-bold text-zinc-400">
+                {formatMonthLabel(group.month)}
+              </h3>
+              <ul className="space-y-3.5">{group.items.map(renderItem)}</ul>
+            </section>
+          ))}
+        </div>
+      ) : (
+        <>
+          {pager.month ? (
+            <MonthPaginator
+              month={pager.month}
+              count={pager.items.length}
+              index={pager.index}
+              total={pager.months.length}
+              onChange={pager.goTo}
+            />
+          ) : null}
+          <ul className="space-y-3.5">{pager.items.map(renderItem)}</ul>
+        </>
+      )}
+      {visibleCount === 0 ? (
+        <p className="py-8 text-center text-sm text-zinc-400">
+          {sessions.length === 0
+            ? SESSIONS_EMPTY_MESSAGE
+            : SESSIONS_NO_MATCH_MESSAGE}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/app/(app)/practice/records/_components/PracticeRecordsSection.tsx
+++ b/app/(app)/practice/records/_components/PracticeRecordsSection.tsx
@@ -1,0 +1,89 @@
+import type {
+  BaseballNoteV2,
+  NoteFetchResult,
+} from "@app/interface/baseballNoteV2";
+import type { FetchResult } from "@app/services/v2/requests";
+import type { PracticeMenu, PracticeSession } from "@app/types/practice";
+import ChartBarIcon from "@heroicons/react/24/outline/ChartBarIcon";
+import ChevronRightIcon from "@heroicons/react/24/outline/ChevronRightIcon";
+import ListBulletIcon from "@heroicons/react/24/outline/ListBulletIcon";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import Link from "next/link";
+import PracticeRecordsBoard from "./PracticeRecordsBoard";
+import {
+  MANAGE_MENUS_LABEL,
+  MENU_SUMMARY_LABEL,
+  RECORD_PRACTICE_LABEL,
+  SESSIONS_FORBIDDEN,
+  SESSIONS_LOAD_ERROR,
+} from "./practiceRecordsCopy";
+
+interface PracticeRecordsSectionProps {
+  sessionsResult: FetchResult<PracticeSession[]>;
+  /** アイコンのカテゴリ判定用。失敗しても一覧自体は出したいので既定アイコンへ倒す。 */
+  menusResult: FetchResult<PracticeMenu[]>;
+  /** ノート紐付けバッジ用。失敗しても一覧自体は出したいのでバッジだけ落とす。 */
+  notesResult: NoteFetchResult<BaseballNoteV2[]>;
+}
+
+const HEADER_LINKS = (
+  <div className="space-y-2.5">
+    <Link
+      href="/practice/menus"
+      className="flex items-center justify-end gap-1.5 text-[13px] font-semibold text-[#d08000]"
+    >
+      <ListBulletIcon className="h-4 w-4 shrink-0" aria-hidden />
+      {MANAGE_MENUS_LABEL}
+      <ChevronRightIcon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+    </Link>
+    <Link
+      href="/practice/record"
+      className="flex items-center justify-center gap-1.5 rounded-[10px] bg-[#d08000] py-3.5 text-sm font-bold text-white"
+    >
+      <PlusIcon className="h-5 w-5 shrink-0" aria-hidden />
+      {RECORD_PRACTICE_LABEL}
+    </Link>
+    <Link
+      href="/practice/summary"
+      className="flex items-center justify-center gap-1.5 rounded-lg border border-[#d08000] bg-[#d08000]/10 py-2.5 text-[13px] font-bold text-[#d08000]"
+    >
+      <ChartBarIcon className="h-4 w-4 shrink-0" aria-hidden />
+      {MENU_SUMMARY_LABEL}
+      <ChevronRightIcon className="h-4 w-4 shrink-0" aria-hidden />
+    </Link>
+  </div>
+);
+
+/** 練習記録タブ。導線を出し、取得結果に応じて一覧かエラー文言へ振り分ける。 */
+export default function PracticeRecordsSection({
+  sessionsResult,
+  menusResult,
+  notesResult,
+}: PracticeRecordsSectionProps) {
+  const sessionIdsWithNote =
+    notesResult.status === "ok"
+      ? notesResult.data
+          .map((note) => note.practice_session_id)
+          .filter((id): id is number => id !== null)
+      : [];
+
+  return (
+    <div className="space-y-4">
+      {HEADER_LINKS}
+      {sessionsResult.status === "ok" ? (
+        <PracticeRecordsBoard
+          sessions={sessionsResult.data}
+          menus={menusResult.status === "ok" ? menusResult.data : []}
+          sessionIdsWithNote={sessionIdsWithNote}
+        />
+      ) : (
+        // 取得失敗を空配列に丸めると「記録が0件」と誤表示してしまう。
+        <p className="py-8 text-center text-sm text-zinc-400">
+          {sessionsResult.status === "forbidden"
+            ? SESSIONS_FORBIDDEN
+            : SESSIONS_LOAD_ERROR}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/practice/records/_components/PracticeSessionListItem.tsx
+++ b/app/(app)/practice/records/_components/PracticeSessionListItem.tsx
@@ -1,0 +1,108 @@
+import type { PracticeCategory, PracticeSession } from "@app/types/practice";
+import DocumentTextIcon from "@heroicons/react/24/outline/DocumentTextIcon";
+import Link from "next/link";
+import {
+  conditionLevelMeta,
+  formatPracticeValue,
+  practiceIconForLog,
+} from "@app/constants/practice";
+import {
+  practiceDayOfMonth,
+  practiceWeekday,
+} from "../_utils/practiceRecordDate";
+import {
+  MENUS_EMPTY_LOG_MESSAGE,
+  NOTE_BADGE_LABEL,
+} from "./practiceRecordsCopy";
+
+interface PracticeSessionListItemProps {
+  session: PracticeSession;
+  /** この日の記録に野球ノートが紐付いているか。 */
+  hasNote: boolean;
+  /** メニュー ID => カテゴリ。アイコンの出し分けに使う（削除済みメニューは未登録）。 */
+  categoryById: Map<number, PracticeCategory>;
+}
+
+/** 一覧1行。左に日付、右にその日のメニューとコンディションの要約を出す。 */
+export default function PracticeSessionListItem({
+  session,
+  hasNote,
+  categoryById,
+}: PracticeSessionListItemProps) {
+  // 体調を優先して1つだけ顔アイコンにする。両方出すと一覧が読みづらくなる。
+  const levelMeta = conditionLevelMeta(
+    session.condition?.physical_level ?? session.condition?.fatigue_level,
+  );
+  const LevelIcon = levelMeta?.icon;
+
+  return (
+    <li className="flex gap-2">
+      <div className="w-10 shrink-0 pt-1 text-center">
+        <p className="text-xl font-extrabold text-white">
+          {practiceDayOfMonth(session.logged_on)}
+        </p>
+        <p className="-mt-0.5 text-[11px] font-bold text-zinc-400">
+          {practiceWeekday(session.logged_on)}
+        </p>
+      </div>
+      <Link
+        href={`/practice/records/${session.id}`}
+        className="flex-1 rounded-xl bg-sub p-3 transition-colors hover:bg-[#4d4d4d]"
+      >
+        {session.practice_logs.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {session.practice_logs.map((log) => {
+              const MenuIcon = practiceIconForLog(
+                log.source,
+                log.practice_menu_id === null
+                  ? undefined
+                  : categoryById.get(log.practice_menu_id),
+              );
+              const value = formatPracticeValue(log);
+              return (
+                <span
+                  key={log.id}
+                  className="inline-flex items-center gap-1 rounded-lg bg-main px-2 py-1.5"
+                >
+                  <MenuIcon
+                    className="h-3.5 w-3.5 shrink-0 text-[#d08000]"
+                    aria-hidden
+                  />
+                  <span className="text-[13px] font-bold text-white">
+                    {log.menu_name}
+                  </span>
+                  {value ? (
+                    <span className="text-[13px] font-extrabold text-[#d08000]">
+                      {value}
+                    </span>
+                  ) : null}
+                </span>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="text-[13px] text-zinc-400">{MENUS_EMPTY_LOG_MESSAGE}</p>
+        )}
+        {levelMeta || hasNote ? (
+          <div className="mt-2 flex items-center gap-2.5">
+            {levelMeta && LevelIcon ? (
+              <LevelIcon
+                className={`h-4 w-4 shrink-0 ${levelMeta.colorClass}`}
+                aria-hidden
+              />
+            ) : null}
+            {hasNote ? (
+              <span className="inline-flex items-center gap-1 text-xs font-bold text-[#d08000]">
+                <DocumentTextIcon
+                  className="h-3.5 w-3.5 shrink-0"
+                  aria-hidden
+                />
+                {NOTE_BADGE_LABEL}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+      </Link>
+    </li>
+  );
+}

--- a/app/(app)/practice/records/_components/RecordsTabBar.tsx
+++ b/app/(app)/practice/records/_components/RecordsTabBar.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { NOTE_TAB_LABEL, PRACTICE_TAB_LABEL } from "./practiceRecordsCopy";
+
+export type RecordsTab = "practice" | "note";
+
+interface RecordsTabBarProps {
+  active: RecordsTab;
+}
+
+const TABS: ReadonlyArray<{ key: RecordsTab; label: string; href: string }> = [
+  {
+    key: "practice",
+    label: PRACTICE_TAB_LABEL,
+    href: "/practice/records",
+  },
+  {
+    key: "note",
+    label: NOTE_TAB_LABEL,
+    href: "/practice/records?tab=note",
+  },
+];
+
+/**
+ * 練習記録 / 野球ノートの切り替え。
+ * 状態ではなくリンクで切り替え、URL（`?tab=`）だけで表示中のタブが決まるようにする。
+ */
+export default function RecordsTabBar({ active }: RecordsTabBarProps) {
+  return (
+    <nav className="flex border-b border-zinc-700">
+      {TABS.map((tab) => (
+        <Link
+          key={tab.key}
+          href={tab.href}
+          aria-current={tab.key === active ? "page" : undefined}
+          className={`flex-1 border-b-2 pb-2.5 text-center text-sm font-bold transition-colors ${
+            tab.key === active
+              ? "border-[#d08000] text-[#d08000]"
+              : "border-transparent text-zinc-400"
+          }`}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/app/(app)/practice/records/_components/practiceRecordsCopy.ts
+++ b/app/(app)/practice/records/_components/practiceRecordsCopy.ts
@@ -1,0 +1,78 @@
+/**
+ * 練習記録の一覧・詳細画面の文言。
+ * mobile の記録タブ / 練習記録詳細と表記を揃えるため1箇所にまとめる。
+ */
+
+export const PAGE_TITLE = "記録";
+
+export const PRACTICE_TAB_LABEL = "練習記録";
+
+export const NOTE_TAB_LABEL = "野球ノート";
+
+export const MANAGE_MENUS_LABEL = "練習メニューを管理";
+
+export const RECORD_PRACTICE_LABEL = "練習を記録";
+
+export const MENU_SUMMARY_LABEL = "メニュー別の積み上げを見る";
+
+export const SEARCH_LABEL = "練習記録を検索";
+
+export const SEARCH_PLACEHOLDER = "メニュー名・メモ・気分などで検索";
+
+export const SESSIONS_EMPTY_MESSAGE = "まだ練習記録がありません。";
+
+export const SESSIONS_NO_MATCH_MESSAGE = "条件に一致する練習記録がありません。";
+
+/** 取得失敗を0件と誤表示しないための文言。 */
+export const SESSIONS_LOAD_ERROR =
+  "練習記録を読み込めませんでした。時間を置いて再度お試しください。";
+
+export const SESSIONS_FORBIDDEN = "練習記録を表示する権限がありません。";
+
+export const MENUS_EMPTY_LOG_MESSAGE = "メニューの記録なし";
+
+export const NOTE_BADGE_LABEL = "ノート";
+
+export const DETAIL_MENU_SECTION_TITLE = "やった練習";
+
+export const DETAIL_MEMO_SECTION_TITLE = "この日のメモ";
+
+export const DETAIL_NOTES_SECTION_TITLE = "紐づく野球ノート";
+
+export const DETAIL_NOTES_EMPTY_MESSAGE =
+  "この練習記録に紐づく野球ノートはありません。";
+
+/** ノート一覧の取得失敗は「ノート0件」と区別する。 */
+export const DETAIL_NOTES_LOAD_ERROR =
+  "紐づく野球ノートを読み込めませんでした。";
+
+export const DETAIL_NOT_FOUND = "練習記録が見つかりません。";
+
+export const DETAIL_LOAD_ERROR =
+  "練習記録を読み込めませんでした。時間を置いて再度お試しください。";
+
+export const DETAIL_FORBIDDEN = "この練習記録を表示する権限がありません。";
+
+export const BACK_TO_LIST_LABEL = "練習記録の一覧へ戻る";
+
+export const EDIT_LABEL = "編集する";
+
+export const DELETE_LABEL = "削除する";
+
+export const DELETE_MODAL_TITLE = "練習記録の削除";
+
+export const DELETE_CANCEL_LABEL = "キャンセル";
+
+export const DELETE_CONFIRM_LABEL = "削除";
+
+export const DELETE_SUCCESS_MESSAGE = "練習記録を削除しました";
+
+/**
+ * 削除確認の説明。back は practice_logs を dependent: :destroy、
+ * baseball_notes を dependent: :nullify で扱い、condition_logs は別テーブルで消えない。
+ */
+export const DELETE_CONFIRM_DESCRIPTION =
+  "この日に記録した練習メニューのログもすべて削除されます。紐づく野球ノートとコンディションの記録は削除されず、練習記録との紐付けだけが外れます。";
+
+export const deleteConfirmQuestion = (date: string): string =>
+  `${date}の練習記録を削除しますか？`;

--- a/app/(app)/practice/records/_utils/practiceRecordDate.ts
+++ b/app/(app)/practice/records/_utils/practiceRecordDate.ts
@@ -1,0 +1,26 @@
+const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"] as const;
+
+/**
+ * `YYYY-MM-DD` をローカル日付として解釈する。
+ * `new Date("2026-07-14")` は UTC 深夜として解釈され、日本時間では前日にずれるため使わない。
+ */
+function parseLocalDate(logged_on: string): Date {
+  const [year, month, day] = logged_on.slice(0, 10).split("-").map(Number);
+  return new Date(year, month - 1, day);
+}
+
+/** 練習日を「7月14日(火)」形式にする。 */
+export function formatPracticeDate(logged_on: string): string {
+  const date = parseLocalDate(logged_on);
+  return `${date.getMonth() + 1}月${date.getDate()}日(${WEEKDAYS[date.getDay()]})`;
+}
+
+/** 一覧のタイムライン左端に出す日（`14`）。 */
+export function practiceDayOfMonth(logged_on: string): number {
+  return parseLocalDate(logged_on).getDate();
+}
+
+/** 一覧のタイムライン左端に出す曜日（`火`）。 */
+export function practiceWeekday(logged_on: string): string {
+  return WEEKDAYS[parseLocalDate(logged_on).getDay()];
+}

--- a/app/(app)/practice/records/_utils/practiceSessionFilter.ts
+++ b/app/(app)/practice/records/_utils/practiceSessionFilter.ts
@@ -1,0 +1,50 @@
+import type { PracticeSession } from "@app/types/practice";
+import {
+  type RecordSearchValues,
+  matchesDateRange,
+  matchesKeyword,
+  toDay,
+} from "@app/utils/recordListFilter";
+import { formatPracticeDate } from "./practiceRecordDate";
+
+// back の GET /api/v2/practice_sessions が受け取るのは from / to / improvement_theme_id だけで、
+// フリーワード検索もページングも無い。日付レンジも往復のたびに再取得が要るため、
+// 一覧は全件を1回で取得してここで絞り込む。
+
+/** セッションの日付（`YYYY-MM-DD`）。月の収集・抽出に渡す。 */
+export function practiceSessionDate(session: PracticeSession): string {
+  return toDay(session.logged_on);
+}
+
+/**
+ * フリーワードの検索対象。
+ * 日付 / セッションメモ / コンディションメモ / 気分 / 怪我の部位 / メニュー名 を横断する。
+ * 日付は `2026-07-14` と `7月14日(火)` の両方を含め、どちらの打ち方でも引けるようにする。
+ */
+export function practiceSessionSearchParts(session: PracticeSession): string[] {
+  const day = practiceSessionDate(session);
+  return [
+    day,
+    formatPracticeDate(day),
+    session.memo ?? "",
+    session.condition?.memo ?? "",
+    session.condition?.mood ?? "",
+    ...(session.condition?.injuries ?? []).map((injury) => injury.part),
+    ...session.practice_logs.map((log) => log.menu_name),
+  ];
+}
+
+/**
+ * フリーワードと日付レンジで絞り込む。日付レンジは開始日・終了日ともに **その日を含む**。
+ * 並び順は back の返却順（練習日の新しい順）を保つ。
+ */
+export function filterPracticeSessions(
+  sessions: PracticeSession[],
+  values: RecordSearchValues,
+): PracticeSession[] {
+  return sessions.filter(
+    (session) =>
+      matchesKeyword(practiceSessionSearchParts(session), values.keyword) &&
+      matchesDateRange(session.logged_on, values),
+  );
+}

--- a/app/(app)/practice/records/page.tsx
+++ b/app/(app)/practice/records/page.tsx
@@ -1,0 +1,76 @@
+import type { RecordsTab } from "./_components/RecordsTabBar";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import NoteListComponent from "@app/components/note/NoteListComponent";
+import { getBaseballNotes } from "@app/services/v2/baseballNoteService";
+import { getNoteTags } from "@app/services/v2/noteTagService";
+import { getPracticeMenus } from "@app/services/v2/practiceMenuService";
+import { getPracticeSessions } from "@app/services/v2/practiceSessionService";
+import { PAGE_TITLE } from "./_components/practiceRecordsCopy";
+import PracticeRecordsSection from "./_components/PracticeRecordsSection";
+import RecordsTabBar from "./_components/RecordsTabBar";
+
+export const metadata = {
+  title: "練習記録",
+};
+
+interface PracticeRecordsSearchParams {
+  /** `note` で野球ノートタブ。未指定・不正値は練習記録タブ。 */
+  tab?: string;
+}
+
+export default async function PracticeRecordsPage({
+  searchParams,
+}: {
+  searchParams: Promise<PracticeRecordsSearchParams>;
+}) {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const { tab } = await searchParams;
+  const activeTab: RecordsTab = tab === "note" ? "note" : "practice";
+
+  // 互いに依存しない取得なので並列で待つ。表示しないタブのデータは取りに行かない
+  // （ノートは練習記録タブでも紐付けバッジに使うため常に取る）。
+  const isNoteTab = activeTab === "note";
+  const [sessionsResult, menusResult, notesResult, tagsResult] =
+    await Promise.all([
+      isNoteTab ? null : getPracticeSessions(),
+      isNoteTab ? null : getPracticeMenus(),
+      getBaseballNotes(),
+      isNoteTab ? getNoteTags() : null,
+    ]);
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            <h2 className="text-2xl font-bold">{PAGE_TITLE}</h2>
+            <div className="mt-5">
+              <RecordsTabBar active={activeTab} />
+            </div>
+            <div className="my-6">
+              {sessionsResult && menusResult ? (
+                <PracticeRecordsSection
+                  sessionsResult={sessionsResult}
+                  menusResult={menusResult}
+                  notesResult={notesResult}
+                />
+              ) : (
+                <NoteListComponent
+                  result={notesResult}
+                  tagsResult={tagsResult ?? { status: "error" }}
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/components/filter/MonthPaginator.tsx
+++ b/app/components/filter/MonthPaginator.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import ChevronLeftIcon from "@heroicons/react/24/outline/ChevronLeftIcon";
+import ChevronRightIcon from "@heroicons/react/24/outline/ChevronRightIcon";
+import { formatMonthCountLabel } from "@app/utils/recordListFilter";
+
+interface MonthPaginatorProps {
+  /** 表示中の年月（`YYYY-MM`）。 */
+  month: string;
+  /** 表示中の月に含まれる件数。 */
+  count: number;
+  /** 表示中の月の位置。0 が最新月。 */
+  index: number;
+  /** 記録がある月の総数。 */
+  total: number;
+  onChange: (index: number) => void;
+}
+
+const NAV_BUTTON_CLASS =
+  "flex h-8 w-8 items-center justify-center rounded-full text-[#d08000] transition-colors hover:bg-[#3A3A3A] disabled:text-zinc-600 disabled:hover:bg-transparent";
+
+/**
+ * 記録がある月を1ページずつ送るナビゲーション（◀ 2026年7月（3件） ▶）。
+ * 新しい月ほど index が小さいため、左（前の月）で index を増やす。
+ */
+export default function MonthPaginator({
+  month,
+  count,
+  index,
+  total,
+  onChange,
+}: MonthPaginatorProps) {
+  return (
+    <div className="flex items-center justify-between rounded-[10px] bg-sub px-4 py-2.5">
+      <button
+        type="button"
+        onClick={() => onChange(index + 1)}
+        disabled={index >= total - 1}
+        className={NAV_BUTTON_CLASS}
+      >
+        <ChevronLeftIcon className="h-5 w-5" aria-hidden />
+        <span className="sr-only">前の月</span>
+      </button>
+      <p className="text-sm font-bold text-white" aria-live="polite">
+        {formatMonthCountLabel(month, count)}
+      </p>
+      <button
+        type="button"
+        onClick={() => onChange(index - 1)}
+        disabled={index <= 0}
+        className={NAV_BUTTON_CLASS}
+      >
+        <ChevronRightIcon className="h-5 w-5" aria-hidden />
+        <span className="sr-only">次の月</span>
+      </button>
+    </div>
+  );
+}

--- a/app/components/filter/RecordSearchFilterBar.tsx
+++ b/app/components/filter/RecordSearchFilterBar.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import type { RecordSearchValues } from "@app/utils/recordListFilter";
+import type { ReactNode } from "react";
+import { alignDateRange } from "@app/utils/recordListFilter";
+
+interface RecordSearchFilterBarProps {
+  values: RecordSearchValues;
+  onChange: (values: RecordSearchValues) => void;
+  /** クリア押下時の初期化。呼び出し側が持つ追加条件もまとめて戻せるよう委ねる。 */
+  onClear: () => void;
+  /** クリアボタンを出すか。追加条件を持つ画面はそれも含めて判定した結果を渡す。 */
+  showClear: boolean;
+  /** 検索欄の読み上げ名。同一画面に複数の検索欄が並んでも区別できるよう画面ごとに変える。 */
+  searchLabel: string;
+  searchPlaceholder: string;
+  /** タグチップなど、画面固有の絞り込み UI を日付行の下に差し込む。 */
+  children?: ReactNode;
+}
+
+/**
+ * 記録系一覧の絞り込みバー（フリーワード + 開始日 / 終了日 + クリア）。
+ *
+ * 成績・試合一覧の FilterBar は「年・月粒度の単一選択ドロップダウン」専用で
+ * フリーワードと日単位の期間を表現できないため、記録系一覧はこちらを共有する。
+ */
+export default function RecordSearchFilterBar({
+  values,
+  onChange,
+  onClear,
+  showClear,
+  searchLabel,
+  searchPlaceholder,
+  children,
+}: RecordSearchFilterBarProps) {
+  return (
+    <div className="space-y-3">
+      <input
+        type="search"
+        aria-label={searchLabel}
+        placeholder={searchPlaceholder}
+        value={values.keyword}
+        onChange={(event) =>
+          onChange({ ...values, keyword: event.target.value })
+        }
+        className="w-full rounded-lg bg-sub px-3 py-2 text-sm text-white placeholder:text-zinc-500"
+      />
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="date"
+          aria-label="開始日"
+          value={values.startDate}
+          onChange={(event) =>
+            onChange(alignDateRange(values, "startDate", event.target.value))
+          }
+          className="rounded-lg bg-sub px-3 py-2 text-sm text-white"
+        />
+        <span className="text-xs text-zinc-400">〜</span>
+        <input
+          type="date"
+          aria-label="終了日"
+          value={values.endDate}
+          onChange={(event) =>
+            onChange(alignDateRange(values, "endDate", event.target.value))
+          }
+          className="rounded-lg bg-sub px-3 py-2 text-sm text-white"
+        />
+        {showClear ? (
+          <button
+            type="button"
+            onClick={onClear}
+            className="px-2 py-1.5 text-xs font-medium text-[#A1A1AA]"
+          >
+            クリア
+          </button>
+        ) : null}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/app/components/header/HeaderRight.tsx
+++ b/app/components/header/HeaderRight.tsx
@@ -66,6 +66,16 @@ export default function HeaderRight() {
                   振り返りテンプレ
                 </DropdownItem>
                 <DropdownItem
+                  key="practice-records"
+                  as={Link}
+                  href="/practice/records"
+                  startContent={
+                    <BallIcon fill="currentColor" width="18" height="18" />
+                  }
+                >
+                  練習記録
+                </DropdownItem>
+                <DropdownItem
                   key="practice-menus"
                   as={Link}
                   href="/practice/menus"

--- a/app/components/note/NoteListBoard.tsx
+++ b/app/components/note/NoteListBoard.tsx
@@ -4,14 +4,14 @@ import type { BaseballNoteV2, NoteTag } from "@app/interface/baseballNoteV2";
 import type { NoteListFilterValues } from "@app/utils/noteListFilter";
 import { Card } from "@heroui/react";
 import { useState } from "react";
+import MonthPaginator from "@app/components/filter/MonthPaginator";
 import NoteListFilterBar from "@app/components/note/NoteListFilterBar";
 import NoteListItem from "@app/components/note/NoteListItem";
+import { useMonthPager } from "@app/hooks/records/useMonthPager";
 import {
   EMPTY_NOTE_FILTERS,
-  collectNoteMonths,
   filterNotes,
-  formatMonthLabel,
-  notesInMonth,
+  noteDate,
 } from "@app/utils/noteListFilter";
 
 interface NoteListBoardProps {
@@ -27,20 +27,15 @@ export default function NoteListBoard({ notes, tags }: NoteListBoardProps) {
   const [filters, setFilters] = useState<NoteListFilterValues>(
     () => EMPTY_NOTE_FILTERS,
   );
-  const [monthIndex, setMonthIndex] = useState(0);
 
   const filtered = filterNotes(notes, filters);
-  const months = collectNoteMonths(filtered);
-  // 絞り込みで月の並びが短くなっても範囲外を指さないよう、描画時に丸める。
-  const currentIndex = Math.min(monthIndex, Math.max(months.length - 1, 0));
-  const currentMonth = months[currentIndex];
-  const visibleNotes = currentMonth ? notesInMonth(filtered, currentMonth) : [];
+  const pager = useMonthPager(filtered, noteDate);
 
   // 絞り込みを変えたら必ず最新の月へ戻す。古いページ番号のまま検索すると
   // 該当ノートがあるのに「結果なし」に見えてしまう。
   const handleFilterChange = (next: NoteListFilterValues) => {
     setFilters(next);
-    setMonthIndex(0);
+    pager.reset();
   };
 
   return (
@@ -50,32 +45,18 @@ export default function NoteListBoard({ notes, tags }: NoteListBoardProps) {
         onChange={handleFilterChange}
         tags={tags}
       />
-      {months.length > 0 ? (
-        <div className="flex items-center justify-between">
-          <button
-            type="button"
-            onClick={() => setMonthIndex(currentIndex + 1)}
-            disabled={currentIndex >= months.length - 1}
-            className="px-2 py-1.5 text-xs font-bold text-zinc-400 disabled:opacity-40"
-          >
-            前の月
-          </button>
-          <p className="text-sm font-bold" aria-live="polite">
-            {formatMonthLabel(currentMonth)}（{visibleNotes.length}件）
-          </p>
-          <button
-            type="button"
-            onClick={() => setMonthIndex(currentIndex - 1)}
-            disabled={currentIndex <= 0}
-            className="px-2 py-1.5 text-xs font-bold text-zinc-400 disabled:opacity-40"
-          >
-            次の月
-          </button>
-        </div>
+      {pager.month ? (
+        <MonthPaginator
+          month={pager.month}
+          count={pager.items.length}
+          index={pager.index}
+          total={pager.months.length}
+          onChange={pager.goTo}
+        />
       ) : null}
       <Card className="pt-2 pb-8 px-6">
-        {visibleNotes.length > 0 ? (
-          visibleNotes.map((note) => <NoteListItem key={note.id} note={note} />)
+        {pager.items.length > 0 ? (
+          pager.items.map((note) => <NoteListItem key={note.id} note={note} />)
         ) : (
           <p className="text-sm text-zinc-400 text-center">
             {notes.length === 0

--- a/app/components/note/NoteListFilterBar.tsx
+++ b/app/components/note/NoteListFilterBar.tsx
@@ -3,6 +3,7 @@
 import type { NoteTag } from "@app/interface/baseballNoteV2";
 import type { NoteListFilterValues } from "@app/utils/noteListFilter";
 import FilterChipGroup from "@app/components/filter/FilterChipGroup";
+import RecordSearchFilterBar from "@app/components/filter/RecordSearchFilterBar";
 import {
   EMPTY_NOTE_FILTERS,
   hasActiveNoteFilter,
@@ -16,13 +17,7 @@ interface NoteListFilterBarProps {
   tags: NoteTag[];
 }
 
-/**
- * ノート一覧の絞り込みバー（フリーワード / 期間 / タグ）。
- *
- * 成績・試合一覧で使う FilterBar は「年・月粒度の単一選択ドロップダウン」専用で、
- * フリーワード・日単位の期間・複数選択タグを表現できないため、チップの並びだけ
- * FilterChipGroup を共有してノート専用のバーを組んでいる。
- */
+/** ノート一覧の絞り込みバー。共通の検索バーへタグチップを差し込んで組み立てる。 */
 export default function NoteListFilterBar({
   values,
   onChange,
@@ -37,61 +32,15 @@ export default function NoteListFilterBar({
     });
   };
 
-  // 開始日が終了日より後になると常に0件になるため、片方を動かしたらもう片方を寄せる。
-  const handleStartDate = (startDate: string) => {
-    const endDate =
-      values.endDate !== "" && startDate !== "" && values.endDate < startDate
-        ? startDate
-        : values.endDate;
-    onChange({ ...values, startDate, endDate });
-  };
-
-  const handleEndDate = (endDate: string) => {
-    const startDate =
-      values.startDate !== "" && endDate !== "" && values.startDate > endDate
-        ? endDate
-        : values.startDate;
-    onChange({ ...values, startDate, endDate });
-  };
-
   return (
-    <div className="space-y-3">
-      <input
-        type="search"
-        aria-label="ノートを検索"
-        placeholder="タイトル・本文・タグで検索"
-        value={values.keyword}
-        onChange={(event) =>
-          onChange({ ...values, keyword: event.target.value })
-        }
-        className="w-full rounded-lg bg-sub px-3 py-2 text-sm text-white placeholder:text-zinc-500"
-      />
-      <div className="flex flex-wrap items-center gap-2">
-        <input
-          type="date"
-          aria-label="開始日"
-          value={values.startDate}
-          onChange={(event) => handleStartDate(event.target.value)}
-          className="rounded-lg bg-sub px-3 py-2 text-sm text-white"
-        />
-        <span className="text-xs text-zinc-400">〜</span>
-        <input
-          type="date"
-          aria-label="終了日"
-          value={values.endDate}
-          onChange={(event) => handleEndDate(event.target.value)}
-          className="rounded-lg bg-sub px-3 py-2 text-sm text-white"
-        />
-        {hasActiveNoteFilter(values) ? (
-          <button
-            type="button"
-            onClick={() => onChange({ ...EMPTY_NOTE_FILTERS })}
-            className="px-2 py-1.5 text-xs font-medium text-[#A1A1AA]"
-          >
-            クリア
-          </button>
-        ) : null}
-      </div>
+    <RecordSearchFilterBar
+      values={values}
+      onChange={(next) => onChange({ ...values, ...next })}
+      onClear={() => onChange({ ...EMPTY_NOTE_FILTERS })}
+      showClear={hasActiveNoteFilter(values)}
+      searchLabel="ノートを検索"
+      searchPlaceholder="タイトル・本文・タグで検索"
+    >
       {tags.length > 0 ? (
         <FilterChipGroup wrap>
           {tags.map((tag) => (
@@ -111,6 +60,6 @@ export default function NoteListFilterBar({
           ))}
         </FilterChipGroup>
       ) : null}
-    </div>
+    </RecordSearchFilterBar>
   );
 }

--- a/app/hooks/records/__tests__/useMonthPager.test.ts
+++ b/app/hooks/records/__tests__/useMonthPager.test.ts
@@ -1,0 +1,75 @@
+import { act, renderHook } from "@testing-library/react";
+import { useMonthPager } from "@app/hooks/records/useMonthPager";
+
+interface Row {
+  id: number;
+  date: string;
+}
+
+const dateOf = (row: Row): string => row.date;
+
+const rows: Row[] = [
+  { id: 1, date: "2026-08-20" },
+  { id: 2, date: "2026-08-05" },
+  { id: 3, date: "2026-07-14" },
+];
+
+describe("useMonthPager", () => {
+  it("初期状態は最新の月を指す", () => {
+    const { result } = renderHook(() => useMonthPager(rows, dateOf));
+
+    expect(result.current.months).toEqual(["2026-08", "2026-07"]);
+    expect(result.current.month).toBe("2026-08");
+    expect(result.current.items.map((row) => row.id)).toEqual([1, 2]);
+  });
+
+  it("index を増やすと古い月へ進む", () => {
+    const { result } = renderHook(() => useMonthPager(rows, dateOf));
+
+    act(() => result.current.goTo(1));
+
+    expect(result.current.month).toBe("2026-07");
+    expect(result.current.items.map((row) => row.id)).toEqual([3]);
+  });
+
+  it("範囲外のページ番号は最古の月へ丸める", () => {
+    const { result } = renderHook(() => useMonthPager(rows, dateOf));
+
+    act(() => result.current.goTo(99));
+
+    expect(result.current.index).toBe(1);
+    expect(result.current.month).toBe("2026-07");
+    expect(result.current.items.map((row) => row.id)).toEqual([3]);
+  });
+
+  it("記録が減って月が消えても範囲外を指さない", () => {
+    const { result, rerender } = renderHook(
+      ({ items }: { items: Row[] }) => useMonthPager(items, dateOf),
+      { initialProps: { items: rows } },
+    );
+
+    act(() => result.current.goTo(1));
+    rerender({ items: rows.filter((row) => row.date.startsWith("2026-08")) });
+
+    expect(result.current.index).toBe(0);
+    expect(result.current.month).toBe("2026-08");
+    expect(result.current.items.map((row) => row.id)).toEqual([1, 2]);
+  });
+
+  it("reset で最新の月へ戻る", () => {
+    const { result } = renderHook(() => useMonthPager(rows, dateOf));
+
+    act(() => result.current.goTo(1));
+    act(() => result.current.reset());
+
+    expect(result.current.month).toBe("2026-08");
+  });
+
+  it("記録が0件なら月を持たない", () => {
+    const { result } = renderHook(() => useMonthPager([] as Row[], dateOf));
+
+    expect(result.current.months).toEqual([]);
+    expect(result.current.month).toBeNull();
+    expect(result.current.items).toEqual([]);
+  });
+});

--- a/app/hooks/records/useMonthPager.ts
+++ b/app/hooks/records/useMonthPager.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+import { collectMonths, itemsInMonth } from "@app/utils/recordListFilter";
+
+interface MonthPagerState<T> {
+  /** 記録がある年月（`YYYY-MM`）を新しい順に並べたもの。記録の無い月は挟まない。 */
+  months: string[];
+  /** 表示中の月の位置。0 が最新月。 */
+  index: number;
+  /** 表示中の年月。記録が1件も無ければ null。 */
+  month: string | null;
+  /** 表示中の月に属する記録。 */
+  items: T[];
+  goTo: (index: number) => void;
+  /** 最新月へ戻す。絞り込みを変えたときに呼ぶ。 */
+  reset: () => void;
+}
+
+/**
+ * 記録がある月だけを1ページとして送る月ページング。
+ *
+ * 絞り込みで月の並びが短くなっても範囲外を指さないよう、保持したページ番号は
+ * 描画時に丸める（state は書き換えないので、絞り込みを戻せば元のページに復帰する）。
+ */
+export function useMonthPager<T>(
+  items: T[],
+  dateOf: (item: T) => string,
+): MonthPagerState<T> {
+  const [index, setIndex] = useState(0);
+
+  const months = collectMonths(items, dateOf);
+  const safeIndex = Math.min(index, Math.max(months.length - 1, 0));
+  const month = months[safeIndex] ?? null;
+
+  return {
+    months,
+    index: safeIndex,
+    month,
+    items: month ? itemsInMonth(items, dateOf, month) : [],
+    goTo: setIndex,
+    reset: () => setIndex(0),
+  };
+}

--- a/app/services/v2/__tests__/practiceServices.test.ts
+++ b/app/services/v2/__tests__/practiceServices.test.ts
@@ -378,8 +378,14 @@ describe("練習ドメインの v2 Server Actions", () => {
       );
     });
 
-    it("他ユーザーのセッション（404）は error を返す", async () => {
+    it("他ユーザーのセッション（404）は取得失敗と区別して not_found を返す", async () => {
       mockResponse(404, {});
+
+      expect(await getPracticeSession(4)).toEqual({ status: "not_found" });
+    });
+
+    it("通信エラーは not_found と区別して error を返す", async () => {
+      mockResponse(500, {});
 
       expect(await getPracticeSession(4)).toEqual({ status: "error" });
     });

--- a/app/services/v2/practiceSessionService.ts
+++ b/app/services/v2/practiceSessionService.ts
@@ -6,9 +6,11 @@ import type {
 } from "@app/types/practice";
 import {
   type DeletedResponse,
+  type DetailFetchResult,
   type FetchResult,
   type MutationResult,
   buildQuery,
+  fetchDetailV2,
   fetchV2,
   mutateV2,
 } from "./requests";
@@ -42,11 +44,18 @@ export async function getPracticeSessions(
   );
 }
 
-/** 日次セッションを1件取得する（GET /api/v2/practice_sessions/:id）。他ユーザーのセッションは 404。 */
+/**
+ * 日次セッションを1件取得する（GET /api/v2/practice_sessions/:id）。
+ * back は current_user のセッションだけを引くため、他ユーザーのセッションも存在しない ID も
+ * 403 ではなく 404 になる。取得失敗と区別できるよう `not_found` として返す。
+ */
 export async function getPracticeSession(
   id: number,
-): Promise<FetchResult<PracticeSession>> {
-  return fetchV2<PracticeSession>(`${BASE_PATH}/${id}`, "getPracticeSession");
+): Promise<DetailFetchResult<PracticeSession>> {
+  return fetchDetailV2<PracticeSession>(
+    `${BASE_PATH}/${id}`,
+    "getPracticeSession",
+  );
 }
 
 /**

--- a/app/services/v2/requests.ts
+++ b/app/services/v2/requests.ts
@@ -71,6 +71,48 @@ export async function fetchV2<T>(
   }
 }
 
+/**
+ * 単一リソース取得系 Server Action の戻り値。
+ * 他ユーザーのリソースを 404 で隠す（存在自体を漏らさない）エンドポイント向けに、
+ * FetchResult へ `not_found` を足したもの。
+ * 「見つからない」を error に丸めると、リンク切れなのに「通信に失敗しました」と誤案内してしまう。
+ */
+export type DetailFetchResult<T> =
+  | { status: "ok"; data: T }
+  | { status: "forbidden" }
+  | { status: "not_found" }
+  | { status: "error" };
+
+/**
+ * v2 API の GET を叩き、404 を「見つからない」として区別して返す。
+ *
+ * @param path `/api/v2/...` から始まるパス（クエリを含めてよい）
+ * @param action Sentry に送るアクション名
+ */
+export async function fetchDetailV2<T>(
+  path: string,
+  action: string,
+): Promise<DetailFetchResult<T>> {
+  try {
+    const headers = await getAuthHeaders();
+    if (!headers) return { status: "error" };
+
+    const response = await fetch(`${RAILS_API_URL}${path}`, {
+      headers,
+      cache: "no-store",
+    });
+
+    if (response.status === 403) return { status: "forbidden" };
+    if (response.status === 404) return { status: "not_found" };
+    if (!response.ok) return { status: "error" };
+
+    return { status: "ok", data: (await response.json()) as T };
+  } catch (error) {
+    captureServerActionError(error, { action });
+    return { status: "error" };
+  }
+}
+
 interface MutateOptions {
   method: "POST" | "PATCH" | "DELETE";
   /** JSON 化して送るリクエストボディ。DELETE のように本文が無い場合は省略する。 */

--- a/app/utils/__tests__/noteListFilter.test.ts
+++ b/app/utils/__tests__/noteListFilter.test.ts
@@ -1,13 +1,16 @@
 import type { BaseballNoteV2, NoteTag } from "@app/interface/baseballNoteV2";
 import {
   EMPTY_NOTE_FILTERS,
-  collectNoteMonths,
   filterNotes,
-  formatMonthLabel,
   hasActiveNoteFilter,
-  notesInMonth,
+  noteDate,
 } from "@app/utils/noteListFilter";
 import { buildMemoJson } from "@app/utils/noteMemo";
+import {
+  collectMonths,
+  formatMonthLabel,
+  itemsInMonth,
+} from "@app/utils/recordListFilter";
 
 const battingTag: NoteTag = { id: 1, name: "打撃", is_preset: true };
 const mentalTag: NoteTag = { id: 2, name: "メンタル", is_preset: false };
@@ -190,13 +193,13 @@ describe("月次ページングの補助", () => {
   ];
 
   it("ノートのある年月を新しい順に重複なく並べる", () => {
-    expect(collectNoteMonths(notes)).toEqual(["2026-08", "2026-06"]);
+    expect(collectMonths(notes, noteDate)).toEqual(["2026-08", "2026-06"]);
   });
 
   it("指定した年月のノートだけを取り出す", () => {
-    expect(notesInMonth(notes, "2026-08").map((note) => note.id)).toEqual([
-      1, 3,
-    ]);
+    expect(
+      itemsInMonth(notes, noteDate, "2026-08").map((note) => note.id),
+    ).toEqual([1, 3]);
   });
 
   it("年月を日本語表記にする", () => {

--- a/app/utils/__tests__/recordListFilter.test.ts
+++ b/app/utils/__tests__/recordListFilter.test.ts
@@ -1,0 +1,166 @@
+import {
+  EMPTY_RECORD_SEARCH,
+  alignDateRange,
+  collectMonths,
+  formatMonthCountLabel,
+  formatMonthLabel,
+  groupByMonth,
+  hasActiveRecordSearch,
+  itemsInMonth,
+  matchesDateRange,
+  matchesKeyword,
+  toDay,
+} from "@app/utils/recordListFilter";
+
+interface Row {
+  id: number;
+  date: string;
+}
+
+const dateOf = (row: Row): string => row.date;
+
+describe("hasActiveRecordSearch", () => {
+  it("何も入っていなければ false", () => {
+    expect(hasActiveRecordSearch(EMPTY_RECORD_SEARCH)).toBe(false);
+  });
+
+  it("空白だけのキーワードは絞り込みとみなさない", () => {
+    expect(
+      hasActiveRecordSearch({ ...EMPTY_RECORD_SEARCH, keyword: "   " }),
+    ).toBe(false);
+  });
+
+  it.each([
+    ["キーワード", { keyword: "素振り" }],
+    ["開始日", { startDate: "2026-07-01" }],
+    ["終了日", { endDate: "2026-07-31" }],
+  ])("%s が入っていれば true", (_label, values) => {
+    expect(hasActiveRecordSearch({ ...EMPTY_RECORD_SEARCH, ...values })).toBe(
+      true,
+    );
+  });
+});
+
+describe("matchesDateRange", () => {
+  it("開始日はその日を含む", () => {
+    const range = { startDate: "2026-07-14", endDate: "" };
+
+    expect(matchesDateRange("2026-07-14", range)).toBe(true);
+    expect(matchesDateRange("2026-07-13", range)).toBe(false);
+  });
+
+  it("終了日はその日を含む", () => {
+    const range = { startDate: "", endDate: "2026-07-14" };
+
+    expect(matchesDateRange("2026-07-14", range)).toBe(true);
+    expect(matchesDateRange("2026-07-15", range)).toBe(false);
+  });
+
+  it("時刻付きの値でも日付だけで比較する", () => {
+    expect(
+      matchesDateRange("2026-07-14T23:00:00+09:00", {
+        startDate: "2026-07-14",
+        endDate: "2026-07-14",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("matchesKeyword", () => {
+  it("空のキーワードは常に一致とみなす", () => {
+    expect(matchesKeyword(["素振り"], "  ")).toBe(true);
+  });
+
+  it("いずれかの断片に含まれれば一致する", () => {
+    expect(matchesKeyword(["素振り", "外角が詰まる"], "外角")).toBe(true);
+    expect(matchesKeyword(["素振り", "外角が詰まる"], "内角")).toBe(false);
+  });
+
+  it("大文字小文字は区別しない", () => {
+    expect(matchesKeyword(["Long Toss"], "long")).toBe(true);
+  });
+});
+
+describe("alignDateRange", () => {
+  it("開始日を終了日より後にすると終了日を寄せる", () => {
+    expect(
+      alignDateRange(
+        { keyword: "", startDate: "", endDate: "2026-07-10" },
+        "startDate",
+        "2026-07-20",
+      ),
+    ).toEqual({ keyword: "", startDate: "2026-07-20", endDate: "2026-07-20" });
+  });
+
+  it("終了日を開始日より前にすると開始日を寄せる", () => {
+    expect(
+      alignDateRange(
+        { keyword: "", startDate: "2026-07-20", endDate: "" },
+        "endDate",
+        "2026-07-10",
+      ),
+    ).toEqual({ keyword: "", startDate: "2026-07-10", endDate: "2026-07-10" });
+  });
+
+  it("矛盾しない変更はもう片方を触らない", () => {
+    expect(
+      alignDateRange(
+        { keyword: "", startDate: "2026-07-01", endDate: "2026-07-31" },
+        "startDate",
+        "2026-07-10",
+      ),
+    ).toEqual({
+      keyword: "",
+      startDate: "2026-07-10",
+      endDate: "2026-07-31",
+    });
+  });
+});
+
+describe("月の集計", () => {
+  const rows: Row[] = [
+    { id: 1, date: "2026-08-10" },
+    { id: 2, date: "2026-06-02" },
+    { id: 3, date: "2026-08-01" },
+  ];
+
+  it("記録がある年月を新しい順に重複なく並べる", () => {
+    expect(collectMonths(rows, dateOf)).toEqual(["2026-08", "2026-06"]);
+  });
+
+  it("指定した年月の記録だけを取り出す", () => {
+    expect(itemsInMonth(rows, dateOf, "2026-08").map((row) => row.id)).toEqual([
+      1, 3,
+    ]);
+  });
+
+  it("並び順を保ったまま年月ごとにまとめる", () => {
+    const sorted: Row[] = [
+      { id: 1, date: "2026-08-10" },
+      { id: 3, date: "2026-08-01" },
+      { id: 2, date: "2026-06-02" },
+    ];
+
+    expect(
+      groupByMonth(sorted, dateOf).map((group) => [
+        group.month,
+        group.items.map((row) => row.id),
+      ]),
+    ).toEqual([
+      ["2026-08", [1, 3]],
+      ["2026-06", [2]],
+    ]);
+  });
+
+  it("年月を日本語表記にする", () => {
+    expect(formatMonthLabel("2026-08")).toBe("2026年8月");
+  });
+
+  it("月ページャの見出しに件数を添える", () => {
+    expect(formatMonthCountLabel("2026-07", 3)).toBe("2026年7月（3件）");
+  });
+
+  it("時刻付きの値からも日付を取り出せる", () => {
+    expect(toDay("2026-07-14T10:00:00+09:00")).toBe("2026-07-14");
+  });
+});

--- a/app/utils/noteListFilter.ts
+++ b/app/utils/noteListFilter.ts
@@ -1,44 +1,39 @@
 import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
 import { extractMemoText } from "@app/utils/noteMemo";
 import { tagLabel } from "@app/utils/noteTags";
+import {
+  type RecordSearchValues,
+  EMPTY_RECORD_SEARCH,
+  hasActiveRecordSearch,
+  matchesDateRange,
+  matchesKeyword,
+  toDay,
+} from "@app/utils/recordListFilter";
 
 // back の GET /api/v2/baseball_notes は date / practice_log_id / practice_session_id /
 // game_result_id / improvement_theme_id しか絞り込めず、全文検索・日付レンジ・タグ絞り込み・
 // ページングのパラメータを持たない。そのため一覧側の検索と絞り込みは取得済みの
-// レスポンスに対してクライアントで行う。
+// レスポンスに対してクライアントで行う（日付レンジ・月分割は recordListFilter と共通）。
 
 /** ノート一覧の絞り込み条件。すべて「空」が絞り込まないことを表す。 */
-export interface NoteListFilterValues {
-  /** タイトル / 本文 / タグを横断するフリーワード。 */
-  keyword: string;
-  /** 期間の開始日 `YYYY-MM-DD`。この日を含む。 */
-  startDate: string;
-  /** 期間の終了日 `YYYY-MM-DD`。この日を含む。 */
-  endDate: string;
+export interface NoteListFilterValues extends RecordSearchValues {
   /** 選択したタグ ID。複数選ぶと「すべて持つノート」に絞られる（AND）。 */
   tagIds: number[];
 }
 
 export const EMPTY_NOTE_FILTERS: NoteListFilterValues = {
-  keyword: "",
-  startDate: "",
-  endDate: "",
+  ...EMPTY_RECORD_SEARCH,
   tagIds: [],
 };
 
 /** 絞り込みが1つでも掛かっているか（クリアボタンの表示判定に使う）。 */
 export function hasActiveNoteFilter(values: NoteListFilterValues): boolean {
-  return (
-    values.keyword.trim() !== "" ||
-    values.startDate !== "" ||
-    values.endDate !== "" ||
-    values.tagIds.length > 0
-  );
+  return hasActiveRecordSearch(values) || values.tagIds.length > 0;
 }
 
-/** `YYYY-MM-DD` 部分だけを取り出す（back が時刻付きで返した場合も比較できるようにする）。 */
-function noteDay(note: BaseballNoteV2): string {
-  return note.date.slice(0, 10);
+/** ノートの日付（`YYYY-MM-DD`）。月の収集・抽出に渡す。 */
+export function noteDate(note: BaseballNoteV2): string {
+  return toDay(note.date);
 }
 
 /**
@@ -46,10 +41,10 @@ function noteDay(note: BaseballNoteV2): string {
  * memo 全文から抽出し、プレビューに載らない後半も検索できるようにする。
  * タグは `#` 付きでも打てるよう両方の表記を含める。
  */
-function searchHaystack(note: BaseballNoteV2): string {
+function searchParts(note: BaseballNoteV2): string[] {
   const memoText = extractMemoText(note.memo) || note.memo_preview;
   const tagTexts = note.tags.flatMap((tag) => [tag.name, tagLabel(tag.name)]);
-  return [note.title ?? "", memoText, ...tagTexts].join("\n").toLowerCase();
+  return [note.title ?? "", memoText, ...tagTexts];
 }
 
 /**
@@ -62,37 +57,13 @@ export function filterNotes(
   notes: BaseballNoteV2[],
   values: NoteListFilterValues,
 ): BaseballNoteV2[] {
-  const keyword = values.keyword.trim().toLowerCase();
-
   return notes.filter((note) => {
-    if (keyword !== "" && !searchHaystack(note).includes(keyword)) return false;
-    const day = noteDay(note);
-    if (values.startDate !== "" && day < values.startDate) return false;
-    if (values.endDate !== "" && day > values.endDate) return false;
+    if (!matchesKeyword(searchParts(note), values.keyword)) return false;
+    if (!matchesDateRange(note.date, values)) return false;
     if (values.tagIds.length > 0) {
       const noteTagIds = note.tags.map((tag) => tag.id);
       if (!values.tagIds.every((id) => noteTagIds.includes(id))) return false;
     }
     return true;
   });
-}
-
-/** ノートが存在する年月（`YYYY-MM`）を新しい順に重複なく並べる。 */
-export function collectNoteMonths(notes: BaseballNoteV2[]): string[] {
-  const months = new Set(notes.map((note) => noteDay(note).slice(0, 7)));
-  return Array.from(months).sort((a, b) => (a < b ? 1 : -1));
-}
-
-/** 指定した年月（`YYYY-MM`）のノートだけを取り出す。 */
-export function notesInMonth(
-  notes: BaseballNoteV2[],
-  month: string,
-): BaseballNoteV2[] {
-  return notes.filter((note) => noteDay(note).startsWith(month));
-}
-
-/** `YYYY-MM` を「2026年8月」形式にする。 */
-export function formatMonthLabel(month: string): string {
-  const [year, monthNumber] = month.split("-");
-  return `${Number(year)}年${Number(monthNumber)}月`;
 }

--- a/app/utils/recordListFilter.ts
+++ b/app/utils/recordListFilter.ts
@@ -1,0 +1,137 @@
+/**
+ * 記録系一覧（練習記録 / 野球ノート）に共通する、日付をキーにした絞り込みユーティリティ。
+ *
+ * back の一覧エンドポイント（`GET /api/v2/baseball_notes` / `GET /api/v2/practice_sessions`）は
+ * フリーワード検索とページングのパラメータを持たず、練習セッションの `from` / `to` も
+ * 日付レンジを1往復ごとに再取得する形でしか使えない。一覧は全件を1回で取得して
+ * クライアント側で検索・レンジ・月分割を行うため、その計算をここへ集約する。
+ */
+
+/** フリーワードと日付レンジ。すべて空文字が「絞り込まない」を表す。 */
+export interface RecordSearchValues {
+  keyword: string;
+  /** 期間の開始日 `YYYY-MM-DD`。この日を含む。 */
+  startDate: string;
+  /** 期間の終了日 `YYYY-MM-DD`。この日を含む。 */
+  endDate: string;
+}
+
+export const EMPTY_RECORD_SEARCH: RecordSearchValues = {
+  keyword: "",
+  startDate: "",
+  endDate: "",
+};
+
+/** back が時刻付きで返した場合も日付だけで比較できるよう `YYYY-MM-DD` に切り詰める。 */
+export function toDay(value: string): string {
+  return value.slice(0, 10);
+}
+
+/** 検索語・日付レンジのいずれかが入っているか。 */
+export function hasActiveRecordSearch(values: RecordSearchValues): boolean {
+  return (
+    values.keyword.trim() !== "" ||
+    values.startDate !== "" ||
+    values.endDate !== ""
+  );
+}
+
+/** 日付レンジに収まるか。開始日・終了日ともに **その日を含む**。 */
+export function matchesDateRange(
+  date: string,
+  values: Pick<RecordSearchValues, "startDate" | "endDate">,
+): boolean {
+  const day = toDay(date);
+  if (values.startDate !== "" && day < values.startDate) return false;
+  if (values.endDate !== "" && day > values.endDate) return false;
+  return true;
+}
+
+/**
+ * 検索対象のテキスト片を連結して検索語を含むか判定する。
+ * 大文字小文字は区別せず、検索語が空なら常に一致とみなす。
+ */
+export function matchesKeyword(parts: string[], keyword: string): boolean {
+  const term = keyword.trim().toLowerCase();
+  if (term === "") return true;
+  return parts.join("\n").toLowerCase().includes(term);
+}
+
+/**
+ * 開始日・終了日の一方を動かしたときに、もう一方を矛盾しない値へ寄せる。
+ * 開始日が終了日より後の状態は常に0件になり、ユーザーには不具合に見えるため許さない。
+ */
+export function alignDateRange(
+  values: RecordSearchValues,
+  changed: "startDate" | "endDate",
+  next: string,
+): RecordSearchValues {
+  if (changed === "startDate") {
+    const endDate =
+      values.endDate !== "" && next !== "" && values.endDate < next
+        ? next
+        : values.endDate;
+    return { ...values, startDate: next, endDate };
+  }
+  const startDate =
+    values.startDate !== "" && next !== "" && values.startDate > next
+      ? next
+      : values.startDate;
+  return { ...values, startDate, endDate: next };
+}
+
+/** 記録が存在する年月（`YYYY-MM`）を新しい順に重複なく並べる。 */
+export function collectMonths<T>(
+  items: T[],
+  dateOf: (item: T) => string,
+): string[] {
+  const months = new Set(items.map((item) => toDay(dateOf(item)).slice(0, 7)));
+  return Array.from(months).sort((a, b) => (a < b ? 1 : -1));
+}
+
+/** 指定した年月（`YYYY-MM`）の記録だけを取り出す。 */
+export function itemsInMonth<T>(
+  items: T[],
+  dateOf: (item: T) => string,
+  month: string,
+): T[] {
+  return items.filter((item) => toDay(dateOf(item)).startsWith(month));
+}
+
+/** 月見出し付きで描画するための、年月ごとのまとまり。並びは元の配列順（新しい順）を保つ。 */
+export interface MonthGroup<T> {
+  month: string;
+  items: T[];
+}
+
+/**
+ * 記録を年月ごとにまとめる。並び順は入力の順序（back は日付の新しい順で返す）に従い、
+ * ここで並べ替えはしない。
+ */
+export function groupByMonth<T>(
+  items: T[],
+  dateOf: (item: T) => string,
+): MonthGroup<T>[] {
+  const groups: MonthGroup<T>[] = [];
+  items.forEach((item) => {
+    const month = toDay(dateOf(item)).slice(0, 7);
+    const last = groups[groups.length - 1];
+    if (last && last.month === month) {
+      last.items.push(item);
+      return;
+    }
+    groups.push({ month, items: [item] });
+  });
+  return groups;
+}
+
+/** `YYYY-MM` を「2026年8月」形式にする。 */
+export function formatMonthLabel(month: string): string {
+  const [year, monthNumber] = month.split("-");
+  return `${Number(year)}年${Number(monthNumber)}月`;
+}
+
+/** 月ページャの見出し「2026年8月（3件）」。件数は絞り込み後のその月の件数。 */
+export function formatMonthCountLabel(month: string, count: number): string {
+  return `${formatMonthLabel(month)}（${count}件）`;
+}


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#471

## 概要

mobile の `app/(records)/list.tsx`（練習タブ）と `app/(practice-record)/[id].tsx` 相当を実装します。

## フィルタ基盤を共通化しました

#476（ノート一覧）が持っていた検索・日付レンジ・月ページングの実装を**再実装せず共通化**し、**ノート側も新しい共通実装に載せ替えました**。

| 切り出したもの | 責務 |
| --- | --- |
| `app/utils/recordListFilter.ts` | 日付レンジ判定（両端含む）/ キーワード一致 / 月の収集・抽出・グルーピング |
| `app/components/filter/RecordSearchFilterBar.tsx` | 検索欄 + 開始日/終了日 + クリア（`children` で画面固有チップを差し込み） |
| `app/components/filter/MonthPaginator.tsx` | ◀「2026年7月（3件）」▶ |
| `app/hooks/records/useMonthPager.ts` | 月ページ状態 |

ノート側の `noteListFilter.ts` は共通実装へ委譲し（タグ AND 絞り込みだけ固有）、既存テストのアサーションは変えずに import だけ差し替えています。

「未フィルタ＝月ページング / フィルタ時＝全期間を月見出し」の出し分けは練習記録固有なので、ボード自体は共通化していません。

## back の契約で判明した点

**`practice_sessions#index` も検索・ページングのパラメータを持ちません**（`from` / `to` / `improvement_theme_id` の3つのみ）。#476 と同じくクライアント実装が必要でした。

**詳細は他人のセッションも存在しない ID も 404**（403 ではない）です。`current_api_v1_user.practice_sessions.find` のため。403 を区別する既存の `FetchResult` に `not_found` を足すと全消費側に影響が出るため、**404 を区別したいエンドポイント専用の `fetchDetailV2` / `DetailFetchResult` を追加**しました。

**削除時に何が消えるか**を実際の `dependent:` 指定から確認し、確認モーダルの文言に反映しています。

- `practice_logs` → `dependent: :destroy`（**その日の練習ログは全部消える**）
- `baseball_notes` → `dependent: :nullify`（**ノートは残り紐付けだけ外れる**）
- `condition_logs` → dependent 指定なし（**消えない**）

文言:「この日に記録した練習メニューのログもすべて削除されます。紐づく野球ノートとコンディションの記録は削除されず、練習記録との紐付けだけが外れます。」

## 検索が横断する6対象

`practiceSessionSearchParts()` で以下を集約しています。**日付は `2026-07-14` と `7月14日(火)` の両方**で引けます。

1. 日付（ISO と日本語表記の両方） 2. セッションメモ 3. コンディションメモ 4. 気分 5. 怪我部位 6. メニュー名

各対象1件ずつの単体テストに加え、**成分を除去するミューテーション6件**で担保しています。

## レビューで確認いただきたい点

1. **「メニュー別の積み上げを見る」の遷移先 `/practice/summary` は #473 で実装されるルートで、現時点ではリンク切れです。** 同一リリースブランチに載る想定でそのまま出しています。先に出したくなければ #473 マージまで外す判断もあり得ます
2. **タブを state ではなくリンク（`?tab=`）にしました**（Server Component 優先 / URL 共有可能）。mobile はローカル state です
3. **Pro ユーザーでコンディション未記録の場合はサンプルを出さず**「この日のコンディションは記録されていません。」としています（サンプルは無料ユーザーのオーバーレイ時のみ）
4. 月ページャは mobile と揃えて「絞り込み前の全セッション」を対象にし、絞り込み中はページャ自体を出しません

## チェックリスト

- [x] `yarn typecheck` / `yarn lint` / `yarn format:check` が通る
- [x] `yarn test` が通る（**140 suites / 1580 tests**。+7 suites / +101 tests）
- [x] `yarn build` が通る（**ローカルで実行済み**）
- [x] ミューテーションテスト **40 設計 / 39 KILLED / 1 SURVIVED（等価変異）**

### ルート表

base（`43e5ac7`）も同条件でビルドして diff を取得しました。

- base: 静的 87 / 動的 45
- HEAD: 静的 87 / 動的 47
- **追加は `/practice/records`・`/practice/records/[id]` の2件のみ。既存ルートの分類変更・削除は0件**

<details>
<summary>ミューテーションテスト詳細</summary>

隔離複製で実施（無改変で全 pass を確認後に開始、検証後に削除）。

検索6対象の各成分を除去6件 / 日付レンジ境界 / フィルタ時に月ページングのままにする / フィルタ変更で月をリセットしない / 月の並び・送り方向 / 件数表示 / 日付形式 / `formatPracticeValue` を通さない / `parseDecimal` を通さない / オーバーレイ表示条件反転 / 削除確認スキップ / 0件と取得失敗の取り違え / API パス・メソッド など。

**SURVIVED 1件は等価変異です**: 「日付を `new Date("YYYY-MM-DD")`（UTC 解釈）に戻す」— jest は `TZ=Asia/Tokyo` 固定で、+09:00 では UTC 深夜も同じ暦日になるため観測できません（負の UTC オフセット環境でのみ日付がずれる）。防御としてローカル日付解釈は残しています。

**初回に2件 SURVIVED**（月ページの範囲丸め / `parseDecimal` 未通過）→ `useMonthPager` の単体テスト追加と、睡眠時間の fixture を `"7.0"` にして「睡眠 7時間」と表示されることを検証するテストに修正して kill しました。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_