### PR TITLE
Add: 定期レビュー（週次/月次レポート・Pro）を実装

### DIFF
--- a/app/(app)/dashboard/_components/PeriodicReviewBanner.tsx
+++ b/app/(app)/dashboard/_components/PeriodicReviewBanner.tsx
@@ -1,0 +1,75 @@
+import type { FetchResult } from "@app/services/v2/requests";
+import type { PeriodicReview } from "@app/types/periodicReview";
+import ChevronRightIcon from "@heroicons/react/24/outline/ChevronRightIcon";
+import ExclamationCircleIcon from "@heroicons/react/24/outline/ExclamationCircleIcon";
+import SparklesIcon from "@heroicons/react/24/solid/SparklesIcon";
+import Link from "next/link";
+import {
+  BANNER_ERROR_SUB,
+  BANNER_ERROR_TITLE,
+  BANNER_TITLE,
+  bannerUnreadLabel,
+} from "@app/(app)/review/_components/periodicReviewCopy";
+import { unreadReviewIds } from "@app/(app)/review/_utils/periodicReviewFormat";
+
+interface PeriodicReviewBannerProps {
+  result: FetchResult<PeriodicReview[]>;
+}
+
+const REVIEW_PATH = "/review";
+
+/**
+ * 未読の週次 / 月次レポートがあるときだけ出す誘導バナー。
+ *
+ * back は entitlement を持たないユーザーへ空配列を返すため、未読が存在するのは Pro のみ。
+ * ここで entitlement を再判定する必要はない（無料ユーザーには件数が届かない）。
+ * 取得失敗は「未読なし」と同一視せず、一覧へ行ける控えめなバナーを出す。
+ */
+export default function PeriodicReviewBanner({
+  result,
+}: PeriodicReviewBannerProps) {
+  if (result.status === "error") {
+    return (
+      <Link
+        href={REVIEW_PATH}
+        className="flex items-center gap-2.5 rounded-[10px] bg-sub p-3.5 transition-opacity hover:opacity-90"
+      >
+        <ExclamationCircleIcon
+          className="h-5 w-5 shrink-0 text-zinc-400"
+          aria-hidden
+        />
+        <span className="min-w-0 flex-1">
+          <span className="block text-sm font-bold text-zinc-300">
+            {BANNER_ERROR_TITLE}
+          </span>
+          <span className="mt-0.5 block text-xs text-[#d08000]">
+            {BANNER_ERROR_SUB}
+          </span>
+        </span>
+      </Link>
+    );
+  }
+
+  if (result.status !== "ok") return null;
+
+  const unreadCount = unreadReviewIds(result.data).length;
+  if (unreadCount === 0) return null;
+
+  return (
+    <Link
+      href={REVIEW_PATH}
+      className="flex items-center gap-2.5 rounded-[10px] bg-[#d08000] p-3.5 transition-opacity hover:opacity-90"
+    >
+      <SparklesIcon className="h-5 w-5 shrink-0 text-white" aria-hidden />
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-bold text-white">
+          {BANNER_TITLE}
+        </span>
+        <span className="mt-0.5 block text-xs text-white">
+          {bannerUnreadLabel(unreadCount)}
+        </span>
+      </span>
+      <ChevronRightIcon className="h-5 w-5 shrink-0 text-white" aria-hidden />
+    </Link>
+  );
+}

