### PR TITLE
Add: メニューセット（練習プランセット）の CRUD を実装

### DIFF
--- a/app/(app)/practice/menu-sets/[id]/__tests__/MenuSetDetailContent.test.tsx
+++ b/app/(app)/practice/menu-sets/[id]/__tests__/MenuSetDetailContent.test.tsx
@@ -1,0 +1,178 @@
+const mockPush = jest.fn();
+const mockRefresh = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@app/services/v2/menuSetService", () => ({
+  deleteMenuSet: jest.fn(),
+}));
+
+import type { MenuSet } from "@app/types/menuSet";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { deleteMenuSet } from "@app/services/v2/menuSetService";
+import MenuSetDetailContent from "../_components/MenuSetDetailContent";
+
+const mockDelete = deleteMenuSet as jest.MockedFunction<typeof deleteMenuSet>;
+
+function buildMenuSet(overrides: Partial<MenuSet> = {}): MenuSet {
+  return {
+    id: 7,
+    name: "オフ日ルーティン",
+    note: null,
+    sort_order: 0,
+    items: [
+      {
+        practice_menu_id: 1,
+        name: "素振り",
+        unit_label: "本",
+        target_value: 200,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("MenuSetDetailContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("表示", () => {
+    it("メニューを「素振り 200本」形式で表示する", () => {
+      render(<MenuSetDetailContent menuSet={buildMenuSet()} />);
+
+      expect(screen.getByText("素振り 200本")).toBeVisible();
+    });
+
+    it("目標量が decimal 文字列で届いても数値に整形して表示する", () => {
+      render(
+        <MenuSetDetailContent
+          menuSet={buildMenuSet({
+            items: [
+              {
+                practice_menu_id: 1,
+                name: "素振り",
+                unit_label: "本",
+                // back の float / decimal は文字列で届くことがある。
+                target_value: "200.0" as unknown as number,
+              },
+            ],
+          })}
+        />,
+      );
+
+      expect(screen.getByText("素振り 200本")).toBeVisible();
+      expect(screen.queryByText(/200\.0/)).toBeNull();
+    });
+
+    it("目標量が未設定のメニューは名前だけを表示する", () => {
+      render(
+        <MenuSetDetailContent
+          menuSet={buildMenuSet({
+            items: [
+              {
+                practice_menu_id: 2,
+                name: "ストレッチ",
+                unit_label: "分",
+                target_value: null,
+              },
+            ],
+          })}
+        />,
+      );
+
+      expect(screen.getByText("ストレッチ")).toBeVisible();
+    });
+
+    it("セット名とメモを表示する", () => {
+      render(
+        <MenuSetDetailContent
+          menuSet={buildMenuSet({ note: "試合前日の軽め調整" })}
+        />,
+      );
+
+      expect(
+        screen.getByRole("heading", { name: "オフ日ルーティン" }),
+      ).toBeVisible();
+      expect(screen.getByText("試合前日の軽め調整")).toBeVisible();
+    });
+
+    it("メモが無いときはメモの見出しごと出さない", () => {
+      render(<MenuSetDetailContent menuSet={buildMenuSet({ note: null })} />);
+
+      expect(screen.queryByRole("heading", { name: "メモ" })).toBeNull();
+    });
+
+    it("メニュー未設定のセットはその旨を表示する", () => {
+      render(<MenuSetDetailContent menuSet={buildMenuSet({ items: [] })} />);
+
+      expect(screen.getByText("メニュー未設定")).toBeVisible();
+    });
+
+    it("編集画面への導線を持つ", () => {
+      render(<MenuSetDetailContent menuSet={buildMenuSet({ id: 42 })} />);
+
+      expect(screen.getByRole("button", { name: "編集" })).toHaveAttribute(
+        "href",
+        "/practice/menu-sets/42/edit",
+      );
+    });
+  });
+
+  describe("削除", () => {
+    it("確認を経てから削除し、一覧へ戻る", async () => {
+      const user = userEvent.setup();
+      mockDelete.mockResolvedValue({
+        ok: true,
+        data: { message: "削除しました" },
+      });
+      render(<MenuSetDetailContent menuSet={buildMenuSet({ id: 7 })} />);
+
+      await user.click(screen.getByRole("button", { name: "削除" }));
+
+      expect(
+        screen.getByText("「オフ日ルーティン」を削除しますか？"),
+      ).toBeInTheDocument();
+      expect(mockDelete).not.toHaveBeenCalled();
+
+      await user.click(
+        screen.getAllByRole("button", { name: "削除" }).at(-1) as HTMLElement,
+      );
+
+      await waitFor(() => expect(mockDelete).toHaveBeenCalledWith(7));
+      await waitFor(() =>
+        expect(mockPush).toHaveBeenCalledWith("/practice/menu-sets"),
+      );
+    });
+
+    it("確認をキャンセルすると削除しない", async () => {
+      const user = userEvent.setup();
+      render(<MenuSetDetailContent menuSet={buildMenuSet()} />);
+
+      await user.click(screen.getByRole("button", { name: "削除" }));
+      await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it("削除確認では紐付いた予定が残ることを伝える", async () => {
+      const user = userEvent.setup();
+      render(<MenuSetDetailContent menuSet={buildMenuSet()} />);
+
+      await user.click(screen.getByRole("button", { name: "削除" }));
+
+      expect(
+        screen.getByText(
+          "このセットを使っている予定は削除されず、メニューの紐付けだけが外れます。",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/app/(app)/practice/menu-sets/[id]/_components/MenuSetDetailContent.tsx
+++ b/app/(app)/practice/menu-sets/[id]/_components/MenuSetDetailContent.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import type { MenuSet } from "@app/types/menuSet";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import { deleteMenuSet } from "@app/services/v2/menuSetService";
+import {
+  CANCEL_LABEL,
+  DELETE_CONFIRM_TITLE,
+  DELETE_KEEPS_SCHEDULES_NOTICE,
+  DELETE_LABEL,
+  DETAIL_MENU_SECTION_TITLE,
+  DETAIL_NOTE_SECTION_TITLE,
+  EDIT_LABEL,
+  ITEMS_EMPTY,
+} from "../../_components/menuSetCopy";
+import { formatMenuSetItem } from "../../_utils/menuSetDisplay";
+
+interface MenuSetDetailContentProps {
+  menuSet: MenuSet;
+}
+
+/**
+ * メニューセット詳細の Container。
+ * セットの中身の表示と、編集への導線・削除の確認を担う。
+ */
+export default function MenuSetDetailContent({
+  menuSet,
+}: MenuSetDetailContentProps) {
+  const router = useRouter();
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    const result = await deleteMenuSet(menuSet.id);
+    setIsDeleting(false);
+
+    if (!result.ok) {
+      toast.error(result.errors[0]);
+      return;
+    }
+    toast.success("メニューセットを削除しました");
+    router.push("/practice/menu-sets");
+    router.refresh();
+  };
+
+  return (
+    <>
+      <h2 className="break-words text-xl font-bold text-white">
+        {menuSet.name}
+      </h2>
+
+      <section className="mt-6">
+        <h3 className="mb-2 text-sm font-bold text-zinc-400">
+          {DETAIL_MENU_SECTION_TITLE}
+        </h3>
+        {menuSet.items.length === 0 ? (
+          <p className="text-sm text-zinc-400">{ITEMS_EMPTY}</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {menuSet.items.map((item) => (
+              <li
+                key={item.practice_menu_id}
+                className="rounded-[10px] bg-sub px-3.5 py-3 text-sm text-white"
+              >
+                {formatMenuSetItem(item)}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {menuSet.note ? (
+        <section className="mt-6">
+          <h3 className="mb-2 text-sm font-bold text-zinc-400">
+            {DETAIL_NOTE_SECTION_TITLE}
+          </h3>
+          <p className="whitespace-pre-wrap text-sm text-white">
+            {menuSet.note}
+          </p>
+        </section>
+      ) : null}
+
+      <div className="mt-8 flex gap-3">
+        <Button
+          as={Link}
+          href={`/practice/menu-sets/${menuSet.id}/edit`}
+          variant="flat"
+          radius="sm"
+          className="flex-1"
+        >
+          {EDIT_LABEL}
+        </Button>
+        <Button
+          color="danger"
+          variant="flat"
+          radius="sm"
+          className="flex-1"
+          onPress={() => setIsDeleteOpen(true)}
+        >
+          {DELETE_LABEL}
+        </Button>
+      </div>
+
+      <Modal
+        isOpen={isDeleteOpen}
+        onClose={() => setIsDeleteOpen(false)}
+        placement="center"
+        className="buzz-dark"
+      >
+        <ModalContent>
+          <ModalHeader className="text-white">
+            {DELETE_CONFIRM_TITLE}
+          </ModalHeader>
+          <ModalBody>
+            <p className="text-sm text-white">
+              「{menuSet.name}」を削除しますか？
+            </p>
+            <p className="text-xs text-zinc-400">
+              {DELETE_KEEPS_SCHEDULES_NOTICE}
+            </p>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="flat"
+              onPress={() => setIsDeleteOpen(false)}
+              isDisabled={isDeleting}
+            >
+              {CANCEL_LABEL}
+            </Button>
+            <Button
+              color="danger"
+              onPress={handleDelete}
+              isDisabled={isDeleting}
+              isLoading={isDeleting}
+            >
+              {DELETE_LABEL}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/app/(app)/practice/menu-sets/[id]/edit/page.tsx
+++ b/app/(app)/practice/menu-sets/[id]/edit/page.tsx
@@ -1,0 +1,55 @@
+import { cookies } from "next/headers";
+import { notFound, redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getMenuSet } from "@app/services/v2/menuSetService";
+import { getPracticeMenus } from "@app/services/v2/practiceMenuService";
+import { EDIT_PAGE_TITLE, LOAD_ERROR } from "../../_components/menuSetCopy";
+import MenuSetFormContent from "../../_components/MenuSetFormContent";
+
+export const metadata = {
+  title: "セットを編集",
+};
+
+export default async function EditMenuSetPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const { id } = await params;
+  const menuSetId = Number(id);
+  if (!Number.isInteger(menuSetId)) notFound();
+
+  const [menuSetResult, menusResult] = await Promise.all([
+    getMenuSet(menuSetId),
+    getPracticeMenus(),
+  ]);
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            <h2 className="mb-6 text-2xl font-bold">{EDIT_PAGE_TITLE}</h2>
+            {menuSetResult.status === "ok" ? (
+              <MenuSetFormContent
+                menuSet={menuSetResult.data}
+                menus={menusResult.status === "ok" ? menusResult.data : []}
+              />
+            ) : (
+              // 取得失敗を空のフォームに丸めると、items 全置換で既存の中身を消してしまう。
+              <p className="py-8 text-center text-sm text-zinc-400">
+                {LOAD_ERROR}
+              </p>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/(app)/practice/menu-sets/[id]/page.tsx
+++ b/app/(app)/practice/menu-sets/[id]/page.tsx
@@ -1,0 +1,48 @@
+import { cookies } from "next/headers";
+import { notFound, redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getMenuSet } from "@app/services/v2/menuSetService";
+import { LOAD_ERROR } from "../_components/menuSetCopy";
+import MenuSetDetailContent from "./_components/MenuSetDetailContent";
+
+export const metadata = {
+  title: "セットの詳細",
+};
+
+export default async function MenuSetDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const { id } = await params;
+  const menuSetId = Number(id);
+  if (!Number.isInteger(menuSetId)) notFound();
+
+  const result = await getMenuSet(menuSetId);
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            {result.status === "ok" ? (
+              <MenuSetDetailContent menuSet={result.data} />
+            ) : (
+              // 404（削除済み・他ユーザーのセット）も通信断も status:"error" に落ちるため、
+              // notFound() には倒さず再試行を促す文言にする。
+              <p className="py-8 text-center text-sm text-zinc-400">
+                {LOAD_ERROR}
+              </p>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/(app)/practice/menu-sets/__tests__/MenuSetFormContent.test.tsx
+++ b/app/(app)/practice/menu-sets/__tests__/MenuSetFormContent.test.tsx
@@ -1,0 +1,377 @@
+const mockPush = jest.fn();
+const mockRefresh = jest.fn();
+const mockBack = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh, back: mockBack }),
+}));
+
+const mockOpenProUpgradeModal = jest.fn();
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({
+    open: mockOpenProUpgradeModal,
+    close: jest.fn(),
+  }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@app/services/v2/menuSetService", () => ({
+  createMenuSet: jest.fn(),
+  updateMenuSet: jest.fn(),
+}));
+
+import type { MenuSet } from "@app/types/menuSet";
+import type { PracticeMenu } from "@app/types/practice";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMenuSet, updateMenuSet } from "@app/services/v2/menuSetService";
+import MenuSetFormContent from "../_components/MenuSetFormContent";
+
+const mockCreate = createMenuSet as jest.MockedFunction<typeof createMenuSet>;
+const mockUpdate = updateMenuSet as jest.MockedFunction<typeof updateMenuSet>;
+
+const menus: PracticeMenu[] = [
+  {
+    id: 1,
+    name: "素振り",
+    category: "batting",
+    unit: "count",
+    unit_label: "本",
+    default_value: "200.0",
+    is_favorite: false,
+    sort_order: 1,
+  },
+  {
+    id: 2,
+    name: "ティー",
+    category: "batting",
+    unit: "count",
+    unit_label: "本",
+    default_value: null,
+    is_favorite: false,
+    sort_order: 2,
+  },
+  {
+    id: 3,
+    name: "ランニング",
+    category: "training",
+    unit: "distance",
+    unit_label: "km",
+    default_value: "5.0",
+    is_favorite: false,
+    sort_order: 3,
+  },
+];
+
+function buildMenuSet(overrides: Partial<MenuSet> = {}): MenuSet {
+  return {
+    id: 7,
+    name: "オフ日ルーティン",
+    note: null,
+    sort_order: 0,
+    items: [],
+    ...overrides,
+  };
+}
+
+const savedMenuSet = buildMenuSet({ id: 7 });
+
+describe("MenuSetFormContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("作成", () => {
+    it("セット名・メモ・メニューを指定して作成できる", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({ ok: true, data: savedMenuSet });
+      render(<MenuSetFormContent menuSet={null} menus={menus} />);
+
+      await user.type(screen.getByLabelText(/セット名/), "オフ日ルーティン");
+      await user.type(screen.getByLabelText(/メモ/), "試合前日の軽め調整");
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+      await user.click(screen.getByRole("button", { name: "作成する" }));
+
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+      expect(mockCreate).toHaveBeenCalledWith({
+        name: "オフ日ルーティン",
+        note: "試合前日の軽め調整",
+        items: [{ practice_menu_id: 1, target_value: 200 }],
+      });
+    });
+
+    it("作成後は詳細画面へ遷移する", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({ ok: true, data: savedMenuSet });
+      render(<MenuSetFormContent menuSet={null} menus={menus} />);
+
+      await user.type(screen.getByLabelText(/セット名/), "オフ日ルーティン");
+      await user.click(screen.getByRole("button", { name: "作成する" }));
+
+      await waitFor(() =>
+        expect(mockPush).toHaveBeenCalledWith("/practice/menu-sets/7"),
+      );
+    });
+
+    it("セット名が未入力なら送信せずエラーを出す", async () => {
+      const user = userEvent.setup();
+      render(<MenuSetFormContent menuSet={null} menus={menus} />);
+
+      await user.click(screen.getByRole("button", { name: "作成する" }));
+
+      expect(
+        await screen.findByText("セット名を入力してください"),
+      ).toBeInTheDocument();
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("メモ未入力なら note は null で送る", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({ ok: true, data: savedMenuSet });
+      render(<MenuSetFormContent menuSet={null} menus={menus} />);
+
+      await user.type(screen.getByLabelText(/セット名/), "朝練");
+      await user.click(screen.getByRole("button", { name: "作成する" }));
+
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+      expect(mockCreate.mock.calls[0][0].note).toBeNull();
+    });
+  });
+
+  describe("メニューの選択と目標量", () => {
+    it("選択したメニューの目標量には default_value が初期表示される", async () => {
+      const user = userEvent.setup();
+      render(<MenuSetFormContent menuSet={null} menus={menus} />);
+
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+
+      expect(screen.getByLabelText("素振りの目標量")).toHaveValue(200);
+    });
+
+    it("default_value は decimal 文字列のまま入力欄へ入れない", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({ ok: true, data: savedMenuSet });
+      render(<MenuSetFormContent menuSet={null} menus={menus} />);
+
+      await user.click(screen.getByRole("checkbox", { name: "ランニング" }));
+
+      expect(screen.getByLabelText("ランニングの目標量")).toHaveValue(5);
+
+      await user.type(screen.getByLabelText(/セット名/), "朝ラン");
+      await user.click(screen.getByRole("button", { name: "作成する" }));
+
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+      expect(mockCreate.mock.calls[0][0].items).toEqual([
+        { practice_menu_id: 3, target_value: 5 },
+      ]);
+    });
+
+    it("default_value が無いメニューは空欄で始まり target_value は null で送る", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({ ok: true, data: savedMenuSet });
+      render(<MenuSetFormContent menuSet={null} menus={menus} />);
+
+      await user.click(screen.getByRole("checkbox", { name: "ティー" }));
+
+      expect(screen.getByLabelText("ティーの目標量")).toHaveValue(null);
+
+      await user.type(screen.getByLabelText(/セット名/), "ティー中心");
+      await user.click(screen.getByRole("button", { name: "作成する" }));
+
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+      expect(mockCreate.mock.calls[0][0].items).toEqual([
+        { practice_menu_id: 2, target_value: null },
+      ]);
+    });
+
+    it("目標量を編集した値が送信される", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({ ok: true, data: savedMenuSet });
+      render(<MenuSetFormContent menuSet={null} menus={menus} />);
+
+      await user.type(screen.getByLabelText(/セット名/), "朝練");
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+      await user.clear(screen.getByLabelText("素振りの目標量"));
+      await user.type(screen.getByLabelText("素振りの目標量"), "300");
+      await user.click(screen.getByRole("button", { name: "作成する" }));
+
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+      expect(mockCreate.mock.calls[0][0].items).toEqual([
+        { practice_menu_id: 1, target_value: 300 },
+      ]);
+    });
+
+    it("選択を外すとその目標量欄も消える", async () => {
+      const user = userEvent.setup();
+      render(<MenuSetFormContent menuSet={null} menus={menus} />);
+
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+
+      expect(screen.queryByLabelText("素振りの目標量")).toBeNull();
+    });
+
+    it("練習メニューが1件も無いときは先に登録するよう案内する", () => {
+      render(<MenuSetFormContent menuSet={null} menus={[]} />);
+
+      expect(
+        screen.getByText(
+          "練習メニューがありません。先に練習メニューを登録すると、セットに入れられます。",
+        ),
+      ).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "練習メニューを登録する" }),
+      ).toHaveAttribute("href", "/practice/menus");
+    });
+  });
+
+  describe("編集", () => {
+    const editing = buildMenuSet({
+      id: 7,
+      name: "オフ日ルーティン",
+      note: "軽め",
+      items: [
+        {
+          practice_menu_id: 1,
+          name: "素振り",
+          unit_label: "本",
+          target_value: 150,
+        },
+        {
+          practice_menu_id: 3,
+          name: "ランニング",
+          unit_label: "km",
+          target_value: 3,
+        },
+      ],
+    });
+
+    it("既存の値がフォームに反映される", () => {
+      render(<MenuSetFormContent menuSet={editing} menus={menus} />);
+
+      expect(screen.getByLabelText(/セット名/)).toHaveValue("オフ日ルーティン");
+      expect(screen.getByLabelText(/メモ/)).toHaveValue("軽め");
+      expect(screen.getByRole("checkbox", { name: "素振り" })).toBeChecked();
+      expect(
+        screen.getByRole("checkbox", { name: "ティー" }),
+      ).not.toBeChecked();
+      expect(screen.getByLabelText("素振りの目標量")).toHaveValue(150);
+    });
+
+    it("セット名を書き換えて更新できる", async () => {
+      const user = userEvent.setup();
+      mockUpdate.mockResolvedValue({ ok: true, data: editing });
+      render(<MenuSetFormContent menuSet={editing} menus={menus} />);
+
+      await user.clear(screen.getByLabelText(/セット名/));
+      await user.type(screen.getByLabelText(/セット名/), "オフ日ルーティン改");
+      await user.click(screen.getByRole("button", { name: "更新する" }));
+
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      expect(mockUpdate.mock.calls[0][0]).toBe(7);
+      expect(mockUpdate.mock.calls[0][1].name).toBe("オフ日ルーティン改");
+    });
+
+    it("items は差分ではなく選択中のメニューを毎回すべて送る", async () => {
+      const user = userEvent.setup();
+      mockUpdate.mockResolvedValue({ ok: true, data: editing });
+      render(<MenuSetFormContent menuSet={editing} menus={menus} />);
+
+      // 「ティー」を足すだけの操作でも、既存の2件を含めた全量が送られる必要がある。
+      await user.click(screen.getByRole("checkbox", { name: "ティー" }));
+      await user.click(screen.getByRole("button", { name: "更新する" }));
+
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      expect(mockUpdate.mock.calls[0][1].items).toEqual([
+        { practice_menu_id: 1, target_value: 150 },
+        { practice_menu_id: 2, target_value: null },
+        { practice_menu_id: 3, target_value: 3 },
+      ]);
+    });
+
+    it("メニューを1件も選ばずに更新すると空配列を送って全解除する", async () => {
+      const user = userEvent.setup();
+      mockUpdate.mockResolvedValue({ ok: true, data: editing });
+      render(<MenuSetFormContent menuSet={editing} menus={menus} />);
+
+      await user.click(screen.getByRole("checkbox", { name: "素振り" }));
+      await user.click(screen.getByRole("checkbox", { name: "ランニング" }));
+      await user.click(screen.getByRole("button", { name: "更新する" }));
+
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      expect(mockUpdate.mock.calls[0][1].items).toEqual([]);
+    });
+
+    it("メニューが全置換されることを保存前に伝える", () => {
+      render(<MenuSetFormContent menuSet={editing} menus={menus} />);
+
+      expect(
+        screen.getByText(
+          "保存すると、このセットのメニューは選択した内容にまるごと置き換わります。",
+        ),
+      ).toBeVisible();
+    });
+  });
+
+  describe("サーバー側のエラー", () => {
+    it("作成が 403 で拒否されたら件数上限の文言とペイウォールを出す", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({
+        ok: false,
+        reason: "forbidden",
+        errors: ["Pro プランでメニューセットを無制限に登録できます"],
+      });
+      render(<MenuSetFormContent menuSet={null} menus={menus} />);
+
+      await user.type(screen.getByLabelText(/セット名/), "3つ目");
+      await user.click(screen.getByRole("button", { name: "作成する" }));
+
+      expect(
+        await screen.findByText(
+          "無料プランで作成できるメニューセットは2件までです。Pro プランなら3つ目以降のメニューセットも自由に作成・編集できます。",
+        ),
+      ).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "unlimited_menu_sets",
+      });
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("作成が 422 で失敗したらサーバーのメッセージを出す", async () => {
+      const user = userEvent.setup();
+      mockCreate.mockResolvedValue({
+        ok: false,
+        reason: "error",
+        errors: ["名前は50文字以内で入力してください"],
+      });
+      render(<MenuSetFormContent menuSet={null} menus={menus} />);
+
+      await user.type(screen.getByLabelText(/セット名/), "セット");
+      await user.click(screen.getByRole("button", { name: "作成する" }));
+
+      expect(
+        await screen.findByText("名前は50文字以内で入力してください"),
+      ).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+
+    it("更新の 403 は件数上限ではないためペイウォールに倒さない", async () => {
+      const user = userEvent.setup();
+      mockUpdate.mockResolvedValue({
+        ok: false,
+        reason: "forbidden",
+        errors: ["更新できません"],
+      });
+      render(<MenuSetFormContent menuSet={buildMenuSet()} menus={menus} />);
+
+      await user.click(screen.getByRole("button", { name: "更新する" }));
+
+      expect(await screen.findByText("更新できません")).toBeInTheDocument();
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/(app)/practice/menu-sets/__tests__/MenuSetsContent.test.tsx
+++ b/app/(app)/practice/menu-sets/__tests__/MenuSetsContent.test.tsx
@@ -1,0 +1,234 @@
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: jest.fn(), back: jest.fn() }),
+}));
+
+const mockOpenProUpgradeModal = jest.fn();
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({
+    open: mockOpenProUpgradeModal,
+    close: jest.fn(),
+  }),
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+jest.mock("@app/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+import type { MenuSet } from "@app/types/menuSet";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import MenuSetsContent from "../_components/MenuSetsContent";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+
+function buildMenuSet(overrides: Partial<MenuSet> = {}): MenuSet {
+  return {
+    id: 1,
+    name: "オフ日ルーティン",
+    note: null,
+    sort_order: 0,
+    items: [],
+    ...overrides,
+  };
+}
+
+function mockEntitlement({
+  granted = false,
+  isLoading = false,
+}: { granted?: boolean; isLoading?: boolean } = {}) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: granted,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading,
+    hasEntitlement: jest.fn(() => granted),
+  });
+}
+
+const twoSets = [
+  buildMenuSet({ id: 1, name: "オフ日ルーティン" }),
+  buildMenuSet({ id: 2, name: "試合前調整" }),
+];
+
+async function clickCreate(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "セットを作る" }));
+}
+
+describe("MenuSetsContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEntitlement();
+  });
+
+  describe("一覧表示", () => {
+    it("含まれるメニュー名を「/」区切りで表示する", () => {
+      render(
+        <MenuSetsContent
+          menuSets={[
+            buildMenuSet({
+              items: [
+                {
+                  practice_menu_id: 1,
+                  name: "素振り",
+                  unit_label: "本",
+                  target_value: 200,
+                },
+                {
+                  practice_menu_id: 2,
+                  name: "ティー",
+                  unit_label: "本",
+                  target_value: 100,
+                },
+                {
+                  practice_menu_id: 3,
+                  name: "ランニング",
+                  unit_label: "km",
+                  target_value: null,
+                },
+              ],
+            }),
+          ]}
+        />,
+      );
+
+      expect(screen.getByText("素振り / ティー / ランニング")).toBeVisible();
+    });
+
+    it("一覧には目標量を出さず、メニュー名だけを並べる", () => {
+      render(
+        <MenuSetsContent
+          menuSets={[
+            buildMenuSet({
+              items: [
+                {
+                  practice_menu_id: 1,
+                  name: "素振り",
+                  unit_label: "本",
+                  target_value: 200,
+                },
+              ],
+            }),
+          ]}
+        />,
+      );
+
+      expect(screen.getByText("素振り")).toBeVisible();
+      expect(screen.queryByText(/200本/)).toBeNull();
+    });
+
+    it("メニュー未設定のセットはその旨を表示する", () => {
+      render(<MenuSetsContent menuSets={[buildMenuSet({ items: [] })]} />);
+
+      expect(screen.getByText("メニュー未設定")).toBeVisible();
+    });
+
+    it("セットが1件も無いときは使い道が分かる空状態を表示する", () => {
+      render(<MenuSetsContent menuSets={[]} />);
+
+      expect(
+        screen.getByText(
+          "よく組む練習をセットにしておくと、予定登録や週プランでそのまま使えます",
+        ),
+      ).toBeVisible();
+    });
+
+    it("セット名から詳細へ遷移できる", () => {
+      render(<MenuSetsContent menuSets={[buildMenuSet({ id: 42 })]} />);
+
+      expect(
+        screen.getByRole("link", { name: /オフ日ルーティン/ }),
+      ).toHaveAttribute("href", "/practice/menu-sets/42");
+    });
+  });
+
+  describe("作成導線", () => {
+    it("上限未満なら作成画面へ遷移する", async () => {
+      const user = userEvent.setup();
+      render(<MenuSetsContent menuSets={[twoSets[0]]} />);
+
+      await clickCreate(user);
+
+      expect(mockPush).toHaveBeenCalledWith("/practice/menu-sets/new");
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+
+    it("上限未満では上限の案内を出さない", () => {
+      render(<MenuSetsContent menuSets={[twoSets[0]]} />);
+
+      expect(
+        screen.queryByText("無料プランで作成できるメニューセットは2件までです"),
+      ).toBeNull();
+    });
+  });
+
+  describe("無料枠の上限", () => {
+    it("無料ユーザーが3件目を作ろうとすると遷移せずペイウォールが出る", async () => {
+      const user = userEvent.setup();
+      render(<MenuSetsContent menuSets={twoSets} />);
+
+      await clickCreate(user);
+
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "unlimited_menu_sets",
+      });
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("上限に達すると Pro 限定ではなく件数上限として案内する", () => {
+      render(<MenuSetsContent menuSets={twoSets} />);
+
+      expect(
+        screen.getByText("無料プランで作成できるメニューセットは2件までです"),
+      ).toBeVisible();
+      expect(
+        screen.getByText(
+          "Pro プランなら3つ目以降のメニューセットも自由に作成・編集できます。",
+        ),
+      ).toBeVisible();
+    });
+
+    it("Pro ユーザーは3件目以降も作成画面へ進める", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ granted: true });
+      render(<MenuSetsContent menuSets={twoSets} />);
+
+      expect(
+        screen.queryByText("無料プランで作成できるメニューセットは2件までです"),
+      ).toBeNull();
+
+      await clickCreate(user);
+
+      expect(mockPush).toHaveBeenCalledWith("/practice/menu-sets/new");
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+
+    it("Pro 判定が未確定の間は上限の案内を出さない", () => {
+      mockEntitlement({ isLoading: true });
+      render(<MenuSetsContent menuSets={twoSets} />);
+
+      expect(
+        screen.queryByText("無料プランで作成できるメニューセットは2件までです"),
+      ).toBeNull();
+    });
+
+    it("Pro 判定が未確定の間はペイウォールも出さない", async () => {
+      const user = userEvent.setup();
+      mockEntitlement({ isLoading: true });
+      render(<MenuSetsContent menuSets={twoSets} />);
+
+      await clickCreate(user);
+
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/(app)/practice/menu-sets/_components/MenuSetForm.tsx
+++ b/app/(app)/practice/menu-sets/_components/MenuSetForm.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import type { MenuSet, MenuSetInput } from "@app/types/menuSet";
+import type { PracticeMenu } from "@app/types/practice";
+import { Button, Input, Textarea } from "@heroui/react";
+import Link from "next/link";
+import { useState } from "react";
+import { MENU_SET_NAME_MAX_LENGTH } from "@app/constants/menuSet";
+import { parseDecimal } from "@app/constants/practice";
+import { buildMenuSetInput, validateMenuSetInput } from "../_utils/menuSetForm";
+import {
+  CANCEL_LABEL,
+  ITEMS_REPLACED_NOTICE,
+  MENUS_EMPTY,
+  MENUS_EMPTY_LINK_LABEL,
+  MENU_LABEL,
+  NAME_LABEL,
+  NAME_PLACEHOLDER,
+  NOTE_LABEL,
+  NOTE_PLACEHOLDER,
+  SAVE_LABEL,
+  UPDATE_LABEL,
+} from "./menuSetCopy";
+
+interface MenuSetFormProps {
+  /** 編集対象。null なら新規作成。 */
+  menuSet: MenuSet | null;
+  menus: PracticeMenu[];
+  isSaving: boolean;
+  /** 保存に失敗したときに出すサーバー由来のメッセージ。 */
+  serverErrors: string[];
+  onSubmit: (input: MenuSetInput) => void;
+  onCancel: () => void;
+}
+
+/** 目標量の表示用文字列。decimal は文字列で届きうるため数値化してから入力欄へ流す。 */
+function toAmountText(value: number | string | null | undefined): string {
+  const parsed = parseDecimal(value);
+  return parsed === null ? "" : String(parsed);
+}
+
+/** 編集時の初期選択。既存 items の目標量をそのまま入力欄の初期値にする。 */
+function initialMenuAmounts(menuSet: MenuSet | null): Record<number, string> {
+  const amounts: Record<number, string> = {};
+  menuSet?.items.forEach((item) => {
+    amounts[item.practice_menu_id] = toAmountText(item.target_value);
+  });
+  return amounts;
+}
+
+/**
+ * メニューセットの作成・編集フォーム。
+ *
+ * 入力値の保持とクライアント側バリデーションだけを担い、
+ * API 呼び出しと画面遷移は呼び出し元（Container）に委ねる。
+ * 初期値は props からマウント時に一度だけ組み立てる（useEffect での同期はしない）。
+ */
+export default function MenuSetForm({
+  menuSet,
+  menus,
+  isSaving,
+  serverErrors,
+  onSubmit,
+  onCancel,
+}: MenuSetFormProps) {
+  const [name, setName] = useState(menuSet?.name ?? "");
+  const [note, setNote] = useState(menuSet?.note ?? "");
+  const [menuAmounts, setMenuAmounts] = useState<Record<number, string>>(() =>
+    initialMenuAmounts(menuSet),
+  );
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const toggleMenu = (menu: PracticeMenu) =>
+    setMenuAmounts((prev) => {
+      if (menu.id in prev) {
+        const next = { ...prev };
+        delete next[menu.id];
+        return next;
+      }
+      // 初期値は練習メニューの default_value から引き、毎回打ち直さずに済むようにする。
+      return { ...prev, [menu.id]: toAmountText(menu.default_value) };
+    });
+
+  const changeMenuAmount = (menuId: number, amount: string) =>
+    setMenuAmounts((prev) => ({ ...prev, [menuId]: amount }));
+
+  const handleSubmit = () => {
+    const input = buildMenuSetInput({ name, note, menuAmounts }, menus);
+    const validationErrors = validateMenuSetInput(input);
+    if (validationErrors.length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+    setErrors([]);
+    onSubmit(input);
+  };
+
+  const messages = errors.length > 0 ? errors : serverErrors;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Input
+        type="text"
+        variant="bordered"
+        label={NAME_LABEL}
+        labelPlacement="outside"
+        isRequired
+        maxLength={MENU_SET_NAME_MAX_LENGTH}
+        placeholder={NAME_PLACEHOLDER}
+        value={name}
+        onChange={(event) => setName(event.target.value)}
+      />
+
+      <Textarea
+        variant="bordered"
+        label={NOTE_LABEL}
+        labelPlacement="outside"
+        minRows={2}
+        placeholder={NOTE_PLACEHOLDER}
+        value={note}
+        onChange={(event) => setNote(event.target.value)}
+      />
+
+      <div>
+        <p className="mb-1.5 text-sm text-white">{MENU_LABEL}</p>
+        {menus.length === 0 ? (
+          <div className="rounded-[10px] bg-sub px-3.5 py-3">
+            <p className="text-xs text-zinc-400">{MENUS_EMPTY}</p>
+            <Link
+              href="/practice/menus"
+              className="mt-2 inline-block text-xs font-bold text-[#d08000] underline"
+            >
+              {MENUS_EMPTY_LINK_LABEL}
+            </Link>
+          </div>
+        ) : (
+          <>
+            <ul className="flex flex-col gap-2">
+              {menus.map((menu) => {
+                const isSelected = menu.id in menuAmounts;
+                return (
+                  <li
+                    key={menu.id}
+                    className="rounded-[10px] bg-sub px-3.5 py-3"
+                  >
+                    <label className="flex items-center gap-2.5 text-sm text-white">
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => toggleMenu(menu)}
+                        className="h-4 w-4 accent-[#d08000]"
+                      />
+                      <span>{menu.name}</span>
+                    </label>
+                    {isSelected ? (
+                      <div className="mt-2.5 flex items-center gap-2 pl-6">
+                        <input
+                          type="number"
+                          aria-label={`${menu.name}の目標量`}
+                          value={menuAmounts[menu.id] ?? ""}
+                          onChange={(event) =>
+                            changeMenuAmount(menu.id, event.target.value)
+                          }
+                          className="w-28 rounded-lg bg-main px-3 py-2 text-sm font-bold text-white"
+                        />
+                        <span className="text-sm text-zinc-400">
+                          {menu.unit_label ?? ""}
+                        </span>
+                      </div>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+            <p className="mt-2 text-xs text-zinc-400">
+              {ITEMS_REPLACED_NOTICE}
+            </p>
+          </>
+        )}
+      </div>
+
+      {messages.length > 0 ? (
+        <ul role="alert" className="space-y-1 text-sm text-danger">
+          {messages.map((message) => (
+            <li key={message}>{message}</li>
+          ))}
+        </ul>
+      ) : null}
+
+      <div className="flex gap-3">
+        <Button
+          variant="flat"
+          radius="sm"
+          className="flex-1"
+          onPress={onCancel}
+          isDisabled={isSaving}
+        >
+          {CANCEL_LABEL}
+        </Button>
+        <Button
+          color="primary"
+          radius="sm"
+          className="flex-1 font-bold"
+          onPress={handleSubmit}
+          isDisabled={isSaving}
+          isLoading={isSaving}
+        >
+          {menuSet ? UPDATE_LABEL : SAVE_LABEL}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/practice/menu-sets/_components/MenuSetFormContent.tsx
+++ b/app/(app)/practice/menu-sets/_components/MenuSetFormContent.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import type { MenuSet, MenuSetInput } from "@app/types/menuSet";
+import type { PracticeMenu } from "@app/types/practice";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+import { createMenuSet, updateMenuSet } from "@app/services/v2/menuSetService";
+import { FREE_LIMIT_SERVER_ERROR } from "./menuSetCopy";
+import MenuSetForm from "./MenuSetForm";
+
+interface MenuSetFormContentProps {
+  /** 編集対象。null なら新規作成。 */
+  menuSet: MenuSet | null;
+  menus: PracticeMenu[];
+}
+
+/**
+ * メニューセットフォーム画面の Container。
+ * Server Action の呼び出しと保存後の遷移を担い、入力 UI は MenuSetForm に委ねる。
+ */
+export default function MenuSetFormContent({
+  menuSet,
+  menus,
+}: MenuSetFormContentProps) {
+  const router = useRouter();
+  const [isSaving, setIsSaving] = useState(false);
+  const [serverErrors, setServerErrors] = useState<string[]>([]);
+  const { open: openProUpgradeModal } = useProUpgradeModal();
+
+  const handleSubmit = async (input: MenuSetInput) => {
+    setIsSaving(true);
+    setServerErrors([]);
+
+    const result = menuSet
+      ? await updateMenuSet(menuSet.id, input)
+      : await createMenuSet(input);
+    setIsSaving(false);
+
+    if (result.ok) {
+      toast.success(
+        menuSet
+          ? "メニューセットを更新しました"
+          : "メニューセットを作成しました",
+      );
+      router.push(`/practice/menu-sets/${result.data.id}`);
+      router.refresh();
+      return;
+    }
+
+    // 作成時の 403 は Pro 限定機能ではなく無料枠の超過を意味する。
+    // 別端末での追加などでクライアント側の件数判定とずれた場合にここへ入る。
+    if (!menuSet && result.reason === "forbidden") {
+      setServerErrors([FREE_LIMIT_SERVER_ERROR]);
+      openProUpgradeModal({ trigger: "unlimited_menu_sets" });
+      return;
+    }
+    setServerErrors(result.errors);
+  };
+
+  return (
+    <MenuSetForm
+      menuSet={menuSet}
+      menus={menus}
+      isSaving={isSaving}
+      serverErrors={serverErrors}
+      onSubmit={handleSubmit}
+      onCancel={() => router.back()}
+    />
+  );
+}

--- a/app/(app)/practice/menu-sets/_components/MenuSetList.tsx
+++ b/app/(app)/practice/menu-sets/_components/MenuSetList.tsx
@@ -1,0 +1,50 @@
+import type { MenuSet } from "@app/types/menuSet";
+import ChevronRightIcon from "@heroicons/react/24/outline/ChevronRightIcon";
+import Link from "next/link";
+import { menuNamesText } from "../_utils/menuSetDisplay";
+import { EMPTY_MESSAGE, ITEMS_EMPTY } from "./menuSetCopy";
+
+interface MenuSetListProps {
+  menuSets: MenuSet[];
+}
+
+/**
+ * メニューセットを一覧表示する。
+ * 中身は名前だけを「/」で連ねて 1 行に収め、詳細で目標量まで確認させる。
+ */
+export default function MenuSetList({ menuSets }: MenuSetListProps) {
+  if (menuSets.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-zinc-400">{EMPTY_MESSAGE}</p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {menuSets.map((menuSet) => {
+        const names = menuNamesText(menuSet);
+        return (
+          <li key={menuSet.id}>
+            <Link
+              href={`/practice/menu-sets/${menuSet.id}`}
+              className="flex items-center gap-3 rounded-[10px] bg-sub px-3.5 py-3 transition-opacity hover:opacity-80"
+            >
+              <span className="min-w-0 flex-1">
+                <span className="block text-sm font-bold text-white">
+                  {menuSet.name}
+                </span>
+                <span className="mt-0.5 block truncate text-xs text-zinc-400">
+                  {names === "" ? ITEMS_EMPTY : names}
+                </span>
+              </span>
+              <ChevronRightIcon
+                className="h-4 w-4 shrink-0 text-zinc-400"
+                aria-hidden
+              />
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/app/(app)/practice/menu-sets/_components/MenuSetsContent.tsx
+++ b/app/(app)/practice/menu-sets/_components/MenuSetsContent.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import type { MenuSet } from "@app/types/menuSet";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import { Button } from "@heroui/react";
+import { useRouter } from "next/navigation";
+import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
+import { MENU_SET_FREE_LIMIT } from "@app/constants/menuSet";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import {
+  CREATE_LABEL,
+  FREE_LIMIT_DESCRIPTION,
+  FREE_LIMIT_TITLE,
+  PAGE_DESCRIPTION,
+  PAGE_TITLE,
+} from "./menuSetCopy";
+import MenuSetList from "./MenuSetList";
+
+interface MenuSetsContentProps {
+  menuSets: MenuSet[];
+}
+
+/**
+ * メニューセット一覧の Container。
+ * 無料枠の判定と作成導線の出し分けを担い、一覧の表示は MenuSetList に委ねる。
+ */
+export default function MenuSetsContent({ menuSets }: MenuSetsContentProps) {
+  const router = useRouter();
+  const { hasEntitlement, isLoading: isEntitlementLoading } = useEntitlement();
+  const { open: openProUpgradeModal } = useProUpgradeModal();
+
+  const hasUnlimited = hasEntitlement("unlimited_menu_sets");
+  // 判定が確定するまでは上限扱いにしない。未確定のまま塞ぐと Pro 加入者に上限を誤って告知してしまう。
+  const isAtFreeLimit =
+    !isEntitlementLoading &&
+    !hasUnlimited &&
+    menuSets.length >= MENU_SET_FREE_LIMIT;
+
+  const handleAdd = () => {
+    if (isAtFreeLimit) {
+      openProUpgradeModal({ trigger: "unlimited_menu_sets" });
+      return;
+    }
+    router.push("/practice/menu-sets/new");
+  };
+
+  return (
+    <>
+      <h2 className="text-2xl font-bold">{PAGE_TITLE}</h2>
+      <p className="mt-2 text-sm text-zinc-300">{PAGE_DESCRIPTION}</p>
+
+      <div className="my-6">
+        <MenuSetList menuSets={menuSets} />
+      </div>
+
+      {isAtFreeLimit ? (
+        <ProUpsellCard
+          feature="unlimited_menu_sets"
+          title={FREE_LIMIT_TITLE}
+          description={FREE_LIMIT_DESCRIPTION}
+          ctaLabel="Pro プランを見る"
+          className="mb-4"
+        />
+      ) : null}
+
+      <Button
+        color="primary"
+        fullWidth
+        radius="sm"
+        className="font-bold"
+        startContent={<PlusIcon className="h-5 w-5" aria-hidden />}
+        isDisabled={isEntitlementLoading}
+        onPress={handleAdd}
+      >
+        {CREATE_LABEL}
+      </Button>
+    </>
+  );
+}

--- a/app/(app)/practice/menu-sets/_components/menuSetCopy.ts
+++ b/app/(app)/practice/menu-sets/_components/menuSetCopy.ts
@@ -1,0 +1,69 @@
+import { MENU_SET_FREE_LIMIT } from "@app/constants/menuSet";
+
+/**
+ * メニューセット画面の文言。
+ * 無料枠の上限は back の 403 と同じ意味（Pro 限定機能ではなく「件数の上限超過」）で伝えるため、
+ * 上限にまつわる文言は件数を明示した表現に統一して1箇所で持つ。
+ */
+
+export const PAGE_TITLE = "メニューセット";
+export const PAGE_DESCRIPTION =
+  "よく組む練習をひとつのセットにまとめておくと、予定登録や週プランでそのまま呼び出せます。";
+
+export const CREATE_LABEL = "セットを作る";
+
+/** セットを1件も持たないユーザーに、何のための機能かを伝える案内。 */
+export const EMPTY_MESSAGE =
+  "よく組む練習をセットにしておくと、予定登録や週プランでそのまま使えます";
+
+export const ITEMS_EMPTY = "メニュー未設定";
+export const LOAD_ERROR =
+  "メニューセットを取得できませんでした。時間を置いて再度お試しください。";
+
+/** メニューが削除済みで serializer が name を返せなかったときの代替表記。 */
+export const UNKNOWN_MENU_NAME = "メニュー";
+
+/** 無料枠を使い切ったユーザーに出す見出し。 */
+export const FREE_LIMIT_TITLE = `無料プランで作成できるメニューセットは${MENU_SET_FREE_LIMIT}件までです`;
+
+/** 上限解放後に何ができるかの説明。 */
+export const FREE_LIMIT_DESCRIPTION = `Pro プランなら${MENU_SET_FREE_LIMIT + 1}つ目以降のメニューセットも自由に作成・編集できます。`;
+
+/**
+ * 作成 API が 403 を返したときにフォーム上へ出すエラー。
+ * クライアント側の件数判定をすり抜けた（別端末で作成した等）ケースで表示する。
+ */
+export const FREE_LIMIT_SERVER_ERROR = `${FREE_LIMIT_TITLE}。${FREE_LIMIT_DESCRIPTION}`;
+
+export const NAME_LABEL = "セット名";
+export const NAME_PLACEHOLDER = "例: オフ日ルーティン";
+export const NOTE_LABEL = "メモ（任意）";
+export const NOTE_PLACEHOLDER = "例: 試合前日の軽め調整";
+export const MENU_LABEL = "メニュー（任意）";
+
+/** 練習メニューが1件も無いと空のセットしか作れないため、先に作る導線を添えて伝える。 */
+export const MENUS_EMPTY =
+  "練習メニューがありません。先に練習メニューを登録すると、セットに入れられます。";
+export const MENUS_EMPTY_LINK_LABEL = "練習メニューを登録する";
+
+/** back の assign_items が既存項目を destroy_all してから作り直すことを、保存前に伝える。 */
+export const ITEMS_REPLACED_NOTICE =
+  "保存すると、このセットのメニューは選択した内容にまるごと置き換わります。";
+
+export const SAVE_LABEL = "作成する";
+export const UPDATE_LABEL = "更新する";
+export const CANCEL_LABEL = "キャンセル";
+
+export const CREATE_PAGE_TITLE = "セットを作る";
+export const EDIT_PAGE_TITLE = "セットを編集";
+
+export const EDIT_LABEL = "編集";
+export const DELETE_LABEL = "削除";
+export const DELETE_CONFIRM_TITLE = "メニューセットの削除";
+
+/** back の has_many :schedules, dependent: :nullify により、紐付いた予定自体は残る。 */
+export const DELETE_KEEPS_SCHEDULES_NOTICE =
+  "このセットを使っている予定は削除されず、メニューの紐付けだけが外れます。";
+
+export const DETAIL_MENU_SECTION_TITLE = "メニュー";
+export const DETAIL_NOTE_SECTION_TITLE = "メモ";

--- a/app/(app)/practice/menu-sets/_utils/__tests__/menuSetDisplay.test.ts
+++ b/app/(app)/practice/menu-sets/_utils/__tests__/menuSetDisplay.test.ts
@@ -1,0 +1,72 @@
+import type { MenuSet, MenuSetItem } from "@app/types/menuSet";
+import { formatMenuSetItem, menuNamesText } from "../menuSetDisplay";
+
+function buildItem(overrides: Partial<MenuSetItem> = {}): MenuSetItem {
+  return {
+    practice_menu_id: 1,
+    name: "素振り",
+    unit_label: "本",
+    target_value: 200,
+    ...overrides,
+  };
+}
+
+function buildMenuSet(items: MenuSetItem[]): MenuSet {
+  return { id: 1, name: "オフ日ルーティン", note: null, sort_order: 0, items };
+}
+
+describe("menuNamesText", () => {
+  it("メニュー名を「/」で連ねる", () => {
+    expect(
+      menuNamesText(
+        buildMenuSet([
+          buildItem({ practice_menu_id: 1, name: "素振り" }),
+          buildItem({ practice_menu_id: 2, name: "ティー" }),
+        ]),
+      ),
+    ).toBe("素振り / ティー");
+  });
+
+  it("メニューが1件なら区切り文字を付けない", () => {
+    expect(menuNamesText(buildMenuSet([buildItem()]))).toBe("素振り");
+  });
+
+  it("メニューが無ければ空文字を返す", () => {
+    expect(menuNamesText(buildMenuSet([]))).toBe("");
+  });
+
+  it("削除済みメニューは代替表記で埋めて件数を落とさない", () => {
+    expect(
+      menuNamesText(
+        buildMenuSet([
+          buildItem({ practice_menu_id: 1, name: null }),
+          buildItem({ practice_menu_id: 2, name: "ティー" }),
+        ]),
+      ),
+    ).toBe("メニュー / ティー");
+  });
+});
+
+describe("formatMenuSetItem", () => {
+  it("「素振り 200本」形式で返す", () => {
+    expect(formatMenuSetItem(buildItem())).toBe("素振り 200本");
+  });
+
+  it("decimal 文字列で届いた目標量も数値として整形する", () => {
+    expect(
+      formatMenuSetItem(
+        buildItem({ target_value: "200.0" as unknown as number }),
+      ),
+    ).toBe("素振り 200本");
+  });
+
+  it("目標量が未設定ならメニュー名だけを返す", () => {
+    expect(formatMenuSetItem(buildItem({ target_value: null }))).toBe("素振り");
+  });
+
+  it("単位ラベルが無ければ数値だけを添える", () => {
+    expect(formatMenuSetItem(buildItem({ unit_label: null }))).toBe(
+      "素振り 200",
+    );
+  });
+});

--- a/app/(app)/practice/menu-sets/_utils/__tests__/menuSetForm.test.ts
+++ b/app/(app)/practice/menu-sets/_utils/__tests__/menuSetForm.test.ts
@@ -1,0 +1,131 @@
+import type { PracticeMenu } from "@app/types/practice";
+import {
+  NAME_REQUIRED_ERROR,
+  NAME_TOO_LONG_ERROR,
+  buildMenuSetInput,
+  validateMenuSetInput,
+} from "../menuSetForm";
+
+const menus: PracticeMenu[] = [
+  {
+    id: 5,
+    name: "素振り",
+    category: "batting",
+    unit: "count",
+    unit_label: "本",
+    default_value: "200.0",
+    is_favorite: false,
+    sort_order: 1,
+  },
+  {
+    id: 2,
+    name: "ティー",
+    category: "batting",
+    unit: "count",
+    unit_label: "本",
+    default_value: null,
+    is_favorite: false,
+    sort_order: 2,
+  },
+];
+
+describe("buildMenuSetInput", () => {
+  it("選択したメニューだけを items に含める", () => {
+    const input = buildMenuSetInput(
+      { name: "朝練", note: "", menuAmounts: { 5: "200" } },
+      menus,
+    );
+
+    expect(input.items).toEqual([{ practice_menu_id: 5, target_value: 200 }]);
+  });
+
+  it("items の並びはメニューの表示順に従う（ID 昇順ではない）", () => {
+    const input = buildMenuSetInput(
+      { name: "朝練", note: "", menuAmounts: { 2: "50", 5: "200" } },
+      menus,
+    );
+
+    expect(input.items?.map((item) => item.practice_menu_id)).toEqual([5, 2]);
+  });
+
+  it("何も選ばなければ空配列を送る（省略はしない）", () => {
+    const input = buildMenuSetInput(
+      { name: "朝練", note: "", menuAmounts: {} },
+      menus,
+    );
+
+    expect(input.items).toEqual([]);
+  });
+
+  it("目標量が空欄なら target_value は null にする", () => {
+    const input = buildMenuSetInput(
+      { name: "朝練", note: "", menuAmounts: { 5: "" } },
+      menus,
+    );
+
+    expect(input.items).toEqual([{ practice_menu_id: 5, target_value: null }]);
+  });
+
+  it("目標量が数値にならない入力は null に倒す", () => {
+    const input = buildMenuSetInput(
+      { name: "朝練", note: "", menuAmounts: { 5: "たくさん" } },
+      menus,
+    );
+
+    expect(input.items).toEqual([{ practice_menu_id: 5, target_value: null }]);
+  });
+
+  it("セット名とメモは前後の空白を落とす", () => {
+    const input = buildMenuSetInput(
+      { name: "  朝練  ", note: "  軽め  ", menuAmounts: {} },
+      menus,
+    );
+
+    expect(input.name).toBe("朝練");
+    expect(input.note).toBe("軽め");
+  });
+
+  it("メモが空白だけなら null にする", () => {
+    const input = buildMenuSetInput(
+      { name: "朝練", note: "   ", menuAmounts: {} },
+      menus,
+    );
+
+    expect(input.note).toBeNull();
+  });
+
+  it("選択肢に無いメニュー ID は送らない", () => {
+    const input = buildMenuSetInput(
+      { name: "朝練", note: "", menuAmounts: { 999: "10" } },
+      menus,
+    );
+
+    expect(input.items).toEqual([]);
+  });
+});
+
+describe("validateMenuSetInput", () => {
+  it("セット名が空ならエラーを返す", () => {
+    expect(validateMenuSetInput({ name: "", note: null, items: [] })).toContain(
+      NAME_REQUIRED_ERROR,
+    );
+  });
+
+  it("セット名が 50 文字ちょうどなら通す", () => {
+    expect(
+      validateMenuSetInput({ name: "あ".repeat(50), note: null, items: [] }),
+    ).toEqual([]);
+  });
+
+  it("セット名が 51 文字ならエラーを返す", () => {
+    expect(
+      validateMenuSetInput({ name: "あ".repeat(51), note: null, items: [] }),
+    ).toContain(NAME_TOO_LONG_ERROR);
+  });
+
+  it("メニューが空でもエラーにしない（back が空セットを許容する）", () => {
+    expect(
+      validateMenuSetInput({ name: "朝練", note: null, items: [] }),
+    ).toEqual([]);
+  });
+});

--- a/app/(app)/practice/menu-sets/_utils/menuSetDisplay.ts
+++ b/app/(app)/practice/menu-sets/_utils/menuSetDisplay.ts
@@ -1,0 +1,35 @@
+import type { MenuSet, MenuSetItem } from "@app/types/menuSet";
+import { formatPracticeValue } from "@app/constants/practice";
+import { UNKNOWN_MENU_NAME } from "../_components/menuSetCopy";
+
+/** セット内メニューの表示名。メニューが削除されていると serializer が null を返す。 */
+function itemName(item: MenuSetItem): string {
+  return item.name ?? UNKNOWN_MENU_NAME;
+}
+
+/**
+ * 一覧でセットの中身を一行に要約する。
+ * 目標量まで並べると行が読めなくなるため、名前だけを「/」で連ねる。
+ *
+ * @returns 「素振り / ティー / ランニング」形式。メニュー未設定なら空文字。
+ */
+export function menuNamesText(menuSet: MenuSet): string {
+  return menuSet.items.map(itemName).join(" / ");
+}
+
+/**
+ * 詳細でセット内メニューを1行に整形する。
+ *
+ * @returns 「素振り 200本」形式。目標量が未設定ならメニュー名のみ。
+ */
+export function formatMenuSetItem(item: MenuSetItem): string {
+  // target_value は float カラムだが、back の decimal 同様に文字列で届く可能性があるため
+  // formatPracticeValue（内部で parseDecimal）を通して数値化してから表示する。
+  const value = formatPracticeValue({
+    amount: item.target_value,
+    weight: null,
+    unit_label: item.unit_label,
+  });
+  const name = itemName(item);
+  return value === "" ? name : `${name} ${value}`;
+}

--- a/app/(app)/practice/menu-sets/_utils/menuSetForm.ts
+++ b/app/(app)/practice/menu-sets/_utils/menuSetForm.ts
@@ -1,0 +1,56 @@
+import type { MenuSetInput } from "@app/types/menuSet";
+import type { PracticeMenu } from "@app/types/practice";
+import { MENU_SET_NAME_MAX_LENGTH } from "@app/constants/menuSet";
+
+export interface MenuSetFormValues {
+  name: string;
+  note: string;
+  /** practice_menu_id → 目標量の入力文字列。キーの存在が「選択中」を意味する。 */
+  menuAmounts: Record<number, string>;
+}
+
+export const NAME_REQUIRED_ERROR = "セット名を入力してください";
+export const NAME_TOO_LONG_ERROR = `セット名は${MENU_SET_NAME_MAX_LENGTH}文字以内で入力してください`;
+
+/** 入力欄の文字列を送信値へ変換する。空文字・非数は null（目標量なし）として送る。 */
+function toNumberOrNull(value: string | undefined): number | null {
+  if (value === undefined || value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * 送信用のパラメータを組み立てる。
+ *
+ * items は差分ではなく毎回すべて送る。back の assign_items が既存の menu_set_items を
+ * destroy_all してから作り直すため、部分的に送ると送らなかったメニューが消える。
+ * 並び順（back 側の sort_order）は menus の表示順に合わせ、保存のたびに入れ替わらないようにする。
+ *
+ * @param values フォームの入力値
+ * @param menus 選択肢として表示している練習メニュー（この順序が items の並びになる）
+ */
+export function buildMenuSetInput(
+  values: MenuSetFormValues,
+  menus: PracticeMenu[],
+): MenuSetInput {
+  return {
+    name: values.name.trim(),
+    note: values.note.trim() === "" ? null : values.note.trim(),
+    items: menus
+      .filter((menu) => menu.id in values.menuAmounts)
+      .map((menu) => ({
+        practice_menu_id: menu.id,
+        target_value: toNumberOrNull(values.menuAmounts[menu.id]),
+      })),
+  };
+}
+
+/** 送信前のクライアント側チェック。back の MenuSet バリデーションと同じ条件を先出しする。 */
+export function validateMenuSetInput(input: MenuSetInput): string[] {
+  const errors: string[] = [];
+  if (input.name === "") errors.push(NAME_REQUIRED_ERROR);
+  if (input.name.length > MENU_SET_NAME_MAX_LENGTH) {
+    errors.push(NAME_TOO_LONG_ERROR);
+  }
+  return errors;
+}

--- a/app/(app)/practice/menu-sets/new/page.tsx
+++ b/app/(app)/practice/menu-sets/new/page.tsx
@@ -1,0 +1,36 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getPracticeMenus } from "@app/services/v2/practiceMenuService";
+import { CREATE_PAGE_TITLE } from "../_components/menuSetCopy";
+import MenuSetFormContent from "../_components/MenuSetFormContent";
+
+export const metadata = {
+  title: "セットを作る",
+};
+
+export default async function NewMenuSetPage() {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const menusResult = await getPracticeMenus();
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            <h2 className="mb-6 text-2xl font-bold">{CREATE_PAGE_TITLE}</h2>
+            <MenuSetFormContent
+              menuSet={null}
+              menus={menusResult.status === "ok" ? menusResult.data : []}
+            />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/(app)/practice/menu-sets/page.tsx
+++ b/app/(app)/practice/menu-sets/page.tsx
@@ -1,0 +1,39 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getMenuSets } from "@app/services/v2/menuSetService";
+import { LOAD_ERROR } from "./_components/menuSetCopy";
+import MenuSetsContent from "./_components/MenuSetsContent";
+
+export const metadata = {
+  title: "メニューセット",
+};
+
+export default async function MenuSetsPage() {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const result = await getMenuSets();
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            {result.status === "ok" ? (
+              <MenuSetsContent menuSets={result.data} />
+            ) : (
+              // 取得失敗を空配列に丸めると「セット未登録」と誤表示し、無料枠の判定も甘くなる。
+              <p className="py-8 text-center text-sm text-zinc-400">
+                {LOAD_ERROR}
+              </p>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/components/header/HeaderRight.tsx
+++ b/app/components/header/HeaderRight.tsx
@@ -87,6 +87,16 @@ export default function HeaderRight() {
                   練習メニュー
                 </DropdownItem>
                 <DropdownItem
+                  key="menu-sets"
+                  as={Link}
+                  href="/practice/menu-sets"
+                  startContent={
+                    <BallIcon fill="currentColor" width="18" height="18" />
+                  }
+                >
+                  メニューセット
+                </DropdownItem>
+                <DropdownItem
                   key="practice-schedules"
                   as={Link}
                   href="/practice/schedules"

--- a/app/components/header/__tests__/HeaderRight.test.tsx
+++ b/app/components/header/__tests__/HeaderRight.test.tsx
@@ -42,6 +42,14 @@ describe("HeaderRight のメニュー", () => {
     ).toHaveAttribute("href", "/practice/menus");
   });
 
+  it("メニューセットへの導線を持つ", async () => {
+    await openMenu();
+
+    expect(
+      screen.getByRole("menuitem", { name: /メニューセット/ }),
+    ).toHaveAttribute("href", "/practice/menu-sets");
+  });
+
   it("練習スケジュールへの導線を持つ", async () => {
     await openMenu();
 

--- a/app/constants/menuSet.ts
+++ b/app/constants/menuSet.ts
@@ -1,2 +1,5 @@
 // back/app/models/concerns/plan_limits.rb の MENU_SET_FREE_LIMIT と一致させる。
 export const MENU_SET_FREE_LIMIT = 2;
+
+// back/app/models/menu_set.rb の validates :name, length: { maximum: 50 } と一致させる。
+export const MENU_SET_NAME_MAX_LENGTH = 50;


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#472

## 概要

よく組む練習メニューの束を「練習プランセット」として保存し、予定登録や週プランで再利用する機能です。mobile の `app/(menu-set)/` 相当。無料は2件まで。

## 変更内容

- 一覧 — セット名＋含まれるメニュー名を「/」区切りで表示、空状態
- 詳細 — セット名、メニュー（「素振り 200本」形式）、メモ、編集/削除
- 作成/編集 — セット名（必須）/ メモ / メニュー複数選択＋目標量入力（初期値は `default_value`）
- 練習メニュー0件時の案内
- 3件目作成時のペイウォール（`unlimited_menu_sets`）と 403 ハンドリング
- `HeaderRight.tsx` に導線を追加

型・定数・サービス（`app/types/menuSet.ts` / `app/constants/menuSet.ts` / `app/services/v2/menuSetService.ts`）は #467 で作成済みのものを使い、新規作成していません。

## `items` は全置換です

back の `assign_items` が `destroy_all` → 再作成するため、**更新時に `items` を渡すと丸ごと差し替わります**（省略すれば維持）。また**他人の `practice_menu_id` はエラーにならず黙って除外される**ため、その挙動も踏まえた実装にしています。

## ペイウォールは「無料枠超過」の文脈です

back の 403 は「Pro 限定機能」ではなく無料枠超過を意味するため、`practice_menus`（#468）と同じ考え方で文言を合わせています。**Pro 判定が未確定の間は上限扱いにしません**（Pro 加入者に誤って上限を告知しないため）。

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn lint` が通る
- [x] `yarn format:check` が通る
- [x] `yarn test` が通る（**147 suites / 1754 tests**）
- [x] `yarn build` — 実装者がローカルで実行済み
- [x] ミューテーションテスト実施済み

### ルート表

新規ルートの追加分以外に既存ルートの分類変更がないことを、base との diff で確認しています。集計は Python で UTF-8 として判定し、行頭の罫線 `┌ ├ └ │` をすべて対象に、凡例行を除外しています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_