### PR TITLE
Add: 目標達成バッジ一覧と月次達成サマリーモーダルを実装

### DIFF
--- a/app/(app)/goals/__tests__/AchievementSummaryModal.test.tsx
+++ b/app/(app)/goals/__tests__/AchievementSummaryModal.test.tsx
@@ -1,0 +1,243 @@
+import type { Goal, GoalBadge } from "@app/types/goal";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderToStaticMarkup } from "react-dom/server";
+import { achievementSummaryShownKey } from "@app/constants/goal";
+import AchievementSummaryModal from "../_components/AchievementSummaryModal";
+
+const MONTH_KEY = "2026-07";
+const NEXT_MONTH_KEY = "2026-08";
+
+function buildGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: 1,
+    title: "月20日練習",
+    kind: "numeric",
+    period_type: "monthly",
+    season_id: null,
+    tournament_id: null,
+    month_start: "2026-07-01",
+    deadline: "2026-07-31",
+    metric_key: "practice_days",
+    target_value: 20,
+    comparison_type: "greater_than",
+    practice_menu_id: null,
+    practice_menu_name: null,
+    custom_metric_label: null,
+    custom_unit: null,
+    manual_current_value: 0,
+    is_achieved: true,
+    is_finalized: true,
+    achieved_value: 20,
+    current_value: 20,
+    progress_percent: 100,
+    days_remaining: 0,
+    ...overrides,
+  };
+}
+
+function buildBadge(overrides: Partial<GoalBadge> = {}): GoalBadge {
+  return {
+    id: 1,
+    badge_type: "monthly_achieved",
+    badge_name: "月間目標達成",
+    awarded_at: "2026-08-01T00:05:00.000+09:00",
+    goal_id: 1,
+    goal_title: "月20日練習",
+    ...overrides,
+  };
+}
+
+const HISTORY = [
+  buildGoal({ id: 1, is_achieved: true }),
+  buildGoal({ id: 2, is_achieved: false }),
+];
+
+const summaryText = () => screen.queryByText(/期限を迎えた目標/);
+
+describe("AchievementSummaryModal", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it("前月に期限を迎えた目標があれば、達成件数付きの振り返りを表示する", () => {
+    render(
+      <AchievementSummaryModal
+        monthKey={MONTH_KEY}
+        history={HISTORY}
+        badges={[]}
+      />,
+    );
+
+    expect(screen.getByText("2026年7月の振り返り")).toBeInTheDocument();
+    expect(screen.getByText(/期限を迎えた目標2件中/)).toBeInTheDocument();
+    expect(screen.getByText("1件達成")).toBeInTheDocument();
+  });
+
+  it("前月に付与されたバッジの個数を表示する", () => {
+    render(
+      <AchievementSummaryModal
+        monthKey={MONTH_KEY}
+        history={HISTORY}
+        badges={[
+          buildBadge({ id: 1, awarded_at: "2026-07-05T10:00:00.000+09:00" }),
+          buildBadge({ id: 2, awarded_at: "2026-07-31T10:00:00.000+09:00" }),
+          buildBadge({ id: 3, awarded_at: "2026-08-01T10:00:00.000+09:00" }),
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText("新しいバッジを2個獲得しました"),
+    ).toBeInTheDocument();
+  });
+
+  it("バッジが 0 個のときは獲得の文言を出さない", () => {
+    render(
+      <AchievementSummaryModal
+        monthKey={MONTH_KEY}
+        history={[buildGoal({ is_achieved: false })]}
+        badges={[]}
+      />,
+    );
+
+    expect(screen.getByText(/期限を迎えた目標1件中/)).toBeInTheDocument();
+    expect(screen.queryByText(/新しいバッジ/)).not.toBeInTheDocument();
+  });
+
+  it("前月に期限を迎えた目標が無ければ表示しない", () => {
+    render(
+      <AchievementSummaryModal
+        monthKey={MONTH_KEY}
+        history={[buildGoal({ deadline: "2026-08-31" })]}
+        badges={[]}
+      />,
+    );
+
+    expect(summaryText()).not.toBeInTheDocument();
+  });
+
+  it("フラグの読み込みが確定するまで表示しない", () => {
+    const html = renderToStaticMarkup(
+      <AchievementSummaryModal
+        monthKey={MONTH_KEY}
+        history={HISTORY}
+        badges={[]}
+      />,
+    );
+
+    expect(html).not.toContain("期限を迎えた目標");
+  });
+
+  it("閉じると表示済みを保存し、同じ月の再訪では表示しない", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(
+      <AchievementSummaryModal
+        monthKey={MONTH_KEY}
+        history={HISTORY}
+        badges={[]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "閉じる" }));
+    expect(summaryText()).not.toBeInTheDocument();
+    expect(localStorage.getItem(achievementSummaryShownKey(MONTH_KEY))).toBe(
+      "1",
+    );
+
+    unmount();
+    render(
+      <AchievementSummaryModal
+        monthKey={MONTH_KEY}
+        history={HISTORY}
+        badges={[]}
+      />,
+    );
+
+    expect(summaryText()).not.toBeInTheDocument();
+  });
+
+  it("前月を表示済みでも、翌月分は改めて表示する", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(
+      <AchievementSummaryModal
+        monthKey={MONTH_KEY}
+        history={HISTORY}
+        badges={[]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "閉じる" }));
+    unmount();
+
+    render(
+      <AchievementSummaryModal
+        monthKey={NEXT_MONTH_KEY}
+        history={[buildGoal({ deadline: "2026-08-31" })]}
+        badges={[]}
+      />,
+    );
+
+    expect(screen.getByText("2026年8月の振り返り")).toBeInTheDocument();
+  });
+
+  it("バッジを見るはバッジ一覧へのリンクで、押すと表示済みになる", async () => {
+    const user = userEvent.setup();
+    render(
+      <AchievementSummaryModal
+        monthKey={MONTH_KEY}
+        history={HISTORY}
+        badges={[]}
+      />,
+    );
+
+    // HeroUI の Button は as={Link} でも role="button" の a 要素を描画する。
+    const link = screen.getByRole("button", { name: "バッジを見る" });
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("href", "/goals/badges");
+
+    await user.click(link);
+
+    expect(localStorage.getItem(achievementSummaryShownKey(MONTH_KEY))).toBe(
+      "1",
+    );
+  });
+
+  it("localStorage の読み込みが例外でも落ちず、表示済み扱いにする", () => {
+    jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+
+    expect(() =>
+      render(
+        <AchievementSummaryModal
+          monthKey={MONTH_KEY}
+          history={HISTORY}
+          badges={[]}
+        />,
+      ),
+    ).not.toThrow();
+    expect(summaryText()).not.toBeInTheDocument();
+  });
+
+  it("localStorage の保存が例外でも落ちず、その場では閉じられる", async () => {
+    const user = userEvent.setup();
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+
+    render(
+      <AchievementSummaryModal
+        monthKey={MONTH_KEY}
+        history={HISTORY}
+        badges={[]}
+      />,
+    );
+
+    await expect(
+      user.click(screen.getByRole("button", { name: "閉じる" })),
+    ).resolves.not.toThrow();
+    expect(summaryText()).not.toBeInTheDocument();
+  });
+});