--- a/app/(app)/dashboard/_components/__tests__/PeriodicReviewBanner.test.tsx
+++ b/app/(app)/dashboard/_components/__tests__/PeriodicReviewBanner.test.tsx
@@ -1,0 +1,74 @@
+import type { FetchResult } from "@app/services/v2/requests";
+import type { PeriodicReview } from "@app/types/periodicReview";
+import { render, screen } from "@testing-library/react";
+import PeriodicReviewBanner from "../PeriodicReviewBanner";
+
+const buildReview = (id: number, read: boolean): PeriodicReview => ({
+  id,
+  period_type: "weekly",
+  period_start: "2026-07-13",
+  period_end: "2026-07-19",
+  read,
+  summary: { practice_days: 5 },
+});
+
+const okResult = (data: PeriodicReview[]): FetchResult<PeriodicReview[]> => ({
+  status: "ok",
+  data,
+});
+
+describe("PeriodicReviewBanner", () => {
+  it("未読があるときだけ一覧への導線を出す", () => {
+    render(
+      <PeriodicReviewBanner
+        result={okResult([buildReview(1, false), buildReview(2, true)])}
+      />,
+    );
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/review");
+    expect(screen.getByText("振り返りレポートが届いています")).toBeVisible();
+  });
+
+  it("未読件数は未読のレポートだけを数える", () => {
+    render(
+      <PeriodicReviewBanner
+        result={okResult([
+          buildReview(1, false),
+          buildReview(2, true),
+          buildReview(3, false),
+        ])}
+      />,
+    );
+
+    expect(screen.getByText("未読 2 件・タップで確認")).toBeInTheDocument();
+  });
+
+  it("すべて既読ならバナーを出さない", () => {
+    const { container } = render(
+      <PeriodicReviewBanner result={okResult([buildReview(1, true)])} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("レポートが 0 件ならバナーを出さない", () => {
+    const { container } = render(
+      <PeriodicReviewBanner result={okResult([])} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("取得失敗は未読なしと同一視せず、一覧へ行ける控えめなバナーを出す", () => {
+    render(<PeriodicReviewBanner result={{ status: "error" }} />);
+
+    expect(
+      screen.getByText("振り返りレポートを取得できませんでした"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/review");
+    expect(
+      screen.queryByText("振り返りレポートが届いています"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -3,7 +3,9 @@ import { redirect } from "next/navigation";
 import { adSlots } from "@app/components/ad/adConfig";
 import AdInFeed from "@app/components/ad/AdInFeed";
 import Header from "@app/components/header/Header";
+import { getPeriodicReviews } from "@app/services/v2/periodicReviewService";
 import DashboardContent from "./_components/DashboardContent";
+import PeriodicReviewBanner from "./_components/PeriodicReviewBanner";
 import { getAvailableSeasons, getDashboardData } from "./actions";
 
 export const metadata = {
@@ -16,9 +18,10 @@ export default async function DashboardPage() {
     redirect("/signup?auth_required=true");
   }
 
-  const [data, seasons] = await Promise.all([
+  const [data, seasons, reviews] = await Promise.all([
     getDashboardData(),
     getAvailableSeasons(),
+    getPeriodicReviews(),
   ]);
 
   return (
@@ -29,7 +32,8 @@ export default async function DashboardPage() {
           <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
             <div className="pt-20 px-4 lg:px-6">
               <h2 className="text-2xl font-bold">ダッシュボード</h2>
-              <div className="my-6">
+              <div className="my-6 flex flex-col gap-6">
+                <PeriodicReviewBanner result={reviews} />
                 <DashboardContent data={data} seasons={seasons} />
                 <AdInFeed
                   slot={adSlots.dashboardInFeed}

--- a/app/(app)/review/_components/PeriodicReviewCard.tsx
+++ b/app/(app)/review/_components/PeriodicReviewCard.tsx
@@ -1,0 +1,133 @@
+import type { PeriodicReview } from "@app/types/periodicReview";
+import {
+  formatCount,
+  formatDelta,
+  formatFixed,
+  formatPeriodDate,
+  formatRatio,
+} from "../_utils/periodicReviewFormat";
+
+interface PeriodicReviewCardProps {
+  review: PeriodicReview;
+}
+
+const periodLabel = (review: PeriodicReview): string =>
+  review.period_type === "monthly" ? "今月の振り返り" : "今週の振り返り";
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex-1 rounded-[10px] bg-main px-2 py-3 text-center">
+      <p className="text-lg font-bold text-[#d08000]">{value}</p>
+      <p className="mt-1 text-[11px] text-zinc-400">{label}</p>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-[72px] flex-1 rounded-[10px] bg-main px-2 py-2.5 text-center">
+      <p className="text-base font-bold text-white">{value}</p>
+      <p className="mt-0.5 text-[11px] text-zinc-400">{label}</p>
+    </div>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <h4 className="mb-2 mt-4 text-xs font-bold text-zinc-400">{children}</h4>
+  );
+}
+
+/**
+ * 週次 / 月次レポート1件のカード。
+ *
+ * 指標を追加する前に生成された古いレポートには summary のキー自体が無いため、
+ * 欠損値はすべて「-」で描く（0 と表示すると「成績が 0 だった」と誤読される）。
+ * 課題別内訳・インサイトは summary に含まれるときだけ描画する。
+ */
+export default function PeriodicReviewCard({
+  review,
+}: PeriodicReviewCardProps) {
+  const { summary } = review;
+  const batting = summary.batting;
+  const pitching = summary.pitching;
+  const themes = summary.theme_breakdown ?? [];
+  // 登板が無い期間は各値 null で返るため、投手ブロックごと出さない。
+  const hasPitching =
+    !!pitching &&
+    [pitching.era, pitching.whip, pitching.k_per_9].some(
+      (value) => value !== null && value !== undefined,
+    );
+  const delta = formatDelta(batting?.delta);
+
+  return (
+    <article className="rounded-[10px] bg-sub p-4">
+      <h3 className="text-base font-bold text-white">{periodLabel(review)}</h3>
+      <p className="mt-1 text-xs text-zinc-400">
+        {formatPeriodDate(review.period_start)} 〜{" "}
+        {formatPeriodDate(review.period_end)}
+      </p>
+
+      <div className="mt-3.5 flex gap-2">
+        <Stat
+          label="練習日数"
+          value={formatCount(summary.practice_days, "日")}
+        />
+        <Stat label="素振り" value={formatCount(summary.total_swings)} />
+        <Stat label="連続" value={formatCount(summary.streak_current, "日")} />
+      </div>
+
+      {batting ? (
+        <>
+          <SectionLabel>打撃</SectionLabel>
+          <div className="flex flex-wrap gap-2">
+            <Metric label="打率" value={formatRatio(batting.batting_average)} />
+            <Metric
+              label="出塁率"
+              value={formatRatio(batting.on_base_percentage)}
+            />
+            <Metric
+              label="長打率"
+              value={formatRatio(batting.slugging_percentage)}
+            />
+            <Metric label="OPS" value={formatRatio(batting.ops)} />
+          </div>
+          {delta ? (
+            <p className="mt-2 text-xs text-zinc-400">打率 前期間比 {delta}</p>
+          ) : null}
+        </>
+      ) : null}
+
+      {hasPitching ? (
+        <>
+          <SectionLabel>投手</SectionLabel>
+          <div className="flex flex-wrap gap-2">
+            <Metric label="防御率" value={formatFixed(pitching?.era, 2)} />
+            <Metric label="WHIP" value={formatFixed(pitching?.whip, 2)} />
+            <Metric label="K/9" value={formatFixed(pitching?.k_per_9, 1)} />
+          </div>
+        </>
+      ) : null}
+
+      {themes.length > 0 ? (
+        <>
+          <SectionLabel>課題</SectionLabel>
+          <ul className="space-y-1 text-sm text-white">
+            {themes.map((theme) => (
+              <li key={theme.id}>
+                {theme.title}（{formatCount(theme.practice_count, "回")}）
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+
+      {summary.insight ? (
+        <>
+          <SectionLabel>インサイト</SectionLabel>
+          <p className="text-sm leading-5 text-white">{summary.insight.body}</p>
+        </>
+      ) : null}
+    </article>
+  );
+}

--- a/app/(app)/review/_components/PeriodicReviewList.tsx
+++ b/app/(app)/review/_components/PeriodicReviewList.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import type { FetchResult } from "@app/services/v2/requests";
+import type { PeriodicReview } from "@app/types/periodicReview";
+import { useEffect, useRef } from "react";
+import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
+import { SampleDataLabel } from "@app/components/pro/SampleDataLabel";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { markPeriodicReviewRead } from "@app/services/v2/periodicReviewService";
+import { unreadReviewIds } from "../_utils/periodicReviewFormat";
+import PeriodicReviewCard from "./PeriodicReviewCard";
+import {
+  LOAD_ERROR_MESSAGE,
+  NOT_GENERATED_MESSAGE,
+} from "./periodicReviewCopy";
+import { SAMPLE_PERIODIC_REVIEWS } from "./periodicReviewSampleData";
+
+interface PeriodicReviewListProps {
+  result: FetchResult<PeriodicReview[]>;
+}
+
+const FEATURE = "advanced_periodic_review" as const;
+
+const LOADING_PLACEHOLDER = (
+  <div className="flex flex-col gap-4" aria-busy="true">
+    <p className="sr-only">読み込み中</p>
+    {[0, 1].map((key) => (
+      <div key={key} className="h-40 animate-pulse rounded-[10px] bg-sub" />
+    ))}
+  </div>
+);
+
+/**
+ * 振り返りレポート一覧。
+ *
+ * back は entitlement を持たないユーザーにも 200 + 空配列を返すため、空配列だけでは
+ * 「Pro 未加入」と「Pro だがまだ生成されていない」を区別できない。entitlement と
+ * 組み合わせて次の3通りに出し分ける。
+ *   判定未確定  … どちらとも決めつけずプレースホルダのみ（訴求も未生成案内も出さない）
+ *   無料        … サンプル + Pro 訴求
+ *   Pro         … 実データ。0 件なら「まだ生成されていない」案内（訴求は出さない）
+ */
+export default function PeriodicReviewList({
+  result,
+}: PeriodicReviewListProps) {
+  const { hasEntitlement, isLoading } = useEntitlement();
+  const canViewReviews = hasEntitlement(FEATURE);
+  // 既読化を送った id。再レンダリングのたびに PATCH を打ち直さないための記録で、
+  // 成否は問わない（失敗しても再送しない代わりに、一覧の閲覧は一切妨げない）。
+  const requestedIdsRef = useRef<Set<number>>(new Set());
+
+  // 一覧を開いた時点で未読をまとめて既読にする（未読バッジの解消）。
+  // 既読化の失敗は握りつぶす。既読が付かなくてもレポートは読めるべきで、
+  // ここでエラーを投げると一覧ごと落ちてしまうため。
+  useEffect(() => {
+    if (isLoading || !canViewReviews || result.status !== "ok") return;
+
+    const targets = unreadReviewIds(result.data).filter(
+      (id) => !requestedIdsRef.current.has(id),
+    );
+    if (targets.length === 0) return;
+
+    targets.forEach((id) => requestedIdsRef.current.add(id));
+    void Promise.allSettled(targets.map((id) => markPeriodicReviewRead(id)));
+  }, [result, canViewReviews, isLoading]);
+
+  if (isLoading) return LOADING_PLACEHOLDER;
+
+  if (!canViewReviews) {
+    return (
+      <div className="flex flex-col gap-y-2">
+        <ProUpsellCard feature={FEATURE} />
+        <SampleDataLabel />
+        <div className="flex flex-col gap-4">
+          {SAMPLE_PERIODIC_REVIEWS.map((review) => (
+            <PeriodicReviewCard key={review.id} review={review} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (result.status !== "ok") {
+    return (
+      <p className="py-8 text-center text-sm text-zinc-400">
+        {LOAD_ERROR_MESSAGE}
+      </p>
+    );
+  }
+
+  if (result.data.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm leading-6 text-zinc-400">
+        {NOT_GENERATED_MESSAGE}
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {result.data.map((review) => (
+        <PeriodicReviewCard key={review.id} review={review} />
+      ))}
+    </div>
+  );
+}

--- a/app/(app)/review/_components/__tests__/PeriodicReviewCard.test.tsx
+++ b/app/(app)/review/_components/__tests__/PeriodicReviewCard.test.tsx
@@ -1,0 +1,231 @@
+import type { PeriodicReview } from "@app/types/periodicReview";
+import { render, screen } from "@testing-library/react";
+import PeriodicReviewCard from "../PeriodicReviewCard";
+
+const buildReview = (
+  overrides: Partial<PeriodicReview> = {},
+): PeriodicReview => ({
+  id: 1,
+  period_type: "weekly",
+  period_start: "2026-07-13",
+  period_end: "2026-07-19",
+  read: false,
+  summary: {
+    period_type: "weekly",
+    practice_days: 5,
+    total_swings: 1200,
+    active_days: 5,
+    streak_current: 12,
+  },
+  ...overrides,
+});
+
+/** 指標名の隣に出ている値を読む（同じ数値が複数箇所に出ても取り違えない）。 */
+function valueOf(label: string): string {
+  const labelNode = screen.getByText(label);
+  return labelNode.parentElement?.firstElementChild?.textContent ?? "";
+}
+
+describe("PeriodicReviewCard", () => {
+  it("週次・月次で見出しを出し分ける", () => {
+    const { rerender } = render(<PeriodicReviewCard review={buildReview()} />);
+    expect(screen.getByText("今週の振り返り")).toBeInTheDocument();
+
+    rerender(
+      <PeriodicReviewCard review={buildReview({ period_type: "monthly" })} />,
+    );
+    expect(screen.getByText("今月の振り返り")).toBeInTheDocument();
+  });
+
+  it("練習量と打撃・投手の指標を表示する", () => {
+    render(
+      <PeriodicReviewCard
+        review={buildReview({
+          summary: {
+            practice_days: 5,
+            total_swings: 1200,
+            streak_current: 12,
+            batting: {
+              batting_average: 0.312,
+              on_base_percentage: 0.388,
+              slugging_percentage: 0.451,
+              ops: 0.839,
+            },
+            pitching: {
+              innings_pitched: 7,
+              era: 2.57,
+              whip: 1.14,
+              k_per_9: 9,
+            },
+          },
+        })}
+      />,
+    );
+
+    expect(valueOf("練習日数")).toBe("5日");
+    expect(valueOf("素振り")).toBe("1,200");
+    expect(valueOf("連続")).toBe("12日");
+    expect(valueOf("打率")).toBe(".312");
+    expect(valueOf("出塁率")).toBe(".388");
+    expect(valueOf("長打率")).toBe(".451");
+    expect(valueOf("OPS")).toBe(".839");
+    expect(valueOf("防御率")).toBe("2.57");
+    expect(valueOf("WHIP")).toBe("1.14");
+    expect(valueOf("K/9")).toBe("9.0");
+  });
+
+  it("旧レポートで欠けている指標は 0 ではなく - を表示する", () => {
+    render(
+      <PeriodicReviewCard
+        review={buildReview({
+          summary: {
+            practice_days: 5,
+            // total_swings / streak_current / 出塁率以降は当時のレポートに存在しない
+            batting: { batting_average: 0.312 },
+          },
+        })}
+      />,
+    );
+
+    expect(valueOf("素振り")).toBe("-");
+    expect(valueOf("連続")).toBe("-");
+    expect(valueOf("出塁率")).toBe("-");
+    expect(valueOf("長打率")).toBe("-");
+    expect(valueOf("OPS")).toBe("-");
+    expect(screen.queryByText("NaN")).not.toBeInTheDocument();
+    expect(valueOf("打率")).toBe(".312");
+  });
+
+  it("値が 0 のときは - ではなく 0 を表示する", () => {
+    render(
+      <PeriodicReviewCard
+        review={buildReview({
+          summary: {
+            practice_days: 0,
+            total_swings: 0,
+            streak_current: 0,
+            batting: { batting_average: 0 },
+          },
+        })}
+      />,
+    );
+
+    expect(valueOf("練習日数")).toBe("0日");
+    expect(valueOf("素振り")).toBe("0");
+    expect(valueOf("打率")).toBe(".000");
+  });
+
+  it("decimal が文字列で返っても数値として整形する", () => {
+    render(
+      <PeriodicReviewCard
+        review={buildReview({
+          summary: {
+            practice_days: "5",
+            total_swings: "1200.0",
+            batting: { batting_average: "0.312", delta: "0.026" },
+            pitching: { era: "2.57", whip: "1.14", k_per_9: "9.0" },
+          },
+        })}
+      />,
+    );
+
+    expect(valueOf("練習日数")).toBe("5日");
+    expect(valueOf("素振り")).toBe("1,200");
+    expect(valueOf("打率")).toBe(".312");
+    expect(valueOf("防御率")).toBe("2.57");
+    expect(screen.getByText("打率 前期間比 +.026")).toBeInTheDocument();
+  });
+
+  it("前期間比は上がった週を + 、下がった週を - で表示する", () => {
+    const { rerender } = render(
+      <PeriodicReviewCard
+        review={buildReview({
+          summary: { batting: { batting_average: 0.312, delta: 0.026 } },
+        })}
+      />,
+    );
+    expect(screen.getByText("打率 前期間比 +.026")).toBeInTheDocument();
+
+    rerender(
+      <PeriodicReviewCard
+        review={buildReview({
+          summary: { batting: { batting_average: 0.274, delta: -0.012 } },
+        })}
+      />,
+    );
+    expect(screen.getByText("打率 前期間比 -.012")).toBeInTheDocument();
+  });
+
+  it("前期間比が無いレポートでは前期間比の行を出さない", () => {
+    render(
+      <PeriodicReviewCard
+        review={buildReview({
+          summary: { batting: { batting_average: 0.312 } },
+        })}
+      />,
+    );
+
+    expect(screen.queryByText(/前期間比/)).not.toBeInTheDocument();
+  });
+
+  it("登板が無い期間は投手ブロックを出さない", () => {
+    render(
+      <PeriodicReviewCard
+        review={buildReview({
+          summary: {
+            practice_days: 5,
+            pitching: {
+              innings_pitched: 0,
+              era: null,
+              whip: null,
+              k_per_9: null,
+            },
+          },
+        })}
+      />,
+    );
+
+    expect(screen.queryByText("投手")).not.toBeInTheDocument();
+  });
+
+  it("課題別内訳とインサイトは summary にあるときだけ表示する", () => {
+    const { rerender } = render(<PeriodicReviewCard review={buildReview()} />);
+    expect(screen.queryByText("課題")).not.toBeInTheDocument();
+    expect(screen.queryByText("インサイト")).not.toBeInTheDocument();
+
+    rerender(
+      <PeriodicReviewCard
+        review={buildReview({
+          summary: {
+            practice_days: 5,
+            theme_breakdown: [{ id: 1, title: "肩の開き", practice_count: 4 }],
+            insight: {
+              key: "swings_batting_average",
+              id: null,
+              title: "素振りと打率の関係",
+              body: "素振りが多い週は打率が高い傾向があります。",
+              metric: "batting_average",
+              dimension: "total_swings",
+              direction: "positive",
+              strength: "strong",
+              sample_weeks: 8,
+              sufficient: true,
+            },
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("肩の開き（4回）")).toBeInTheDocument();
+    expect(
+      screen.getByText("素振りが多い週は打率が高い傾向があります。"),
+    ).toBeInTheDocument();
+  });
+
+  it("期間を日付で表示する", () => {
+    render(<PeriodicReviewCard review={buildReview()} />);
+
+    expect(screen.getByText(/2026\/07\/13/)).toBeInTheDocument();
+    expect(screen.getByText(/2026\/07\/19/)).toBeInTheDocument();
+  });
+});

--- a/app/(app)/review/_components/__tests__/PeriodicReviewList.test.tsx
+++ b/app/(app)/review/_components/__tests__/PeriodicReviewList.test.tsx
@@ -1,0 +1,214 @@
+const mockHasEntitlement = jest.fn();
+const mockIsLoading = jest.fn(() => false);
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: () => ({
+    isPro: mockHasEntitlement("advanced_periodic_review"),
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading: mockIsLoading(),
+    hasEntitlement: mockHasEntitlement,
+  }),
+}));
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: jest.fn(), close: jest.fn() }),
+}));
+
+jest.mock("@app/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("@app/services/v2/periodicReviewService", () => ({
+  markPeriodicReviewRead: jest.fn(),
+}));
+
+import type { FetchResult } from "@app/services/v2/requests";
+import type { PeriodicReview } from "@app/types/periodicReview";
+import { render, screen, waitFor } from "@testing-library/react";
+import { markPeriodicReviewRead } from "@app/services/v2/periodicReviewService";
+import PeriodicReviewList from "../PeriodicReviewList";
+
+const mockMarkRead = markPeriodicReviewRead as jest.MockedFunction<
+  typeof markPeriodicReviewRead
+>;
+
+const UPSELL_CTA = "Pro プランを見る";
+const SAMPLE_LABEL = "サンプルデータ（実際の記録ではありません）";
+const NOT_GENERATED = /まだレポートがありません/;
+
+const buildReview = (
+  overrides: Partial<PeriodicReview> = {},
+): PeriodicReview => ({
+  id: 1,
+  period_type: "weekly",
+  period_start: "2026-07-13",
+  period_end: "2026-07-19",
+  read: true,
+  summary: {
+    period_type: "weekly",
+    practice_days: 99,
+    total_swings: 5000,
+    active_days: 7,
+    streak_current: 40,
+  },
+  ...overrides,
+});
+
+const okResult = (data: PeriodicReview[]): FetchResult<PeriodicReview[]> => ({
+  status: "ok",
+  data,
+});
+
+describe("PeriodicReviewList", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsLoading.mockReturnValue(false);
+    mockHasEntitlement.mockReturnValue(true);
+    mockMarkRead.mockResolvedValue({ ok: true, data: buildReview() });
+  });
+
+  describe("空配列の出し分け", () => {
+    it("無料ユーザーには 0 件でもサンプルと Pro 訴求を出す", () => {
+      mockHasEntitlement.mockReturnValue(false);
+
+      render(<PeriodicReviewList result={okResult([])} />);
+
+      expect(screen.getByText(SAMPLE_LABEL)).toBeInTheDocument();
+      expect(
+        screen.getAllByRole("button", { name: new RegExp(UPSELL_CTA) }).length,
+      ).toBeGreaterThan(0);
+      // サンプルは3週分。実データと取り違えないよう未生成の案内は出さない。
+      expect(screen.getAllByText("今週の振り返り")).toHaveLength(3);
+      expect(screen.queryByText(NOT_GENERATED)).not.toBeInTheDocument();
+    });
+
+    it("Pro ユーザーで 0 件なら未生成の案内を出し、訴求もサンプルも出さない", () => {
+      mockHasEntitlement.mockReturnValue(true);
+
+      render(<PeriodicReviewList result={okResult([])} />);
+
+      expect(screen.getByText(NOT_GENERATED)).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: new RegExp(UPSELL_CTA) }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(SAMPLE_LABEL)).not.toBeInTheDocument();
+    });
+
+    it("Pro 判定が未確定の間は訴求も未生成の案内も出さない", () => {
+      mockIsLoading.mockReturnValue(true);
+      mockHasEntitlement.mockReturnValue(false);
+
+      render(<PeriodicReviewList result={okResult([])} />);
+
+      expect(screen.queryByText(SAMPLE_LABEL)).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: new RegExp(UPSELL_CTA) }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(NOT_GENERATED)).not.toBeInTheDocument();
+    });
+
+    it("Pro 判定が未確定の間は実データも既読化もしない", () => {
+      mockIsLoading.mockReturnValue(true);
+      mockHasEntitlement.mockReturnValue(true);
+
+      render(
+        <PeriodicReviewList
+          result={okResult([buildReview({ read: false })])}
+        />,
+      );
+
+      expect(screen.queryByText("99日")).not.toBeInTheDocument();
+      expect(mockMarkRead).not.toHaveBeenCalled();
+    });
+  });
+
+  it("Pro ユーザーには実データを表示する", () => {
+    render(<PeriodicReviewList result={okResult([buildReview()])} />);
+
+    expect(screen.getByText("99日")).toBeInTheDocument();
+    expect(screen.queryByText(SAMPLE_LABEL)).not.toBeInTheDocument();
+  });
+
+  it("取得失敗は 0 件と区別してエラー文言を出す", () => {
+    render(<PeriodicReviewList result={{ status: "error" }} />);
+
+    expect(
+      screen.getByText(/振り返りレポートを取得できませんでした/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(NOT_GENERATED)).not.toBeInTheDocument();
+  });
+
+  describe("既読化", () => {
+    it("表示時に未読だけをまとめて既読にする", async () => {
+      render(
+        <PeriodicReviewList
+          result={okResult([
+            buildReview({ id: 1, read: false }),
+            buildReview({ id: 2, read: true }),
+            buildReview({ id: 3, read: false }),
+          ])}
+        />,
+      );
+
+      await waitFor(() => expect(mockMarkRead).toHaveBeenCalledTimes(2));
+      expect(mockMarkRead).toHaveBeenCalledWith(1);
+      expect(mockMarkRead).toHaveBeenCalledWith(3);
+      expect(mockMarkRead).not.toHaveBeenCalledWith(2);
+    });
+
+    it("無料ユーザーのサンプル表示では既読化しない", () => {
+      mockHasEntitlement.mockReturnValue(false);
+
+      render(
+        <PeriodicReviewList
+          result={okResult([buildReview({ read: false })])}
+        />,
+      );
+
+      expect(mockMarkRead).not.toHaveBeenCalled();
+    });
+
+    it("再レンダリングされても同じレポートへ既読化を繰り返さない", async () => {
+      const result = okResult([buildReview({ id: 1, read: false })]);
+      const { rerender } = render(<PeriodicReviewList result={result} />);
+
+      await waitFor(() => expect(mockMarkRead).toHaveBeenCalledTimes(1));
+
+      rerender(<PeriodicReviewList result={result} />);
+      rerender(<PeriodicReviewList result={{ ...result }} />);
+
+      await waitFor(() => expect(mockMarkRead).toHaveBeenCalledTimes(1));
+    });
+
+    it("既読化が失敗しても一覧は表示され続ける", async () => {
+      mockMarkRead.mockResolvedValue({
+        ok: false,
+        reason: "error",
+        errors: ["既読にできませんでした"],
+      });
+
+      render(
+        <PeriodicReviewList
+          result={okResult([buildReview({ read: false })])}
+        />,
+      );
+
+      await waitFor(() => expect(mockMarkRead).toHaveBeenCalledTimes(1));
+      expect(screen.getByText("99日")).toBeInTheDocument();
+    });
+
+    it("既読化が例外で落ちても一覧は表示され続ける", async () => {
+      mockMarkRead.mockRejectedValue(new Error("network"));
+
+      render(
+        <PeriodicReviewList
+          result={okResult([buildReview({ read: false })])}
+        />,
+      );
+
+      await waitFor(() => expect(mockMarkRead).toHaveBeenCalledTimes(1));
+      expect(screen.getByText("99日")).toBeInTheDocument();
+    });
+  });
+});

--- a/app/(app)/review/_components/periodicReviewCopy.ts
+++ b/app/(app)/review/_components/periodicReviewCopy.ts
@@ -1,0 +1,19 @@
+export const PAGE_TITLE = "振り返りレポート";
+export const PAGE_DESCRIPTION =
+  "週末・月末に、その期間の練習量と成績の変化を自動でまとめてお届けします。";
+
+/** Pro だがまだレポートが生成されていないときの案内。訴求は出さない（すでに加入済みのため）。 */
+export const NOT_GENERATED_MESSAGE =
+  "まだレポートがありません。週明け・月初に、その期間のがんばりと成績の振り返りがここに届きます。";
+
+/** 取得失敗。0 件（未生成）と同じ文言にすると「届いていない」と誤解させるため分ける。 */
+export const LOAD_ERROR_MESSAGE =
+  "振り返りレポートを取得できませんでした。時間をおいて再度お試しください。";
+
+export const BANNER_TITLE = "振り返りレポートが届いています";
+export const BANNER_ERROR_TITLE = "振り返りレポートを取得できませんでした";
+export const BANNER_ERROR_SUB = "タップで一覧を開く";
+
+/** 未読件数の表示。0 件では呼ばない（バナー自体を出さない）。 */
+export const bannerUnreadLabel = (count: number): string =>
+  `未読 ${count} 件・タップで確認`;

--- a/app/(app)/review/_components/periodicReviewSampleData.ts
+++ b/app/(app)/review/_components/periodicReviewSampleData.ts
@@ -1,0 +1,125 @@
+import type { PeriodicReview } from "@app/types/periodicReview";
+
+/**
+ * 無料ユーザーに見せるサンプルレポート。
+ * ダミー UI ではなく実カードへ流し込み、加入後に何が届くのかを実レイアウトのまま伝える。
+ * 毎週届く機能だと分かるよう 3 週分並べる。値は実在の記録ではない架空の選手のもの。
+ *
+ * id は実データと取り違えないよう負の値にする（既読化の対象にもしない）。
+ */
+export const SAMPLE_PERIODIC_REVIEWS: PeriodicReview[] = [
+  {
+    id: -1,
+    period_type: "weekly",
+    period_start: "2026-07-06",
+    period_end: "2026-07-12",
+    read: true,
+    summary: {
+      period_type: "weekly",
+      practice_days: 5,
+      total_swings: 1200,
+      active_days: 5,
+      streak_current: 12,
+      batting: {
+        batting_average: 0.312,
+        on_base_percentage: 0.388,
+        slugging_percentage: 0.451,
+        ops: 0.839,
+        previous_batting_average: 0.286,
+        delta: 0.026,
+      },
+      pitching: {
+        innings_pitched: 7,
+        era: 2.57,
+        whip: 1.14,
+        k_per_9: 9,
+      },
+      theme_breakdown: [{ id: -1, title: "肩の開き", practice_count: 4 }],
+      condition: { sleep_hours_avg: 7.2, fatigue_level_avg: 2.4 },
+      insight: {
+        key: "sample-1",
+        id: null,
+        title: "素振りと打率の関係",
+        body: "素振りを週1500本以上やった週は、打率が.045高い傾向があります。",
+        metric: "batting_average",
+        dimension: "total_swings",
+        direction: "positive",
+        strength: "strong",
+        sample_weeks: 8,
+        sufficient: true,
+      },
+    },
+  },
+  {
+    id: -2,
+    period_type: "weekly",
+    period_start: "2026-06-29",
+    period_end: "2026-07-05",
+    read: true,
+    summary: {
+      period_type: "weekly",
+      practice_days: 4,
+      total_swings: 900,
+      active_days: 4,
+      streak_current: 20,
+      batting: {
+        batting_average: 0.286,
+        on_base_percentage: 0.351,
+        slugging_percentage: 0.401,
+        ops: 0.752,
+        previous_batting_average: 0.298,
+        delta: -0.012,
+      },
+      theme_breakdown: [{ id: -2, title: "体重移動", practice_count: 3 }],
+      condition: { sleep_hours_avg: 6.8, fatigue_level_avg: 2.8 },
+      insight: {
+        key: "sample-2",
+        id: null,
+        title: "睡眠時間と調子の関係",
+        body: "睡眠が7時間を下回った週は、疲労度の自己評価が高くなる傾向があります。",
+        metric: "fatigue_level_avg",
+        dimension: "sleep_hours_avg",
+        direction: "negative",
+        strength: "moderate",
+        sample_weeks: 6,
+        sufficient: true,
+      },
+    },
+  },
+  {
+    id: -3,
+    period_type: "weekly",
+    period_start: "2026-06-22",
+    period_end: "2026-06-28",
+    read: true,
+    summary: {
+      period_type: "weekly",
+      practice_days: 6,
+      total_swings: 1500,
+      active_days: 6,
+      streak_current: 18,
+      batting: {
+        batting_average: 0.333,
+        on_base_percentage: 0.402,
+        slugging_percentage: 0.478,
+        ops: 0.88,
+        previous_batting_average: 0.312,
+        delta: 0.021,
+      },
+      theme_breakdown: [{ id: -3, title: "外角対応", practice_count: 5 }],
+      condition: { sleep_hours_avg: 7.5, fatigue_level_avg: 2.1 },
+      insight: {
+        key: "sample-3",
+        id: null,
+        title: "練習日数と打率の関係",
+        body: "週6日以上練習した週は、翌週の打率が上がる傾向があります。",
+        metric: "batting_average",
+        dimension: "practice_days",
+        direction: "positive",
+        strength: "strong",
+        sample_weeks: 10,
+        sufficient: true,
+      },
+    },
+  },
+];

--- a/app/(app)/review/_utils/__tests__/periodicReviewFormat.test.ts
+++ b/app/(app)/review/_utils/__tests__/periodicReviewFormat.test.ts
@@ -1,0 +1,84 @@
+import type { PeriodicReview } from "@app/types/periodicReview";
+import {
+  formatCount,
+  formatDelta,
+  formatFixed,
+  formatRatio,
+  unreadReviewIds,
+} from "../periodicReviewFormat";
+
+const buildReview = (id: number, read: boolean): PeriodicReview => ({
+  id,
+  period_type: "weekly",
+  period_start: "2026-07-13",
+  period_end: "2026-07-19",
+  read,
+  summary: {},
+});
+
+describe("formatRatio", () => {
+  it("先頭の 0 を落とした .XXX 表記にする", () => {
+    expect(formatRatio(0.312)).toBe(".312");
+    expect(formatRatio("0.312")).toBe(".312");
+    expect(formatRatio(1)).toBe("1.000");
+  });
+
+  it("欠損は - を返す（0 と区別する）", () => {
+    expect(formatRatio(undefined)).toBe("-");
+    expect(formatRatio(null)).toBe("-");
+    expect(formatRatio("")).toBe("-");
+    expect(formatRatio(0)).toBe(".000");
+  });
+});
+
+describe("formatDelta", () => {
+  it("上昇は + 、下降は - を付ける", () => {
+    expect(formatDelta(0.026)).toBe("+.026");
+    expect(formatDelta(-0.012)).toBe("-.012");
+    expect(formatDelta(0)).toBe("+.000");
+  });
+
+  it("欠損は null を返して行ごと出さない", () => {
+    expect(formatDelta(undefined)).toBeNull();
+    expect(formatDelta("abc")).toBeNull();
+  });
+});
+
+describe("formatFixed", () => {
+  it("桁数を指定して整形する", () => {
+    expect(formatFixed(2.5, 2)).toBe("2.50");
+    expect(formatFixed("9.0", 1)).toBe("9.0");
+  });
+
+  it("欠損は - を返す", () => {
+    expect(formatFixed(null, 2)).toBe("-");
+  });
+});
+
+describe("formatCount", () => {
+  it("桁区切りと単位を付ける", () => {
+    expect(formatCount(1200)).toBe("1,200");
+    expect(formatCount("5", "日")).toBe("5日");
+    expect(formatCount(0, "日")).toBe("0日");
+  });
+
+  it("欠損は単位を付けず - を返す", () => {
+    expect(formatCount(undefined, "日")).toBe("-");
+  });
+});
+
+describe("unreadReviewIds", () => {
+  it("未読のレポートの id だけを返す", () => {
+    expect(
+      unreadReviewIds([
+        buildReview(1, false),
+        buildReview(2, true),
+        buildReview(3, false),
+      ]),
+    ).toEqual([1, 3]);
+  });
+
+  it("すべて既読なら空配列を返す", () => {
+    expect(unreadReviewIds([buildReview(1, true)])).toEqual([]);
+  });
+});

--- a/app/(app)/review/_utils/periodicReviewFormat.ts
+++ b/app/(app)/review/_utils/periodicReviewFormat.ts
@@ -1,0 +1,55 @@
+import type { PeriodicReview } from "@app/types/periodicReview";
+import type { DecimalValue } from "@app/types/practice";
+import { parseDecimal } from "@app/constants/practice";
+
+/** 値が欠損している（＝旧レポートに指標が無い）ことを示す表示。0 と取り違えさせない。 */
+export const MISSING_VALUE = "-";
+
+/**
+ * 率系（打率・出塁率・長打率・OPS）を野球慣用の「.XXX」表記にする。
+ * 値が無い場合は 0 ではなく「-」を返す。
+ */
+export function formatRatio(value: DecimalValue | null | undefined): string {
+  const parsed = parseDecimal(value);
+  if (parsed === null) return MISSING_VALUE;
+  return parsed.toFixed(3).replace(/^(-?)0\./, "$1.");
+}
+
+/** 打率の前期間比。符号付きで返す（+.026 / -.012）。値が無ければ null。 */
+export function formatDelta(
+  value: DecimalValue | null | undefined,
+): string | null {
+  const parsed = parseDecimal(value);
+  if (parsed === null) return null;
+  return `${parsed >= 0 ? "+" : ""}${formatRatio(parsed)}`;
+}
+
+/** 防御率・WHIP などの小数指標。桁数を指定する。値が無ければ「-」。 */
+export function formatFixed(
+  value: DecimalValue | null | undefined,
+  digits: number,
+): string {
+  const parsed = parseDecimal(value);
+  if (parsed === null) return MISSING_VALUE;
+  return parsed.toFixed(digits);
+}
+
+/** 練習日数・素振り数などの整数系。単位を付けて返す。値が無ければ単位も付けず「-」。 */
+export function formatCount(
+  value: DecimalValue | null | undefined,
+  unit = "",
+): string {
+  const parsed = parseDecimal(value);
+  if (parsed === null) return MISSING_VALUE;
+  return `${parsed.toLocaleString("ja-JP")}${unit}`;
+}
+
+/** 「2026/07/06」形式。back は "2026-07-06" を返す。 */
+export function formatPeriodDate(value: string): string {
+  return value.replaceAll("-", "/");
+}
+
+/** 未読レポートの id 一覧。既読化の対象を決めるのに使う。 */
+export function unreadReviewIds(reviews: PeriodicReview[]): number[] {
+  return reviews.filter((review) => !review.read).map((review) => review.id);
+}

--- a/app/(app)/review/page.tsx
+++ b/app/(app)/review/page.tsx
@@ -1,0 +1,37 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getPeriodicReviews } from "@app/services/v2/periodicReviewService";
+import { PAGE_DESCRIPTION, PAGE_TITLE } from "./_components/periodicReviewCopy";
+import PeriodicReviewList from "./_components/PeriodicReviewList";
+
+export const metadata = {
+  title: PAGE_TITLE,
+};
+
+export default async function ReviewPage() {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const result = await getPeriodicReviews();
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            <h2 className="text-2xl font-bold">{PAGE_TITLE}</h2>
+            <p className="mt-2 text-sm text-zinc-300">{PAGE_DESCRIPTION}</p>
+
+            <div className="my-6">
+              <PeriodicReviewList result={result} />
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/components/header/HeaderRight.tsx
+++ b/app/components/header/HeaderRight.tsx
@@ -15,6 +15,7 @@ import { MailIcon } from "@app/components/icon/MailIcon";
 import { MenuIcon } from "@app/components/icon/MenuIcon";
 import { NoteIcon } from "@app/components/icon/NoteIcon";
 import { RankingIcon } from "@app/components/icon/RankingIcon";
+import { StatsIcon } from "@app/components/icon/StatsIcon";
 import NotificationBadge from "@app/components/notification/NotificationBadge";
 import UserSearch from "@app/components/user/UserSearch";
 import { useAuthContext } from "@app/contexts/useAuthContext";
@@ -65,6 +66,16 @@ export default function HeaderRight() {
                   }
                 >
                   振り返りテンプレ
+                </DropdownItem>
+                <DropdownItem
+                  key="review"
+                  as={Link}
+                  href="/review"
+                  startContent={
+                    <StatsIcon fill="currentColor" width="18" height="18" />
+                  }
+                >
+                  振り返りレポート
                 </DropdownItem>
                 <DropdownItem
                   key="goals"

--- a/app/services/v2/__tests__/periodicReviewService.test.ts
+++ b/app/services/v2/__tests__/periodicReviewService.test.ts
@@ -1,0 +1,110 @@
+const mockGet = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(() => Promise.resolve({ get: mockGet })),
+}));
+
+jest.mock("@app/constants/api", () => ({
+  RAILS_API_URL: "http://back:3000",
+}));
+
+jest.mock("../../../../lib/sentry-helpers", () => ({
+  captureServerActionError: jest.fn(),
+}));
+
+import {
+  getPeriodicReviews,
+  markPeriodicReviewRead,
+} from "../periodicReviewService";
+
+function setupAuthCookies() {
+  mockGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: "test-uid" },
+    };
+    return values[key];
+  });
+}
+
+function mockResponse(status: number, body: unknown) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+function requestedUrl(): string {
+  return (global.fetch as jest.Mock).mock.calls[0][0] as string;
+}
+
+function requestedInit(): RequestInit {
+  return (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+}
+
+const review = {
+  id: 1,
+  period_type: "weekly",
+  period_start: "2026-07-13",
+  period_end: "2026-07-19",
+  read: false,
+  summary: { practice_days: 5 },
+};
+
+describe("振り返りレポートの v2 Server Actions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    setupAuthCookies();
+  });
+
+  describe("getPeriodicReviews", () => {
+    it("GET /api/v2/periodic_reviews を叩いて一覧を返す", async () => {
+      mockResponse(200, [review]);
+
+      const result = await getPeriodicReviews();
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/periodic_reviews");
+      expect(requestedInit().method).toBeUndefined();
+      expect(result).toEqual({ status: "ok", data: [review] });
+    });
+
+    it("0 件は取得成功として空配列を返す（未加入と未生成の区別は UI 側で行う）", async () => {
+      mockResponse(200, []);
+
+      expect(await getPeriodicReviews()).toEqual({ status: "ok", data: [] });
+    });
+
+    it("取得失敗は 0 件と区別して error を返す", async () => {
+      mockResponse(500, {});
+
+      expect(await getPeriodicReviews()).toEqual({ status: "error" });
+    });
+  });
+
+  describe("markPeriodicReviewRead", () => {
+    it("PATCH /api/v2/periodic_reviews/:id を叩く", async () => {
+      mockResponse(200, { ...review, read: true });
+
+      const result = await markPeriodicReviewRead(7);
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/periodic_reviews/7");
+      expect(requestedInit().method).toBe("PATCH");
+      expect(result).toEqual({ ok: true, data: { ...review, read: true } });
+    });
+
+    it("対象が見つからないときはエラーを返す", async () => {
+      mockResponse(404, { error: "Not Found" });
+
+      const result = await markPeriodicReviewRead(7);
+
+      expect(result).toEqual({
+        ok: false,
+        reason: "error",
+        errors: ["Not Found"],
+      });
+    });
+  });
+});

--- a/app/services/v2/periodicReviewService.ts
+++ b/app/services/v2/periodicReviewService.ts
@@ -1,0 +1,42 @@
+"use server";
+
+import type { PeriodicReview } from "@app/types/periodicReview";
+import {
+  type FetchResult,
+  type MutationResult,
+  fetchV2,
+  mutateV2,
+} from "./requests";
+
+const BASE_PATH = "/api/v2/periodic_reviews";
+
+/**
+ * 週次 / 月次レポート一覧を取得する（GET /api/v2/periodic_reviews）。
+ * 期間の新しい順で返る。
+ *
+ * back は advanced_periodic_review を持たないユーザーへは 403 ではなく 200 + 空配列を返すため、
+ * 空配列だけでは「Pro 未加入」と「Pro だがまだ生成されていない」を区別できない。
+ * 呼び出し側で entitlement と組み合わせて出し分けること。
+ */
+export async function getPeriodicReviews(): Promise<
+  FetchResult<PeriodicReview[]>
+> {
+  return fetchV2<PeriodicReview[]>(BASE_PATH, "getPeriodicReviews");
+}
+
+/**
+ * レポート1件を既読にする（PATCH /api/v2/periodic_reviews/:id）。
+ * 無料ユーザーはレコードごと隠されるため 404（reason:"error"）が返る。
+ */
+export async function markPeriodicReviewRead(
+  id: number,
+): Promise<MutationResult<PeriodicReview>> {
+  return mutateV2<PeriodicReview>(`${BASE_PATH}/${id}`, {
+    method: "PATCH",
+    // 更新する属性は無い（read: true を立てるだけ）が、Content-Type: application/json に対して
+    // 本文を空にすると Rails 側でパースエラーになり得るため空オブジェクトを送る。
+    body: {},
+    action: "markPeriodicReviewRead",
+    fallbackMessage: "既読にできませんでした",
+  });
+}

--- a/app/types/periodicReview.ts
+++ b/app/types/periodicReview.ts
@@ -1,0 +1,72 @@
+import type { DecimalValue } from "@app/types/practice";
+
+export type PeriodicReviewType = "weekly" | "monthly";
+
+export type InsightDirection = "positive" | "negative" | "unknown";
+
+/** 相関インサイト（Insights::CorrelationBuilder が生成するカード）。 */
+export interface CorrelationInsight {
+  key: string;
+  /** 自作カードは組み合わせ id を持つ。プリセットは null。 */
+  id: number | null;
+  title: string;
+  body: string;
+  metric: string;
+  dimension: string;
+  direction: InsightDirection;
+  strength: string;
+  sample_weeks: number;
+  sufficient: boolean;
+}
+
+export interface PeriodicReviewThemeBreakdown {
+  id: number;
+  title: string;
+  practice_count: number;
+}
+
+/**
+ * レポート本体（PeriodicReviews::Generator が summary に保存する JSON）。
+ *
+ * すべてのキーを任意にしているのは、指標を追加する前に生成された古いレポートには
+ * キー自体が存在しないため。欠損を 0 として描くと「成績が 0 だった」と誤読されるので、
+ * 表示側は必ず「-」へフォールバックする。
+ * 数値は decimal 由来で文字列になり得るため DecimalValue で受け、parseDecimal を通す。
+ */
+export interface PeriodicReviewSummary {
+  period_type?: PeriodicReviewType;
+  practice_days?: DecimalValue | null;
+  total_swings?: DecimalValue | null;
+  active_days?: DecimalValue | null;
+  streak_current?: DecimalValue | null;
+  batting?: {
+    batting_average?: DecimalValue | null;
+    on_base_percentage?: DecimalValue | null;
+    slugging_percentage?: DecimalValue | null;
+    ops?: DecimalValue | null;
+    previous_batting_average?: DecimalValue | null;
+    delta?: DecimalValue | null;
+  } | null;
+  /** 登板が無い期間は各値 null。 */
+  pitching?: {
+    innings_pitched?: DecimalValue | null;
+    era?: DecimalValue | null;
+    whip?: DecimalValue | null;
+    k_per_9?: DecimalValue | null;
+  } | null;
+  theme_breakdown?: PeriodicReviewThemeBreakdown[] | null;
+  condition?: {
+    sleep_hours_avg?: DecimalValue | null;
+    fatigue_level_avg?: DecimalValue | null;
+  } | null;
+  insight?: CorrelationInsight | null;
+}
+
+export interface PeriodicReview {
+  id: number;
+  period_type: PeriodicReviewType;
+  period_start: string;
+  period_end: string;
+  read: boolean;
+  summary: PeriodicReviewSummary;
+}


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#481

## 概要

バッチ生成された週次/月次レポートのフィード表示と既読管理です。Pro 限定機能で、無料ユーザーにはダミーデータを実レイアウトのまま見せて訴求します。

## ⚠️ 空配列の3状態を出し分けています（本 PR の核心）

issue が明記している注意点への対応です。

> back は `advanced_periodic_review` 非保持の場合 **0件** を返す。空配列＝未加入 or レポート未生成 の区別を UI で扱う必要がある。

空配列だけでは判別できないため、entitlement と組み合わせて出し分けています。

| 状態 | 表示 |
| --- | --- |
| 無料 | ダミー3週分＋`SampleDataLabel`＋`ProUpsellCard` |
| Pro かつ0件 | 「まだレポートがありません」の案内。**訴求は出さない**（既に課金済みのため） |
| Pro かつ1件以上 | 実データ |
| **Pro 判定が未確定** | **どちらとも決めつけない** |

「Pro なのに課金を促される」のは体験として最悪なので、この分岐をミューテーションで固定しています。

## 欠損キーは `-` にフォールバックします

旧レポートに新しい指標が無い場合、**`0` と表示すると「成績が0だった」と誤解されます**。`-` にフォールバックし、`0` や `NaN` を表示しないことをテストで固定しています。

## 変更内容

- `app/services/v2/periodicReviewService.ts`（index / 既読 PATCH）
- レポートカード — 練習日数/素振り数/連続日数、打撃（打率・出塁率・長打率・OPS・前期間比）、投手（防御率・WHIP・K/9）、課題別内訳、相関インサイト
- 表示時に未読を一括既読化
- ダッシュボードへの未読バッジ付きバナー
- `HeaderRight.tsx` に導線を追加

無料ユーザーへのサンプル表示は、既存の `app/(app)/stats/_components/analysis/` の `ProSampleSection` / `proStatsSampleData.ts` の作法に揃えています。

## 設計上の配慮

- **既読化が失敗してもユーザー操作を壊さない**（既読が失敗しても一覧は見られる）
- **既読化を無限に繰り返さない**（表示のたびに PATCH を打ち続けない）

## チェックリスト

- [x] `yarn typecheck` が通る
- [x] `yarn test` が通る（**147 suites / 1734 tests**）
- [x] `yarn build` — 実装者がローカルで実行済み
- [x] ミューテーションテスト実施済み

### ルート表

新規ルートの追加分以外に既存ルートの分類変更がないことを base との diff で確認しています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_