### PR TITLE
Add: 野球ノートへのメディア添付（画像・動画）を実装

### DIFF
--- a/app/(app)/note/[slulg]/_components/NoteEditForm.tsx
+++ b/app/(app)/note/[slulg]/_components/NoteEditForm.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import HeaderNote from "@app/components/header/HeaderNote";
+import NoteMediaSection from "@app/components/note/media/NoteMediaSection";
 import NoteMenu from "@app/components/note/NoteMenu";
 import NoteTagSection from "@app/components/note/NoteTagSection";
 import ReflectionTemplateSection from "@app/components/note/ReflectionTemplateSection";
@@ -195,6 +196,10 @@ export default function NoteEditForm({
                   selectedIds={tagIds}
                   onChange={setTagIds}
                   canEdit={canEditTags}
+                />
+                <NoteMediaSection
+                  noteId={note.id}
+                  attachments={note.media_attachments}
                 />
               </div>
             </form>

--- a/app/(app)/note/[slulg]/_components/__tests__/NoteEditForm.test.tsx
+++ b/app/(app)/note/[slulg]/_components/__tests__/NoteEditForm.test.tsx
@@ -9,6 +9,13 @@ jest.mock("@app/services/v2/baseballNoteService", () => ({
   deleteBaseballNote: jest.fn(),
 }));
 
+jest.mock("@app/services/v2/mediaAttachmentService", () => ({
+  presignMediaUpload: jest.fn(),
+  completeMediaUpload: jest.fn(),
+  updateMediaAttachmentMemo: jest.fn(),
+  deleteMediaAttachment: jest.fn(),
+}));
+
 jest.mock("@app/services/v2/noteTagService", () => ({
   createNoteTag: jest.fn(),
 }));

--- a/app/(app)/note/[slulg]/_components/__tests__/NoteFormTagPayload.test.tsx
+++ b/app/(app)/note/[slulg]/_components/__tests__/NoteFormTagPayload.test.tsx
@@ -10,6 +10,13 @@ jest.mock("@app/services/v2/baseballNoteService", () => ({
   deleteBaseballNote: jest.fn(),
 }));
 
+jest.mock("@app/services/v2/mediaAttachmentService", () => ({
+  presignMediaUpload: jest.fn(),
+  completeMediaUpload: jest.fn(),
+  updateMediaAttachmentMemo: jest.fn(),
+  deleteMediaAttachment: jest.fn(),
+}));
+
 // タグ選択 UI 側のガードを外し、フォームの送信ペイロード組み立てだけを検証する。
 // UI を隠すだけでは不十分で、ペイロード組み立ての時点で entitlement を見て
 // tag_ids キーごと落としていることを担保する。

--- a/app/(app)/note/new/_components/NoteCreateForm.tsx
+++ b/app/(app)/note/new/_components/NoteCreateForm.tsx
@@ -1,19 +1,37 @@
 "use client";
 
 import type { NoteTag, ReflectionAnswer } from "@app/interface/baseballNoteV2";
+import type { StagedMediaAsset } from "@app/interface/mediaAttachmentV2";
 import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
 import type { FetchResult } from "@app/services/v2/requests";
-import { Input } from "@heroui/react";
+import { Button, Input } from "@heroui/react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import HeaderNote from "@app/components/header/HeaderNote";
+import {
+  FREE_LIMIT_DESCRIPTION,
+  FREE_LIMIT_NOTICE,
+  FREE_LIMIT_TITLE,
+  ROLLBACK_MESSAGE,
+} from "@app/components/note/media/mediaCopy";
+import StagedMediaSection from "@app/components/note/media/StagedMediaSection";
 import NoteTagSection from "@app/components/note/NoteTagSection";
 import ReflectionTemplateSection from "@app/components/note/ReflectionTemplateSection";
+import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
+import { useMediaUpload } from "@app/hooks/media/useMediaUpload";
 import { useNoteTagEditing } from "@app/hooks/note/useNoteTagEditing";
-import { createBaseballNote } from "@app/services/v2/baseballNoteService";
+import {
+  createBaseballNote,
+  deleteBaseballNote,
+} from "@app/services/v2/baseballNoteService";
+import {
+  buildStagedUploadNotice,
+  summarizeStagedUploads,
+  toPreparedMedia,
+} from "@app/utils/media/stagedUpload";
 import { buildAnswerList, resolveNoteMemo } from "@app/utils/noteMemo";
 import { buildTagIdsPayload } from "@app/utils/noteTags";
 
@@ -27,6 +45,12 @@ const NoteEditor = dynamic(() => import("@app/components/note/NoteEditor"), {
 interface NoteCreateFormProps {
   templatesResult: FetchResult<ReflectionTemplate[]>;
   tagsResult: FetchResult<NoteTag[]>;
+}
+
+/** 保存は済んだが、添付の一部が上がらなかったときに見せる結果。 */
+interface SaveOutcome {
+  notice: string | null;
+  isLimitReached: boolean;
 }
 
 /** 日付入力（`type="date"`）が要求する `YYYY-MM-DD` をローカル時刻で組み立てる。 */
@@ -43,6 +67,7 @@ export default function NoteCreateForm({
 }: NoteCreateFormProps) {
   const router = useRouter();
   const { canEditTags } = useNoteTagEditing();
+  const { uploadAll } = useMediaUpload();
   const [initialDate] = useState(todayString);
   const [date, setDate] = useState(initialDate);
   const [title, setTitle] = useState("");
@@ -52,8 +77,10 @@ export default function NoteCreateForm({
   // 回答は問い文をキーに保持する。テンプレを切り替えて戻ってきても入力済みの回答が残る。
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [tagIds, setTagIds] = useState<number[]>([]);
+  const [stagedMedia, setStagedMedia] = useState<StagedMediaAsset[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
+  const [saveOutcome, setSaveOutcome] = useState<SaveOutcome | null>(null);
 
   const reflectionAnswers: ReflectionAnswer[] = buildAnswerList(
     questions,
@@ -65,7 +92,8 @@ export default function NoteCreateForm({
     memo !== "" ||
     templateId !== null ||
     reflectionAnswers.length > 0 ||
-    tagIds.length > 0;
+    tagIds.length > 0 ||
+    stagedMedia.length > 0;
 
   const setErrorsWithTimeout = (newErrors: string[]) => {
     setErrors(newErrors);
@@ -80,8 +108,67 @@ export default function NoteCreateForm({
   const handleChangeAnswer = (question: string, answer: string) =>
     setAnswers((prev) => ({ ...prev, [question]: answer }));
 
+  const handleRemoveStaged = (localId: string) =>
+    setStagedMedia((prev) =>
+      prev.filter((asset) => {
+        if (asset.localId !== localId) return true;
+        if (asset.previewUrl) URL.revokeObjectURL(asset.previewUrl);
+        return false;
+      }),
+    );
+
+  const handleUpdateStagedMemo = (localId: string, nextMemo: string) =>
+    setStagedMedia((prev) =>
+      prev.map((asset) =>
+        asset.localId === localId ? { ...asset, memo: nextMemo } : asset,
+      ),
+    );
+
+  /**
+   * ノート保存後にステージ中のメディアを順にアップロードする。
+   *
+   * 技術的失敗（通信断・5xx など）が1件でもあればノートごと取り消す。添付ありきで
+   * 書かれたノートが本文だけ残るのを防ぐため。逆にユーザーが中断した場合と、
+   * サーバーが内容や上限を理由に拒否した場合は取り消さない。書いた本文を本人の
+   * 意図に反して消してしまうためで、その場合はノートを残したまま結果だけ伝える。
+   */
+  const uploadStagedMedia = async (noteId: number): Promise<void> => {
+    const results = await uploadAll(stagedMedia.map(toPreparedMedia), noteId);
+    const summary = summarizeStagedUploads(results);
+
+    if (summary.shouldRollbackNote) {
+      await deleteBaseballNote(noteId);
+      setErrorsWithTimeout([ROLLBACK_MESSAGE]);
+      setIsSubmitting(false);
+      return;
+    }
+
+    stagedMedia.forEach((asset) => {
+      if (asset.previewUrl) URL.revokeObjectURL(asset.previewUrl);
+    });
+    setStagedMedia([]);
+
+    if (
+      summary.limitReached > 0 ||
+      summary.canceled > 0 ||
+      summary.rejected > 0
+    ) {
+      setSaveOutcome({
+        notice:
+          summary.limitReached > 0
+            ? FREE_LIMIT_NOTICE
+            : buildStagedUploadNotice(summary),
+        isLimitReached: summary.limitReached > 0,
+      });
+      setIsSubmitting(false);
+      return;
+    }
+
+    router.push("/note");
+  };
+
   const handleSubmit = async () => {
-    if (isSubmitting) return;
+    if (isSubmitting || saveOutcome !== null) return;
     if (!date) {
       setErrorsWithTimeout(["日付が未設定です。"]);
       return;
@@ -108,7 +195,12 @@ export default function NoteCreateForm({
       setIsSubmitting(false);
       return;
     }
-    router.push("/note");
+
+    if (stagedMedia.length === 0) {
+      router.push("/note");
+      return;
+    }
+    await uploadStagedMedia(result.data.id);
   };
 
   return (
@@ -116,58 +208,89 @@ export default function NoteCreateForm({
       <HeaderNote
         onNoteSave={handleSubmit}
         isSubmitting={isSubmitting}
-        hasChanges={hasChanges}
+        hasChanges={hasChanges && saveOutcome === null}
       />
       {isSubmitting ? <LoadingSpinner /> : null}
       <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
         <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
           <ErrorMessages errors={errors} />
           <div className="pt-14 px-4 lg:px-6 lg:pb-14">
-            <form>
-              <div>
-                <div>
-                  <Input
-                    isRequired
-                    type="date"
-                    size="sm"
-                    variant="underlined"
-                    className="w-28 [&>div&>div]:p-0"
-                    aria-label="日付"
-                    value={date}
-                    onChange={(e) => setDate(e.target.value)}
+            {saveOutcome ? (
+              <div className="py-10">
+                <p className="text-sm text-white">{saveOutcome.notice}</p>
+                {saveOutcome.isLimitReached ? (
+                  <ProUpsellCard
+                    feature="unlimited_media_uploads"
+                    title={FREE_LIMIT_TITLE}
+                    description={FREE_LIMIT_DESCRIPTION}
+                    className="mt-4"
                   />
-                </div>
-                <div>
-                  <Input
-                    type="text"
-                    size="lg"
-                    variant="underlined"
-                    className="w-full [&>div]:pt-0.5 [&>div]:h-12 font-bold"
-                    placeholder="タイトル"
-                    aria-label="タイトル"
-                    value={title}
-                    onChange={(e) => setTitle(e.target.value)}
-                  />
-                </div>
-                <div className="mt-10 w-full h-full">
-                  <NoteEditor memo={memo} setMemo={setMemo} />
-                </div>
-                <ReflectionTemplateSection
-                  templatesResult={templatesResult}
-                  selectedTemplateId={templateId}
-                  questions={questions}
-                  answers={answers}
-                  onSelectTemplate={handleSelectTemplate}
-                  onChangeAnswer={handleChangeAnswer}
-                />
-                <NoteTagSection
-                  tagsResult={tagsResult}
-                  selectedIds={tagIds}
-                  onChange={setTagIds}
-                  canEdit={canEditTags}
-                />
+                ) : null}
+                <Button
+                  color="primary"
+                  radius="sm"
+                  fullWidth
+                  className="mt-6 font-bold"
+                  onPress={() => router.push("/note")}
+                >
+                  ノート一覧へ
+                </Button>
               </div>
-            </form>
+            ) : (
+              <form>
+                <div>
+                  <div>
+                    <Input
+                      isRequired
+                      type="date"
+                      size="sm"
+                      variant="underlined"
+                      className="w-28 [&>div&>div]:p-0"
+                      aria-label="日付"
+                      value={date}
+                      onChange={(e) => setDate(e.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <Input
+                      type="text"
+                      size="lg"
+                      variant="underlined"
+                      className="w-full [&>div]:pt-0.5 [&>div]:h-12 font-bold"
+                      placeholder="タイトル"
+                      aria-label="タイトル"
+                      value={title}
+                      onChange={(e) => setTitle(e.target.value)}
+                    />
+                  </div>
+                  <div className="mt-10 w-full h-full">
+                    <NoteEditor memo={memo} setMemo={setMemo} />
+                  </div>
+                  <ReflectionTemplateSection
+                    templatesResult={templatesResult}
+                    selectedTemplateId={templateId}
+                    questions={questions}
+                    answers={answers}
+                    onSelectTemplate={handleSelectTemplate}
+                    onChangeAnswer={handleChangeAnswer}
+                  />
+                  <NoteTagSection
+                    tagsResult={tagsResult}
+                    selectedIds={tagIds}
+                    onChange={setTagIds}
+                    canEdit={canEditTags}
+                  />
+                  <StagedMediaSection
+                    assets={stagedMedia}
+                    onStage={(asset) =>
+                      setStagedMedia((prev) => [...prev, asset])
+                    }
+                    onRemove={handleRemoveStaged}
+                    onUpdateMemo={handleUpdateStagedMemo}
+                  />
+                </div>
+              </form>
+            )}
           </div>
         </div>
       </main>

--- a/app/(app)/note/new/_components/__tests__/NoteCreateForm.test.tsx
+++ b/app/(app)/note/new/_components/__tests__/NoteCreateForm.test.tsx
@@ -8,6 +8,13 @@ jest.mock("@app/services/v2/baseballNoteService", () => ({
   createBaseballNote: jest.fn(),
 }));
 
+jest.mock("@app/services/v2/mediaAttachmentService", () => ({
+  presignMediaUpload: jest.fn(),
+  completeMediaUpload: jest.fn(),
+  updateMediaAttachmentMemo: jest.fn(),
+  deleteMediaAttachment: jest.fn(),
+}));
+
 jest.mock("@app/services/v2/noteTagService", () => ({
   createNoteTag: jest.fn(),
 }));

--- a/app/(app)/note/new/_components/__tests__/NoteCreateFormMedia.test.tsx
+++ b/app/(app)/note/new/_components/__tests__/NoteCreateFormMedia.test.tsx
@@ -1,0 +1,300 @@
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@app/services/v2/baseballNoteService", () => ({
+  createBaseballNote: jest.fn(),
+  deleteBaseballNote: jest.fn(),
+}));
+
+jest.mock("@app/services/v2/noteTagService", () => ({
+  createNoteTag: jest.fn(),
+}));
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: jest.fn(), close: jest.fn() }),
+}));
+
+jest.mock("@app/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: () => ({
+    isPro: false,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading: false,
+    hasEntitlement: () => false,
+  }),
+}));
+
+jest.mock("@app/utils/media/prepareMedia", () => ({
+  prepareMediaFile: jest.fn(),
+}));
+
+jest.mock("@app/utils/media/uploadPipeline", () => ({
+  uploadPreparedMedia: jest.fn(),
+}));
+
+// 実エディタは Slate に依存するため、メモ入力だけを模した textarea に差し替える。
+jest.mock("next/dynamic", () => () => {
+  const react = jest.requireActual<typeof ReactModule>("react");
+  return function MockNoteEditor({
+    memo,
+    setMemo,
+  }: {
+    memo: string;
+    setMemo: (value: string) => void;
+  }) {
+    return react.createElement("textarea", {
+      "aria-label": "メモ",
+      defaultValue: memo,
+      onChange: (event: { target: { value: string } }) =>
+        setMemo(event.target.value),
+    });
+  };
+});
+
+import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
+import type { FetchResult } from "@app/services/v2/requests";
+import type { PreparedMedia } from "@app/utils/media/uploadPipeline";
+import type ReactModule from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  createBaseballNote,
+  deleteBaseballNote,
+} from "@app/services/v2/baseballNoteService";
+import { prepareMediaFile } from "@app/utils/media/prepareMedia";
+import { uploadPreparedMedia } from "@app/utils/media/uploadPipeline";
+import NoteCreateForm from "../NoteCreateForm";
+
+const mockCreateNote = createBaseballNote as jest.MockedFunction<
+  typeof createBaseballNote
+>;
+const mockDeleteNote = deleteBaseballNote as jest.MockedFunction<
+  typeof deleteBaseballNote
+>;
+const mockPrepare = prepareMediaFile as jest.MockedFunction<
+  typeof prepareMediaFile
+>;
+const mockUpload = uploadPreparedMedia as jest.MockedFunction<
+  typeof uploadPreparedMedia
+>;
+
+const createdNote = { id: 42 } as BaseballNoteV2;
+
+const prepared: PreparedMedia = {
+  mediaType: "image",
+  contentType: "image/jpeg",
+  file: new Blob(["x"], { type: "image/jpeg" }),
+  thumbnail: null,
+  width: 1080,
+  height: 720,
+};
+
+const attachment = {
+  id: 1,
+  media_type: "image" as const,
+  status: "ready" as const,
+  file_size_bytes: 1,
+  duration_seconds: null,
+  width: null,
+  height: null,
+  position: 0,
+  memo: null,
+  playback_url: null,
+  thumbnail_url: null,
+  created_at: "2026-08-01T00:00:00Z",
+};
+
+const emptyResult: FetchResult<never[]> = { status: "ok", data: [] };
+
+function renderForm() {
+  render(
+    <NoteCreateForm templatesResult={emptyResult} tagsResult={emptyResult} />,
+  );
+}
+
+function typeTitle() {
+  fireEvent.change(screen.getByLabelText("タイトル"), {
+    target: { value: "本日の練習" },
+  });
+}
+
+async function stageFile() {
+  fireEvent.change(screen.getByLabelText("画像・動画を追加"), {
+    target: { files: [new File(["x"], "swing.jpg", { type: "image/jpeg" })] },
+  });
+  await screen.findByText("保存後にアップロードします");
+}
+
+function save() {
+  fireEvent.click(screen.getByRole("button", { name: "保存" }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  URL.createObjectURL = jest.fn(() => "blob:preview");
+  URL.revokeObjectURL = jest.fn();
+  mockCreateNote.mockResolvedValue({ ok: true, data: createdNote });
+  mockDeleteNote.mockResolvedValue({ ok: true, data: null });
+  mockPrepare.mockResolvedValue({ ok: true, prepared });
+  mockUpload.mockResolvedValue({ ok: true, attachment });
+});
+
+describe("新規作成時の staged media", () => {
+  it("選択しただけではアップロードせず、ノート保存が成功してからアップロードする", async () => {
+    renderForm();
+    typeTitle();
+    await stageFile();
+
+    expect(mockUpload).not.toHaveBeenCalled();
+
+    save();
+
+    await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(1));
+    expect(mockCreateNote).toHaveBeenCalledTimes(1);
+    expect(mockUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: "image/jpeg" }),
+      42,
+      expect.anything(),
+    );
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/note"));
+  });
+
+  it("ノートの保存に失敗したらアップロードしない", async () => {
+    mockCreateNote.mockResolvedValue({
+      ok: false,
+      errors: ["ノートの保存に失敗しました"],
+    });
+    renderForm();
+    typeTitle();
+    await stageFile();
+
+    save();
+
+    await waitFor(() => expect(mockCreateNote).toHaveBeenCalled());
+    expect(mockUpload).not.toHaveBeenCalled();
+    expect(mockDeleteNote).not.toHaveBeenCalled();
+  });
+
+  it("技術的失敗ではノートごとロールバックする", async () => {
+    mockUpload.mockResolvedValue({
+      ok: false,
+      reason: "technical",
+      message: "アップロードに失敗しました",
+    });
+    renderForm();
+    typeTitle();
+    await stageFile();
+
+    save();
+
+    await waitFor(() => expect(mockDeleteNote).toHaveBeenCalledWith(42));
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText(/ノートは保存されませんでした/),
+    ).toBeInTheDocument();
+  });
+
+  it("ロールバックしても書いた本文は残す", async () => {
+    mockUpload.mockResolvedValue({
+      ok: false,
+      reason: "technical",
+      message: "アップロードに失敗しました",
+    });
+    renderForm();
+    typeTitle();
+    await stageFile();
+
+    save();
+
+    await waitFor(() => expect(mockDeleteNote).toHaveBeenCalled());
+    expect(screen.getByLabelText("タイトル")).toHaveValue("本日の練習");
+  });
+
+  it("ユーザーが中断した場合はロールバックしない", async () => {
+    mockUpload.mockResolvedValue({ ok: false, reason: "canceled" });
+    renderForm();
+    typeTitle();
+    await stageFile();
+
+    save();
+
+    await waitFor(() => expect(mockUpload).toHaveBeenCalled());
+    expect(mockDeleteNote).not.toHaveBeenCalled();
+    expect(await screen.findByText(/ノートは保存済みです/)).toBeInTheDocument();
+  });
+
+  it("サーバーが内容を理由に拒否した場合もロールバックしない", async () => {
+    mockUpload.mockResolvedValue({
+      ok: false,
+      reason: "rejected",
+      message: "アップロード可能な上限を超えています",
+    });
+    renderForm();
+    typeTitle();
+    await stageFile();
+
+    save();
+
+    await waitFor(() => expect(mockUpload).toHaveBeenCalled());
+    expect(mockDeleteNote).not.toHaveBeenCalled();
+  });
+
+  it("月次上限の 403 ではロールバックせず、無料枠超過として案内する", async () => {
+    mockUpload.mockResolvedValue({
+      ok: false,
+      reason: "limit_reached",
+      message: "今月のアップロード上限に達しています",
+    });
+    renderForm();
+    typeTitle();
+    await stageFile();
+
+    save();
+
+    await waitFor(() => expect(mockUpload).toHaveBeenCalled());
+    expect(mockDeleteNote).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText(
+        "無料プランでアップロードできる画像・動画は月3件までです",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Pro 限定/)).not.toBeInTheDocument();
+  });
+
+  it("添付が無ければアップロード処理を挟まずに一覧へ戻る", async () => {
+    renderForm();
+    typeTitle();
+
+    save();
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/note"));
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it("ステージしたメディアは保存前に取り消せる", async () => {
+    renderForm();
+    typeTitle();
+    await stageFile();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "選択した画像・動画を取り消す" }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText("保存後にアップロードします"),
+      ).not.toBeInTheDocument(),
+    );
+
+    save();
+
+    await waitFor(() => expect(mockCreateNote).toHaveBeenCalled());
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/note/media/MediaAttachmentList.tsx
+++ b/app/components/note/media/MediaAttachmentList.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import type { MediaViewerContent } from "./MediaViewer";
+import type { NoteMediaAttachment } from "@app/interface/mediaAttachmentV2";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import { useState } from "react";
+import {
+  deleteMediaAttachment,
+  updateMediaAttachmentMemo,
+} from "@app/services/v2/mediaAttachmentService";
+import { DELETE_CONFIRM_BODY, DELETE_CONFIRM_TITLE } from "./mediaCopy";
+import MediaThumbnail from "./MediaThumbnail";
+import MediaViewer from "./MediaViewer";
+
+interface MediaAttachmentListProps {
+  attachments: NoteMediaAttachment[];
+  noteId: number;
+  /** 自分のノートを編集しているときだけ削除・メモ編集を許す。 */
+  editable?: boolean;
+  /** 削除・メモ更新が成功したときに呼ぶ（一覧の再取得用）。 */
+  onChanged?: () => void;
+}
+
+const STATUS_LABEL: Record<string, string | undefined> = {
+  pending: "処理中…",
+  failed: "アップロードに失敗しました",
+};
+
+/** ノートに保存済みの画像・動画の一覧。タップで拡大表示とメモ編集。 */
+export default function MediaAttachmentList({
+  attachments,
+  noteId,
+  editable = false,
+  onChanged,
+}: MediaAttachmentListProps) {
+  const [viewingId, setViewingId] = useState<number | null>(null);
+  const [deletingTargetId, setDeletingTargetId] = useState<number | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isSavingMemo, setIsSavingMemo] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (attachments.length === 0) return null;
+
+  const viewing = attachments.find((item) => item.id === viewingId) ?? null;
+  const viewerContent: MediaViewerContent | null = viewing
+    ? {
+        key: `${viewing.id}-${viewing.memo ?? ""}`,
+        mediaType: viewing.media_type,
+        url: viewing.playback_url,
+        memo: viewing.memo ?? "",
+      }
+    : null;
+
+  const handleDelete = async () => {
+    if (deletingTargetId === null) return;
+    setIsDeleting(true);
+    const result = await deleteMediaAttachment(deletingTargetId, noteId);
+    setIsDeleting(false);
+    setDeletingTargetId(null);
+    if (!result.ok) {
+      setError(result.errors[0] ?? "削除に失敗しました");
+      return;
+    }
+    setError(null);
+    if (viewingId === deletingTargetId) setViewingId(null);
+    onChanged?.();
+  };
+
+  const handleSaveMemo = async (memo: string) => {
+    if (!viewing) return;
+    setIsSavingMemo(true);
+    const result = await updateMediaAttachmentMemo(
+      viewing.id,
+      { memo },
+      noteId,
+    );
+    setIsSavingMemo(false);
+    if (!result.ok) {
+      setError(result.errors[0] ?? "メモの保存に失敗しました");
+      return;
+    }
+    setError(null);
+    setViewingId(null);
+    onChanged?.();
+  };
+
+  return (
+    <div className="mt-3">
+      <ul className="grid grid-cols-3 gap-3">
+        {attachments.map((attachment) => (
+          <li key={attachment.id}>
+            <MediaThumbnail
+              previewUrl={attachment.thumbnail_url ?? attachment.playback_url}
+              mediaType={attachment.media_type}
+              memo={attachment.memo}
+              statusLabel={STATUS_LABEL[attachment.status]}
+              onOpen={
+                attachment.status === "ready"
+                  ? () => setViewingId(attachment.id)
+                  : undefined
+              }
+              onRemove={
+                editable ? () => setDeletingTargetId(attachment.id) : undefined
+              }
+              removeLabel="この添付を削除"
+            />
+          </li>
+        ))}
+      </ul>
+
+      {error ? (
+        <p role="alert" className="mt-2 text-xs text-red-400">
+          {error}
+        </p>
+      ) : null}
+
+      <MediaViewer
+        content={viewerContent}
+        onClose={() => setViewingId(null)}
+        editableMemo={editable}
+        isSavingMemo={isSavingMemo}
+        onSaveMemo={(memo) => void handleSaveMemo(memo)}
+      />
+
+      <Modal
+        isOpen={deletingTargetId !== null}
+        onClose={() => setDeletingTargetId(null)}
+        size="sm"
+        placement="center"
+        className="buzz-dark"
+      >
+        <ModalContent>
+          <ModalHeader className="text-base text-white">
+            {DELETE_CONFIRM_TITLE}
+          </ModalHeader>
+          <ModalBody>
+            <p className="text-sm text-zinc-300">{DELETE_CONFIRM_BODY}</p>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="light"
+              className="text-white"
+              onPress={() => setDeletingTargetId(null)}
+            >
+              キャンセル
+            </Button>
+            <Button
+              color="danger"
+              radius="sm"
+              isLoading={isDeleting}
+              onPress={() => void handleDelete()}
+            >
+              削除する
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+}

--- a/app/components/note/media/MediaPicker.tsx
+++ b/app/components/note/media/MediaPicker.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import type { StagedMediaAsset } from "@app/interface/mediaAttachmentV2";
+import type { PreparedMedia } from "@app/utils/media/uploadPipeline";
+import { Button } from "@heroui/react";
+import { useRef, useState } from "react";
+import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
+import { useMediaUpload } from "@app/hooks/media/useMediaUpload";
+import {
+  MEDIA_ACCEPT_ATTRIBUTE,
+  buildStagedLocalId,
+} from "@app/utils/media/mediaFile";
+import { UPLOAD_PHASE_LABEL } from "@app/utils/media/uploadPhase";
+import {
+  ADD_BUTTON_LABEL,
+  CANCEL_UPLOAD_LABEL,
+  FREE_LIMIT_DESCRIPTION,
+  FREE_LIMIT_NOTICE,
+  FREE_LIMIT_TITLE,
+  pickerHint,
+} from "./mediaCopy";
+
+interface MediaPickerProps {
+  /**
+   * 保存済みノートの ID。渡された場合は選択直後にアップロードする。
+   * 未指定（新規作成中）は `onStage` へ渡すだけにとどめ、ノート保存後にまとめて送る。
+   */
+  baseballNoteId?: number;
+  onStage?: (asset: StagedMediaAsset) => void;
+  onUploaded?: () => void;
+}
+
+/** 動画のサムネイル生成に失敗した場合はプレビューを諦める（選択自体は継続させる）。 */
+function buildPreviewUrl(prepared: PreparedMedia): string | null {
+  if (prepared.thumbnail) return URL.createObjectURL(prepared.thumbnail);
+  if (prepared.mediaType === "image") return URL.createObjectURL(prepared.file);
+  return null;
+}
+
+/** ノートに画像・動画を添付するためのファイル選択。 */
+export default function MediaPicker({
+  baseballNoteId,
+  onStage,
+  onUploaded,
+}: MediaPickerProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const {
+    phase,
+    progress,
+    isBusy,
+    hasUnlimitedUploads,
+    prepare,
+    upload,
+    cancel,
+    reset,
+  } = useMediaUpload();
+  const [error, setError] = useState<string | null>(null);
+  const [isLimitReached, setIsLimitReached] = useState(false);
+
+  const handleSelect = async (file: File) => {
+    setError(null);
+    const prepared = await prepare(file);
+    if (!prepared.ok) {
+      setError(prepared.message);
+      reset();
+      return;
+    }
+
+    if (baseballNoteId === undefined) {
+      onStage?.({
+        localId: buildStagedLocalId(),
+        file: prepared.prepared.file,
+        fileName: file.name,
+        mediaType: prepared.prepared.mediaType,
+        contentType: prepared.prepared.contentType,
+        thumbnail: prepared.prepared.thumbnail,
+        previewUrl: buildPreviewUrl(prepared.prepared),
+        durationSeconds: prepared.prepared.durationSeconds,
+        width: prepared.prepared.width,
+        height: prepared.prepared.height,
+        memo: "",
+      });
+      reset();
+      return;
+    }
+
+    const result = await upload(prepared.prepared, baseballNoteId);
+    if (result.ok) {
+      reset();
+      onUploaded?.();
+      return;
+    }
+    if (result.reason === "limit_reached") {
+      setIsLimitReached(true);
+      setError(FREE_LIMIT_NOTICE);
+    } else if (result.reason !== "canceled") {
+      setError(result.message);
+    }
+    reset();
+  };
+
+  const phaseLabel = UPLOAD_PHASE_LABEL[phase];
+
+  return (
+    <div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept={MEDIA_ACCEPT_ATTRIBUTE}
+        aria-label={ADD_BUTTON_LABEL}
+        className="hidden"
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          // 同じファイルを選び直しても change が発火するよう毎回クリアする。
+          event.target.value = "";
+          if (file) void handleSelect(file);
+        }}
+      />
+      <Button
+        radius="sm"
+        variant="bordered"
+        className="text-white"
+        isDisabled={isBusy}
+        onPress={() => inputRef.current?.click()}
+      >
+        {ADD_BUTTON_LABEL}
+      </Button>
+      <p className="mt-1.5 text-xs text-zinc-400">
+        {pickerHint(hasUnlimitedUploads)}
+      </p>
+
+      {isBusy && phaseLabel ? (
+        <div className="mt-2 flex items-center gap-3">
+          <p role="status" className="text-xs text-zinc-300">
+            {phaseLabel}
+            {progress.total > 1
+              ? `（${progress.completed + 1}/${progress.total}）`
+              : ""}
+          </p>
+          <button
+            type="button"
+            onClick={cancel}
+            className="text-xs font-bold text-zinc-400 underline"
+          >
+            {CANCEL_UPLOAD_LABEL}
+          </button>
+        </div>
+      ) : null}
+
+      {error ? (
+        <p role="alert" className="mt-2 text-xs text-red-400">
+          {error}
+        </p>
+      ) : null}
+
+      {isLimitReached ? (
+        <ProUpsellCard
+          feature="unlimited_media_uploads"
+          title={FREE_LIMIT_TITLE}
+          description={FREE_LIMIT_DESCRIPTION}
+          className="mt-3"
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/note/media/MediaThumbnail.tsx
+++ b/app/components/note/media/MediaThumbnail.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import type { MediaType } from "@app/interface/mediaAttachmentV2";
+import { XMarkIcon } from "@heroicons/react/24/solid";
+import { useState } from "react";
+import { buildMediaMemoLabel } from "@app/utils/media/mediaMemoLabel";
+
+interface MediaThumbnailProps {
+  previewUrl: string | null;
+  mediaType: MediaType;
+  memo: string | null;
+  /** サムネイルの代わりに出す状態ラベル（処理中・失敗など）。指定時は開けない。 */
+  statusLabel?: string;
+  onOpen?: () => void;
+  onRemove?: () => void;
+  removeLabel: string;
+  isRemoving?: boolean;
+}
+
+/** 添付・ステージ済みメディアで共通のサムネイルタイル。 */
+export default function MediaThumbnail({
+  previewUrl,
+  mediaType,
+  memo,
+  statusLabel,
+  onOpen,
+  onRemove,
+  removeLabel,
+  isRemoving = false,
+}: MediaThumbnailProps) {
+  // 動画のサムネイルは PUT に失敗しても本体は再生できるため、画像の読み込み失敗は
+  // 添付そのものの失敗として扱わずプレースホルダに落とす。
+  const [hasImageError, setHasImageError] = useState(false);
+  const showsImage = previewUrl !== null && !hasImageError && !statusLabel;
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={onOpen}
+        disabled={statusLabel !== undefined || onOpen === undefined}
+        aria-label={`${mediaType === "video" ? "動画" : "画像"}を開く`}
+        className="block w-full overflow-hidden rounded-[10px] bg-sub disabled:cursor-default"
+      >
+        <span className="flex aspect-square w-full items-center justify-center">
+          {showsImage ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={previewUrl}
+              alt=""
+              onError={() => setHasImageError(true)}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <span className="px-2 text-center text-xs text-zinc-400">
+              {statusLabel ?? (mediaType === "video" ? "動画" : "画像")}
+            </span>
+          )}
+        </span>
+        {statusLabel ? null : (
+          <span className="absolute inset-x-0 bottom-0 truncate rounded-b-[10px] bg-black/60 px-2 py-1.5 text-left text-xs font-bold text-white">
+            {buildMediaMemoLabel(mediaType, memo)}
+          </span>
+        )}
+      </button>
+      {mediaType === "video" && !statusLabel ? (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute right-2 top-2 rounded-full bg-black/60 px-2 py-0.5 text-[10px] font-bold text-white"
+        >
+          ▶
+        </span>
+      ) : null}
+      {onRemove ? (
+        <button
+          type="button"
+          aria-label={removeLabel}
+          disabled={isRemoving}
+          onClick={onRemove}
+          className="absolute -right-2 -top-2 rounded-full bg-zinc-900 p-1 text-white disabled:opacity-50"
+        >
+          <XMarkIcon className="h-4 w-4" aria-hidden />
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/note/media/MediaViewer.tsx
+++ b/app/components/note/media/MediaViewer.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import type { MediaType } from "@app/interface/mediaAttachmentV2";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import { useState } from "react";
+import { MEMO_PLACEHOLDER } from "./mediaCopy";
+
+export interface MediaViewerContent {
+  /** 同じ添付を開き直したときにメモ入力を初期化するためのキー。 */
+  key: string;
+  mediaType: MediaType;
+  /** 保存済みは playback_url、保存前は blob の object URL。 */
+  url: string | null;
+  memo: string;
+}
+
+interface MediaViewerProps {
+  content: MediaViewerContent | null;
+  onClose: () => void;
+  /** 自分のノートを編集しているときだけメモを編集させる。 */
+  editableMemo?: boolean;
+  isSavingMemo?: boolean;
+  onSaveMemo?: (memo: string) => void;
+}
+
+interface MemoEditorProps {
+  initialMemo: string;
+  isSaving: boolean;
+  onSave: (memo: string) => void;
+}
+
+/**
+ * メモ入力。開いている添付が変わったら親が `key` を変えて作り直すため、
+ * props と state を useEffect で同期しない。
+ */
+function MemoEditor({ initialMemo, isSaving, onSave }: MemoEditorProps) {
+  const [memo, setMemo] = useState(initialMemo);
+  const hasChanges = memo !== initialMemo;
+
+  return (
+    <div className="w-full">
+      <textarea
+        aria-label="メディアのメモ"
+        placeholder={MEMO_PLACEHOLDER}
+        value={memo}
+        onChange={(event) => setMemo(event.target.value)}
+        rows={4}
+        className="w-full rounded-lg bg-sub p-3 text-sm text-white placeholder:text-zinc-500"
+      />
+      <Button
+        color="primary"
+        radius="sm"
+        fullWidth
+        className="mt-2 font-bold"
+        isDisabled={!hasChanges || isSaving}
+        isLoading={isSaving}
+        onPress={() => onSave(memo)}
+      >
+        メモを保存
+      </Button>
+    </div>
+  );
+}
+
+/** 添付した画像・動画の拡大表示とメモ編集。 */
+export default function MediaViewer({
+  content,
+  onClose,
+  editableMemo = false,
+  isSavingMemo = false,
+  onSaveMemo,
+}: MediaViewerProps) {
+  return (
+    <Modal
+      isOpen={content !== null}
+      onClose={onClose}
+      size="2xl"
+      placement="center"
+      scrollBehavior="inside"
+      className="buzz-dark"
+    >
+      <ModalContent>
+        <ModalHeader className="text-base text-white">
+          {content?.mediaType === "video" ? "動画" : "画像"}
+        </ModalHeader>
+        <ModalBody className="gap-3">
+          {content?.url ? (
+            content.mediaType === "video" ? (
+              <video
+                src={content.url}
+                controls
+                playsInline
+                className="max-h-[60vh] w-full rounded-lg bg-black"
+              />
+            ) : (
+              // R2 の公開ドメインと blob: を混在で扱うため next/image は使わない。
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={content.url}
+                alt="添付した画像"
+                className="max-h-[60vh] w-full rounded-lg object-contain"
+              />
+            )
+          ) : (
+            <p className="text-sm text-zinc-400">
+              メディアを表示できませんでした。
+            </p>
+          )}
+
+          {editableMemo && content ? (
+            <MemoEditor
+              key={content.key}
+              initialMemo={content.memo}
+              isSaving={isSavingMemo}
+              onSave={(memo) => onSaveMemo?.(memo)}
+            />
+          ) : content?.memo ? (
+            <p className="whitespace-pre-wrap text-sm text-zinc-200">
+              {content.memo}
+            </p>
+          ) : null}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="light" className="text-white" onPress={onClose}>
+            閉じる
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/app/components/note/media/NoteMediaSection.tsx
+++ b/app/components/note/media/NoteMediaSection.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import type { NoteMediaAttachment } from "@app/interface/mediaAttachmentV2";
+import { useRouter } from "next/navigation";
+import MediaAttachmentList from "./MediaAttachmentList";
+import { SECTION_HEADING } from "./mediaCopy";
+import MediaPicker from "./MediaPicker";
+
+interface NoteMediaSectionProps {
+  noteId: number;
+  attachments: NoteMediaAttachment[];
+}
+
+/**
+ * 保存済みノートの添付セクション。
+ * 追加・削除・メモ更新はいずれも Server Action 経由で、成功後に
+ * `router.refresh()` でサーバー側の一覧を引き直す（クライアントに写しを持たない）。
+ */
+export default function NoteMediaSection({
+  noteId,
+  attachments,
+}: NoteMediaSectionProps) {
+  const router = useRouter();
+  const refresh = () => router.refresh();
+
+  return (
+    <section aria-labelledby="note-media-heading" className="mt-8">
+      <h3
+        id="note-media-heading"
+        className="mb-2 text-sm font-bold text-zinc-400"
+      >
+        {SECTION_HEADING}
+      </h3>
+      <MediaPicker baseballNoteId={noteId} onUploaded={refresh} />
+      <MediaAttachmentList
+        attachments={attachments}
+        noteId={noteId}
+        editable
+        onChanged={refresh}
+      />
+    </section>
+  );
+}

--- a/app/components/note/media/StagedMediaList.tsx
+++ b/app/components/note/media/StagedMediaList.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import type { MediaViewerContent } from "./MediaViewer";
+import type { StagedMediaAsset } from "@app/interface/mediaAttachmentV2";
+import { useState } from "react";
+import { STAGED_HEADING } from "./mediaCopy";
+import MediaThumbnail from "./MediaThumbnail";
+import MediaViewer from "./MediaViewer";
+
+interface StagedMediaListProps {
+  assets: StagedMediaAsset[];
+  onRemove: (localId: string) => void;
+  onUpdateMemo: (localId: string, memo: string) => void;
+}
+
+/**
+ * ノート新規作成中に選択済みで、まだアップロードしていないメディアの一覧。
+ * メモはローカルに保持し、保存後のアップロードで完了通知と一緒に送る。
+ */
+export default function StagedMediaList({
+  assets,
+  onRemove,
+  onUpdateMemo,
+}: StagedMediaListProps) {
+  const [viewingId, setViewingId] = useState<string | null>(null);
+
+  if (assets.length === 0) return null;
+
+  const viewing = assets.find((asset) => asset.localId === viewingId) ?? null;
+  const viewerContent: MediaViewerContent | null = viewing
+    ? {
+        key: `${viewing.localId}-${viewing.memo}`,
+        mediaType: viewing.mediaType,
+        url: viewing.previewUrl,
+        memo: viewing.memo,
+      }
+    : null;
+
+  return (
+    <div className="mt-3">
+      <p className="text-xs text-zinc-400">{STAGED_HEADING}</p>
+      <ul className="mt-2 grid grid-cols-3 gap-3">
+        {assets.map((asset) => (
+          <li key={asset.localId}>
+            <MediaThumbnail
+              previewUrl={asset.previewUrl}
+              mediaType={asset.mediaType}
+              memo={asset.memo}
+              onOpen={() => setViewingId(asset.localId)}
+              onRemove={() => onRemove(asset.localId)}
+              removeLabel="選択した画像・動画を取り消す"
+            />
+          </li>
+        ))}
+      </ul>
+
+      <MediaViewer
+        content={viewerContent}
+        onClose={() => setViewingId(null)}
+        editableMemo
+        onSaveMemo={(memo) => {
+          if (!viewing) return;
+          onUpdateMemo(viewing.localId, memo);
+          setViewingId(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/app/components/note/media/StagedMediaSection.tsx
+++ b/app/components/note/media/StagedMediaSection.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { StagedMediaAsset } from "@app/interface/mediaAttachmentV2";
+import { SECTION_HEADING } from "./mediaCopy";
+import MediaPicker from "./MediaPicker";
+import StagedMediaList from "./StagedMediaList";
+
+interface StagedMediaSectionProps {
+  assets: StagedMediaAsset[];
+  onStage: (asset: StagedMediaAsset) => void;
+  onRemove: (localId: string) => void;
+  onUpdateMemo: (localId: string, memo: string) => void;
+}
+
+/**
+ * ノート新規作成中の添付セクション。
+ * この時点では baseball_note_id が無く presign できないため、選択したものは
+ * ブラウザ側に留め、ノートの保存が成功してからまとめてアップロードする。
+ */
+export default function StagedMediaSection({
+  assets,
+  onStage,
+  onRemove,
+  onUpdateMemo,
+}: StagedMediaSectionProps) {
+  return (
+    <section aria-labelledby="staged-media-heading" className="mt-8">
+      <h3
+        id="staged-media-heading"
+        className="mb-2 text-sm font-bold text-zinc-400"
+      >
+        {SECTION_HEADING}
+      </h3>
+      <MediaPicker onStage={onStage} />
+      <StagedMediaList
+        assets={assets}
+        onRemove={onRemove}
+        onUpdateMemo={onUpdateMemo}
+      />
+    </section>
+  );
+}

--- a/app/components/note/media/__tests__/MediaAttachmentList.test.tsx
+++ b/app/components/note/media/__tests__/MediaAttachmentList.test.tsx
@@ -1,0 +1,197 @@
+jest.mock("@app/services/v2/mediaAttachmentService", () => ({
+  deleteMediaAttachment: jest.fn(),
+  updateMediaAttachmentMemo: jest.fn(),
+}));
+
+import type { NoteMediaAttachment } from "@app/interface/mediaAttachmentV2";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  deleteMediaAttachment,
+  updateMediaAttachmentMemo,
+} from "@app/services/v2/mediaAttachmentService";
+import MediaAttachmentList from "../MediaAttachmentList";
+
+const mockDelete = deleteMediaAttachment as jest.MockedFunction<
+  typeof deleteMediaAttachment
+>;
+const mockUpdateMemo = updateMediaAttachmentMemo as jest.MockedFunction<
+  typeof updateMediaAttachmentMemo
+>;
+
+function buildAttachment(
+  overrides: Partial<NoteMediaAttachment> = {},
+): NoteMediaAttachment {
+  return {
+    id: 1,
+    media_type: "image",
+    status: "ready",
+    file_size_bytes: 1024,
+    duration_seconds: null,
+    width: 1080,
+    height: 720,
+    position: 0,
+    memo: null,
+    playback_url: "https://cdn.example.com/1.jpg",
+    thumbnail_url: null,
+    created_at: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDelete.mockResolvedValue({ ok: true, data: { message: "削除しました" } });
+  mockUpdateMemo.mockResolvedValue({
+    ok: true,
+    data: buildAttachment({ memo: "始動が早い" }),
+  });
+});
+
+describe("MediaAttachmentList", () => {
+  it("添付が無ければ何も描画しない", () => {
+    const { container } = render(
+      <MediaAttachmentList attachments={[]} noteId={3} editable />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("メモ未記入なら記入を促し、記入済みなら内容を出す", () => {
+    render(
+      <MediaAttachmentList
+        attachments={[
+          buildAttachment({ id: 1 }),
+          buildAttachment({ id: 2, media_type: "video", memo: "始動が早い" }),
+        ]}
+        noteId={3}
+        editable
+      />,
+    );
+
+    expect(screen.getByText("画像にメモを記入")).toBeInTheDocument();
+    expect(screen.getByText("始動が早い")).toBeInTheDocument();
+  });
+
+  it("アップロード処理中の添付は開けない", () => {
+    render(
+      <MediaAttachmentList
+        attachments={[buildAttachment({ status: "pending" })]}
+        noteId={3}
+        editable
+      />,
+    );
+
+    expect(screen.getByText("処理中…")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "画像を開く" })).toBeDisabled();
+  });
+
+  it("失敗した添付は失敗と分かるように出す", () => {
+    render(
+      <MediaAttachmentList
+        attachments={[buildAttachment({ status: "failed" })]}
+        noteId={3}
+        editable
+      />,
+    );
+
+    expect(screen.getByText("アップロードに失敗しました")).toBeInTheDocument();
+  });
+
+  it("確認を経てから削除する", async () => {
+    const onChanged = jest.fn();
+    render(
+      <MediaAttachmentList
+        attachments={[buildAttachment()]}
+        noteId={3}
+        editable
+        onChanged={onChanged}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "この添付を削除" }));
+    expect(mockDelete).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText("この添付を削除しますか？"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "削除する" }));
+
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith(1, 3));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  it("確認をキャンセルしたら削除しない", async () => {
+    render(
+      <MediaAttachmentList
+        attachments={[buildAttachment()]}
+        noteId={3}
+        editable
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "この添付を削除" }));
+    fireEvent.click(await screen.findByRole("button", { name: "キャンセル" }));
+
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("削除に失敗したらエラーを出す", async () => {
+    mockDelete.mockResolvedValue({
+      ok: false,
+      reason: "error",
+      errors: ["削除に失敗しました"],
+    });
+    render(
+      <MediaAttachmentList
+        attachments={[buildAttachment()]}
+        noteId={3}
+        editable
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "この添付を削除" }));
+    fireEvent.click(await screen.findByRole("button", { name: "削除する" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "削除に失敗しました",
+    );
+  });
+
+  it("拡大表示からメモを保存する", async () => {
+    const onChanged = jest.fn();
+    render(
+      <MediaAttachmentList
+        attachments={[buildAttachment()]}
+        noteId={3}
+        editable
+        onChanged={onChanged}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "画像を開く" }));
+    const textarea = await screen.findByLabelText("メディアのメモ");
+    fireEvent.change(textarea, { target: { value: "始動が早い" } });
+    fireEvent.click(screen.getByRole("button", { name: "メモを保存" }));
+
+    await waitFor(() =>
+      expect(mockUpdateMemo).toHaveBeenCalledWith(1, { memo: "始動が早い" }, 3),
+    );
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  it("閲覧専用では削除もメモ編集もできない", async () => {
+    render(
+      <MediaAttachmentList attachments={[buildAttachment()]} noteId={3} />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "この添付を削除" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "画像を開く" }));
+
+    await waitFor(() =>
+      expect(screen.queryByLabelText("メディアのメモ")).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/app/components/note/media/__tests__/MediaPicker.test.tsx
+++ b/app/components/note/media/__tests__/MediaPicker.test.tsx
@@ -1,0 +1,182 @@
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: jest.fn(), close: jest.fn() }),
+}));
+
+jest.mock("@app/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+const mockHasEntitlement = jest.fn(() => false);
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: () => ({
+    isPro: false,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading: false,
+    hasEntitlement: mockHasEntitlement,
+  }),
+}));
+
+jest.mock("@app/utils/media/prepareMedia", () => ({
+  prepareMediaFile: jest.fn(),
+}));
+
+jest.mock("@app/utils/media/uploadPipeline", () => ({
+  uploadPreparedMedia: jest.fn(),
+}));
+
+import type { StagedMediaAsset } from "@app/interface/mediaAttachmentV2";
+import type { PreparedMedia } from "@app/utils/media/uploadPipeline";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { prepareMediaFile } from "@app/utils/media/prepareMedia";
+import { uploadPreparedMedia } from "@app/utils/media/uploadPipeline";
+import MediaPicker from "../MediaPicker";
+
+const mockPrepare = prepareMediaFile as jest.MockedFunction<
+  typeof prepareMediaFile
+>;
+const mockUpload = uploadPreparedMedia as jest.MockedFunction<
+  typeof uploadPreparedMedia
+>;
+
+const prepared: PreparedMedia = {
+  mediaType: "image",
+  contentType: "image/jpeg",
+  file: new Blob(["x"], { type: "image/jpeg" }),
+  thumbnail: null,
+  width: 1080,
+  height: 720,
+};
+
+const attachment = {
+  id: 1,
+  media_type: "image" as const,
+  status: "ready" as const,
+  file_size_bytes: 1,
+  duration_seconds: null,
+  width: null,
+  height: null,
+  position: 0,
+  memo: null,
+  playback_url: null,
+  thumbnail_url: null,
+  created_at: "2026-08-01T00:00:00Z",
+};
+
+function selectFile() {
+  const input = screen.getByLabelText("画像・動画を追加");
+  fireEvent.change(input, {
+    target: {
+      files: [new File(["x"], "swing.jpg", { type: "image/jpeg" })],
+    },
+  });
+}
+
+function dispatchBeforeUnload(): Event {
+  const event = new Event("beforeunload", { cancelable: true });
+  window.dispatchEvent(event);
+  return event;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // jsdom は Blob のプレビュー URL を作れないため、生成だけ差し替える。
+  URL.createObjectURL = jest.fn(() => "blob:preview");
+  URL.revokeObjectURL = jest.fn();
+  mockPrepare.mockResolvedValue({ ok: true, prepared });
+  mockUpload.mockResolvedValue({ ok: true, attachment });
+});
+
+describe("MediaPicker", () => {
+  it("保存済みノートでは選択直後にアップロードする", async () => {
+    const onUploaded = jest.fn();
+    render(<MediaPicker baseballNoteId={9} onUploaded={onUploaded} />);
+
+    selectFile();
+
+    await waitFor(() => expect(onUploaded).toHaveBeenCalled());
+    expect(mockUpload).toHaveBeenCalledWith(
+      prepared,
+      9,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+  });
+
+  it("新規作成中はアップロードせずステージするだけにする", async () => {
+    const onStage = jest.fn();
+    render(<MediaPicker onStage={onStage} />);
+
+    selectFile();
+
+    await waitFor(() => expect(onStage).toHaveBeenCalled());
+    expect(mockUpload).not.toHaveBeenCalled();
+    expect((onStage.mock.calls[0][0] as StagedMediaAsset).memo).toBe("");
+  });
+
+  it("クライアント側の上限チェックで弾かれたらアップロードしない", async () => {
+    mockPrepare.mockResolvedValue({
+      ok: false,
+      message: "動画は30秒以内にしてください（Pro プランなら180秒まで）。",
+    });
+    render(<MediaPicker baseballNoteId={9} />);
+
+    selectFile();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("30秒以内");
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it("月次上限の 403 では無料枠超過として案内する（Pro 限定機能とは書かない）", async () => {
+    mockUpload.mockResolvedValue({
+      ok: false,
+      reason: "limit_reached",
+      message: "今月のアップロード上限に達しています",
+    });
+    render(<MediaPicker baseballNoteId={9} />);
+
+    selectFile();
+
+    const heading = await screen.findByText(
+      "無料プランでアップロードできる画像・動画は月3件までです",
+    );
+    expect(heading).toBeInTheDocument();
+    expect(screen.queryByText(/Pro 限定/)).not.toBeInTheDocument();
+  });
+
+  it("ユーザーが中断した場合はエラーを出さない", async () => {
+    mockUpload.mockResolvedValue({ ok: false, reason: "canceled" });
+    render(<MediaPicker baseballNoteId={9} />);
+
+    selectFile();
+
+    await waitFor(() => expect(mockUpload).toHaveBeenCalled());
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("アップロード中はページ離脱を警告し、完了後は警告しない", async () => {
+    let resolveUpload: (value: {
+      ok: false;
+      reason: "canceled";
+    }) => void = () => {};
+    mockUpload.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveUpload = resolve;
+        }),
+    );
+    render(<MediaPicker baseballNoteId={9} />);
+
+    selectFile();
+
+    await screen.findByText("アップロード中…");
+    expect(dispatchBeforeUnload().defaultPrevented).toBe(true);
+
+    resolveUpload({ ok: false, reason: "canceled" });
+
+    await waitFor(() =>
+      expect(screen.queryByText("アップロード中…")).not.toBeInTheDocument(),
+    );
+    expect(dispatchBeforeUnload().defaultPrevented).toBe(false);
+  });
+});

--- a/app/components/note/media/mediaCopy.ts
+++ b/app/components/note/media/mediaCopy.ts
@@ -1,0 +1,54 @@
+import {
+  FREE_VIDEO_MAX_DURATION_SECONDS,
+  FREE_VIDEO_MAX_HEIGHT,
+  MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH,
+  PRO_VIDEO_MAX_DURATION_SECONDS,
+} from "@app/constants/mediaAttachment";
+
+/**
+ * メディア添付の文言。
+ * back の 403 は「Pro 限定機能」ではなく「無料枠（月3件）の超過」を意味するため、
+ * 上限まわりの表現は件数を明示した文言に統一して1箇所で持つ。
+ */
+
+/** 無料枠を使い切ったユーザーに出す見出し。 */
+export const FREE_LIMIT_TITLE = `無料プランでアップロードできる画像・動画は月${MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH}件までです`;
+
+/** 上限解放後に何ができるかの説明。 */
+export const FREE_LIMIT_DESCRIPTION = `Pro プランなら${MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH + 1}件目以降も無制限にアップロードでき、動画も${PRO_VIDEO_MAX_DURATION_SECONDS}秒まで保存できます。`;
+
+/** 上限に達したことをその場で伝える1行（403 を受けたとき）。 */
+export const FREE_LIMIT_NOTICE = `${FREE_LIMIT_TITLE}。今月はこれ以上アップロードできません。`;
+
+export const SECTION_HEADING = "画像・動画";
+
+/**
+ * 選択ボタンの下に出す注意書き。
+ * 件数の判定は back の 403 に委ねるため、ここは表示の出し分けだけに使う
+ * （グランドファザリングで無料ユーザーが entitlement を持つ場合もある）。
+ */
+export function pickerHint(hasUnlimitedUploads: boolean): string {
+  return hasUnlimitedUploads
+    ? `動画は${PRO_VIDEO_MAX_DURATION_SECONDS}秒以内。ブラウザでは動画のトリミングはできません。`
+    : `無料プランは月${MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH}件まで。動画は${FREE_VIDEO_MAX_DURATION_SECONDS}秒・${FREE_VIDEO_MAX_HEIGHT}px 以内（Pro は${PRO_VIDEO_MAX_DURATION_SECONDS}秒）。`;
+}
+
+export const ADD_BUTTON_LABEL = "画像・動画を追加";
+
+export const CANCEL_UPLOAD_LABEL = "アップロードを中断";
+
+/** アップロード中に離脱しようとしたときの警告。実際の文言はブラウザ既定に置き換わる。 */
+export const LEAVE_WARNING_MESSAGE =
+  "アップロードが完了していません。このページを離れると中断されます。";
+
+export const ROLLBACK_MESSAGE =
+  "メディアの保存に失敗したため、ノートは保存されませんでした。もう一度お試しください。";
+
+export const DELETE_CONFIRM_TITLE = "この添付を削除しますか？";
+
+export const DELETE_CONFIRM_BODY =
+  "削除すると元に戻せません。メモも一緒に削除されます。";
+
+export const MEMO_PLACEHOLDER = "このメディアについてのメモ";
+
+export const STAGED_HEADING = "保存後にアップロードします";

--- a/app/components/pro/__tests__/proFeatureCatalog.test.ts
+++ b/app/components/pro/__tests__/proFeatureCatalog.test.ts
@@ -47,6 +47,7 @@ const WEB_DELIVERED_FEATURES: ProFeature[] = [
   "count_situation_average",
   "pitch_type_average",
   "pitcher_faceoff_average",
+  "unlimited_media_uploads",
 ];
 
 describe("FEATURE_COMPARISONS", () => {

--- a/app/components/pro/proFeatureCatalog.ts
+++ b/app/components/pro/proFeatureCatalog.ts
@@ -41,7 +41,7 @@ export const FEATURE_COMPARISONS: Record<ProFeature, FeatureComparison> = {
   unlimited_media_uploads: {
     free: "月3件",
     pro: "無制限",
-    availability: "app_only",
+    availability: "web_and_app",
   },
   schedule_copy_next_week: {
     free: "手動",

--- a/app/constants/mediaAttachment.ts
+++ b/app/constants/mediaAttachment.ts
@@ -1,0 +1,44 @@
+// back/app/models/concerns/plan_limits.rb の MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH と一致させる。
+// 表示・文言用の参考値であり、この値でアップロードをブロックしてはならない。
+// 保有 entitlement はグランドファザリングで無料ユーザーにも付きうるため、
+// 可否の判定は必ず back の 403 に委ねる。
+export const MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH = 3;
+
+// back/app/services/media_attachments/limit_validator.rb と同じ境界値。
+// サーバー検証の代わりではなく、無駄なアップロードを事前に止めるための事前チェック用。
+export const FREE_VIDEO_MAX_DURATION_SECONDS = 30;
+export const PRO_VIDEO_MAX_DURATION_SECONDS = 180;
+export const FREE_VIDEO_MAX_HEIGHT = 480;
+export const PRO_VIDEO_MAX_HEIGHT = 1080;
+export const FREE_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+export const PRO_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
+
+// back/app/services/media_attachments/presigned_url_service.rb の PUT_EXPIRES_IN（10分）。
+export const PRESIGN_URL_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * 署名URLを「期限切れ間近」とみなす余裕。
+ * PUT の開始時点で残りがこれ未満なら、送信中に期限を跨ぐ可能性が高いため取り直す。
+ */
+export const PRESIGN_URL_SAFETY_MARGIN_MS = 60 * 1000;
+
+/**
+ * back の Api::V2::MediaAttachments::PresignsController が受け付ける content_type。
+ * ここに無い形式は presign が 422 を返すため、選択時点で弾く。
+ */
+export const SUPPORTED_IMAGE_CONTENT_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/heic",
+] as const;
+
+export const SUPPORTED_VIDEO_CONTENT_TYPES = [
+  "video/mp4",
+  "video/quicktime",
+] as const;
+
+/** 画像をブラウザ側で縮小するときの長辺の目安（R2 の保存コスト対策）。 */
+export const IMAGE_RESIZE_MAX_EDGE = 1080;
+
+/** 縮小後の JPEG 品質。 */
+export const IMAGE_RESIZE_QUALITY = 0.8;

--- a/app/hooks/media/__tests__/useUploadLeaveWarning.test.tsx
+++ b/app/hooks/media/__tests__/useUploadLeaveWarning.test.tsx
@@ -1,0 +1,42 @@
+import { renderHook } from "@testing-library/react";
+import { useUploadLeaveWarning } from "@app/hooks/media/useUploadLeaveWarning";
+
+function dispatchBeforeUnload(): Event {
+  const event = new Event("beforeunload", { cancelable: true });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe("useUploadLeaveWarning", () => {
+  it("アップロード中はページ離脱を引き止める", () => {
+    renderHook(() => useUploadLeaveWarning(true));
+
+    expect(dispatchBeforeUnload().defaultPrevented).toBe(true);
+  });
+
+  it("アップロードしていない間は引き止めない", () => {
+    renderHook(() => useUploadLeaveWarning(false));
+
+    expect(dispatchBeforeUnload().defaultPrevented).toBe(false);
+  });
+
+  it("アップロードが完了したら引き止めをやめる", () => {
+    const { rerender } = renderHook(
+      ({ isUploading }) => useUploadLeaveWarning(isUploading),
+      { initialProps: { isUploading: true } },
+    );
+    expect(dispatchBeforeUnload().defaultPrevented).toBe(true);
+
+    rerender({ isUploading: false });
+
+    expect(dispatchBeforeUnload().defaultPrevented).toBe(false);
+  });
+
+  it("アンマウント後は引き止めない", () => {
+    const { unmount } = renderHook(() => useUploadLeaveWarning(true));
+
+    unmount();
+
+    expect(dispatchBeforeUnload().defaultPrevented).toBe(false);
+  });
+});

--- a/app/hooks/media/useMediaUpload.ts
+++ b/app/hooks/media/useMediaUpload.ts
@@ -1,0 +1,137 @@
+"use client";
+
+import type { PrepareMediaResult } from "@app/utils/media/prepareMedia";
+import type { UploadPhase } from "@app/utils/media/uploadPhase";
+import type {
+  MediaUploadResult,
+  PreparedMedia,
+} from "@app/utils/media/uploadPipeline";
+import { useCallback, useRef, useState } from "react";
+import { useUploadLeaveWarning } from "@app/hooks/media/useUploadLeaveWarning";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { prepareMediaFile } from "@app/utils/media/prepareMedia";
+import { uploadPreparedMedia } from "@app/utils/media/uploadPipeline";
+
+export interface MediaUploadProgress {
+  completed: number;
+  total: number;
+}
+
+interface UseMediaUploadReturn {
+  phase: UploadPhase;
+  progress: MediaUploadProgress;
+  isBusy: boolean;
+  /** 上限の表示を出し分けるための entitlement 判定。可否の判断には使わない。 */
+  hasUnlimitedUploads: boolean;
+  /** 選択直後の圧縮・サムネイル生成・上限チェック。 */
+  prepare: (file: File) => Promise<PrepareMediaResult>;
+  /** 1件アップロードする。 */
+  upload: (
+    prepared: PreparedMedia,
+    baseballNoteId: number,
+  ) => Promise<MediaUploadResult>;
+  /** 複数件を順にアップロードする。中断されたら残りも中断として返す。 */
+  uploadAll: (
+    items: PreparedMedia[],
+    baseballNoteId: number,
+  ) => Promise<MediaUploadResult[]>;
+  cancel: () => void;
+  reset: () => void;
+}
+
+const BUSY_PHASES: UploadPhase[] = ["compressing", "uploading", "finalizing"];
+
+/**
+ * 画像・動画のアップロード進行（圧縮 → アップロード → 仕上げ）を1箇所で持つフック。
+ *
+ * 進捗はバイト単位では出さない。fetch の PUT は送信バイト数を通知しないため、
+ * フェーズと「何件目か」で進行を表す。
+ * アップロード中はページ離脱の警告を張り、終わったら必ず外す。
+ */
+export function useMediaUpload(): UseMediaUploadReturn {
+  const { hasEntitlement } = useEntitlement();
+  const isPro = hasEntitlement("unlimited_media_uploads");
+  const [phase, setPhase] = useState<UploadPhase>("idle");
+  const [progress, setProgress] = useState<MediaUploadProgress>({
+    completed: 0,
+    total: 0,
+  });
+  const abortRef = useRef<AbortController | null>(null);
+
+  const isBusy = BUSY_PHASES.includes(phase);
+  useUploadLeaveWarning(isBusy);
+
+  const prepare = useCallback(
+    async (file: File): Promise<PrepareMediaResult> => {
+      setPhase("compressing");
+      const result = await prepareMediaFile(file, isPro);
+      setPhase(result.ok ? "idle" : "error");
+      return result;
+    },
+    [isPro],
+  );
+
+  const uploadAll = useCallback(
+    async (
+      items: PreparedMedia[],
+      baseballNoteId: number,
+    ): Promise<MediaUploadResult[]> => {
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setProgress({ completed: 0, total: items.length });
+      // pipeline からのフェーズ通知を待たずに「実行中」にする。
+      // 待つと通知が来るまでの間だけ離脱警告が外れてしまう。
+      setPhase("uploading");
+
+      const results: MediaUploadResult[] = [];
+      for (const item of items) {
+        const result = await uploadPreparedMedia(item, baseballNoteId, {
+          signal: controller.signal,
+          onPhase: setPhase,
+        });
+        results.push(result);
+        setProgress((prev) => ({ ...prev, completed: prev.completed + 1 }));
+
+        if (!result.ok && result.reason === "canceled") {
+          // 中断は「残り全部やめる」意思表示として扱う。1件ずつ聞き直さない。
+          while (results.length < items.length) {
+            results.push({ ok: false, reason: "canceled" });
+          }
+          break;
+        }
+      }
+
+      abortRef.current = null;
+      setPhase(results.every((result) => result.ok) ? "done" : "error");
+      return results;
+    },
+    [],
+  );
+
+  const upload = useCallback(
+    async (prepared: PreparedMedia, baseballNoteId: number) => {
+      const [result] = await uploadAll([prepared], baseballNoteId);
+      return result;
+    },
+    [uploadAll],
+  );
+
+  const cancel = useCallback(() => abortRef.current?.abort(), []);
+
+  const reset = useCallback(() => {
+    setPhase("idle");
+    setProgress({ completed: 0, total: 0 });
+  }, []);
+
+  return {
+    phase,
+    progress,
+    isBusy,
+    hasUnlimitedUploads: isPro,
+    prepare,
+    upload,
+    uploadAll,
+    cancel,
+    reset,
+  };
+}

--- a/app/hooks/media/useUploadLeaveWarning.ts
+++ b/app/hooks/media/useUploadLeaveWarning.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { LEAVE_WARNING_MESSAGE } from "@app/components/note/media/mediaCopy";
+
+/**
+ * アップロード中のタブ離脱・リロードを確認ダイアログで引き止める。
+ *
+ * 中断すると R2 への PUT が途中で切れ、back には pending のまま残る。
+ * `isUploading` が false に戻ったら必ずリスナーを外す。完了後も警告し続けると
+ * 「保存できたのに離れられない」誤解を与えるため。
+ */
+export function useUploadLeaveWarning(isUploading: boolean): void {
+  useEffect(() => {
+    if (!isUploading) return;
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      // 旧仕様のブラウザ向け。現行ブラウザは既定文言に置き換えるため表示はされない。
+      event.returnValue = LEAVE_WARNING_MESSAGE;
+      return LEAVE_WARNING_MESSAGE;
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [isUploading]);
+}

--- a/app/interface/mediaAttachmentV2.ts
+++ b/app/interface/mediaAttachmentV2.ts
@@ -1,0 +1,66 @@
+// v2 メディア添付 API（/api/v2/media_attachments）の型。
+// レスポンスのキーは back のシリアライザ（V2::MediaAttachmentSerializer）に合わせて snake_case のまま扱う。
+
+import type { MediaType, NoteMediaAttachment } from "./baseballNoteV2";
+
+export type { MediaType, NoteMediaAttachment };
+
+/** POST /api/v2/media_attachments/presign のパラメータ。 */
+export interface MediaAttachmentPresignInput {
+  baseball_note_id: number;
+  media_type: MediaType;
+  /** R2 へ PUT するときの Content-Type。署名に含まれるため PUT 時と必ず一致させる。 */
+  content_type: string;
+}
+
+/**
+ * presign のレスポンス。この時点で `status: "pending"` のレコードが作られている。
+ * `upload_url` は10分で失効するため、発行時刻とセットで扱うこと。
+ */
+export interface MediaAttachmentPresignResponse {
+  id: number;
+  media_type: MediaType;
+  status: "pending";
+  upload_url: string;
+  /** 動画のみ。サムネイル画像（image/jpeg）を PUT する先。 */
+  thumbnail_upload_url: string | null;
+}
+
+/**
+ * アップロード完了通知のパラメータ。
+ * back は `file_size_bytes` キーの有無で「完了通知」と「メモ更新」を判別するため、
+ * 完了通知では必ず含めること。
+ */
+export interface MediaAttachmentCompleteInput {
+  file_size_bytes: number;
+  duration_seconds?: number;
+  width?: number;
+  height?: number;
+  memo?: string;
+}
+
+/** メモだけの更新。`file_size_bytes` を含めてはならない（完了通知として扱われる）。 */
+export interface MediaAttachmentMemoInput {
+  memo: string;
+}
+
+/**
+ * ノート新規作成中（baseball_note_id 未確定）にブラウザ側で保持する選択済みメディア。
+ * ノート保存成功後にまとめてアップロードする。
+ */
+export interface StagedMediaAsset {
+  localId: string;
+  /** 圧縮・変換まで済ませた実データ。presign の content_type はこの blob の type と揃える。 */
+  file: Blob;
+  fileName: string;
+  mediaType: MediaType;
+  contentType: string;
+  /** 動画の場合のみ生成したサムネイル。生成に失敗した場合は null。 */
+  thumbnail: Blob | null;
+  /** プレビュー表示用の object URL。解放漏れを防ぐため破棄時に revokeObjectURL する。 */
+  previewUrl: string | null;
+  durationSeconds?: number;
+  width?: number;
+  height?: number;
+  memo: string;
+}

--- a/app/services/v2/__tests__/mediaAttachmentService.test.ts
+++ b/app/services/v2/__tests__/mediaAttachmentService.test.ts
@@ -1,0 +1,224 @@
+const mockGet = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(() => Promise.resolve({ get: mockGet })),
+}));
+
+jest.mock("next/cache", () => ({
+  revalidatePath: jest.fn(),
+}));
+
+jest.mock("@app/constants/api", () => ({
+  RAILS_API_URL: "http://back:3000",
+}));
+
+jest.mock("../../../../lib/sentry-helpers", () => ({
+  captureServerActionError: jest.fn(),
+}));
+
+import {
+  completeMediaUpload,
+  deleteMediaAttachment,
+  presignMediaUpload,
+  updateMediaAttachmentMemo,
+} from "../mediaAttachmentService";
+
+function setupAuthCookies() {
+  mockGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: "test-uid" },
+    };
+    return values[key];
+  });
+}
+
+function mockResponse(status: number, body: unknown) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+function requestedUrl(callIndex = 0): string {
+  return (global.fetch as jest.Mock).mock.calls[callIndex][0] as string;
+}
+
+function requestedInit(callIndex = 0): RequestInit {
+  return (global.fetch as jest.Mock).mock.calls[callIndex][1] as RequestInit;
+}
+
+function sentBody(callIndex = 0): unknown {
+  return JSON.parse(requestedInit(callIndex).body as string);
+}
+
+const presignResponse = {
+  id: 5,
+  media_type: "video",
+  status: "pending",
+  upload_url: "https://r2.example.com/put?sig=1",
+  thumbnail_upload_url: "https://r2.example.com/thumb?sig=1",
+};
+
+const attachment = {
+  id: 5,
+  media_type: "video",
+  status: "ready",
+  file_size_bytes: 1024,
+  duration_seconds: 20,
+  width: 854,
+  height: 480,
+  position: 0,
+  memo: "スイング",
+  playback_url: "https://cdn.example.com/5.mp4",
+  thumbnail_url: "https://cdn.example.com/5_thumb.jpg",
+  created_at: "2026-08-01T00:00:00Z",
+};
+
+describe("メディア添付の v2 Server Actions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    setupAuthCookies();
+  });
+
+  describe("presignMediaUpload", () => {
+    it("署名 URL 発行のエンドポイントへ POST する", async () => {
+      mockResponse(201, presignResponse);
+
+      const result = await presignMediaUpload({
+        baseball_note_id: 3,
+        media_type: "video",
+        content_type: "video/mp4",
+      });
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/media_attachments/presign",
+      );
+      expect(requestedInit().method).toBe("POST");
+      expect(sentBody()).toEqual({
+        media_attachment: {
+          baseball_note_id: 3,
+          media_type: "video",
+          content_type: "video/mp4",
+        },
+      });
+      expect(result).toEqual({ ok: true, data: presignResponse });
+    });
+
+    it("月次上限超過の 403 は forbidden として返す", async () => {
+      mockResponse(403, { error: "今月のアップロード上限に達しています" });
+
+      const result = await presignMediaUpload({
+        baseball_note_id: 3,
+        media_type: "image",
+        content_type: "image/jpeg",
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        reason: "forbidden",
+        errors: ["今月のアップロード上限に達しています"],
+      });
+    });
+
+    it("認証 cookie が無ければ通信しない", async () => {
+      mockGet.mockReturnValue(undefined);
+
+      const result = await presignMediaUpload({
+        baseball_note_id: 3,
+        media_type: "image",
+        content_type: "image/jpeg",
+      });
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe("completeMediaUpload", () => {
+    it("完了通知として file_size_bytes 付きで PATCH する", async () => {
+      mockResponse(200, attachment);
+
+      const result = await completeMediaUpload(
+        5,
+        {
+          file_size_bytes: 1024,
+          duration_seconds: 20,
+          width: 854,
+          height: 480,
+          memo: "スイング",
+        },
+        3,
+      );
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/media_attachments/5",
+      );
+      expect(requestedInit().method).toBe("PATCH");
+      expect(sentBody()).toEqual({
+        media_attachment: {
+          file_size_bytes: 1024,
+          duration_seconds: 20,
+          width: 854,
+          height: 480,
+          memo: "スイング",
+        },
+      });
+      expect(result).toEqual({ ok: true, data: attachment });
+    });
+
+    it("上限超過の 422 はエラーメッセージを返す", async () => {
+      mockResponse(422, { errors: ["アップロード可能な上限を超えています"] });
+
+      const result = await completeMediaUpload(5, { file_size_bytes: 99 });
+
+      expect(result).toEqual({
+        ok: false,
+        reason: "error",
+        errors: ["アップロード可能な上限を超えています"],
+      });
+    });
+  });
+
+  describe("updateMediaAttachmentMemo", () => {
+    it("完了通知と区別できるよう file_size_bytes を送らない", async () => {
+      mockResponse(200, attachment);
+
+      await updateMediaAttachmentMemo(5, { memo: "始動が早い" }, 3);
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/media_attachments/5",
+      );
+      expect(requestedInit().method).toBe("PATCH");
+      expect(sentBody()).toEqual({
+        media_attachment: { memo: "始動が早い" },
+      });
+    });
+  });
+
+  describe("deleteMediaAttachment", () => {
+    it("DELETE で削除する", async () => {
+      mockResponse(200, { message: "削除しました" });
+
+      const result = await deleteMediaAttachment(5, 3);
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/media_attachments/5",
+      );
+      expect(requestedInit().method).toBe("DELETE");
+      expect(requestedInit().body).toBeUndefined();
+      expect(result).toEqual({ ok: true, data: { message: "削除しました" } });
+    });
+
+    it("失敗時はエラーメッセージを返す", async () => {
+      mockResponse(404, null);
+
+      const result = await deleteMediaAttachment(5);
+
+      expect(result).toMatchObject({ ok: false, reason: "error" });
+    });
+  });
+});

--- a/app/services/v2/mediaAttachmentService.ts
+++ b/app/services/v2/mediaAttachmentService.ts
@@ -1,0 +1,98 @@
+"use server";
+
+import type {
+  MediaAttachmentCompleteInput,
+  MediaAttachmentMemoInput,
+  MediaAttachmentPresignInput,
+  MediaAttachmentPresignResponse,
+  NoteMediaAttachment,
+} from "@app/interface/mediaAttachmentV2";
+import { revalidatePath } from "next/cache";
+import {
+  type DeletedResponse,
+  type MutationResult,
+  mutateV2,
+} from "./requests";
+
+const BASE_PATH = "/api/v2/media_attachments";
+
+/** 添付の増減・メモ更新はノート詳細と一覧の両方に出るため、まとめて再検証する。 */
+async function revalidateNotes(noteId?: number): Promise<void> {
+  revalidatePath("/note");
+  if (noteId) revalidatePath(`/note/${noteId}`);
+}
+
+/**
+ * 署名付きアップロード URL を発行する（POST /api/v2/media_attachments/presign）。
+ *
+ * 呼び出した時点で back に `status: "pending"` のレコードが作られる。
+ * 無料枠（月3件）を使い切っている場合は 403（reason:"forbidden"）が返るため、
+ * Pro 限定機能ではなく「無料枠超過」の文脈で案内すること。
+ * `upload_url` の有効期限は10分。発行から時間が空いたら PUT せずに取り直す。
+ */
+export async function presignMediaUpload(
+  input: MediaAttachmentPresignInput,
+): Promise<MutationResult<MediaAttachmentPresignResponse>> {
+  return mutateV2<MediaAttachmentPresignResponse>(`${BASE_PATH}/presign`, {
+    method: "POST",
+    body: { media_attachment: input },
+    action: "presignMediaUpload",
+    fallbackMessage: "アップロードの準備に失敗しました",
+  });
+}
+
+/**
+ * R2 への PUT 完了を back へ通知し、`pending` から `ready` へ遷移させる
+ * （PATCH /api/v2/media_attachments/:id）。
+ *
+ * back は `file_size_bytes` キーの有無でメモ更新と区別するため必ず含める。
+ * 自己申告値は R2 上の実サイズで上書きされたうえで上限が再検証され、
+ * 超過や PUT 未達の場合は 422 とともに `failed` へ落ちる（`pending` のままにはならない）。
+ */
+export async function completeMediaUpload(
+  id: number,
+  input: MediaAttachmentCompleteInput,
+  noteId?: number,
+): Promise<MutationResult<NoteMediaAttachment>> {
+  const result = await mutateV2<NoteMediaAttachment>(`${BASE_PATH}/${id}`, {
+    method: "PATCH",
+    body: { media_attachment: input },
+    action: "completeMediaUpload",
+    fallbackMessage: "アップロードの完了処理に失敗しました",
+  });
+  if (result.ok) await revalidateNotes(noteId);
+  return result;
+}
+
+/**
+ * 添付ごとのメモを更新する（PATCH /api/v2/media_attachments/:id）。
+ * `file_size_bytes` を送らないことで back 側は完了通知ではなくメモ更新として扱う。
+ */
+export async function updateMediaAttachmentMemo(
+  id: number,
+  input: MediaAttachmentMemoInput,
+  noteId?: number,
+): Promise<MutationResult<NoteMediaAttachment>> {
+  const result = await mutateV2<NoteMediaAttachment>(`${BASE_PATH}/${id}`, {
+    method: "PATCH",
+    body: { media_attachment: input },
+    action: "updateMediaAttachmentMemo",
+    fallbackMessage: "メモの保存に失敗しました",
+  });
+  if (result.ok) await revalidateNotes(noteId);
+  return result;
+}
+
+/** 添付を削除する（DELETE /api/v2/media_attachments/:id）。R2 上の実体は back が非同期に消す。 */
+export async function deleteMediaAttachment(
+  id: number,
+  noteId?: number,
+): Promise<MutationResult<DeletedResponse>> {
+  const result = await mutateV2<DeletedResponse>(`${BASE_PATH}/${id}`, {
+    method: "DELETE",
+    action: "deleteMediaAttachment",
+    fallbackMessage: "削除に失敗しました",
+  });
+  if (result.ok) await revalidateNotes(noteId);
+  return result;
+}

--- a/app/utils/media/__tests__/mediaFile.test.ts
+++ b/app/utils/media/__tests__/mediaFile.test.ts
@@ -1,0 +1,88 @@
+import {
+  MEDIA_ACCEPT_ATTRIBUTE,
+  buildStagedLocalId,
+  computeResizeTarget,
+  resolveMediaKind,
+} from "@app/utils/media/mediaFile";
+import { buildMediaMemoLabel } from "@app/utils/media/mediaMemoLabel";
+
+describe("resolveMediaKind", () => {
+  it("back が許可する画像形式を image として扱う", () => {
+    expect(resolveMediaKind("image/jpeg")).toEqual({
+      mediaType: "image",
+      contentType: "image/jpeg",
+    });
+    expect(resolveMediaKind("image/png")?.mediaType).toBe("image");
+    expect(resolveMediaKind("image/heic")?.mediaType).toBe("image");
+  });
+
+  it("back が許可する動画形式を video として扱う", () => {
+    expect(resolveMediaKind("video/mp4")?.mediaType).toBe("video");
+    expect(resolveMediaKind("video/quicktime")?.mediaType).toBe("video");
+  });
+
+  it("パラメータ付き・大文字の MIME も正規化する", () => {
+    expect(resolveMediaKind("VIDEO/MP4; codecs=avc1")).toEqual({
+      mediaType: "video",
+      contentType: "video/mp4",
+    });
+  });
+
+  it("back が受け付けない形式は null", () => {
+    expect(resolveMediaKind("image/webp")).toBeNull();
+    expect(resolveMediaKind("image/gif")).toBeNull();
+    expect(resolveMediaKind("application/pdf")).toBeNull();
+    expect(resolveMediaKind("")).toBeNull();
+  });
+
+  it("accept 属性には対応形式だけを載せる", () => {
+    expect(MEDIA_ACCEPT_ATTRIBUTE).toBe(
+      "image/jpeg,image/png,image/heic,video/mp4,video/quicktime",
+    );
+  });
+});
+
+describe("computeResizeTarget", () => {
+  it("長辺が上限以下なら縮小しない", () => {
+    expect(computeResizeTarget(800, 600, 1080)).toEqual({
+      width: 800,
+      height: 600,
+    });
+  });
+
+  it("長辺を上限に合わせ、縦横比を保つ", () => {
+    expect(computeResizeTarget(4000, 2000, 1080)).toEqual({
+      width: 1080,
+      height: 540,
+    });
+    expect(computeResizeTarget(2000, 4000, 1080)).toEqual({
+      width: 540,
+      height: 1080,
+    });
+  });
+
+  it("サイズ不明（0）でも例外にしない", () => {
+    expect(computeResizeTarget(0, 0, 1080)).toEqual({ width: 0, height: 0 });
+  });
+});
+
+describe("buildStagedLocalId", () => {
+  it("連続して呼んでも重複しない", () => {
+    const ids = new Set(Array.from({ length: 50 }, () => buildStagedLocalId()));
+    expect(ids.size).toBe(50);
+  });
+});
+
+describe("buildMediaMemoLabel", () => {
+  it("未記入なら記入を促す", () => {
+    expect(buildMediaMemoLabel("video", null)).toBe("動画にメモを記入");
+    expect(buildMediaMemoLabel("image", "   ")).toBe("画像にメモを記入");
+  });
+
+  it("記入済みなら内容を出し、長い場合は省略する", () => {
+    expect(buildMediaMemoLabel("image", "始動が早い")).toBe("始動が早い");
+    expect(buildMediaMemoLabel("image", "あ".repeat(20))).toBe(
+      `${"あ".repeat(14)}…`,
+    );
+  });
+});

--- a/app/utils/media/__tests__/mediaLimits.test.ts
+++ b/app/utils/media/__tests__/mediaLimits.test.ts
@@ -1,0 +1,133 @@
+import {
+  FREE_IMAGE_MAX_BYTES,
+  FREE_VIDEO_MAX_DURATION_SECONDS,
+  FREE_VIDEO_MAX_HEIGHT,
+  MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH,
+  PRESIGN_URL_TTL_MS,
+  PRO_IMAGE_MAX_BYTES,
+  PRO_VIDEO_MAX_DURATION_SECONDS,
+  PRO_VIDEO_MAX_HEIGHT,
+} from "@app/constants/mediaAttachment";
+import {
+  isExpiredUploadStatus,
+  isPresignExpiring,
+  mediaLimitsFor,
+  validateImageSize,
+  validateVideoMeta,
+} from "@app/utils/media/mediaLimits";
+
+describe("プラン別の上限値", () => {
+  it("back の PlanLimits / LimitValidator と同じ値を持つ", () => {
+    expect(MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH).toBe(3);
+    expect(FREE_VIDEO_MAX_DURATION_SECONDS).toBe(30);
+    expect(PRO_VIDEO_MAX_DURATION_SECONDS).toBe(180);
+    expect(FREE_VIDEO_MAX_HEIGHT).toBe(480);
+    expect(PRO_VIDEO_MAX_HEIGHT).toBe(1080);
+    expect(FREE_IMAGE_MAX_BYTES).toBe(5 * 1024 * 1024);
+    expect(PRO_IMAGE_MAX_BYTES).toBe(10 * 1024 * 1024);
+  });
+
+  it("Pro かどうかで上限が切り替わる", () => {
+    expect(mediaLimitsFor(false)).toEqual({
+      videoMaxDurationSeconds: 30,
+      videoMaxHeight: 480,
+      imageMaxBytes: 5 * 1024 * 1024,
+    });
+    expect(mediaLimitsFor(true)).toEqual({
+      videoMaxDurationSeconds: 180,
+      videoMaxHeight: 1080,
+      imageMaxBytes: 10 * 1024 * 1024,
+    });
+  });
+});
+
+describe("validateImageSize", () => {
+  it("無料は5MBちょうどまで通す", () => {
+    expect(validateImageSize(5 * 1024 * 1024, false)).toBeNull();
+  });
+
+  it("無料で5MBを超えると弾き、Pro の上限を案内する", () => {
+    const message = validateImageSize(5 * 1024 * 1024 + 1, false);
+    expect(message).toContain("5MB");
+    expect(message).toContain("10MB");
+  });
+
+  it("Pro は10MBまで通す", () => {
+    expect(validateImageSize(10 * 1024 * 1024, true)).toBeNull();
+    expect(validateImageSize(10 * 1024 * 1024 + 1, true)).toContain("10MB");
+  });
+});
+
+describe("validateVideoMeta", () => {
+  it("無料は30秒・480pまで通す", () => {
+    expect(
+      validateVideoMeta(
+        { durationSeconds: 30, width: 854, height: 480 },
+        false,
+      ),
+    ).toBeNull();
+  });
+
+  it("無料で30秒を超える動画は弾く", () => {
+    const message = validateVideoMeta(
+      { durationSeconds: 31, width: 854, height: 480 },
+      false,
+    );
+    expect(message).toContain("30秒");
+    expect(message).toContain("180");
+  });
+
+  it("無料で縦解像度が480pxを超える動画は弾く", () => {
+    expect(
+      validateVideoMeta(
+        { durationSeconds: 10, width: 1920, height: 1080 },
+        false,
+      ),
+    ).toContain("480px");
+  });
+
+  it("Pro は180秒・1080pまで通し、超えたら弾く", () => {
+    expect(
+      validateVideoMeta(
+        { durationSeconds: 180, width: 1920, height: 1080 },
+        true,
+      ),
+    ).toBeNull();
+    expect(
+      validateVideoMeta(
+        { durationSeconds: 181, width: 1920, height: 1080 },
+        true,
+      ),
+    ).toContain("180秒");
+    expect(
+      validateVideoMeta(
+        { durationSeconds: 10, width: 3840, height: 2160 },
+        true,
+      ),
+    ).toContain("1080px");
+  });
+});
+
+describe("署名 URL の有効期限", () => {
+  it("back の PUT_EXPIRES_IN（10分）と同じ", () => {
+    expect(PRESIGN_URL_TTL_MS).toBe(10 * 60 * 1000);
+  });
+
+  it("発行直後は期限切れ扱いにしない", () => {
+    expect(isPresignExpiring(1_000, 1_000)).toBe(false);
+  });
+
+  it("送信中に期限を跨ぎうる時間まで進んだら期限切れ扱いにする", () => {
+    const issuedAt = 0;
+    expect(isPresignExpiring(issuedAt, 8 * 60 * 1000)).toBe(false);
+    expect(isPresignExpiring(issuedAt, 9 * 60 * 1000)).toBe(true);
+    expect(isPresignExpiring(issuedAt, 11 * 60 * 1000)).toBe(true);
+  });
+
+  it("R2 の署名失効に相当するステータスだけを失効として扱う", () => {
+    expect(isExpiredUploadStatus(403)).toBe(true);
+    expect(isExpiredUploadStatus(401)).toBe(true);
+    expect(isExpiredUploadStatus(500)).toBe(false);
+    expect(isExpiredUploadStatus(404)).toBe(false);
+  });
+});

--- a/app/utils/media/__tests__/prepareMedia.test.ts
+++ b/app/utils/media/__tests__/prepareMedia.test.ts
@@ -1,0 +1,150 @@
+jest.mock("@app/utils/media/mediaProcessing", () => ({
+  processImage: jest.fn(),
+  readVideoMeta: jest.fn(),
+  captureVideoThumbnail: jest.fn(),
+}));
+
+import {
+  captureVideoThumbnail,
+  processImage,
+  readVideoMeta,
+} from "@app/utils/media/mediaProcessing";
+import { prepareMediaFile } from "@app/utils/media/prepareMedia";
+
+const mockProcessImage = processImage as jest.MockedFunction<
+  typeof processImage
+>;
+const mockReadVideoMeta = readVideoMeta as jest.MockedFunction<
+  typeof readVideoMeta
+>;
+const mockCaptureThumbnail = captureVideoThumbnail as jest.MockedFunction<
+  typeof captureVideoThumbnail
+>;
+
+function imageFile(type = "image/jpeg", size = 1) {
+  return new File(["x".repeat(size)], "swing.jpg", { type });
+}
+
+function videoFile() {
+  return new File(["x"], "swing.mp4", { type: "video/mp4" });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockProcessImage.mockResolvedValue({
+    blob: new Blob(["small"], { type: "image/jpeg" }),
+    contentType: "image/jpeg",
+    width: 1080,
+    height: 720,
+  });
+  mockReadVideoMeta.mockResolvedValue({
+    durationSeconds: 20,
+    width: 854,
+    height: 480,
+  });
+  mockCaptureThumbnail.mockResolvedValue(
+    new Blob(["t"], { type: "image/jpeg" }),
+  );
+});
+
+describe("prepareMediaFile", () => {
+  it("back が受け付けない形式は選択の時点で弾く", async () => {
+    const result = await prepareMediaFile(imageFile("image/webp"), false);
+
+    expect(result).toMatchObject({ ok: false });
+    expect(mockProcessImage).not.toHaveBeenCalled();
+  });
+
+  it("画像は縮小して JPEG として送る", async () => {
+    const result = await prepareMediaFile(imageFile(), false);
+
+    expect(result).toMatchObject({
+      ok: true,
+      prepared: { mediaType: "image", contentType: "image/jpeg" },
+    });
+  });
+
+  it("縮小できない形式（HEIC など）は元ファイルのまま送る", async () => {
+    mockProcessImage.mockRejectedValue(new Error("decode failed"));
+    const file = imageFile("image/heic");
+
+    const result = await prepareMediaFile(file, false);
+
+    expect(result).toMatchObject({
+      ok: true,
+      prepared: { contentType: "image/heic", file },
+    });
+  });
+
+  it("縮小しても無料の上限を超える画像は弾く", async () => {
+    mockProcessImage.mockResolvedValue({
+      blob: new Blob(["x".repeat(6 * 1024 * 1024)], { type: "image/jpeg" }),
+      contentType: "image/jpeg",
+      width: 1080,
+      height: 720,
+    });
+
+    const result = await prepareMediaFile(imageFile(), false);
+
+    expect(result).toMatchObject({ ok: false });
+  });
+
+  it("動画のメタ情報とサムネイルを添えて送る", async () => {
+    const result = await prepareMediaFile(videoFile(), false);
+
+    expect(result).toMatchObject({
+      ok: true,
+      prepared: {
+        mediaType: "video",
+        contentType: "video/mp4",
+        durationSeconds: 20,
+        width: 854,
+        height: 480,
+      },
+    });
+  });
+
+  it("上限を超える動画はサムネイル生成前に弾く", async () => {
+    mockReadVideoMeta.mockResolvedValue({
+      durationSeconds: 45,
+      width: 854,
+      height: 480,
+    });
+
+    const result = await prepareMediaFile(videoFile(), false);
+
+    expect(result).toMatchObject({ ok: false });
+    expect(mockCaptureThumbnail).not.toHaveBeenCalled();
+  });
+
+  it("Pro なら無料では超過する動画も通す", async () => {
+    mockReadVideoMeta.mockResolvedValue({
+      durationSeconds: 120,
+      width: 1920,
+      height: 1080,
+    });
+
+    expect(await prepareMediaFile(videoFile(), true)).toMatchObject({
+      ok: true,
+    });
+    expect(await prepareMediaFile(videoFile(), false)).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("サムネイル生成に失敗しても選択自体は成立させる", async () => {
+    mockCaptureThumbnail.mockResolvedValue(null);
+
+    const result = await prepareMediaFile(videoFile(), false);
+
+    expect(result).toMatchObject({ ok: true, prepared: { thumbnail: null } });
+  });
+
+  it("動画のメタ情報を読めなければ弾く", async () => {
+    mockReadVideoMeta.mockRejectedValue(new Error("decode failed"));
+
+    expect(await prepareMediaFile(videoFile(), false)).toMatchObject({
+      ok: false,
+    });
+  });
+});

--- a/app/utils/media/__tests__/stagedUpload.test.ts
+++ b/app/utils/media/__tests__/stagedUpload.test.ts
@@ -1,0 +1,135 @@
+import type { StagedMediaAsset } from "@app/interface/mediaAttachmentV2";
+import type { MediaUploadResult } from "@app/utils/media/uploadPipeline";
+import {
+  buildStagedUploadNotice,
+  summarizeStagedUploads,
+  toPreparedMedia,
+} from "@app/utils/media/stagedUpload";
+
+const uploaded: MediaUploadResult = {
+  ok: true,
+  attachment: {
+    id: 1,
+    media_type: "image",
+    status: "ready",
+    file_size_bytes: 10,
+    duration_seconds: null,
+    width: null,
+    height: null,
+    position: 0,
+    memo: null,
+    playback_url: null,
+    thumbnail_url: null,
+    created_at: "2026-08-01T00:00:00Z",
+  },
+};
+const canceled: MediaUploadResult = { ok: false, reason: "canceled" };
+const limitReached: MediaUploadResult = {
+  ok: false,
+  reason: "limit_reached",
+  message: "今月のアップロード上限に達しています",
+};
+const rejected: MediaUploadResult = {
+  ok: false,
+  reason: "rejected",
+  message: "アップロード可能な上限を超えています",
+};
+const technical: MediaUploadResult = {
+  ok: false,
+  reason: "technical",
+  message: "アップロードに失敗しました",
+};
+
+describe("summarizeStagedUploads", () => {
+  it("すべて成功したらロールバックしない", () => {
+    const summary = summarizeStagedUploads([uploaded, uploaded]);
+
+    expect(summary.uploaded).toBe(2);
+    expect(summary.shouldRollbackNote).toBe(false);
+  });
+
+  it("技術的失敗が1件でもあればノートをロールバックする", () => {
+    expect(
+      summarizeStagedUploads([uploaded, technical]).shouldRollbackNote,
+    ).toBe(true);
+  });
+
+  it("ユーザーが中断しただけならロールバックしない", () => {
+    const summary = summarizeStagedUploads([canceled, canceled]);
+
+    expect(summary.canceled).toBe(2);
+    expect(summary.shouldRollbackNote).toBe(false);
+  });
+
+  it("無料枠超過（403）ではロールバックしない", () => {
+    const summary = summarizeStagedUploads([uploaded, limitReached]);
+
+    expect(summary.limitReached).toBe(1);
+    expect(summary.shouldRollbackNote).toBe(false);
+  });
+
+  it("サーバーが内容を理由に拒否した場合もロールバックしない", () => {
+    const summary = summarizeStagedUploads([rejected]);
+
+    expect(summary.rejected).toBe(1);
+    expect(summary.shouldRollbackNote).toBe(false);
+  });
+
+  it("中断と技術的失敗が混ざったら技術的失敗を優先してロールバックする", () => {
+    expect(
+      summarizeStagedUploads([canceled, technical]).shouldRollbackNote,
+    ).toBe(true);
+  });
+
+  it("1件もアップロードしていなければロールバックしない", () => {
+    expect(summarizeStagedUploads([]).shouldRollbackNote).toBe(false);
+  });
+});
+
+describe("buildStagedUploadNotice", () => {
+  it("中断・拒否があればノートが残っていることを添えて伝える", () => {
+    const notice = buildStagedUploadNotice(
+      summarizeStagedUploads([uploaded, canceled]),
+    );
+
+    expect(notice).toContain("ノートは保存済みです");
+    expect(notice).toContain("1件");
+  });
+
+  it("すべて成功なら伝えることはない", () => {
+    expect(
+      buildStagedUploadNotice(summarizeStagedUploads([uploaded])),
+    ).toBeNull();
+  });
+});
+
+describe("toPreparedMedia", () => {
+  it("ローカルのメモをアップロード対象に引き継ぐ", () => {
+    const file = new Blob(["x"], { type: "video/mp4" });
+    const thumbnail = new Blob(["t"], { type: "image/jpeg" });
+    const asset: StagedMediaAsset = {
+      localId: "a",
+      file,
+      fileName: "swing.mp4",
+      mediaType: "video",
+      contentType: "video/mp4",
+      thumbnail,
+      previewUrl: "blob:preview",
+      durationSeconds: 12,
+      width: 854,
+      height: 480,
+      memo: "テイクバック",
+    };
+
+    expect(toPreparedMedia(asset)).toEqual({
+      mediaType: "video",
+      contentType: "video/mp4",
+      file,
+      thumbnail,
+      durationSeconds: 12,
+      width: 854,
+      height: 480,
+      memo: "テイクバック",
+    });
+  });
+});

--- a/app/utils/media/__tests__/uploadPipeline.test.ts
+++ b/app/utils/media/__tests__/uploadPipeline.test.ts
@@ -1,0 +1,331 @@
+jest.mock("@app/services/v2/mediaAttachmentService", () => ({
+  presignMediaUpload: jest.fn(),
+  completeMediaUpload: jest.fn(),
+}));
+
+jest.mock("@app/utils/media/r2Upload", () => ({
+  putToPresignedUrl: jest.fn(),
+}));
+
+import type { NoteMediaAttachment } from "@app/interface/mediaAttachmentV2";
+import type { MutationResult } from "@app/services/v2/requests";
+import type { PreparedMedia } from "@app/utils/media/uploadPipeline";
+import {
+  completeMediaUpload,
+  presignMediaUpload,
+} from "@app/services/v2/mediaAttachmentService";
+import { putToPresignedUrl } from "@app/utils/media/r2Upload";
+import { uploadPreparedMedia } from "@app/utils/media/uploadPipeline";
+
+const mockPresign = presignMediaUpload as jest.MockedFunction<
+  typeof presignMediaUpload
+>;
+const mockComplete = completeMediaUpload as jest.MockedFunction<
+  typeof completeMediaUpload
+>;
+const mockPut = putToPresignedUrl as jest.MockedFunction<
+  typeof putToPresignedUrl
+>;
+
+/** 呼び出し順を1本の配列で確認するための記録先。 */
+let callOrder: string[] = [];
+
+const attachment: NoteMediaAttachment = {
+  id: 11,
+  media_type: "image",
+  status: "ready",
+  file_size_bytes: 1234,
+  duration_seconds: null,
+  width: 1080,
+  height: 720,
+  position: 0,
+  memo: null,
+  playback_url: "https://cdn.example.com/1.jpg",
+  thumbnail_url: null,
+  created_at: "2026-08-01T00:00:00Z",
+};
+
+function presignOk(overrides: Partial<{ thumbnailUrl: string | null }> = {}) {
+  return {
+    ok: true as const,
+    data: {
+      id: 11,
+      media_type: "image" as const,
+      status: "pending" as const,
+      upload_url: "https://r2.example.com/put?sig=1",
+      thumbnail_upload_url: overrides.thumbnailUrl ?? null,
+    },
+  };
+}
+
+function imageMedia(): PreparedMedia {
+  return {
+    mediaType: "image",
+    contentType: "image/jpeg",
+    file: new Blob(["abcd"], { type: "image/jpeg" }),
+    thumbnail: null,
+    width: 1080,
+    height: 720,
+  };
+}
+
+function videoMedia(): PreparedMedia {
+  return {
+    mediaType: "video",
+    contentType: "video/mp4",
+    file: new Blob(["abcd"], { type: "video/mp4" }),
+    thumbnail: new Blob(["t"], { type: "image/jpeg" }),
+    durationSeconds: 20,
+    width: 854,
+    height: 480,
+    memo: "スイングの軌道",
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  callOrder = [];
+  mockPresign.mockImplementation(async () => {
+    callOrder.push("presign");
+    return presignOk();
+  });
+  mockPut.mockImplementation(async () => {
+    callOrder.push("put");
+    return { ok: true };
+  });
+  mockComplete.mockImplementation(async () => {
+    callOrder.push("complete");
+    return { ok: true, data: attachment };
+  });
+});
+
+describe("uploadPreparedMedia", () => {
+  it("presign → R2 へ PUT → 完了通知 の順で実行する", async () => {
+    const result = await uploadPreparedMedia(imageMedia(), 7);
+
+    expect(callOrder).toEqual(["presign", "put", "complete"]);
+    expect(result).toEqual({ ok: true, attachment });
+  });
+
+  it("presign には baseball_note_id と media_type / content_type を送る", async () => {
+    await uploadPreparedMedia(imageMedia(), 7);
+
+    expect(mockPresign).toHaveBeenCalledWith({
+      baseball_note_id: 7,
+      media_type: "image",
+      content_type: "image/jpeg",
+    });
+  });
+
+  it("PUT には presign が返した URL と同じ content_type を送る", async () => {
+    await uploadPreparedMedia(imageMedia(), 7);
+
+    expect(mockPut).toHaveBeenCalledWith(
+      "https://r2.example.com/put?sig=1",
+      expect.any(Blob),
+      "image/jpeg",
+      undefined,
+    );
+  });
+
+  it("完了通知には実サイズとメタ情報・メモを送る", async () => {
+    mockPresign.mockResolvedValue(
+      presignOk({ thumbnailUrl: "https://r2.example.com/thumb?sig=1" }),
+    );
+
+    await uploadPreparedMedia(videoMedia(), 7);
+
+    expect(mockComplete).toHaveBeenCalledWith(
+      11,
+      {
+        file_size_bytes: 4,
+        duration_seconds: 20,
+        width: 854,
+        height: 480,
+        memo: "スイングの軌道",
+      },
+      7,
+    );
+  });
+
+  it("動画は本体とサムネイルの2回 PUT する", async () => {
+    mockPresign.mockImplementation(async () => {
+      callOrder.push("presign");
+      return presignOk({ thumbnailUrl: "https://r2.example.com/thumb?sig=1" });
+    });
+
+    await uploadPreparedMedia(videoMedia(), 7);
+
+    expect(callOrder).toEqual(["presign", "put", "put", "complete"]);
+    expect(mockPut).toHaveBeenNthCalledWith(
+      2,
+      "https://r2.example.com/thumb?sig=1",
+      expect.any(Blob),
+      "image/jpeg",
+      undefined,
+    );
+  });
+
+  it("サムネイルの PUT に失敗しても本体は完了させる", async () => {
+    mockPresign.mockResolvedValue(
+      presignOk({ thumbnailUrl: "https://r2.example.com/thumb?sig=1" }),
+    );
+    mockPut
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: false, canceled: false, status: 500 });
+
+    const result = await uploadPreparedMedia(videoMedia(), 7);
+
+    expect(mockComplete).toHaveBeenCalledTimes(1);
+    expect(result.ok).toBe(true);
+  });
+
+  describe("失敗の分類", () => {
+    it("presign が 403 なら無料枠超過として返し、PUT も完了通知もしない", async () => {
+      mockPresign.mockResolvedValue({
+        ok: false,
+        reason: "forbidden",
+        errors: ["今月のアップロード上限に達しています"],
+      } as MutationResult<never>);
+
+      const result = await uploadPreparedMedia(imageMedia(), 7);
+
+      expect(result).toEqual({
+        ok: false,
+        reason: "limit_reached",
+        message: "今月のアップロード上限に達しています",
+      });
+      expect(mockPut).not.toHaveBeenCalled();
+      expect(mockComplete).not.toHaveBeenCalled();
+    });
+
+    it("presign が通信エラーなら技術的失敗として返す", async () => {
+      mockPresign.mockResolvedValue({
+        ok: false,
+        reason: "error",
+        errors: ["アップロードの準備に失敗しました"],
+      } as MutationResult<never>);
+
+      const result = await uploadPreparedMedia(imageMedia(), 7);
+
+      expect(result).toMatchObject({ ok: false, reason: "technical" });
+      expect(mockComplete).not.toHaveBeenCalled();
+    });
+
+    it("PUT が 5xx なら技術的失敗として返し、完了通知はしない", async () => {
+      mockPut.mockResolvedValue({ ok: false, canceled: false, status: 500 });
+
+      const result = await uploadPreparedMedia(imageMedia(), 7);
+
+      expect(result).toMatchObject({ ok: false, reason: "technical" });
+      expect(mockComplete).not.toHaveBeenCalled();
+    });
+
+    it("完了通知が 422 ならサーバー拒否として返す（技術的失敗にしない）", async () => {
+      mockComplete.mockResolvedValue({
+        ok: false,
+        reason: "error",
+        errors: ["アップロード可能な上限を超えています"],
+      } as MutationResult<never>);
+
+      const result = await uploadPreparedMedia(imageMedia(), 7);
+
+      expect(result).toEqual({
+        ok: false,
+        reason: "rejected",
+        message: "アップロード可能な上限を超えています",
+      });
+    });
+
+    it("ユーザーが中断したら canceled として返し、完了通知はしない", async () => {
+      mockPut.mockResolvedValue({ ok: false, canceled: true });
+
+      const result = await uploadPreparedMedia(imageMedia(), 7);
+
+      expect(result).toEqual({ ok: false, reason: "canceled" });
+      expect(mockComplete).not.toHaveBeenCalled();
+    });
+
+    it("開始前に中断済みなら presign すらしない", async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const result = await uploadPreparedMedia(imageMedia(), 7, {
+        signal: controller.signal,
+      });
+
+      expect(result).toEqual({ ok: false, reason: "canceled" });
+      expect(mockPresign).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("署名 URL の期限切れ", () => {
+    it("PUT が 403 で落ちたら presign を取り直して送り直す", async () => {
+      mockPut
+        .mockImplementationOnce(async () => {
+          callOrder.push("put");
+          return { ok: false, canceled: false, status: 403 };
+        })
+        .mockImplementationOnce(async () => {
+          callOrder.push("put");
+          return { ok: true };
+        });
+
+      const result = await uploadPreparedMedia(imageMedia(), 7);
+
+      expect(callOrder).toEqual([
+        "presign",
+        "put",
+        "presign",
+        "put",
+        "complete",
+      ]);
+      expect(result.ok).toBe(true);
+    });
+
+    it("取り直しても期限切れなら技術的失敗として返す", async () => {
+      mockPut.mockResolvedValue({ ok: false, canceled: false, status: 403 });
+
+      const result = await uploadPreparedMedia(imageMedia(), 7);
+
+      expect(mockPresign).toHaveBeenCalledTimes(2);
+      expect(result).toMatchObject({ ok: false, reason: "technical" });
+      expect(mockComplete).not.toHaveBeenCalled();
+    });
+
+    it("本体の送信が長引き期限が近ければ、サムネイル送信前に取り直す", async () => {
+      mockPresign.mockImplementation(async () => {
+        callOrder.push("presign");
+        return presignOk({
+          thumbnailUrl: "https://r2.example.com/thumb?sig=1",
+        });
+      });
+      // 1回目の本体 PUT に9分かかった状況を作る。
+      const timestamps = [0, 9 * 60 * 1000, 9 * 60 * 1000, 9 * 60 * 1000];
+      let index = 0;
+      const now = () => timestamps[Math.min(index++, timestamps.length - 1)];
+
+      const result = await uploadPreparedMedia(videoMedia(), 7, { now });
+
+      expect(callOrder).toEqual([
+        "presign",
+        "put",
+        "presign",
+        "put",
+        "put",
+        "complete",
+      ]);
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  it("フェーズをアップロード中 → 仕上げ中 → 完了の順に通知する", async () => {
+    const phases: string[] = [];
+
+    await uploadPreparedMedia(imageMedia(), 7, {
+      onPhase: (phase) => phases.push(phase),
+    });
+
+    expect(phases).toEqual(["uploading", "finalizing", "done"]);
+  });
+});

--- a/app/utils/media/mediaFile.ts
+++ b/app/utils/media/mediaFile.ts
@@ -1,0 +1,63 @@
+import type { MediaType } from "@app/interface/mediaAttachmentV2";
+import {
+  SUPPORTED_IMAGE_CONTENT_TYPES,
+  SUPPORTED_VIDEO_CONTENT_TYPES,
+} from "@app/constants/mediaAttachment";
+
+export interface SelectedMediaKind {
+  mediaType: MediaType;
+  contentType: string;
+}
+
+/**
+ * 選択されたファイルの MIME から media_type / content_type を決める。
+ *
+ * back は media_type と content_type の組み合わせを許可リストで検証する
+ * （画像に動画の content_type を渡して動画の長さチェックを回避されるのを防ぐため）。
+ * 対応外の形式は presign が 422 を返すので、ここで先に弾く。
+ *
+ * @returns 対応形式なら種別、対応外なら null
+ */
+export function resolveMediaKind(
+  contentType: string,
+): SelectedMediaKind | null {
+  const normalized = contentType.toLowerCase().split(";")[0].trim();
+
+  if ((SUPPORTED_IMAGE_CONTENT_TYPES as readonly string[]).includes(normalized))
+    return { mediaType: "image", contentType: normalized };
+
+  if ((SUPPORTED_VIDEO_CONTENT_TYPES as readonly string[]).includes(normalized))
+    return { mediaType: "video", contentType: normalized };
+
+  return null;
+}
+
+/** ファイル選択ダイアログに渡す accept 属性。対応形式だけを最初から見せる。 */
+export const MEDIA_ACCEPT_ATTRIBUTE = [
+  ...SUPPORTED_IMAGE_CONTENT_TYPES,
+  ...SUPPORTED_VIDEO_CONTENT_TYPES,
+].join(",");
+
+/**
+ * 縮小後の描画サイズ。長辺が maxEdge を超える場合だけ縦横比を保って縮める。
+ * 拡大はしない（元より大きくしても画質は上がらず容量だけ増えるため）。
+ */
+export function computeResizeTarget(
+  width: number,
+  height: number,
+  maxEdge: number,
+): { width: number; height: number } {
+  const longestEdge = Math.max(width, height);
+  if (longestEdge <= maxEdge || longestEdge === 0) return { width, height };
+
+  const scale = maxEdge / longestEdge;
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  };
+}
+
+/** ステージ中メディアの一意キー。同一ファイルを続けて選んでも衝突しない程度の粒度で足りる。 */
+export function buildStagedLocalId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}

--- a/app/utils/media/mediaLimits.ts
+++ b/app/utils/media/mediaLimits.ts
@@ -1,0 +1,113 @@
+import {
+  FREE_IMAGE_MAX_BYTES,
+  FREE_VIDEO_MAX_DURATION_SECONDS,
+  FREE_VIDEO_MAX_HEIGHT,
+  PRESIGN_URL_SAFETY_MARGIN_MS,
+  PRESIGN_URL_TTL_MS,
+  PRO_IMAGE_MAX_BYTES,
+  PRO_VIDEO_MAX_DURATION_SECONDS,
+  PRO_VIDEO_MAX_HEIGHT,
+} from "@app/constants/mediaAttachment";
+
+export interface MediaLimits {
+  videoMaxDurationSeconds: number;
+  videoMaxHeight: number;
+  imageMaxBytes: number;
+}
+
+/**
+ * プランごとの上限値。back の MediaAttachments::LimitValidator と同じ境界で判定する。
+ *
+ * これはサーバー検証の代わりではない。back は完了通知時に R2 上の実サイズで再検証するため、
+ * ここを通ってもサーバーに落とされることはある（逆にここで落とすものはサーバーでも必ず落ちる）。
+ */
+export function mediaLimitsFor(isPro: boolean): MediaLimits {
+  return {
+    videoMaxDurationSeconds: isPro
+      ? PRO_VIDEO_MAX_DURATION_SECONDS
+      : FREE_VIDEO_MAX_DURATION_SECONDS,
+    videoMaxHeight: isPro ? PRO_VIDEO_MAX_HEIGHT : FREE_VIDEO_MAX_HEIGHT,
+    imageMaxBytes: isPro ? PRO_IMAGE_MAX_BYTES : FREE_IMAGE_MAX_BYTES,
+  };
+}
+
+function toMegabytes(bytes: number): string {
+  return (bytes / (1024 * 1024)).toFixed(0);
+}
+
+/**
+ * 画像がプランの上限に収まるか。収まらなければ表示用のメッセージを返す。
+ *
+ * 縮小後のサイズで判定すること。back は R2 上の実サイズで検証するため、
+ * 元ファイルのサイズで弾くと縮小すれば通るものまで拒否してしまう。
+ */
+export function validateImageSize(
+  sizeBytes: number,
+  isPro: boolean,
+): string | null {
+  const { imageMaxBytes } = mediaLimitsFor(isPro);
+  if (sizeBytes <= imageMaxBytes) return null;
+
+  const limit = `${toMegabytes(imageMaxBytes)}MB`;
+  return isPro
+    ? `画像は${limit}以内にしてください。`
+    : `画像は${limit}以内にしてください（Pro プランなら${toMegabytes(PRO_IMAGE_MAX_BYTES)}MB まで）。`;
+}
+
+export interface VideoMeta {
+  durationSeconds: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * 動画がプランの上限に収まるか。収まらなければ表示用のメッセージを返す。
+ *
+ * ブラウザには動画のトリミング・再エンコード手段を持たせていないため、超過した動画は
+ * 選択の時点で弾く。アップロードしても back の LimitValidator が必ず 422 を返し、
+ * 通信時間だけ消費して `failed` レコードが増えるだけになるため。
+ */
+export function validateVideoMeta(
+  meta: VideoMeta,
+  isPro: boolean,
+): string | null {
+  const { videoMaxDurationSeconds, videoMaxHeight } = mediaLimitsFor(isPro);
+
+  if (meta.durationSeconds > videoMaxDurationSeconds) {
+    return isPro
+      ? `動画は${videoMaxDurationSeconds}秒以内にしてください。`
+      : `動画は${videoMaxDurationSeconds}秒以内にしてください（Pro プランなら${PRO_VIDEO_MAX_DURATION_SECONDS}秒まで）。`;
+  }
+
+  if (meta.height > videoMaxHeight) {
+    return isPro
+      ? `動画の縦解像度は${videoMaxHeight}px 以内にしてください。`
+      : `動画の縦解像度は${videoMaxHeight}px 以内にしてください（Pro プランなら${PRO_VIDEO_MAX_HEIGHT}px まで）。`;
+  }
+
+  return null;
+}
+
+/**
+ * 署名 URL が期限切れ、または送信中に期限を跨ぎそうか。
+ *
+ * back の有効期限は10分。判定に余裕（PRESIGN_URL_SAFETY_MARGIN_MS）を持たせるのは、
+ * PUT の途中で失効すると R2 側が 403 を返し、アップロードし直しになるため。
+ *
+ * @param issuedAtMs presign が返ってきた時刻（epoch ミリ秒）
+ * @param nowMs 判定時刻（epoch ミリ秒）
+ */
+export function isPresignExpiring(issuedAtMs: number, nowMs: number): boolean {
+  return (
+    nowMs - issuedAtMs >= PRESIGN_URL_TTL_MS - PRESIGN_URL_SAFETY_MARGIN_MS
+  );
+}
+
+/**
+ * R2 への PUT が「署名 URL の失効」で失敗したか。
+ * S3 互換の署名失効は 403、稀に前段のプロキシが 401 を返すため両方を失効として扱い、
+ * 一度だけ presign し直す判断に使う。
+ */
+export function isExpiredUploadStatus(status: number): boolean {
+  return status === 401 || status === 403;
+}

--- a/app/utils/media/mediaMemoLabel.ts
+++ b/app/utils/media/mediaMemoLabel.ts
@@ -1,0 +1,20 @@
+import type { MediaType } from "@app/interface/mediaAttachmentV2";
+
+const MEMO_PREVIEW_MAX_LENGTH = 14;
+
+/**
+ * サムネイル上に重ねるメモ状況ラベル。未記入なら記入を促す文言、
+ * 記入済みならその内容のプレビューを返す（mobile の buildMediaMemoLabel と同じ表記）。
+ */
+export function buildMediaMemoLabel(
+  mediaType: MediaType,
+  memo: string | null | undefined,
+): string {
+  const trimmed = memo?.trim() ?? "";
+  if (trimmed.length > 0) {
+    return trimmed.length > MEMO_PREVIEW_MAX_LENGTH
+      ? `${trimmed.slice(0, MEMO_PREVIEW_MAX_LENGTH)}…`
+      : trimmed;
+  }
+  return `${mediaType === "video" ? "動画" : "画像"}にメモを記入`;
+}

--- a/app/utils/media/mediaProcessing.ts
+++ b/app/utils/media/mediaProcessing.ts
@@ -1,0 +1,183 @@
+import type { VideoMeta } from "./mediaLimits";
+import {
+  IMAGE_RESIZE_MAX_EDGE,
+  IMAGE_RESIZE_QUALITY,
+} from "@app/constants/mediaAttachment";
+import { computeResizeTarget } from "./mediaFile";
+
+// メタ読み込み・シークがブラウザ側で返ってこないまま固まるケースの安全網。
+const VIDEO_TIMEOUT_MS = 15_000;
+const IMAGE_TIMEOUT_MS = 15_000;
+// サムネイルは 0 秒だと黒フレームになりやすいので、わずかに進めた位置を切り出す。
+const THUMBNAIL_SEEK_SECONDS = 0.1;
+const THUMBNAIL_MAX_EDGE = 640;
+
+export interface ProcessedImage {
+  blob: Blob;
+  contentType: string;
+  width: number;
+  height: number;
+}
+
+function withTimeout<T>(
+  executor: (
+    resolve: (value: T) => void,
+    reject: (reason: Error) => void,
+  ) => void,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    const settle =
+      <A extends unknown[]>(handler: (...args: A) => void) =>
+      (...args: A) => {
+        clearTimeout(timer);
+        handler(...args);
+      };
+    executor(settle(resolve), settle(reject));
+  });
+}
+
+function drawToCanvas(
+  source: CanvasImageSource,
+  width: number,
+  height: number,
+  quality: number,
+): Promise<Blob> {
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext("2d");
+  if (!context) return Promise.reject(new Error("canvas を利用できません"));
+  context.drawImage(source, 0, 0, width, height);
+
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) =>
+        blob ? resolve(blob) : reject(new Error("画像の変換に失敗しました")),
+      "image/jpeg",
+      quality,
+    );
+  });
+}
+
+/**
+ * 画像をブラウザ側で縮小し、JPEG として書き出す。
+ *
+ * R2 の保存コストを抑えるだけでなく、無料プランの5MB上限に収める役割も持つ。
+ * HEIC のように canvas がデコードできない形式では失敗するため、呼び出し側は
+ * 元ファイルのまま送るフォールバックを用意すること。
+ */
+export async function processImage(
+  file: Blob,
+  maxEdge: number = IMAGE_RESIZE_MAX_EDGE,
+  quality: number = IMAGE_RESIZE_QUALITY,
+): Promise<ProcessedImage> {
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    const image = await withTimeout<HTMLImageElement>(
+      (resolve, reject) => {
+        const element = new Image();
+        element.onload = () => resolve(element);
+        element.onerror = () => reject(new Error("画像を読み込めませんでした"));
+        element.src = objectUrl;
+      },
+      IMAGE_TIMEOUT_MS,
+      "画像の読み込みがタイムアウトしました",
+    );
+
+    const target = computeResizeTarget(
+      image.naturalWidth,
+      image.naturalHeight,
+      maxEdge,
+    );
+    const blob = await drawToCanvas(
+      image,
+      target.width,
+      target.height,
+      quality,
+    );
+    return {
+      blob,
+      contentType: "image/jpeg",
+      width: target.width,
+      height: target.height,
+    };
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+function loadVideoElement(objectUrl: string): Promise<HTMLVideoElement> {
+  return withTimeout<HTMLVideoElement>(
+    (resolve, reject) => {
+      const video = document.createElement("video");
+      video.preload = "metadata";
+      // 自動再生ポリシーに関係なくデコードを進めるため、常にミュートで扱う。
+      video.muted = true;
+      video.playsInline = true;
+      video.onloadedmetadata = () => resolve(video);
+      video.onerror = () => reject(new Error("動画を読み込めませんでした"));
+      video.src = objectUrl;
+    },
+    VIDEO_TIMEOUT_MS,
+    "動画情報の取得がタイムアウトしました",
+  );
+}
+
+/** 動画の長さ・解像度を読む。上限チェックとアップロード完了通知の両方で使う。 */
+export async function readVideoMeta(file: Blob): Promise<VideoMeta> {
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    const video = await loadVideoElement(objectUrl);
+    return {
+      durationSeconds: Number.isFinite(video.duration)
+        ? Math.round(video.duration)
+        : 0,
+      width: video.videoWidth,
+      height: video.videoHeight,
+    };
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+/**
+ * 動画の先頭付近のフレームからサムネイル（JPEG）を作る。
+ * サムネイルが無くても本体のアップロードは成立するため、失敗時は null を返す。
+ */
+export async function captureVideoThumbnail(file: Blob): Promise<Blob | null> {
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    const video = await loadVideoElement(objectUrl);
+    await withTimeout<void>(
+      (resolve, reject) => {
+        video.onseeked = () => resolve();
+        video.onerror = () => reject(new Error("シークに失敗しました"));
+        video.currentTime = Math.min(
+          THUMBNAIL_SEEK_SECONDS,
+          Number.isFinite(video.duration) ? video.duration / 2 : 0,
+        );
+      },
+      VIDEO_TIMEOUT_MS,
+      "サムネイル生成がタイムアウトしました",
+    );
+
+    const target = computeResizeTarget(
+      video.videoWidth,
+      video.videoHeight,
+      THUMBNAIL_MAX_EDGE,
+    );
+    return await drawToCanvas(
+      video,
+      target.width,
+      target.height,
+      IMAGE_RESIZE_QUALITY,
+    );
+  } catch {
+    return null;
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}

--- a/app/utils/media/prepareMedia.ts
+++ b/app/utils/media/prepareMedia.ts
@@ -1,0 +1,98 @@
+import type { PreparedMedia } from "./uploadPipeline";
+import { resolveMediaKind } from "./mediaFile";
+import { validateImageSize, validateVideoMeta } from "./mediaLimits";
+import {
+  captureVideoThumbnail,
+  processImage,
+  readVideoMeta,
+} from "./mediaProcessing";
+
+export type PrepareMediaResult =
+  | { ok: true; prepared: PreparedMedia }
+  | { ok: false; message: string };
+
+const UNSUPPORTED_MESSAGE =
+  "対応していない形式です。JPEG / PNG / HEIC の画像、MP4 / MOV の動画を選んでください。";
+
+/**
+ * 選択されたファイルを、そのままアップロードできる形まで整える。
+ *
+ * 画像は canvas で縮小して JPEG に揃える。HEIC のように canvas がデコードできない
+ * 形式では縮小できないため、元ファイルのまま送って上限判定に委ねる。
+ * 動画はブラウザで再エンコードする手段を持たないため、上限を超えていればここで弾く。
+ */
+export async function prepareMediaFile(
+  file: File,
+  isPro: boolean,
+): Promise<PrepareMediaResult> {
+  const kind = resolveMediaKind(file.type);
+  if (!kind) return { ok: false, message: UNSUPPORTED_MESSAGE };
+
+  return kind.mediaType === "image"
+    ? prepareImage(file, kind.contentType, isPro)
+    : prepareVideo(file, kind.contentType, isPro);
+}
+
+async function prepareImage(
+  file: File,
+  contentType: string,
+  isPro: boolean,
+): Promise<PrepareMediaResult> {
+  let prepared: PreparedMedia;
+  try {
+    const processed = await processImage(file);
+    prepared = {
+      mediaType: "image",
+      contentType: processed.contentType,
+      file: processed.blob,
+      thumbnail: null,
+      width: processed.width,
+      height: processed.height,
+    };
+  } catch {
+    prepared = {
+      mediaType: "image",
+      contentType,
+      file,
+      thumbnail: null,
+    };
+  }
+
+  const sizeError = validateImageSize(prepared.file.size, isPro);
+  if (sizeError) return { ok: false, message: sizeError };
+
+  return { ok: true, prepared };
+}
+
+async function prepareVideo(
+  file: File,
+  contentType: string,
+  isPro: boolean,
+): Promise<PrepareMediaResult> {
+  let meta;
+  try {
+    meta = await readVideoMeta(file);
+  } catch {
+    return {
+      ok: false,
+      message:
+        "動画を読み込めませんでした。MP4 / MOV 形式の動画を選んでください。",
+    };
+  }
+
+  const metaError = validateVideoMeta(meta, isPro);
+  if (metaError) return { ok: false, message: metaError };
+
+  return {
+    ok: true,
+    prepared: {
+      mediaType: "video",
+      contentType,
+      file,
+      thumbnail: await captureVideoThumbnail(file),
+      durationSeconds: meta.durationSeconds,
+      width: meta.width,
+      height: meta.height,
+    },
+  };
+}

--- a/app/utils/media/r2Upload.ts
+++ b/app/utils/media/r2Upload.ts
@@ -1,0 +1,37 @@
+export type R2PutResult =
+  | { ok: true }
+  | { ok: false; canceled: true }
+  | { ok: false; canceled: false; status: number | null };
+
+/**
+ * 署名付き URL へ本体を直接 PUT する。
+ *
+ * back を経由せずブラウザから R2 へ直接送るため、認証ヘッダーは付けない
+ * （署名が認可そのもので、余計なヘッダーは署名不一致の原因になる）。
+ * `Content-Type` は presign 時に署名へ含まれているので、同じ値を必ず送る。
+ *
+ * 進捗はバイト単位では取得できない。fetch のリクエストボディはストリーム化しても
+ * 送信量を通知しないため、呼び出し側はフェーズと件数で進捗を表現すること。
+ */
+export async function putToPresignedUrl(
+  uploadUrl: string,
+  body: Blob,
+  contentType: string,
+  signal?: AbortSignal,
+): Promise<R2PutResult> {
+  try {
+    const response = await fetch(uploadUrl, {
+      method: "PUT",
+      headers: { "Content-Type": contentType },
+      body,
+      signal,
+    });
+    if (response.ok) return { ok: true };
+    return { ok: false, canceled: false, status: response.status };
+  } catch (error) {
+    if (signal?.aborted || (error as Error)?.name === "AbortError") {
+      return { ok: false, canceled: true };
+    }
+    return { ok: false, canceled: false, status: null };
+  }
+}

--- a/app/utils/media/stagedUpload.ts
+++ b/app/utils/media/stagedUpload.ts
@@ -1,0 +1,77 @@
+import type { MediaUploadResult, PreparedMedia } from "./uploadPipeline";
+import type { StagedMediaAsset } from "@app/interface/mediaAttachmentV2";
+
+/** ステージ中のメディアをアップロード対象へ変換する。メモは完了通知と一緒に送る。 */
+export function toPreparedMedia(asset: StagedMediaAsset): PreparedMedia {
+  return {
+    mediaType: asset.mediaType,
+    contentType: asset.contentType,
+    file: asset.file,
+    thumbnail: asset.thumbnail,
+    durationSeconds: asset.durationSeconds,
+    width: asset.width,
+    height: asset.height,
+    memo: asset.memo,
+  };
+}
+
+export interface StagedUploadSummary {
+  uploaded: number;
+  canceled: number;
+  limitReached: number;
+  rejected: number;
+  technical: number;
+  /**
+   * ノートごと取り消すべきか。
+   *
+   * ノート保存後に一括アップロードする都合上、失敗すると「本文だけのノート」が残る。
+   * 添付が前提で書かれたノートではそれが望ましくないため取り消す。
+   * ただし取り消すのは技術的失敗（通信断・5xx など）だけに限る。ユーザーが自分で
+   * 中断した場合や、サーバーが内容を理由に拒否した場合まで巻き添えにすると、
+   * ユーザーが書いた本文を本人の意図に反して消すことになる。
+   */
+  shouldRollbackNote: boolean;
+}
+
+/** 一括アップロードの結果を集計し、ノートをロールバックすべきかを決める。 */
+export function summarizeStagedUploads(
+  results: MediaUploadResult[],
+): StagedUploadSummary {
+  const summary = {
+    uploaded: 0,
+    canceled: 0,
+    limitReached: 0,
+    rejected: 0,
+    technical: 0,
+  };
+
+  for (const result of results) {
+    if (result.ok) {
+      summary.uploaded += 1;
+      continue;
+    }
+    if (result.reason === "canceled") summary.canceled += 1;
+    if (result.reason === "limit_reached") summary.limitReached += 1;
+    if (result.reason === "rejected") summary.rejected += 1;
+    if (result.reason === "technical") summary.technical += 1;
+  }
+
+  return { ...summary, shouldRollbackNote: summary.technical > 0 };
+}
+
+/**
+ * ロールバックしなかったときにユーザーへ伝える要約。伝えることが無ければ null。
+ * 中断・拒否は「ノートは保存されている」ことを必ず添える（消えたと誤解させないため）。
+ */
+export function buildStagedUploadNotice(
+  summary: StagedUploadSummary,
+): string | null {
+  const parts: string[] = [];
+  if (summary.canceled > 0)
+    parts.push(`${summary.canceled}件のアップロードを中断しました`);
+  if (summary.rejected > 0)
+    parts.push(`${summary.rejected}件は保存できませんでした`);
+  if (parts.length === 0) return null;
+
+  return `ノートは保存済みです。${parts.join("。")}。`;
+}

--- a/app/utils/media/uploadPhase.ts
+++ b/app/utils/media/uploadPhase.ts
@@ -1,0 +1,19 @@
+/**
+ * アップロードの進行フェーズ。mobile の UploadPhase と同じ区切り・同じ文言にする。
+ *
+ * Server Action を持つモジュールから切り離しておくことで、表示側が
+ * `next/cache` などサーバー専用の依存を引き込まずに済む。
+ */
+export type UploadPhase =
+  | "idle"
+  | "compressing"
+  | "uploading"
+  | "finalizing"
+  | "done"
+  | "error";
+
+export const UPLOAD_PHASE_LABEL: Partial<Record<UploadPhase, string>> = {
+  compressing: "圧縮中…",
+  uploading: "アップロード中…",
+  finalizing: "仕上げ中…",
+};

--- a/app/utils/media/uploadPipeline.ts
+++ b/app/utils/media/uploadPipeline.ts
@@ -1,0 +1,171 @@
+import type { UploadPhase } from "./uploadPhase";
+import type {
+  MediaType,
+  NoteMediaAttachment,
+} from "@app/interface/mediaAttachmentV2";
+import {
+  completeMediaUpload,
+  presignMediaUpload,
+} from "@app/services/v2/mediaAttachmentService";
+import { isExpiredUploadStatus, isPresignExpiring } from "./mediaLimits";
+import { putToPresignedUrl } from "./r2Upload";
+
+/** 圧縮・サムネイル生成まで済ませた、これ以上ブラウザ API を触らないアップロード対象。 */
+export interface PreparedMedia {
+  mediaType: MediaType;
+  contentType: string;
+  file: Blob;
+  thumbnail: Blob | null;
+  durationSeconds?: number;
+  width?: number;
+  height?: number;
+  memo?: string;
+}
+
+/**
+ * アップロード結果。ロールバック要否を呼び出し側が判断できるよう、
+ * 「ユーザーが止めた」「サーバーに拒否された」「技術的に失敗した」を必ず分ける。
+ */
+export type MediaUploadResult =
+  | { ok: true; attachment: NoteMediaAttachment }
+  /** 無料枠（月3件）を使い切っている。ノートは保存済みのままにする。 */
+  | { ok: false; reason: "limit_reached"; message: string }
+  /** ユーザーが中断した。書きかけの本文を巻き添えにしてはならない。 */
+  | { ok: false; reason: "canceled" }
+  /** サーバーが内容を理由に拒否した（上限超過など）。ノートは残す。 */
+  | { ok: false; reason: "rejected"; message: string }
+  /** 通信断・5xx など、ユーザーの意図とも内容とも無関係な失敗。 */
+  | { ok: false; reason: "technical"; message: string };
+
+// 署名 URL の失効に備えた presign のやり直し回数（初回 + 1回）。
+const MAX_PRESIGN_ATTEMPTS = 2;
+
+const NETWORK_ERROR_MESSAGE =
+  "アップロードに失敗しました。通信環境を確認して再度お試しください。";
+
+interface UploadOptions {
+  signal?: AbortSignal;
+  onPhase?: (phase: UploadPhase) => void;
+  /** テストから時刻を差し替えるための注入点。 */
+  now?: () => number;
+}
+
+function canceledResult(): MediaUploadResult {
+  return { ok: false, reason: "canceled" };
+}
+
+/**
+ * presign → R2 へ直接 PUT → 完了通知、の一連の流れを実行する。
+ *
+ * 署名 URL の有効期限は10分しかないため、PUT が 401/403 で落ちた場合と、
+ * サムネイル送信の直前に期限が近づいている場合は presign から取り直す
+ * （古い pending レコードは back 側で1時間後に無料枠の集計から外れる）。
+ */
+export async function uploadPreparedMedia(
+  prepared: PreparedMedia,
+  baseballNoteId: number,
+  { signal, onPhase, now = Date.now }: UploadOptions = {},
+): Promise<MediaUploadResult> {
+  for (let attempt = 0; attempt < MAX_PRESIGN_ATTEMPTS; attempt += 1) {
+    const canRetry = attempt + 1 < MAX_PRESIGN_ATTEMPTS;
+    if (signal?.aborted) return canceledResult();
+
+    onPhase?.("uploading");
+    const presigned = await presignMediaUpload({
+      baseball_note_id: baseballNoteId,
+      media_type: prepared.mediaType,
+      content_type: prepared.contentType,
+    });
+    if (!presigned.ok) {
+      if (presigned.reason === "forbidden") {
+        return {
+          ok: false,
+          reason: "limit_reached",
+          message:
+            presigned.errors[0] ?? "今月のアップロード上限に達しています",
+        };
+      }
+      return {
+        ok: false,
+        reason: "technical",
+        message: presigned.errors[0] ?? NETWORK_ERROR_MESSAGE,
+      };
+    }
+    const issuedAt = now();
+
+    const putResult = await putToPresignedUrl(
+      presigned.data.upload_url,
+      prepared.file,
+      prepared.contentType,
+      signal,
+    );
+    if (!putResult.ok) {
+      if (putResult.canceled) return canceledResult();
+      if (canRetry && isExpiredUploadStatus(putResult.status ?? 0)) continue;
+      return {
+        ok: false,
+        reason: "technical",
+        message: NETWORK_ERROR_MESSAGE,
+      };
+    }
+
+    if (prepared.thumbnail && presigned.data.thumbnail_upload_url) {
+      // 本体の送信が長引くと、サムネイルを送る頃には署名が切れている。
+      if (canRetry && isPresignExpiring(issuedAt, now())) continue;
+
+      const thumbnailResult = await putToPresignedUrl(
+        presigned.data.thumbnail_upload_url,
+        prepared.thumbnail,
+        "image/jpeg",
+        signal,
+      );
+      if (!thumbnailResult.ok) {
+        if (thumbnailResult.canceled) return canceledResult();
+        if (
+          canRetry &&
+          isExpiredUploadStatus(thumbnailResult.status ?? 0) &&
+          !thumbnailResult.canceled
+        ) {
+          continue;
+        }
+        // サムネイルは表示上の補助でしかない。本体が届いている以上、ここで
+        // 失敗させると送信済みの動画ごと捨てることになるため完了通知へ進む。
+      }
+    }
+
+    if (signal?.aborted) return canceledResult();
+
+    onPhase?.("finalizing");
+    const completed = await completeMediaUpload(
+      presigned.data.id,
+      {
+        file_size_bytes: prepared.file.size,
+        ...(prepared.durationSeconds === undefined
+          ? {}
+          : { duration_seconds: prepared.durationSeconds }),
+        ...(prepared.width === undefined ? {} : { width: prepared.width }),
+        ...(prepared.height === undefined ? {} : { height: prepared.height }),
+        ...(prepared.memo ? { memo: prepared.memo } : {}),
+      },
+      baseballNoteId,
+    );
+    if (!completed.ok) {
+      // back は上限超過・PUT 未達を 422 で返しつつ、レコードを failed にしている。
+      // 内容起因の拒否なので、ユーザーが書いたノート本文を巻き添えにはしない。
+      return {
+        ok: false,
+        reason: "rejected",
+        message: completed.errors[0] ?? "アップロードを完了できませんでした",
+      };
+    }
+
+    onPhase?.("done");
+    return { ok: true, attachment: completed.data };
+  }
+
+  return {
+    ok: false,
+    reason: "technical",
+    message: "アップロードの有効期限が切れました。もう一度お試しください。",
+  };
+}


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#477

## 🔴 デプロイ前に必ず確認が必要な事項が2件あります

### 1. R2 バケットの CORS 設定が未確認です（未設定ならこの機能は動きません）

ブラウザからの直 PUT には R2 側で以下が必要です。

- `AllowedOrigins` にフロントのオリジン
- `AllowedMethods: ["PUT"]`
- `AllowedHeaders: ["content-type"]`（**署名に `content_type` が含まれるため必須**）

**mobile は `expo-file-system` のネイティブ PUT なので CORS の影響を受けません。Web で初めて必要になる設定です。** 未設定ならブラウザの preflight で全アップロードが失敗します。リポジトリ内に該当設定は見当たらず（バケット側の設定のため）、この環境では検証できませんでした。

### 2. 無料プランの動画 480px 制限を「選択時に弾く」実装にしています（プロダクト判断が必要）

**スマホ撮影の動画は通常 1080p なので、Web の無料ユーザーは実質的に動画をほぼアップロードできません。**

mobile は `react-native-compressor` でネイティブ圧縮して 480p に落とせますが、**Web には再エンコード手段がありません**（ffmpeg.wasm 等は未導入）。

「弾く」を選んだ理由は、back の `LimitValidator` が制限超過を**必ず 422 + `failed`** にするため、数十MB送ってから失敗させるのは通信・時間の純損だからです。ただし**プロダクトとして許容できるかは判断が必要**です。代替案は ffmpeg.wasm の導入か、無料プランの解像度制限の緩和です。

## 実装内容

presign → R2 直 PUT → 完了通知の一連フローと、添付の一覧・メモ編集・削除・ビューアです。

- `app/services/v2/mediaAttachmentService.ts` — presign / 完了通知 / メモ更新 / 削除
- `app/utils/media/` — 純粋ロジック（制限検証・リサイズ計算・ロールバック判定・フェーズ）とブラウザ API 依存部分（Canvas / `<video>` / `fetch` PUT）を分離
- `app/hooks/media/` — アップロード状態と `beforeunload`
- `app/components/note/media/` — `MediaPicker` / `MediaAttachmentList` / `StagedMediaList` / `MediaViewer` 等
- `proFeatureCatalog.ts` — `unlimited_media_uploads` を `app_only` → `web_and_app`

## ロールバックの条件（要件「ユーザーの本文を予期せず消さない」への対応）

失敗を4分類し、**`technical` のときだけノートを削除**します。

| 分類 | 発生源 | ロールバック |
| --- | --- | --- |
| `technical` | presign の非403失敗 / PUT の 5xx・通信断 / 期限切れリトライ枯渇 | **する** |
| `canceled` | ユーザーが中断（`AbortController`） | しない |
| `rejected` | 完了通知が 422（back が内容・上限を理由に拒否） | しない |
| `limit_reached` | presign が 403（無料枠超過） | しない |

**ユーザーキャンセルは `AbortSignal` 由来かで判定し、通信エラーと同じ catch に落としていません。** また**ロールバック時も遷移せずフォームに留まり、本文・タイトル・staged media を保持**します。

**`rejected`（422）を `technical` と分けたのは私の判断です。** issue は「技術的失敗ならロールバック」としか書いていませんが、「サーバーが内容を理由に拒否」でノート本文まで消すのは要件に反すると考えました。

## back の契約で判明した点

- **署名 URL は10分**。`content_type` が署名に含まれるため PUT 時に同じ値を送らないと署名不一致
- 完了通知は **`file_size_bytes` キーの有無で「完了通知」と「メモ更新」を判別**
- **サーバーが自己申告を信用しません**: `ObjectSizeFetcher` が R2 の実サイズを `head_object` で取得して上書きし、`LimitValidator` が再検証。presign では `media_type × content_type` の組み合わせも許可リスト検証（image に video/mp4 を渡して動画チェックを回避する攻撃を封じている）
- **403 は presign のみ**（完了通知・メモ更新・削除には無い）

## ⚠️ 検証できていないこと（推測で「動く」とは書いていません）

- 🔴 **R2 への実 PUT は一切実行していません**（認証情報が無く、全テストでモック）
- 🔴 **R2 の CORS 設定は未確認**（上記）
- 🔴 **Canvas / `<video>` の実挙動は未検証**（jsdom は `canvas.toBlob` も `video.videoWidth` も持たないため、モック越しにしかテストしていません）。特に **HEIC のフォールバック**、**`.mov`（H.265）のメタ取得可否**、**動画サムネの seek タイミングで黒フレームにならないか**は実ブラウザでの確認が必要です
- 🟡 **進捗はバイト単位ではありません**（`fetch` の PUT は送信バイト数を通知しないため、フェーズ + 件数のみ）。真の進捗バーが要るなら XHR への切り替えが必要です

### 検証できたこと

呼び出し順序と各段階の失敗分岐 / 署名 URL 期限切れの再取得 / ロールバックの4分類（本文が残ることも含む）/ 403 のペイウォール文言 / クライアント制限値が back の定数と一致 / 添付の一覧・メモ編集・削除 / `beforeunload` の付け外し（jsdom で実イベントを dispatch し `defaultPrevented` を確認）/ 本番ビルドとルート表

## その他の判断

- **サムネイル PUT の失敗を致命的にしていません。** 数十MB送り終えた動画をサムネ1枚のために捨てるのは損なので完了通知へ進めます（表示側はプレースホルダに落ちる）。**mobile は throw する実装なので方針が分かれています**

## チェックリスト

- [x] `yarn typecheck` / `yarn lint` / `yarn format:check` が通る
- [x] `yarn test` が通る（**147 suites / 1734 tests**。+3 suites / +43 tests）
- [x] `yarn build` が通る（ローカルで実行済み）
- [x] ミューテーションテスト **28 設計 / 28 KILLED / 0 SURVIVED**

### ルート表

base（`cdd43aa`）も同条件でビルドして diff を取得しました。**added: 0 / removed: 0 / changed: 0** — 静的 87 / 動的 46 で完全一致です。

<details>
<summary>ミューテーションテスト詳細</summary>

順序3件（完了通知を先に / 送らない / PUT せず通知だけ）/ **ロールバック5件**（技術的失敗でしない / キャンセルでする / 422 でする / 403 でする / フォーム側で実行しない）/ 期限切れ3件 / 上限値4件 / ペイウォール2件 / `beforeunload` 3件 / 削除確認 / API 契約3件 / その他4件 — 全 KILLED。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_