--- a/app/(app)/goals/__tests__/GoalsContent.test.tsx
+++ b/app/(app)/goals/__tests__/GoalsContent.test.tsx
@@ -142,6 +142,17 @@ describe("GoalsContent", () => {
     mockEntitlement();
   });
 
+  describe("達成バッジへの導線", () => {
+    it("バッジ一覧へのリンクを出す", () => {
+      renderContent();
+
+      expect(screen.getByRole("link", { name: "達成バッジ" })).toHaveAttribute(
+        "href",
+        "/goals/badges",
+      );
+    });
+  });
+
   describe("3タブの分類", () => {
     const activeGoals = [
       buildGoal({ id: 1, title: "進行中の目標" }),

--- a/app/(app)/goals/__tests__/achievementSummary.test.ts
+++ b/app/(app)/goals/__tests__/achievementSummary.test.ts
@@ -1,0 +1,204 @@
+import type { Goal, GoalBadge } from "@app/types/goal";
+import {
+  formatMonthKeyJa,
+  hasAchievementSummary,
+  isDateInMonth,
+  monthKeyOf,
+  previousMonthKey,
+  summarizeAchievements,
+} from "../_utils/achievementSummary";
+
+function buildGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: 1,
+    title: "月20日練習",
+    kind: "numeric",
+    period_type: "monthly",
+    season_id: null,
+    tournament_id: null,
+    month_start: "2026-07-01",
+    deadline: "2026-07-31",
+    metric_key: "practice_days",
+    target_value: 20,
+    comparison_type: "greater_than",
+    practice_menu_id: null,
+    practice_menu_name: null,
+    custom_metric_label: null,
+    custom_unit: null,
+    manual_current_value: 0,
+    is_achieved: false,
+    is_finalized: true,
+    achieved_value: 20,
+    current_value: 20,
+    progress_percent: 100,
+    days_remaining: 0,
+    ...overrides,
+  };
+}
+
+function buildBadge(overrides: Partial<GoalBadge> = {}): GoalBadge {
+  return {
+    id: 1,
+    badge_type: "monthly_achieved",
+    badge_name: "月間目標達成",
+    awarded_at: "2026-08-01T00:05:00.000+09:00",
+    goal_id: 1,
+    goal_title: "月20日練習",
+    ...overrides,
+  };
+}
+
+describe("previousMonthKey", () => {
+  it("直前に終わった月を返す", () => {
+    expect(previousMonthKey(new Date("2026-08-03T12:00:00+09:00"))).toBe(
+      "2026-07",
+    );
+  });
+
+  it("1月は前年12月を返す", () => {
+    expect(previousMonthKey(new Date("2026-01-15T12:00:00+09:00"))).toBe(
+      "2025-12",
+    );
+  });
+
+  it("月初 0 時ちょうどでも前月を返す", () => {
+    expect(previousMonthKey(new Date("2026-08-01T00:00:00+09:00"))).toBe(
+      "2026-07",
+    );
+  });
+
+  it("月末 23:59 はまだ当月なので前々月ではなく前月を返す", () => {
+    expect(previousMonthKey(new Date("2026-07-31T23:59:00+09:00"))).toBe(
+      "2026-06",
+    );
+  });
+
+  it("UTC ではまだ前月でも Asia/Tokyo で月が変わっていれば新しい月として扱う", () => {
+    // UTC 2026-01-31 15:30 = JST 2026-02-01 00:30。UTC 判定だと 2025-12 になってしまう。
+    expect(previousMonthKey(new Date("2026-01-31T15:30:00Z"))).toBe("2026-01");
+  });
+
+  it("UTC で年が変わる前でも Asia/Tokyo で年が明けていれば前年12月を返す", () => {
+    // UTC 2025-12-31 16:00 = JST 2026-01-01 01:00。
+    expect(previousMonthKey(new Date("2025-12-31T16:00:00Z"))).toBe("2025-12");
+  });
+});
+
+describe("monthKeyOf", () => {
+  it("日付のみの値はタイムゾーン変換せずそのまま月を切り出す", () => {
+    expect(monthKeyOf("2026-07-01")).toBe("2026-07");
+    expect(monthKeyOf("2026-07-31")).toBe("2026-07");
+  });
+
+  it("日時は Asia/Tokyo の月に変換する", () => {
+    // JST 2026-08-01 00:30 は 7 月ではなく 8 月。
+    expect(monthKeyOf("2026-07-31T15:30:00Z")).toBe("2026-08");
+    expect(monthKeyOf("2026-08-01T00:30:00+09:00")).toBe("2026-08");
+  });
+
+  it("解釈できない値はどの月にも一致しない", () => {
+    expect(monthKeyOf("")).toBe("");
+    expect(isDateInMonth("不正な日付", "2026-07")).toBe(false);
+  });
+});
+
+describe("isDateInMonth", () => {
+  it("月内の日付だけ true を返す", () => {
+    expect(isDateInMonth("2026-07-31", "2026-07")).toBe(true);
+    expect(isDateInMonth("2026-08-01", "2026-07")).toBe(false);
+    expect(isDateInMonth("2026-06-30", "2026-07")).toBe(false);
+  });
+
+  it("年が違えば同じ月番号でも false", () => {
+    expect(isDateInMonth("2025-12-31", "2026-12")).toBe(false);
+  });
+});
+
+describe("formatMonthKeyJa", () => {
+  it("先頭 0 を落とした日本語表記にする", () => {
+    expect(formatMonthKeyJa("2026-07")).toBe("2026年7月");
+    expect(formatMonthKeyJa("2025-12")).toBe("2025年12月");
+  });
+});
+
+describe("summarizeAchievements", () => {
+  const monthKey = "2026-07";
+
+  it("対象月に期限を迎えた確定済み目標を分母、達成を分子に数える", () => {
+    const history = [
+      buildGoal({ id: 1, deadline: "2026-07-31", is_achieved: true }),
+      buildGoal({ id: 2, deadline: "2026-07-01", is_achieved: false }),
+      buildGoal({ id: 3, deadline: "2026-07-15", is_achieved: true }),
+    ];
+
+    const summary = summarizeAchievements(history, [], monthKey);
+
+    expect(summary.finalizedCount).toBe(3);
+    expect(summary.achievedCount).toBe(2);
+  });
+
+  it("対象月以外に期限を迎えた目標は数えない", () => {
+    const history = [
+      buildGoal({ id: 1, deadline: "2026-06-30", is_achieved: true }),
+      buildGoal({ id: 2, deadline: "2026-08-01", is_achieved: true }),
+      buildGoal({ id: 3, deadline: "2026-07-31", is_achieved: true }),
+    ];
+
+    const summary = summarizeAchievements(history, [], monthKey);
+
+    expect(summary.finalizedCount).toBe(1);
+    expect(summary.achievedCount).toBe(1);
+  });
+
+  it("未確定の目標は期限が対象月でも数えない", () => {
+    const history = [
+      buildGoal({ id: 1, deadline: "2026-07-31", is_finalized: false }),
+    ];
+
+    expect(summarizeAchievements(history, [], monthKey).finalizedCount).toBe(0);
+  });
+
+  it("対象月に付与されたバッジだけを数える", () => {
+    const badges = [
+      buildBadge({ id: 1, awarded_at: "2026-07-02T09:00:00.000+09:00" }),
+      buildBadge({ id: 2, awarded_at: "2026-07-31T23:00:00.000+09:00" }),
+      buildBadge({ id: 3, awarded_at: "2026-08-01T00:05:00.000+09:00" }),
+    ];
+
+    expect(summarizeAchievements([], badges, monthKey).badgeCount).toBe(2);
+  });
+
+  it("達成もバッジも 0 件なら 0 を返す", () => {
+    const history = [buildGoal({ deadline: "2026-07-31", is_achieved: false })];
+
+    const summary = summarizeAchievements(history, [], monthKey);
+
+    expect(summary).toEqual({
+      finalizedCount: 1,
+      achievedCount: 0,
+      badgeCount: 0,
+    });
+  });
+});
+
+describe("hasAchievementSummary", () => {
+  it("期限を迎えた目標が 1 件でもあれば振り返る対象がある", () => {
+    expect(
+      hasAchievementSummary({
+        finalizedCount: 1,
+        achievedCount: 0,
+        badgeCount: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("期限を迎えた目標が無ければ振り返る対象が無い", () => {
+    expect(
+      hasAchievementSummary({
+        finalizedCount: 0,
+        achievedCount: 0,
+        badgeCount: 0,
+      }),
+    ).toBe(false);
+  });
+});

--- a/app/(app)/goals/_components/AchievementSummaryModal.tsx
+++ b/app/(app)/goals/_components/AchievementSummaryModal.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import type { Goal, GoalBadge } from "@app/types/goal";
+import TrophyIcon from "@heroicons/react/24/outline/TrophyIcon";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import Link from "next/link";
+import { achievementSummaryShownKey } from "@app/constants/goal";
+import { useOnboardingFlag } from "@app/hooks/onboarding/useOnboardingFlag";
+import {
+  formatMonthKeyJa,
+  hasAchievementSummary,
+  summarizeAchievements,
+} from "../_utils/achievementSummary";
+
+interface AchievementSummaryModalProps {
+  /** 振り返る対象月（YYYY-MM）。SSR / CSR でずれないようサーバー側で確定させて渡す。 */
+  monthKey: string;
+  history: Goal[];
+  badges: GoalBadge[];
+}
+
+/**
+ * 前月に期限を迎えた目標の達成サマリーを、その月について一度だけ表示するモーダル。
+ *
+ * 表示済みの記録は月キーを含む localStorage のキーで持つため、
+ * 翌月になればキーが変わり、再び一度だけ表示される。
+ */
+export default function AchievementSummaryModal({
+  monthKey,
+  history,
+  badges,
+}: AchievementSummaryModalProps) {
+  const { isMarked, mark } = useOnboardingFlag(
+    achievementSummaryShownKey(monthKey),
+  );
+  const summary = summarizeAchievements(history, badges, monthKey);
+
+  // 読み込み確定前（null）に描画すると、表示済みでも一瞬モーダルが見えてしまう。
+  if (isMarked !== false) return null;
+  if (!hasAchievementSummary(summary)) return null;
+
+  return (
+    <Modal isOpen onClose={mark} placement="center" className="buzz-dark">
+      <ModalContent>
+        <ModalHeader className="flex items-center gap-2 text-white">
+          <TrophyIcon className="h-5 w-5 text-[#d08000]" aria-hidden />
+          {formatMonthKeyJa(monthKey)}の振り返り
+        </ModalHeader>
+        <ModalBody>
+          <p className="text-sm text-white">
+            期限を迎えた目標{summary.finalizedCount}件中{" "}
+            <span className="font-bold text-[#d08000]">
+              {summary.achievedCount}件達成
+            </span>
+          </p>
+          {summary.badgeCount > 0 ? (
+            <p className="text-xs text-zinc-400">
+              新しいバッジを{summary.badgeCount}個獲得しました
+            </p>
+          ) : null}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="flat" onPress={mark}>
+            閉じる
+          </Button>
+          <Button as={Link} href="/goals/badges" color="primary" onPress={mark}>
+            バッジを見る
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/app/(app)/goals/_components/GoalsContent.tsx
+++ b/app/(app)/goals/_components/GoalsContent.tsx
@@ -4,6 +4,7 @@ import type { SeasonData, TournamentData } from "@app/interface";
 import type { Goal } from "@app/types/goal";
 import type { PracticeMenu } from "@app/types/practice";
 import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import TrophyIcon from "@heroicons/react/24/outline/TrophyIcon";
 import {
   Button,
   Modal,
@@ -12,6 +13,7 @@ import {
   ModalFooter,
   ModalHeader,
 } from "@heroui/react";
+import Link from "next/link";
 import { useState } from "react";
 import { toast } from "sonner";
 import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
@@ -37,6 +39,7 @@ import {
   isAtGoalFreeLimit,
 } from "../_utils/goalList";
 import {
+  BADGES_TITLE,
   DELETE_CONFIRM_NOTICE,
   EMPTY_MESSAGE,
   FREE_LIMIT_DESCRIPTION,
@@ -198,7 +201,16 @@ export default function GoalsContent({
 
   return (
     <>
-      <h2 className="text-2xl font-bold">目標</h2>
+      <div className="flex items-start justify-between gap-3">
+        <h2 className="text-2xl font-bold">目標</h2>
+        <Link
+          href="/goals/badges"
+          className="mt-1 inline-flex shrink-0 items-center gap-1 text-sm text-[#d08000]"
+        >
+          <TrophyIcon className="h-4 w-4" aria-hidden />
+          {BADGES_TITLE}
+        </Link>
+      </div>
       <p className="mt-2 text-sm text-zinc-300">
         練習量や成績の目標を決めると、記録した内容から進み具合を自動で計算します。数字にできない目標は達成ボタンで管理できます。
       </p>

--- a/app/(app)/goals/_components/goalCopy.ts
+++ b/app/(app)/goals/_components/goalCopy.ts
@@ -22,6 +22,20 @@ export const EMPTY_MESSAGE: Record<GoalTab, string> = {
 export const LOAD_ERROR_MESSAGE =
   "目標を取得できませんでした。時間を置いて再度お試しください。";
 
+export const BADGES_TITLE = "達成バッジ";
+
+export const BADGES_DESCRIPTION =
+  "期限を迎えた目標を達成すると、自動でバッジが増えます。";
+
+/** 空状態の文言はモバイルアプリのバッジ一覧と揃える。 */
+export const BADGES_EMPTY_TITLE = "まだ達成バッジはありません";
+
+export const BADGES_EMPTY_DESCRIPTION =
+  "目標を達成すると、ここにバッジが並びます";
+
+export const BADGES_LOAD_ERROR_MESSAGE =
+  "達成バッジを取得できませんでした。時間を置いて再度お試しください。";
+
 export const HISTORY_LOAD_ERROR_MESSAGE =
   "達成・未達の履歴を取得できませんでした。進行中の目標のみ表示しています。";
 

--- a/app/(app)/goals/_utils/achievementSummary.ts
+++ b/app/(app)/goals/_utils/achievementSummary.ts
@@ -1,0 +1,114 @@
+import type { Goal, GoalBadge } from "@app/types/goal";
+import { todayString } from "./goalForm";
+
+/**
+ * 月の境界は back の FinalizeGoalsJob（Asia/Tokyo で期限到来を判定）と揃える。
+ * 実行環境のタイムゾーンに任せると、月初・月末に前月がひと月ずれる。
+ */
+const TIME_ZONE = "Asia/Tokyo";
+
+const MONTH_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  timeZone: TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+});
+
+// back が Date 型カラム（deadline）を返す形式。日時と違いタイムゾーンを持たない。
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const pad = (value: number): string => String(value).padStart(2, "0");
+
+function tokyoMonthKey(date: Date): string {
+  const parts = MONTH_FORMATTER.formatToParts(date);
+  const year = parts.find((part) => part.type === "year")?.value ?? "";
+  const month = parts.find((part) => part.type === "month")?.value ?? "";
+  return `${year}-${month}`;
+}
+
+/**
+ * ISO の日付・日時を月キー（YYYY-MM）へ変換する。
+ *
+ * 日付のみ（YYYY-MM-DD）はタイムゾーンを持たないため文字列のまま切り出す。
+ * Date へ通すと UTC 深夜として解釈され、月初・月末の deadline が隣の月へ移ってしまう。
+ *
+ * @param iso `YYYY-MM-DD` またはオフセット付きの ISO8601 日時
+ * @returns 月キー。解釈できない値なら空文字（どの月にも一致しない）。
+ */
+export function monthKeyOf(iso: string): string {
+  if (DATE_ONLY_PATTERN.test(iso)) return iso.slice(0, 7);
+
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return tokyoMonthKey(date);
+}
+
+/**
+ * 直近の「終わった月」のキー（YYYY-MM）。
+ * 今月はまだ期限未到来の目標が残るため振り返りの対象にしない。
+ *
+ * @param now 判定の基準時刻（既定は現在時刻）
+ */
+export function previousMonthKey(now: Date = new Date()): string {
+  const [year, month] = todayString(now).split("-").map(Number);
+  return month === 1 ? `${year - 1}-12` : `${year}-${pad(month - 1)}`;
+}
+
+/** ISO の日付・日時が指定した月キーに属するか。 */
+export function isDateInMonth(iso: string, monthKey: string): boolean {
+  return monthKeyOf(iso) === monthKey;
+}
+
+/** 月キー（YYYY-MM）を日本語表示（YYYY年M月）へ変換する。 */
+export function formatMonthKeyJa(monthKey: string): string {
+  const [year, month] = monthKey.split("-").map(Number);
+  return `${year}年${month}月`;
+}
+
+export interface AchievementSummary {
+  /** 対象月にその月の期限を迎え、確定した目標の件数（「N件中」の N）。 */
+  finalizedCount: number;
+  /** そのうち達成で確定した件数（「M件達成」の M）。 */
+  achievedCount: number;
+  /** 対象月に付与されたバッジの個数。 */
+  badgeCount: number;
+}
+
+/**
+ * 対象月の達成サマリーを集計する。
+ *
+ * 「期限を迎えた目標」は back の FinalizeGoalsJob に合わせて
+ * 「deadline が対象月にあり、かつ確定済み（is_finalized）の目標」と定義する。
+ * 期限前に手動達成しただけの未確定目標は、まだ期限を迎えていないので数えない。
+ *
+ * @param history 確定済み目標の履歴（GET /api/v2/goals/history）
+ * @param badges 付与済みバッジ（GET /api/v2/goal_badges）
+ * @param monthKey 対象月（YYYY-MM）
+ */
+export function summarizeAchievements(
+  history: Goal[],
+  badges: GoalBadge[],
+  monthKey: string,
+): AchievementSummary {
+  const finalized = history.filter(
+    (goal) => goal.is_finalized && isDateInMonth(goal.deadline, monthKey),
+  );
+
+  return {
+    finalizedCount: finalized.length,
+    achievedCount: finalized.filter((goal) => goal.is_achieved).length,
+    badgeCount: badges.filter((badge) =>
+      isDateInMonth(badge.awarded_at, monthKey),
+    ).length,
+  };
+}
+
+/**
+ * 振り返るものがある月か。
+ *
+ * 達成 0 件でもモーダルは出す（未達で終わったことに気づける方が価値があり、
+ * 達成 0 件のときは祝う文言を出さない作りにしてある）。
+ * 期限を迎えた目標が 1 件も無い月だけ、振り返る対象が無いので出さない。
+ */
+export function hasAchievementSummary(summary: AchievementSummary): boolean {
+  return summary.finalizedCount > 0;
+}

--- a/app/(app)/goals/badges/__tests__/GoalBadgeList.test.tsx
+++ b/app/(app)/goals/badges/__tests__/GoalBadgeList.test.tsx
@@ -1,0 +1,62 @@
+import type { GoalBadge } from "@app/types/goal";
+import { render, screen } from "@testing-library/react";
+import GoalBadgeList from "../_components/GoalBadgeList";
+
+function buildBadge(overrides: Partial<GoalBadge> = {}): GoalBadge {
+  return {
+    id: 1,
+    badge_type: "monthly_achieved",
+    badge_name: "月間目標達成",
+    awarded_at: "2026-08-01T00:05:00.000+09:00",
+    goal_id: 1,
+    goal_title: "月20日練習",
+    ...overrides,
+  };
+}
+
+describe("GoalBadgeList", () => {
+  it("バッジ名・元の目標・付与日を並べる", () => {
+    render(<GoalBadgeList badges={[buildBadge()]} />);
+
+    expect(screen.getByText("月間目標達成")).toBeInTheDocument();
+    expect(screen.getByText("月20日練習")).toBeInTheDocument();
+    expect(screen.getByText("2026/8/1")).toBeInTheDocument();
+  });
+
+  it("渡された順（back の付与日降順）をそのまま保つ", () => {
+    render(
+      <GoalBadgeList
+        badges={[
+          buildBadge({ id: 1, badge_name: "シーズン目標達成" }),
+          buildBadge({ id: 2, badge_name: "大会目標達成" }),
+        ]}
+      />,
+    );
+
+    const names = screen
+      .getAllByRole("listitem")
+      .map((item) => item.textContent);
+    expect(names[0]).toContain("シーズン目標達成");
+    expect(names[1]).toContain("大会目標達成");
+  });
+
+  it("バッジが 0 件なら空状態を出す", () => {
+    render(<GoalBadgeList badges={[]} />);
+
+    expect(screen.getByText("まだ達成バッジはありません")).toBeInTheDocument();
+    expect(
+      screen.getByText("目標を達成すると、ここにバッジが並びます"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
+  });
+
+  it("付与日時が Asia/Tokyo で日をまたぐ値でも東京の日付で表示する", () => {
+    render(
+      <GoalBadgeList
+        badges={[buildBadge({ awarded_at: "2026-07-31T15:30:00Z" })]}
+      />,
+    );
+
+    expect(screen.getByText("2026/8/1")).toBeInTheDocument();
+  });
+});

--- a/app/(app)/goals/badges/_components/GoalBadgeList.tsx
+++ b/app/(app)/goals/badges/_components/GoalBadgeList.tsx
@@ -1,0 +1,60 @@
+import type { GoalBadge } from "@app/types/goal";
+import TrophyIcon from "@heroicons/react/24/outline/TrophyIcon";
+import {
+  BADGES_EMPTY_DESCRIPTION,
+  BADGES_EMPTY_TITLE,
+} from "../../_components/goalCopy";
+
+// 付与日時は back が Asia/Tokyo のオフセット付きで返すが、
+// 表示端末のタイムゾーンに引きずられないよう明示的に固定する。
+const DATE_FORMATTER = new Intl.DateTimeFormat("ja-JP", {
+  timeZone: "Asia/Tokyo",
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+});
+
+function formatAwardedAt(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return DATE_FORMATTER.format(date);
+}
+
+interface GoalBadgeListProps {
+  badges: GoalBadge[];
+}
+
+/** 獲得済みの達成バッジを新しい順に並べる（並び順は back の awarded_at 降順をそのまま使う）。 */
+export default function GoalBadgeList({ badges }: GoalBadgeListProps) {
+  if (badges.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 rounded-lg bg-sub px-4 py-10 text-center">
+        <TrophyIcon className="h-10 w-10 text-zinc-500" aria-hidden />
+        <p className="text-sm font-bold text-white">{BADGES_EMPTY_TITLE}</p>
+        <p className="text-xs text-zinc-400">{BADGES_EMPTY_DESCRIPTION}</p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-3">
+      {badges.map((badge) => (
+        <li
+          key={badge.id}
+          className="flex items-center gap-3 rounded-lg bg-sub p-4"
+        >
+          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[#d08000]/20">
+            <TrophyIcon className="h-6 w-6 text-[#d08000]" aria-hidden />
+          </span>
+          <div className="min-w-0">
+            <p className="text-sm font-bold text-white">{badge.badge_name}</p>
+            <p className="truncate text-xs text-zinc-300">{badge.goal_title}</p>
+            <p className="text-xs text-zinc-500">
+              {formatAwardedAt(badge.awarded_at)}
+            </p>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/app/(app)/goals/badges/page.tsx
+++ b/app/(app)/goals/badges/page.tsx
@@ -1,0 +1,57 @@
+import ArrowLeftIcon from "@heroicons/react/24/outline/ArrowLeftIcon";
+import { cookies } from "next/headers";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getGoalBadges } from "@app/services/v2/goalService";
+import {
+  BADGES_DESCRIPTION,
+  BADGES_LOAD_ERROR_MESSAGE,
+  BADGES_TITLE,
+} from "../_components/goalCopy";
+import GoalBadgeList from "./_components/GoalBadgeList";
+
+export const metadata = {
+  title: BADGES_TITLE,
+};
+
+export default async function GoalBadgesPage() {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const badgesResult = await getGoalBadges();
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            <Link
+              href="/goals"
+              className="inline-flex items-center gap-1 text-sm text-zinc-300"
+            >
+              <ArrowLeftIcon className="h-4 w-4" aria-hidden />
+              目標
+            </Link>
+            <h2 className="mt-3 text-2xl font-bold">{BADGES_TITLE}</h2>
+            <p className="mt-2 text-sm text-zinc-300">{BADGES_DESCRIPTION}</p>
+
+            <div className="my-6">
+              {badgesResult.status === "ok" ? (
+                <GoalBadgeList badges={badgesResult.data} />
+              ) : (
+                // 取得失敗を空配列に丸めると「まだバッジが無い」と誤って伝わる。
+                <p className="py-8 text-center text-sm text-zinc-400">
+                  {BADGES_LOAD_ERROR_MESSAGE}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/(app)/goals/page.tsx
+++ b/app/(app)/goals/page.tsx
@@ -1,10 +1,16 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import Header from "@app/components/header/Header";
-import { getGoalHistory, getGoals } from "@app/services/v2/goalService";
+import {
+  getGoalBadges,
+  getGoalHistory,
+  getGoals,
+} from "@app/services/v2/goalService";
 import { getPracticeMenus } from "@app/services/v2/practiceMenuService";
+import AchievementSummaryModal from "./_components/AchievementSummaryModal";
 import { LOAD_ERROR_MESSAGE } from "./_components/goalCopy";
 import GoalsContent from "./_components/GoalsContent";
+import { previousMonthKey } from "./_utils/achievementSummary";
 import { todayString } from "./_utils/goalForm";
 import { getGoalSeasonOptions, getGoalTournamentOptions } from "./actions";
 
@@ -18,14 +24,26 @@ export default async function GoalsPage() {
     redirect("/signup?auth_required=true");
   }
 
-  const [goalsResult, historyResult, seasonsResult, tournamentsResult, menus] =
-    await Promise.all([
-      getGoals(),
-      getGoalHistory(),
-      getGoalSeasonOptions(),
-      getGoalTournamentOptions(),
-      getPracticeMenus(),
-    ]);
+  const [
+    goalsResult,
+    historyResult,
+    badgesResult,
+    seasonsResult,
+    tournamentsResult,
+    menus,
+  ] = await Promise.all([
+    getGoals(),
+    getGoalHistory(),
+    getGoalBadges(),
+    getGoalSeasonOptions(),
+    getGoalTournamentOptions(),
+    getPracticeMenus(),
+  ]);
+
+  const history = historyResult.status === "ok" ? historyResult.data : [];
+  // 履歴が取れていないと「N件中M件」が実際より少なく出るため、その月は振り返りを出さない。
+  const summaryMonthKey =
+    historyResult.status === "ok" ? previousMonthKey() : null;
 
   return (
     <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
@@ -36,9 +54,7 @@ export default async function GoalsPage() {
             {goalsResult.status === "ok" ? (
               <GoalsContent
                 initialGoals={goalsResult.data}
-                initialHistory={
-                  historyResult.status === "ok" ? historyResult.data : []
-                }
+                initialHistory={history}
                 historyLoadFailed={historyResult.status !== "ok"}
                 seasons={
                   seasonsResult.status === "ok" ? seasonsResult.data : []
@@ -60,6 +76,14 @@ export default async function GoalsPage() {
           </div>
         </div>
       </main>
+
+      {summaryMonthKey !== null ? (
+        <AchievementSummaryModal
+          monthKey={summaryMonthKey}
+          history={history}
+          badges={badgesResult.status === "ok" ? badgesResult.data : []}
+        />
+      ) : null}
     </div>
   );
 }

--- a/app/constants/goal.ts
+++ b/app/constants/goal.ts
@@ -10,6 +10,20 @@ import { parseDecimal } from "@app/constants/practice";
 // back/app/models/concerns/plan_limits.rb の MONTHLY_GOAL_FREE_LIMIT と一致させる。
 export const MONTHLY_GOAL_FREE_LIMIT = 2;
 
+// オンボーディング（buzzbase.onboarding.*）とは別機能なので接頭辞を分ける。
+const GOAL_STORAGE_PREFIX = "buzzbase.goal.";
+
+/**
+ * 達成サマリーモーダルを対象月について表示済みか、を保持する localStorage キー。
+ *
+ * 「月に一度だけ」を値ではなくキーの一部（YYYY-MM）で表すことで、既存の
+ * readOnboardingFlag / writeOnboardingFlag（boolean 前提）をそのまま使える。
+ *
+ * @param monthKey 対象月（YYYY-MM）
+ */
+export const achievementSummaryShownKey = (monthKey: string): string =>
+  `${GOAL_STORAGE_PREFIX}achievementSummaryShown.${monthKey}`;
+
 /**
  * 無料枠を共有する個人の期間目標。back の Goal::PERSONAL_PERIOD_TYPES と一致させる。
  * season / tournament は件数ではなく Pro 限定機能として別に判定される。

--- a/app/services/v2/goalService.ts
+++ b/app/services/v2/goalService.ts
@@ -1,6 +1,11 @@
 "use server";
 
-import type { Goal, GoalInput, GoalUpdateInput } from "@app/types/goal";
+import type {
+  Goal,
+  GoalBadge,
+  GoalInput,
+  GoalUpdateInput,
+} from "@app/types/goal";
 import {
   type DeletedResponse,
   type FetchResult,
@@ -10,6 +15,15 @@ import {
 } from "./requests";
 
 const BASE_PATH = "/api/v2/goals";
+const BADGES_PATH = "/api/v2/goal_badges";
+
+/**
+ * 達成バッジの一覧を取得する（GET /api/v2/goal_badges）。
+ * back は自分のバッジだけを awarded_at の降順で返す。
+ */
+export async function getGoalBadges(): Promise<FetchResult<GoalBadge[]>> {
+  return fetchV2<GoalBadge[]>(BADGES_PATH, "getGoalBadges");
+}
 
 /**
  * 進行中（未確定）の目標一覧を取得する（GET /api/v2/goals）。

--- a/app/types/goal.ts
+++ b/app/types/goal.ts
@@ -117,3 +117,21 @@ export interface GoalUpdateInput {
   custom_unit?: string | null;
   manual_current_value?: number;
 }
+
+/**
+ * 目標達成バッジ1件。
+ * back/app/serializers/v2/goal_badge_serializer.rb に対応する。
+ *
+ * 付与するのは FinalizeGoalsJob だけで、フロントから作成・削除はできない。
+ */
+export interface GoalBadge {
+  id: number;
+  /** `<period_type>_achieved` 形式の種別。表示は badge_name を使い、種別の判定にだけ使う。 */
+  badge_type: string;
+  badge_name: string;
+  /** 付与日時（ISO8601）。back は Asia/Tokyo のオフセット付きで返す。 */
+  awarded_at: string;
+  goal_id: number;
+  /** 付与時点の目標タイトル。目標が削除されるとバッジも消えるため常に存在する。 */
+  goal_title: string;
+}


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#480

## 概要

`FinalizeGoalsJob` が付与した達成バッジの一覧と、前月に期限を迎えた目標の達成サマリーを月に一度だけ表示するモーダルです。mobile の `badges.tsx` + `AchievementSummaryModal.tsx` 相当。

## 変更内容

- バッジ一覧ページ（`GET /api/v2/goal_badges`）と空状態
- 達成サマリーモーダル —「◯月の振り返り: 期限を迎えた目標N件中M件達成」「新しいバッジをK個獲得」＋「バッジを見る」導線
- 前月キー算出・月内判定ユーティリティ
- 表示済みフラグの永続化

## 永続フラグは既存基盤に乗せています

#413 で導入した `app/utils/onboardingStorage.ts` / `useOnboardingFlag` の仕組みを使い、**新しい localStorage アクセス経路を作っていません**。本 issue のフラグは「月ごとに1回」なので単純な boolean とは異なりますが、既存の `try/catch` 方針を踏襲した最小限の拡張にとどめています。

`isMarked === null`（未確定）の間はモーダルを出さないちらつき防止の規約にも従っています。

## 境界の扱い

「月に一度だけ」の判定は境界バグが出やすく本番でしか気づけない類のため、以下をテストで固定しています。

- **年またぎ**（1月に前月＝前年12月）
- 月初・月末
- **タイムゾーン**（UTC で判定すると月初・月末がずれるため Asia/Tokyo で判定）

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn test` が通る（**145 suites / 1727 tests**）
- [x] `yarn build` — 実装者がローカルで実行済み
- [x] ミューテーションテスト実施済み

### ルート表

新規ルートの追加分以外に既存ルートの分類変更がないことを base との diff で確認しています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_