### PR TITLE
Add: 改善テーマ（課題）機能一式とノートへの紐付けを実装

### DIFF
--- a/app/(app)/note/[slulg]/_components/NoteEditForm.tsx
+++ b/app/(app)/note/[slulg]/_components/NoteEditForm.tsx
@@ -3,18 +3,26 @@
 import type { BaseballNoteV2, NoteTag } from "@app/interface/baseballNoteV2";
 import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
 import type { FetchResult } from "@app/services/v2/requests";
+import type { GameResultLinkOption } from "@app/types/gameResultLink";
+import type { ImprovementTheme } from "@app/types/improvementTheme";
 import { Input } from "@heroui/react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import HeaderNote from "@app/components/header/HeaderNote";
+import NoteGameResultSection from "@app/components/note/NoteGameResultSection";
 import NoteMenu from "@app/components/note/NoteMenu";
 import NoteTagSection from "@app/components/note/NoteTagSection";
+import NoteThemeSection from "@app/components/note/NoteThemeSection";
 import ReflectionTemplateSection from "@app/components/note/ReflectionTemplateSection";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import { useNoteTagEditing } from "@app/hooks/note/useNoteTagEditing";
 import { updateBaseballNote } from "@app/services/v2/baseballNoteService";
+import {
+  buildGameResultIdsUpdate,
+  buildImprovementThemeIdsUpdate,
+} from "@app/utils/noteLinks";
 import {
   buildAnswerList,
   extractMemoText,
@@ -39,12 +47,17 @@ interface NoteEditFormProps {
   note: BaseballNoteV2;
   templatesResult: FetchResult<ReflectionTemplate[]>;
   tagsResult: FetchResult<NoteTag[]>;
+  themesResult: FetchResult<ImprovementTheme[]>;
+  /** 紐付け済みの試合記録。取得できなかった分は含まれない。 */
+  linkedGameResults: GameResultLinkOption[];
 }
 
 export default function NoteEditForm({
   note,
   templatesResult,
   tagsResult,
+  themesResult,
+  linkedGameResults,
 }: NoteEditFormProps) {
   const router = useRouter();
   const { canEditTags } = useNoteTagEditing();
@@ -87,6 +100,12 @@ export default function NoteEditForm({
     [note.tags],
   );
   const [tagIds, setTagIds] = useState<number[]>(initialTagIds);
+  const [themeIds, setThemeIds] = useState<number[]>(
+    note.improvement_theme_ids,
+  );
+  const [gameResultIds, setGameResultIds] = useState<number[]>(
+    note.game_result_ids,
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
 
@@ -101,9 +120,10 @@ export default function NoteEditForm({
     reflectionAnswers: initialAnswers,
   };
 
-  // 送るのは変更したキーだけ。試合 / 課題の紐付けとテンプレ ID はこの画面で編集しないため
-  // キー自体を送らず、back 側の「未送信＝変更なし」に委ねる（送ると上書きされる）。
-  // タグも Pro 判定が確定して entitlement を持ち、かつ実際に選択が変わったときだけキーを生やす。
+  // 送るのは変更したキーだけ。テンプレ ID はこの画面で編集しないためキー自体を送らず、
+  // back 側の「未送信＝変更なし」に委ねる（送ると上書きされる）。
+  // 紐付け（試合 / 課題 / タグ）も、選択が実際に変わったときだけキーを生やす。
+  // 変わったときは空配列でも必ず送る（`[]` が「全解除」の意思表示になる）。
   const updateInput = {
     ...buildNoteUpdateInput(initialValues, {
       date,
@@ -113,6 +133,14 @@ export default function NoteEditForm({
       reflectionAnswers: currentAnswers,
     }),
     ...buildTagIdsUpdate({ canEditTags, initialTagIds, tagIds }),
+    ...buildImprovementThemeIdsUpdate({
+      initialIds: note.improvement_theme_ids,
+      ids: themeIds,
+    }),
+    ...buildGameResultIdsUpdate({
+      initialIds: note.game_result_ids,
+      ids: gameResultIds,
+    }),
   };
   const hasChanges = hasNoteChanges(updateInput);
 
@@ -195,6 +223,18 @@ export default function NoteEditForm({
                   selectedIds={tagIds}
                   onChange={setTagIds}
                   canEdit={canEditTags}
+                />
+                <NoteThemeSection
+                  themesResult={themesResult}
+                  selectedIds={themeIds}
+                  onChange={setThemeIds}
+                  initialCount={note.improvement_theme_ids.length}
+                />
+                <NoteGameResultSection
+                  selectedIds={gameResultIds}
+                  onChange={setGameResultIds}
+                  initialCount={note.game_result_ids.length}
+                  linkedOptions={linkedGameResults}
                 />
               </div>
             </form>

--- a/app/(app)/note/[slulg]/_components/__tests__/NoteEditForm.test.tsx
+++ b/app/(app)/note/[slulg]/_components/__tests__/NoteEditForm.test.tsx
@@ -13,6 +13,16 @@ jest.mock("@app/services/v2/noteTagService", () => ({
   createNoteTag: jest.fn(),
 }));
 
+jest.mock("@app/services/v2/gameResultLinkService", () => ({
+  searchGameResultOptions: jest.fn(() =>
+    Promise.resolve({ status: "ok", data: [] }),
+  ),
+}));
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: jest.fn(), close: jest.fn() }),
+}));
+
 const mockHasEntitlement = jest.fn(() => false);
 const mockIsEntitlementLoading = jest.fn(() => false);
 
@@ -105,6 +115,8 @@ function renderForm(overrides: Partial<BaseballNoteV2> = {}) {
       note={{ ...note, ...overrides }}
       templatesResult={templatesResult}
       tagsResult={tagsResult}
+      themesResult={{ status: "ok", data: [] }}
+      linkedGameResults={[]}
     />,
   );
 }

--- a/app/(app)/note/[slulg]/_components/__tests__/NoteFormTagPayload.test.tsx
+++ b/app/(app)/note/[slulg]/_components/__tests__/NoteFormTagPayload.test.tsx
@@ -10,6 +10,16 @@ jest.mock("@app/services/v2/baseballNoteService", () => ({
   deleteBaseballNote: jest.fn(),
 }));
 
+jest.mock("@app/services/v2/gameResultLinkService", () => ({
+  searchGameResultOptions: jest.fn(() =>
+    Promise.resolve({ status: "ok", data: [] }),
+  ),
+}));
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: jest.fn(), close: jest.fn() }),
+}));
+
 // タグ選択 UI 側のガードを外し、フォームの送信ペイロード組み立てだけを検証する。
 // UI を隠すだけでは不十分で、ペイロード組み立ての時点で entitlement を見て
 // tag_ids キーごと落としていることを担保する。
@@ -125,6 +135,7 @@ describe("ノートフォームの tag_ids 送信ガード（UI を迂回して�
         <NoteCreateForm
           templatesResult={templatesResult}
           tagsResult={tagsResult}
+          themesResult={{ status: "ok", data: [] }}
         />,
       );
       fireEvent.change(screen.getByLabelText("タイトル"), {
@@ -170,6 +181,8 @@ describe("ノートフォームの tag_ids 送信ガード（UI を迂回して�
           note={note}
           templatesResult={templatesResult}
           tagsResult={tagsResult}
+          themesResult={{ status: "ok", data: [] }}
+          linkedGameResults={[]}
         />,
       );
     }

--- a/app/(app)/note/[slulg]/_components/__tests__/NoteLinkPayload.test.tsx
+++ b/app/(app)/note/[slulg]/_components/__tests__/NoteLinkPayload.test.tsx
@@ -1,0 +1,317 @@
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@app/services/v2/baseballNoteService", () => ({
+  createBaseballNote: jest.fn(),
+  updateBaseballNote: jest.fn(),
+  deleteBaseballNote: jest.fn(),
+}));
+
+jest.mock("@app/services/v2/noteTagService", () => ({
+  createNoteTag: jest.fn(),
+}));
+
+// 紐付け UI のガード（Pro 判定・ピッカー操作）を外し、フォームの送信ペイロード組み立てだけを検証する。
+// 「変えていないならキーごと送らない」「全解除は [] を送る」はペイロード組み立ての責務。
+jest.mock("@app/components/note/NoteThemeSection", () => {
+  const react = jest.requireActual<typeof ReactModule>("react");
+  return function StubThemeSection({
+    selectedIds,
+    onChange,
+  }: {
+    selectedIds: number[];
+    onChange: (ids: number[]) => void;
+  }) {
+    return react.createElement(
+      "div",
+      null,
+      react.createElement(
+        "button",
+        { type: "button", onClick: () => onChange([...selectedIds, 999]) },
+        "課題を足す",
+      ),
+      react.createElement(
+        "button",
+        { type: "button", onClick: () => onChange([]) },
+        "課題を全部外す",
+      ),
+      react.createElement(
+        "button",
+        { type: "button", onClick: () => onChange([...selectedIds].reverse()) },
+        "課題を並べ替える",
+      ),
+    );
+  };
+});
+
+jest.mock("@app/components/note/NoteGameResultSection", () => {
+  const react = jest.requireActual<typeof ReactModule>("react");
+  return function StubGameSection({
+    selectedIds,
+    onChange,
+  }: {
+    selectedIds: number[];
+    onChange: (ids: number[]) => void;
+  }) {
+    return react.createElement(
+      "div",
+      null,
+      react.createElement(
+        "button",
+        { type: "button", onClick: () => onChange([...selectedIds, 888]) },
+        "試合を足す",
+      ),
+      react.createElement(
+        "button",
+        { type: "button", onClick: () => onChange([]) },
+        "試合を全部外す",
+      ),
+      react.createElement(
+        "button",
+        { type: "button", onClick: () => onChange(selectedIds.slice(0, -1)) },
+        "試合を1件外す",
+      ),
+    );
+  };
+});
+
+jest.mock("@app/components/note/NoteTagSection", () => {
+  const react = jest.requireActual<typeof ReactModule>("react");
+  return function StubTagSection() {
+    return react.createElement("div");
+  };
+});
+
+jest.mock("next/dynamic", () => () => {
+  const react = jest.requireActual<typeof ReactModule>("react");
+  return function MockNoteEditor({
+    memo,
+    setMemo,
+  }: {
+    memo: string;
+    setMemo: (value: string) => void;
+  }) {
+    return react.createElement("textarea", {
+      "aria-label": "メモ",
+      defaultValue: memo,
+      onChange: (event: { target: { value: string } }) =>
+        setMemo(event.target.value),
+    });
+  };
+});
+
+const mockHasEntitlement = jest.fn(() => false);
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: () => ({
+    isPro: false,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading: false,
+    hasEntitlement: mockHasEntitlement,
+  }),
+}));
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: jest.fn(), close: jest.fn() }),
+}));
+
+import type { BaseballNoteV2, NoteTag } from "@app/interface/baseballNoteV2";
+import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
+import type { FetchResult } from "@app/services/v2/requests";
+import type ReactModule from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import NoteCreateForm from "@app/(app)/note/new/_components/NoteCreateForm";
+import {
+  createBaseballNote,
+  updateBaseballNote,
+} from "@app/services/v2/baseballNoteService";
+import NoteEditForm from "../NoteEditForm";
+
+const mockCreate = createBaseballNote as jest.MockedFunction<
+  typeof createBaseballNote
+>;
+const mockUpdate = updateBaseballNote as jest.MockedFunction<
+  typeof updateBaseballNote
+>;
+
+const note: BaseballNoteV2 = {
+  id: 12,
+  title: "気づき",
+  date: "2026-08-01",
+  memo: '[{"type":"paragraph","children":[{"text":"外角が詰まる"}]}]',
+  memo_preview: "外角が詰まる",
+  game_result_ids: [101, 102, 103],
+  practice_log_id: null,
+  practice_session_id: null,
+  improvement_theme_ids: [201],
+  reflection_template_id: null,
+  reflection_answers: [],
+  tags: [],
+  media_attachments: [],
+};
+
+const templatesResult: FetchResult<ReflectionTemplate[]> = {
+  status: "ok",
+  data: [],
+};
+const tagsResult: FetchResult<NoteTag[]> = { status: "ok", data: [] };
+const themesResult: FetchResult<never[]> = { status: "ok", data: [] };
+
+function renderEditForm(overrides: Partial<BaseballNoteV2> = {}) {
+  render(
+    <NoteEditForm
+      note={{ ...note, ...overrides }}
+      templatesResult={templatesResult}
+      tagsResult={tagsResult}
+      themesResult={themesResult}
+      linkedGameResults={[]}
+    />,
+  );
+}
+
+function renderCreateForm() {
+  render(
+    <NoteCreateForm
+      templatesResult={templatesResult}
+      tagsResult={tagsResult}
+      themesResult={themesResult}
+    />,
+  );
+  fireEvent.change(screen.getByLabelText("タイトル"), {
+    target: { value: "気づき" },
+  });
+}
+
+function save() {
+  fireEvent.click(screen.getByRole("button", { name: "保存" }));
+}
+
+async function sentUpdate() {
+  await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+  return mockUpdate.mock.calls[0][1];
+}
+
+async function sentCreate() {
+  await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+  return mockCreate.mock.calls[0][0];
+}
+
+describe("ノート更新時の紐付けペイロード", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasEntitlement.mockReturnValue(false);
+    mockCreate.mockResolvedValue({ ok: true, data: note });
+    mockUpdate.mockResolvedValue({ ok: true, data: note });
+  });
+
+  it("紐付けを触らなければ紐付けのキーを一切送らない（既存の紐付けを消さない）", async () => {
+    renderEditForm();
+    fireEvent.change(screen.getByLabelText("タイトル"), {
+      target: { value: "更新後" },
+    });
+
+    save();
+
+    const payload = await sentUpdate();
+    expect(payload).not.toHaveProperty("improvement_theme_ids");
+    expect(payload).not.toHaveProperty("game_result_ids");
+    expect(payload.title).toBe("更新後");
+  });
+
+  it("課題を全解除したときは空配列を明示して送る", async () => {
+    renderEditForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "課題を全部外す" }));
+    save();
+
+    const payload = await sentUpdate();
+    expect(payload.improvement_theme_ids).toEqual([]);
+    // 触っていない試合の紐付けは巻き込まない。
+    expect(payload).not.toHaveProperty("game_result_ids");
+  });
+
+  it("試合を全解除したときは空配列を明示して送る", async () => {
+    renderEditForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "試合を全部外す" }));
+    save();
+
+    const payload = await sentUpdate();
+    expect(payload.game_result_ids).toEqual([]);
+    expect(payload).not.toHaveProperty("improvement_theme_ids");
+  });
+
+  it("課題を足したときはその内容を送る", async () => {
+    renderEditForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "課題を足す" }));
+    save();
+
+    expect((await sentUpdate()).improvement_theme_ids).toEqual([201, 999]);
+  });
+
+  it("並び替えただけならキーを送らない（集合として同じなら変更なし）", async () => {
+    renderEditForm({ improvement_theme_ids: [201, 202] });
+    fireEvent.change(screen.getByLabelText("タイトル"), {
+      target: { value: "更新後" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "課題を並べ替える" }));
+    save();
+
+    expect(await sentUpdate()).not.toHaveProperty("improvement_theme_ids");
+  });
+
+  it("無料ユーザーでも既存の複数紐付けを減らして保存できる（グランドファザリング）", async () => {
+    renderEditForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "試合を1件外す" }));
+    save();
+
+    expect((await sentUpdate()).game_result_ids).toEqual([101, 102]);
+  });
+
+  it("紐付けだけを変えた場合も保存できる", async () => {
+    renderEditForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "課題を足す" }));
+    save();
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(mockPush).toHaveBeenCalledWith("/note");
+  });
+});
+
+describe("ノート作成時の紐付けペイロード", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasEntitlement.mockReturnValue(false);
+    mockCreate.mockResolvedValue({ ok: true, data: note });
+  });
+
+  it("紐付けが無ければ紐付けのキーを送らない", async () => {
+    renderCreateForm();
+
+    save();
+
+    const payload = await sentCreate();
+    expect("improvement_theme_ids" in payload).toBe(false);
+    expect("game_result_ids" in payload).toBe(false);
+  });
+
+  it("選んだ課題・試合を送る", async () => {
+    renderCreateForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "課題を足す" }));
+    fireEvent.click(screen.getByRole("button", { name: "試合を足す" }));
+    save();
+
+    const payload = await sentCreate();
+    expect(payload.improvement_theme_ids).toEqual([999]);
+    expect(payload.game_result_ids).toEqual([888]);
+  });
+});

--- a/app/(app)/note/[slulg]/page.tsx
+++ b/app/(app)/note/[slulg]/page.tsx
@@ -1,9 +1,26 @@
+import type { GameResultLinkOption } from "@app/types/gameResultLink";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { getBaseballNote } from "@app/services/v2/baseballNoteService";
+import { getGameResultOption } from "@app/services/v2/gameResultLinkService";
+import { getImprovementThemes } from "@app/services/v2/improvementThemeService";
 import { getNoteTags } from "@app/services/v2/noteTagService";
 import { getReflectionTemplates } from "@app/services/v2/reflectionTemplateService";
 import NoteEditForm from "./_components/NoteEditForm";
+
+/**
+ * 紐付け済みの試合記録を表示用に取得する。
+ * 取得できなかった分は落とすだけにして、ノート本体の表示は止めない
+ * （紐付け自体は `game_result_ids` に残っており、フォーム側で ID のまま扱える）。
+ */
+async function fetchLinkedGameResults(
+  ids: number[],
+): Promise<GameResultLinkOption[]> {
+  const results = await Promise.all(ids.map((id) => getGameResultOption(id)));
+  return results.flatMap((result) =>
+    result.status === "ok" ? [result.data] : [],
+  );
+}
 
 function NoteLoadError({ message }: { message: string }) {
   return (
@@ -28,11 +45,14 @@ export default async function NoteDetail(props: {
   }
 
   // 互いに依存しない取得なので並列で待つ。
-  const [result, templatesResult, tagsResult] = await Promise.all([
-    getBaseballNote(noteId),
-    getReflectionTemplates(),
-    getNoteTags(),
-  ]);
+  const [result, templatesResult, tagsResult, themesResult] = await Promise.all(
+    [
+      getBaseballNote(noteId),
+      getReflectionTemplates(),
+      getNoteTags(),
+      getImprovementThemes(),
+    ],
+  );
   if (result.status === "forbidden") {
     return <NoteLoadError message="このノートを表示する権限がありません。" />;
   }
@@ -40,11 +60,18 @@ export default async function NoteDetail(props: {
     return <NoteLoadError message="野球ノートの読み込みに失敗しました。" />;
   }
 
+  // 紐付け先はノートを取得しないと分からないため、ここだけ直列になる。
+  const linkedGameResults = await fetchLinkedGameResults(
+    result.data.game_result_ids,
+  );
+
   return (
     <NoteEditForm
       note={result.data}
       templatesResult={templatesResult}
       tagsResult={tagsResult}
+      themesResult={themesResult}
+      linkedGameResults={linkedGameResults}
     />
   );
 }

--- a/app/(app)/note/new/_components/NoteCreateForm.tsx
+++ b/app/(app)/note/new/_components/NoteCreateForm.tsx
@@ -3,17 +3,24 @@
 import type { NoteTag, ReflectionAnswer } from "@app/interface/baseballNoteV2";
 import type { ReflectionTemplate } from "@app/interface/reflectionTemplate";
 import type { FetchResult } from "@app/services/v2/requests";
+import type { ImprovementTheme } from "@app/types/improvementTheme";
 import { Input } from "@heroui/react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import HeaderNote from "@app/components/header/HeaderNote";
+import NoteGameResultSection from "@app/components/note/NoteGameResultSection";
 import NoteTagSection from "@app/components/note/NoteTagSection";
+import NoteThemeSection from "@app/components/note/NoteThemeSection";
 import ReflectionTemplateSection from "@app/components/note/ReflectionTemplateSection";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import { useNoteTagEditing } from "@app/hooks/note/useNoteTagEditing";
 import { createBaseballNote } from "@app/services/v2/baseballNoteService";
+import {
+  buildGameResultIdsPayload,
+  buildImprovementThemeIdsPayload,
+} from "@app/utils/noteLinks";
 import { buildAnswerList, resolveNoteMemo } from "@app/utils/noteMemo";
 import { buildTagIdsPayload } from "@app/utils/noteTags";
 
@@ -27,6 +34,9 @@ const NoteEditor = dynamic(() => import("@app/components/note/NoteEditor"), {
 interface NoteCreateFormProps {
   templatesResult: FetchResult<ReflectionTemplate[]>;
   tagsResult: FetchResult<NoteTag[]>;
+  themesResult: FetchResult<ImprovementTheme[]>;
+  /** 課題詳細の「この課題でノートを書く」から来たときに、あらかじめ紐付けておく課題。 */
+  initialThemeIds?: number[];
 }
 
 /** 日付入力（`type="date"`）が要求する `YYYY-MM-DD` をローカル時刻で組み立てる。 */
@@ -40,6 +50,8 @@ function todayString(): string {
 export default function NoteCreateForm({
   templatesResult,
   tagsResult,
+  themesResult,
+  initialThemeIds = [],
 }: NoteCreateFormProps) {
   const router = useRouter();
   const { canEditTags } = useNoteTagEditing();
@@ -52,6 +64,8 @@ export default function NoteCreateForm({
   // 回答は問い文をキーに保持する。テンプレを切り替えて戻ってきても入力済みの回答が残る。
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [tagIds, setTagIds] = useState<number[]>([]);
+  const [themeIds, setThemeIds] = useState<number[]>(initialThemeIds);
+  const [gameResultIds, setGameResultIds] = useState<number[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
 
@@ -65,7 +79,9 @@ export default function NoteCreateForm({
     memo !== "" ||
     templateId !== null ||
     reflectionAnswers.length > 0 ||
-    tagIds.length > 0;
+    tagIds.length > 0 ||
+    themeIds.length !== initialThemeIds.length ||
+    gameResultIds.length > 0;
 
   const setErrorsWithTimeout = (newErrors: string[]) => {
     setErrors(newErrors);
@@ -93,7 +109,7 @@ export default function NoteCreateForm({
       return;
     }
     setIsSubmitting(true);
-    // 試合 / 課題の紐付けは新規作成画面では扱わないためキーごと送らない。
+    // 紐付けが1件も無いときはキーごと落とす。
     // タグも Pro 判定が確定して entitlement を持つときだけキーを生やす。
     const result = await createBaseballNote({
       date,
@@ -101,6 +117,8 @@ export default function NoteCreateForm({
       memo: resolveNoteMemo(memo, reflectionAnswers),
       reflection_template_id: templateId,
       reflection_answers: reflectionAnswers,
+      ...buildImprovementThemeIdsPayload(themeIds),
+      ...buildGameResultIdsPayload(gameResultIds),
       ...buildTagIdsPayload({ canEditTags, tagIds }),
     });
     if (!result.ok) {
@@ -165,6 +183,18 @@ export default function NoteCreateForm({
                   selectedIds={tagIds}
                   onChange={setTagIds}
                   canEdit={canEditTags}
+                />
+                <NoteThemeSection
+                  themesResult={themesResult}
+                  selectedIds={themeIds}
+                  onChange={setThemeIds}
+                  initialCount={0}
+                />
+                <NoteGameResultSection
+                  selectedIds={gameResultIds}
+                  onChange={setGameResultIds}
+                  initialCount={0}
+                  linkedOptions={[]}
                 />
               </div>
             </form>

--- a/app/(app)/note/new/_components/__tests__/NoteCreateForm.test.tsx
+++ b/app/(app)/note/new/_components/__tests__/NoteCreateForm.test.tsx
@@ -12,6 +12,16 @@ jest.mock("@app/services/v2/noteTagService", () => ({
   createNoteTag: jest.fn(),
 }));
 
+jest.mock("@app/services/v2/gameResultLinkService", () => ({
+  searchGameResultOptions: jest.fn(() =>
+    Promise.resolve({ status: "ok", data: [] }),
+  ),
+}));
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: jest.fn(), close: jest.fn() }),
+}));
+
 const mockHasEntitlement = jest.fn(() => false);
 const mockIsEntitlementLoading = jest.fn(() => false);
 
@@ -95,6 +105,7 @@ function renderForm(
     <NoteCreateForm
       templatesResult={templatesResult}
       tagsResult={tagsResult}
+      themesResult={{ status: "ok", data: [] }}
     />,
   );
 }

--- a/app/(app)/note/new/page.tsx
+++ b/app/(app)/note/new/page.tsx
@@ -1,20 +1,37 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getImprovementThemes } from "@app/services/v2/improvementThemeService";
 import { getNoteTags } from "@app/services/v2/noteTagService";
 import { getReflectionTemplates } from "@app/services/v2/reflectionTemplateService";
 import NoteCreateForm from "./_components/NoteCreateForm";
 
-export default async function NoteNew() {
+/** 課題詳細からの導線（`?improvement_theme_id=`）を紐付け済みの課題として受け取る。 */
+function initialThemeIds(value: string | string[] | undefined): number[] {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const id = Number(raw);
+  return Number.isInteger(id) && id > 0 ? [id] : [];
+}
+
+export default async function NoteNew(props: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   const cookieStore = await cookies();
   if (!cookieStore.get("access-token")) {
     redirect("/signup?auth_required=true");
   }
+  const searchParams = await props.searchParams;
   // 互いに依存しない取得なので並列で待つ。
-  const [templatesResult, tagsResult] = await Promise.all([
+  const [templatesResult, tagsResult, themesResult] = await Promise.all([
     getReflectionTemplates(),
     getNoteTags(),
+    getImprovementThemes(),
   ]);
   return (
-    <NoteCreateForm templatesResult={templatesResult} tagsResult={tagsResult} />
+    <NoteCreateForm
+      templatesResult={templatesResult}
+      tagsResult={tagsResult}
+      themesResult={themesResult}
+      initialThemeIds={initialThemeIds(searchParams.improvement_theme_id)}
+    />
   );
 }

--- a/app/(app)/themes/[id]/_components/ThemeDetailContent.tsx
+++ b/app/(app)/themes/[id]/_components/ThemeDetailContent.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
+import type {
+  ImprovementTheme,
+  ImprovementThemeInput,
+  ImprovementThemeStatus,
+} from "@app/types/improvementTheme";
+import type { PracticeSession } from "@app/types/practice";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import { themeCategoryLabel } from "@app/constants/improvementTheme";
+import {
+  deleteImprovementTheme,
+  updateImprovementTheme,
+} from "@app/services/v2/improvementThemeService";
+import { formatJaFullDate } from "@app/utils/formatDate";
+import {
+  DELETE_CONFIRM_NOTICE,
+  LINKED_NOTES_LOAD_ERROR,
+  LINKED_SESSIONS_LOAD_ERROR,
+} from "../../_components/themeCopy";
+import ThemeFormModal from "../../_components/ThemeFormModal";
+import {
+  buildThemeStatusInput,
+  themeTransitions,
+} from "../../_utils/themeList";
+
+interface ThemeDetailContentProps {
+  theme: ImprovementTheme;
+  sessions: PracticeSession[];
+  /** 練習記録の取得に失敗したか。空配列と区別して「0件」の誤表示を避ける。 */
+  sessionsLoadFailed: boolean;
+  notes: BaseballNoteV2[];
+  /** ノートの取得に失敗したか。空配列と区別して「0件」の誤表示を避ける。 */
+  notesLoadFailed: boolean;
+  /** 克服日に記録する当日（YYYY-MM-DD）。 */
+  today: string;
+}
+
+/**
+ * 課題詳細の Container。
+ * 統計は back が集計した値をそのまま表示し、紐づく記録の件数から数え直さない。
+ */
+export default function ThemeDetailContent({
+  theme: initialTheme,
+  sessions,
+  sessionsLoadFailed,
+  notes,
+  notesLoadFailed,
+  today,
+}: ThemeDetailContentProps) {
+  const router = useRouter();
+  const [theme, setTheme] = useState(initialTheme);
+  const [formToken, setFormToken] = useState<number | null>(null);
+  const [formErrors, setFormErrors] = useState<string[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleteOpen, setDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const transitions = themeTransitions(theme.status);
+
+  const applyUpdate = async (input: ImprovementThemeInput) => {
+    setIsSaving(true);
+    const result = await updateImprovementTheme(theme.id, input);
+    setIsSaving(false);
+    if (!result.ok) {
+      setFormErrors(result.errors);
+      toast.error(result.errors[0]);
+      return false;
+    }
+    setTheme(result.data);
+    return true;
+  };
+
+  const handleTransition = async (status: ImprovementThemeStatus) => {
+    const succeeded = await applyUpdate(buildThemeStatusInput(status, today));
+    if (succeeded) {
+      toast.success(
+        status === "achieved"
+          ? "課題を克服にしました"
+          : status === "open"
+            ? "課題を取組中に戻しました"
+            : "課題をアーカイブしました",
+      );
+    }
+  };
+
+  const handleEditSubmit = async (input: ImprovementThemeInput) => {
+    setFormErrors([]);
+    const succeeded = await applyUpdate(input);
+    if (succeeded) {
+      setFormToken(null);
+      toast.success("課題を更新しました");
+    }
+  };
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    const result = await deleteImprovementTheme(theme.id);
+    setIsDeleting(false);
+    if (!result.ok) {
+      toast.error(result.errors[0]);
+      return;
+    }
+    setDeleteOpen(false);
+    toast.success("課題を削除しました");
+    router.push("/themes");
+  };
+
+  return (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-2xl font-bold text-white">{theme.title}</h2>
+          <p className="mt-2 text-sm text-zinc-400">
+            {themeCategoryLabel(theme.category)}・
+            {formatJaFullDate(theme.started_on)} 開始
+            {theme.achieved_on
+              ? `・${formatJaFullDate(theme.achieved_on)} 克服`
+              : ""}
+          </p>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <Button
+            size="sm"
+            variant="flat"
+            onPress={() => {
+              setFormErrors([]);
+              setFormToken(Date.now());
+            }}
+          >
+            編集
+          </Button>
+          <Button
+            size="sm"
+            variant="flat"
+            color="danger"
+            onPress={() => setDeleteOpen(true)}
+          >
+            削除
+          </Button>
+        </div>
+      </div>
+
+      {theme.purpose ? (
+        <p className="mt-4 whitespace-pre-wrap text-sm text-white">
+          {theme.purpose}
+        </p>
+      ) : null}
+
+      <dl className="mt-6 grid grid-cols-3 gap-3">
+        <Stat label="取組日数" value={`${theme.active_days}日`} />
+        <Stat label="練習" value={`${theme.practice_logs_count}`} />
+        <Stat label="ノート" value={`${theme.notes_count}`} />
+      </dl>
+
+      <h3 className="mt-8 text-sm font-bold text-white">紐づく練習記録</h3>
+      {sessionsLoadFailed ? (
+        <p className="mt-2 text-xs text-zinc-400">
+          {LINKED_SESSIONS_LOAD_ERROR}
+        </p>
+      ) : sessions.length === 0 ? (
+        <p className="mt-2 text-xs text-zinc-500">まだありません</p>
+      ) : (
+        <ul className="mt-2 flex flex-col gap-2">
+          {sessions.map((session) => (
+            <li
+              key={session.id}
+              className="rounded-lg bg-sub px-3 py-3 text-sm text-white"
+            >
+              <span className="font-bold">
+                {formatJaFullDate(session.logged_on)}
+              </span>
+              {session.practice_logs.length > 0 ? (
+                <span className="ml-2 text-xs text-zinc-400">
+                  {session.practice_logs.map((log) => log.menu_name).join("、")}
+                </span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <h3 className="mt-8 text-sm font-bold text-white">紐づく野球ノート</h3>
+      {notesLoadFailed ? (
+        <p className="mt-2 text-xs text-zinc-400">{LINKED_NOTES_LOAD_ERROR}</p>
+      ) : notes.length === 0 ? (
+        <p className="mt-2 text-xs text-zinc-500">まだありません</p>
+      ) : (
+        <ul className="mt-2 flex flex-col gap-2">
+          {notes.map((note) => (
+            <li key={note.id}>
+              <Link
+                href={`/note/${note.id}`}
+                className="block rounded-lg bg-sub px-3 py-3 text-sm text-white transition-colors hover:bg-zinc-700"
+              >
+                <span className="font-bold">{formatJaFullDate(note.date)}</span>
+                <span className="ml-2 text-xs text-zinc-400">
+                  {note.title || "無題のノート"}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="mt-8 flex flex-col gap-3">
+        <Button
+          as={Link}
+          href={`/note/new?improvement_theme_id=${theme.id}`}
+          color="primary"
+          fullWidth
+          radius="sm"
+          className="font-bold"
+        >
+          この課題でノートを書く
+        </Button>
+        {transitions.canAchieve ? (
+          <Button
+            fullWidth
+            radius="sm"
+            variant="bordered"
+            className="border-[#d08000] font-bold text-[#d08000]"
+            isDisabled={isSaving}
+            onPress={() => handleTransition("achieved")}
+          >
+            克服した（達成）
+          </Button>
+        ) : null}
+        {transitions.canReopen ? (
+          <Button
+            fullWidth
+            radius="sm"
+            variant="flat"
+            isDisabled={isSaving}
+            onPress={() => handleTransition("open")}
+          >
+            取組中に戻す
+          </Button>
+        ) : null}
+        {transitions.canArchive ? (
+          <Button
+            fullWidth
+            radius="sm"
+            variant="flat"
+            isDisabled={isSaving}
+            onPress={() => handleTransition("archived")}
+          >
+            アーカイブ
+          </Button>
+        ) : null}
+      </div>
+
+      {formToken === null ? null : (
+        <ThemeFormModal
+          key={formToken}
+          theme={theme}
+          isSaving={isSaving}
+          serverErrors={formErrors}
+          onClose={() => setFormToken(null)}
+          onSubmit={handleEditSubmit}
+        />
+      )}
+
+      <Modal
+        isOpen={isDeleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        placement="center"
+        className="buzz-dark"
+      >
+        <ModalContent>
+          <ModalHeader className="text-white">課題の削除</ModalHeader>
+          <ModalBody>
+            <p className="text-sm text-white">
+              「{theme.title}」を削除しますか？
+            </p>
+            <p className="text-xs text-zinc-400">{DELETE_CONFIRM_NOTICE}</p>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="flat"
+              onPress={() => setDeleteOpen(false)}
+              isDisabled={isDeleting}
+            >
+              キャンセル
+            </Button>
+            <Button
+              color="danger"
+              onPress={handleDelete}
+              isDisabled={isDeleting}
+              isLoading={isDeleting}
+            >
+              削除
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl bg-sub py-4 text-center">
+      <dd className="text-xl font-bold text-[#d08000]">{value}</dd>
+      <dt className="mt-1 text-xs text-zinc-400">{label}</dt>
+    </div>
+  );
+}

--- a/app/(app)/themes/[id]/_components/__tests__/ThemeDetailContent.test.tsx
+++ b/app/(app)/themes/[id]/_components/__tests__/ThemeDetailContent.test.tsx
@@ -1,0 +1,295 @@
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@app/services/v2/improvementThemeService", () => ({
+  updateImprovementTheme: jest.fn(),
+  deleteImprovementTheme: jest.fn(),
+}));
+
+import type { BaseballNoteV2 } from "@app/interface/baseballNoteV2";
+import type { ImprovementTheme } from "@app/types/improvementTheme";
+import type { PracticeSession } from "@app/types/practice";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  deleteImprovementTheme,
+  updateImprovementTheme,
+} from "@app/services/v2/improvementThemeService";
+import ThemeDetailContent from "../ThemeDetailContent";
+
+const mockUpdate = updateImprovementTheme as jest.MockedFunction<
+  typeof updateImprovementTheme
+>;
+const mockDelete = deleteImprovementTheme as jest.MockedFunction<
+  typeof deleteImprovementTheme
+>;
+
+function buildTheme(
+  overrides: Partial<ImprovementTheme> = {},
+): ImprovementTheme {
+  return {
+    id: 5,
+    title: "肩の開きを抑える",
+    category: "batting",
+    purpose: "外角に対して体が早く開かないようにする",
+    status: "open",
+    started_on: "2026-07-01",
+    achieved_on: null,
+    sort_order: 0,
+    practice_logs_count: 30,
+    notes_count: 4,
+    active_days: 12,
+    created_at: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const session = {
+  id: 71,
+  logged_on: "2026-07-20",
+  memo: null,
+  improvement_theme_ids: [5],
+  practice_logs: [
+    {
+      id: 1,
+      practice_menu_id: 2,
+      schedule_id: null,
+      logged_on: "2026-07-20",
+      amount: "200.0",
+      weight: null,
+      menu_name: "素振り",
+      unit_label: "本",
+      source: "manual",
+      memo: null,
+      created_at: "2026-07-20T00:00:00.000Z",
+    },
+  ],
+  condition: null,
+  created_at: "2026-07-20T00:00:00.000Z",
+} as PracticeSession;
+
+const note = {
+  id: 12,
+  title: "気づき",
+  date: "2026-07-21",
+  memo: null,
+  memo_preview: "外角が詰まる",
+  game_result_ids: [],
+  practice_log_id: null,
+  practice_session_id: null,
+  improvement_theme_ids: [5],
+  reflection_template_id: null,
+  reflection_answers: [],
+  tags: [],
+  media_attachments: [],
+} as BaseballNoteV2;
+
+function renderDetail(
+  props: Partial<React.ComponentProps<typeof ThemeDetailContent>> = {},
+) {
+  return render(
+    <ThemeDetailContent
+      theme={buildTheme()}
+      sessions={[]}
+      sessionsLoadFailed={false}
+      notes={[]}
+      notesLoadFailed={false}
+      today="2026-08-03"
+      {...props}
+    />,
+  );
+}
+
+describe("課題の詳細", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("back が集計した統計をそのまま表示する", () => {
+    renderDetail({
+      theme: buildTheme({
+        active_days: 12,
+        practice_logs_count: 30,
+        notes_count: 4,
+      }),
+      // 紐づく記録の件数から数え直していないことを、統計と食い違う一覧で確かめる。
+      sessions: [session],
+      notes: [note],
+    });
+
+    expect(screen.getByText("12日")).toBeInTheDocument();
+    expect(screen.getByText("30")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("紐づく練習記録とノートを一覧する", () => {
+    renderDetail({ sessions: [session], notes: [note] });
+
+    expect(screen.getByText("2026年7月20日")).toBeInTheDocument();
+    expect(screen.getByText("素振り")).toBeInTheDocument();
+    expect(screen.getByText("2026年7月21日")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /気づき/ })).toHaveAttribute(
+      "href",
+      "/note/12",
+    );
+  });
+
+  it("紐づく記録が0件のときは0件として表示する", () => {
+    renderDetail();
+
+    expect(screen.getAllByText("まだありません")).toHaveLength(2);
+  });
+
+  it("紐づく記録の取得失敗は0件と区別して表示する", () => {
+    renderDetail({ sessionsLoadFailed: true, notesLoadFailed: true });
+
+    expect(
+      screen.getByText("紐づく練習記録を取得できませんでした。"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("紐づくノートを取得できませんでした。"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("まだありません")).not.toBeInTheDocument();
+  });
+
+  it("取組中では克服とアーカイブだけを操作できる", () => {
+    renderDetail({ theme: buildTheme({ status: "open" }) });
+
+    expect(
+      screen.getByRole("button", { name: "克服した（達成）" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "アーカイブ" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "取組中に戻す" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("克服すると status:achieved と達成日を送る", async () => {
+    const user = userEvent.setup();
+    mockUpdate.mockResolvedValue({
+      ok: true,
+      data: buildTheme({ status: "achieved", achieved_on: "2026-08-03" }),
+    });
+    renderDetail();
+
+    await user.click(screen.getByRole("button", { name: "克服した（達成）" }));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(mockUpdate).toHaveBeenCalledWith(5, {
+      status: "achieved",
+      achieved_on: "2026-08-03",
+    });
+    expect(
+      await screen.findByRole("button", { name: "取組中に戻す" }),
+    ).toBeInTheDocument();
+  });
+
+  it("克服済みを再開すると status:open と達成日の消去を送る", async () => {
+    const user = userEvent.setup();
+    mockUpdate.mockResolvedValue({
+      ok: true,
+      data: buildTheme({ status: "open" }),
+    });
+    renderDetail({
+      theme: buildTheme({ status: "achieved", achieved_on: "2026-08-01" }),
+    });
+
+    await user.click(screen.getByRole("button", { name: "取組中に戻す" }));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(mockUpdate).toHaveBeenCalledWith(5, {
+      status: "open",
+      achieved_on: null,
+    });
+  });
+
+  it("アーカイブすると status:archived を送り、アーカイブ操作は消える", async () => {
+    const user = userEvent.setup();
+    mockUpdate.mockResolvedValue({
+      ok: true,
+      data: buildTheme({ status: "archived" }),
+    });
+    renderDetail();
+
+    await user.click(screen.getByRole("button", { name: "アーカイブ" }));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(mockUpdate).toHaveBeenCalledWith(5, { status: "archived" });
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "アーカイブ" }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("アーカイブ済みは再開だけを操作できる", () => {
+    renderDetail({ theme: buildTheme({ status: "archived" }) });
+
+    expect(
+      screen.getByRole("button", { name: "取組中に戻す" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "アーカイブ" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "克服した（達成）" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("編集するとタイトルと目的を更新する", async () => {
+    const user = userEvent.setup();
+    mockUpdate.mockResolvedValue({
+      ok: true,
+      data: buildTheme({ title: "体重移動" }),
+    });
+    renderDetail();
+
+    await user.click(screen.getByRole("button", { name: "編集" }));
+    const titleInput = screen.getByLabelText(/いま取り組む課題/);
+    await user.clear(titleInput);
+    await user.type(titleInput, "体重移動");
+    await user.click(screen.getByRole("button", { name: "更新" }));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(mockUpdate.mock.calls[0][1]).toEqual({
+      title: "体重移動",
+      category: "batting",
+      purpose: "外角に対して体が早く開かないようにする",
+    });
+    expect(await screen.findByText("体重移動")).toBeInTheDocument();
+  });
+
+  it("削除すると一覧へ戻る", async () => {
+    const user = userEvent.setup();
+    mockDelete.mockResolvedValue({
+      ok: true,
+      data: { message: "削除しました" },
+    });
+    renderDetail();
+
+    await user.click(screen.getByRole("button", { name: "削除" }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "削除" }));
+
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith(5));
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/themes"));
+  });
+
+  it("この課題でノートを書く導線に課題 ID を載せる", () => {
+    renderDetail();
+
+    // HeroUI の Button は as={Link} でも role="button" を付けるため、href で導線を確かめる。
+    expect(
+      screen.getByRole("button", { name: "この課題でノートを書く" }),
+    ).toHaveAttribute("href", "/note/new?improvement_theme_id=5");
+  });
+});

--- a/app/(app)/themes/[id]/page.tsx
+++ b/app/(app)/themes/[id]/page.tsx
@@ -1,0 +1,92 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getBaseballNotes } from "@app/services/v2/baseballNoteService";
+import { getImprovementThemes } from "@app/services/v2/improvementThemeService";
+import { getPracticeSessions } from "@app/services/v2/practiceSessionService";
+import { todayString } from "@app/utils/formatDate";
+import {
+  LOAD_ERROR_MESSAGE,
+  NOT_FOUND_MESSAGE,
+} from "../_components/themeCopy";
+import ThemeDetailContent from "./_components/ThemeDetailContent";
+
+export const metadata = {
+  title: "課題の詳細",
+};
+
+function ThemeDetailShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">{children}</div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default async function ThemeDetailPage(props: {
+  params: Promise<{ id: string }>;
+}) {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const { id } = await props.params;
+  const themeId = Number(id);
+  if (!Number.isInteger(themeId) || themeId <= 0) {
+    return (
+      <ThemeDetailShell>
+        <p className="py-8 text-center text-sm text-zinc-400">
+          {NOT_FOUND_MESSAGE}
+        </p>
+      </ThemeDetailShell>
+    );
+  }
+
+  // back に課題の show エンドポイントは無いため、一覧から該当の1件を取り出す。
+  // 紐づく記録の取得は課題の取得結果に依存しないので並列で待つ。
+  const [themesResult, sessionsResult, notesResult] = await Promise.all([
+    getImprovementThemes(),
+    getPracticeSessions({ improvement_theme_id: themeId }),
+    getBaseballNotes({ improvementThemeId: themeId }),
+  ]);
+
+  if (themesResult.status !== "ok") {
+    return (
+      <ThemeDetailShell>
+        <p className="py-8 text-center text-sm text-zinc-400">
+          {LOAD_ERROR_MESSAGE}
+        </p>
+      </ThemeDetailShell>
+    );
+  }
+
+  const theme = themesResult.data.find((item) => item.id === themeId) ?? null;
+  if (!theme) {
+    return (
+      <ThemeDetailShell>
+        <p className="py-8 text-center text-sm text-zinc-400">
+          {NOT_FOUND_MESSAGE}
+        </p>
+      </ThemeDetailShell>
+    );
+  }
+
+  return (
+    <ThemeDetailShell>
+      <ThemeDetailContent
+        theme={theme}
+        sessions={sessionsResult.status === "ok" ? sessionsResult.data : []}
+        sessionsLoadFailed={sessionsResult.status !== "ok"}
+        notes={notesResult.status === "ok" ? notesResult.data : []}
+        notesLoadFailed={notesResult.status !== "ok"}
+        today={todayString()}
+      />
+    </ThemeDetailShell>
+  );
+}

--- a/app/(app)/themes/__tests__/ThemesContent.test.tsx
+++ b/app/(app)/themes/__tests__/ThemesContent.test.tsx
@@ -1,0 +1,285 @@
+const mockOpenProUpgradeModal = jest.fn();
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({
+    open: mockOpenProUpgradeModal,
+    close: jest.fn(),
+  }),
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+jest.mock("@app/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@app/services/v2/improvementThemeService", () => ({
+  createImprovementTheme: jest.fn(),
+}));
+
+import type { ImprovementTheme } from "@app/types/improvementTheme";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { createImprovementTheme } from "@app/services/v2/improvementThemeService";
+import ThemesContent from "../_components/ThemesContent";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+const mockCreate = createImprovementTheme as jest.MockedFunction<
+  typeof createImprovementTheme
+>;
+
+function buildTheme(
+  overrides: Partial<ImprovementTheme> = {},
+): ImprovementTheme {
+  return {
+    id: 1,
+    title: "肩の開きを抑える",
+    category: "batting",
+    purpose: null,
+    status: "open",
+    started_on: "2026-07-01",
+    achieved_on: null,
+    sort_order: 0,
+    practice_logs_count: 0,
+    notes_count: 0,
+    active_days: 0,
+    created_at: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function mockEntitlement({
+  granted = false,
+  isLoading = false,
+}: { granted?: boolean; isLoading?: boolean } = {}) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: granted,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading,
+    hasEntitlement: () => granted,
+  } as unknown as ReturnType<typeof useEntitlement>);
+}
+
+function tab(name: string) {
+  return screen.getByRole("tab", { name: new RegExp(name) });
+}
+
+describe("課題一覧", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEntitlement();
+  });
+
+  it("3タブに件数バッジを出し、取組中を初期表示する", () => {
+    render(
+      <ThemesContent
+        initialThemes={[
+          buildTheme({ id: 1, title: "課題A", status: "open" }),
+          buildTheme({ id: 2, title: "課題B", status: "open" }),
+          buildTheme({ id: 3, title: "課題C", status: "achieved" }),
+          buildTheme({ id: 4, title: "課題D", status: "archived" }),
+        ]}
+      />,
+    );
+
+    expect(within(tab("取組中")).getByText("2")).toBeInTheDocument();
+    expect(within(tab("克服")).getByText("1")).toBeInTheDocument();
+    expect(within(tab("アーカイブ")).getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("課題A")).toBeInTheDocument();
+    expect(screen.queryByText("課題C")).not.toBeInTheDocument();
+  });
+
+  it("タブを切り替えるとそのステータスの課題だけを出す", async () => {
+    const user = userEvent.setup();
+    render(
+      <ThemesContent
+        initialThemes={[
+          buildTheme({ id: 1, title: "課題A", status: "open" }),
+          buildTheme({ id: 3, title: "課題C", status: "achieved" }),
+        ]}
+      />,
+    );
+
+    await user.click(tab("克服"));
+
+    expect(screen.getByText("課題C")).toBeInTheDocument();
+    expect(screen.queryByText("課題A")).not.toBeInTheDocument();
+  });
+
+  it("課題が無いタブには専用の空メッセージを出す", async () => {
+    const user = userEvent.setup();
+    render(<ThemesContent initialThemes={[]} />);
+
+    expect(screen.getByText(/いま取り組む課題を決めると/)).toBeInTheDocument();
+
+    await user.click(tab("アーカイブ"));
+    expect(
+      screen.getByText("アーカイブした課題はありません。"),
+    ).toBeInTheDocument();
+  });
+
+  it("統計は back の集計値をそのまま出す", () => {
+    render(
+      <ThemesContent
+        initialThemes={[
+          buildTheme({
+            active_days: 12,
+            practice_logs_count: 30,
+            notes_count: 4,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("取組 12日")).toBeInTheDocument();
+    expect(screen.getByText("練習 30件")).toBeInTheDocument();
+    expect(screen.getByText("ノート 4件")).toBeInTheDocument();
+  });
+
+  it("課題を作成すると一覧へ加わる", async () => {
+    const user = userEvent.setup();
+    mockCreate.mockResolvedValue({
+      ok: true,
+      data: buildTheme({ id: 9, title: "体重移動" }),
+    });
+    render(<ThemesContent initialThemes={[]} />);
+
+    await user.click(
+      screen.getByRole("button", { name: /新しい課題に取り組む/ }),
+    );
+    await user.type(screen.getByLabelText(/いま取り組む課題/), "体重移動");
+    await user.click(
+      screen.getByRole("button", { name: "この課題に取り組む" }),
+    );
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+    expect(mockCreate.mock.calls[0][0]).toEqual({
+      title: "体重移動",
+      category: "batting",
+      purpose: null,
+    });
+    expect(await screen.findByText("体重移動")).toBeInTheDocument();
+  });
+
+  it("タイトルが空なら送信しない", async () => {
+    const user = userEvent.setup();
+    render(<ThemesContent initialThemes={[]} />);
+
+    await user.click(
+      screen.getByRole("button", { name: /新しい課題に取り組む/ }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "この課題に取り組む" }),
+    );
+
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("課題のタイトルを入力してください。"),
+    ).toBeInTheDocument();
+  });
+
+  it("無料で取組中が2件あると3件目の作成で Pro 訴求を出す", async () => {
+    const user = userEvent.setup();
+    render(
+      <ThemesContent
+        initialThemes={[
+          buildTheme({ id: 1, status: "open" }),
+          buildTheme({ id: 2, status: "open" }),
+        ]}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /新しい課題に取り組む/ }),
+    );
+
+    expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+      trigger: "unlimited_improvement_themes",
+    });
+    expect(
+      screen.queryByRole("button", { name: "この課題に取り組む" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("克服・アーカイブ済みは無料枠に数えず、3件目を作成できる", async () => {
+    const user = userEvent.setup();
+    mockCreate.mockResolvedValue({ ok: true, data: buildTheme({ id: 9 }) });
+    render(
+      <ThemesContent
+        initialThemes={[
+          buildTheme({ id: 1, status: "open" }),
+          buildTheme({ id: 2, status: "achieved" }),
+          buildTheme({ id: 3, status: "archived" }),
+        ]}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /新しい課題に取り組む/ }),
+    );
+
+    expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "この課題に取り組む" }),
+    ).toBeInTheDocument();
+  });
+
+  it("Pro は取組中が2件を超えても作成フォームを開ける", async () => {
+    const user = userEvent.setup();
+    mockEntitlement({ granted: true });
+    render(
+      <ThemesContent
+        initialThemes={[
+          buildTheme({ id: 1, status: "open" }),
+          buildTheme({ id: 2, status: "open" }),
+        ]}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /新しい課題に取り組む/ }),
+    );
+
+    expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "この課題に取り組む" }),
+    ).toBeInTheDocument();
+  });
+
+  it("サーバー側で上限に弾かれたらフォームに上限の案内を出す", async () => {
+    const user = userEvent.setup();
+    mockCreate.mockResolvedValue({
+      ok: false,
+      reason: "forbidden",
+      errors: ["取組中の課題は無料プランで2つまでです"],
+    });
+    render(<ThemesContent initialThemes={[]} />);
+
+    await user.click(
+      screen.getByRole("button", { name: /新しい課題に取り組む/ }),
+    );
+    await user.type(screen.getByLabelText(/いま取り組む課題/), "3つ目");
+    await user.click(
+      screen.getByRole("button", { name: "この課題に取り組む" }),
+    );
+
+    await waitFor(() =>
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "unlimited_improvement_themes",
+      }),
+    );
+    expect(
+      screen.getByText(/無料プランで同時に取り組める課題は2件までです/),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/(app)/themes/__tests__/themeList.test.ts
+++ b/app/(app)/themes/__tests__/themeList.test.ts
@@ -1,0 +1,197 @@
+import type { ImprovementTheme } from "@app/types/improvementTheme";
+import {
+  THEME_TABS,
+  buildThemeStatusInput,
+  countOpenThemes,
+  groupThemesByStatus,
+  isAtThemeFreeLimit,
+  themeTransitions,
+} from "../_utils/themeList";
+
+function buildTheme(
+  overrides: Partial<ImprovementTheme> = {},
+): ImprovementTheme {
+  return {
+    id: 1,
+    title: "肩の開きを抑える",
+    category: "batting",
+    purpose: null,
+    status: "open",
+    started_on: "2026-07-01",
+    achieved_on: null,
+    sort_order: 0,
+    practice_logs_count: 0,
+    notes_count: 0,
+    active_days: 0,
+    created_at: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("課題のタブ分類", () => {
+  it("back の status enum と同じ3タブを持つ", () => {
+    expect(THEME_TABS.map((tab) => tab.key)).toEqual([
+      "open",
+      "achieved",
+      "archived",
+    ]);
+  });
+
+  it("status ごとに振り分ける", () => {
+    const open = buildTheme({ id: 1, status: "open" });
+    const achieved = buildTheme({ id: 2, status: "achieved" });
+    const archived = buildTheme({ id: 3, status: "archived" });
+    const openTwo = buildTheme({ id: 4, status: "open" });
+
+    const grouped = groupThemesByStatus([open, achieved, archived, openTwo]);
+
+    expect(grouped.open.map((theme) => theme.id)).toEqual([1, 4]);
+    expect(grouped.achieved.map((theme) => theme.id)).toEqual([2]);
+    expect(grouped.archived.map((theme) => theme.id)).toEqual([3]);
+  });
+
+  it("課題が無ければ全タブが空になる", () => {
+    expect(groupThemesByStatus([])).toEqual({
+      open: [],
+      achieved: [],
+      archived: [],
+    });
+  });
+});
+
+describe("無料枠の判定", () => {
+  it("取組中（open）だけを数える", () => {
+    const themes = [
+      buildTheme({ id: 1, status: "open" }),
+      buildTheme({ id: 2, status: "achieved" }),
+      buildTheme({ id: 3, status: "archived" }),
+    ];
+
+    expect(countOpenThemes(themes)).toBe(1);
+  });
+
+  it("取組中が2件で上限に達する", () => {
+    const themes = [
+      buildTheme({ id: 1, status: "open" }),
+      buildTheme({ id: 2, status: "open" }),
+    ];
+
+    expect(
+      isAtThemeFreeLimit({
+        themes,
+        hasUnlimited: false,
+        isEntitlementLoading: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("取組中が1件なら上限に達しない", () => {
+    const themes = [
+      buildTheme({ id: 1, status: "open" }),
+      buildTheme({ id: 2, status: "achieved" }),
+      buildTheme({ id: 3, status: "archived" }),
+    ];
+
+    expect(
+      isAtThemeFreeLimit({
+        themes,
+        hasUnlimited: false,
+        isEntitlementLoading: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("克服・アーカイブ済みが何件あっても枠を消費しない", () => {
+    const themes = [
+      buildTheme({ id: 1, status: "achieved" }),
+      buildTheme({ id: 2, status: "achieved" }),
+      buildTheme({ id: 3, status: "archived" }),
+      buildTheme({ id: 4, status: "archived" }),
+    ];
+
+    expect(
+      isAtThemeFreeLimit({
+        themes,
+        hasUnlimited: false,
+        isEntitlementLoading: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("Pro は取組中が上限を超えていても上限扱いにしない", () => {
+    const themes = [
+      buildTheme({ id: 1, status: "open" }),
+      buildTheme({ id: 2, status: "open" }),
+      buildTheme({ id: 3, status: "open" }),
+    ];
+
+    expect(
+      isAtThemeFreeLimit({
+        themes,
+        hasUnlimited: true,
+        isEntitlementLoading: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("Pro 判定が未確定の間は上限扱いにしない", () => {
+    const themes = [
+      buildTheme({ id: 1, status: "open" }),
+      buildTheme({ id: 2, status: "open" }),
+    ];
+
+    expect(
+      isAtThemeFreeLimit({
+        themes,
+        hasUnlimited: false,
+        isEntitlementLoading: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("状態遷移", () => {
+  it("取組中では克服とアーカイブだけを出す", () => {
+    expect(themeTransitions("open")).toEqual({
+      canAchieve: true,
+      canReopen: false,
+      canArchive: true,
+    });
+  });
+
+  it("克服済みでは再開とアーカイブを出す", () => {
+    expect(themeTransitions("achieved")).toEqual({
+      canAchieve: false,
+      canReopen: true,
+      canArchive: true,
+    });
+  });
+
+  it("アーカイブ済みでは再開だけを出す", () => {
+    expect(themeTransitions("archived")).toEqual({
+      canAchieve: false,
+      canReopen: true,
+      canArchive: false,
+    });
+  });
+
+  it("克服では達成日を記録する", () => {
+    expect(buildThemeStatusInput("achieved", "2026-08-03")).toEqual({
+      status: "achieved",
+      achieved_on: "2026-08-03",
+    });
+  });
+
+  it("取組中へ戻すときは達成日を消す", () => {
+    expect(buildThemeStatusInput("open", "2026-08-03")).toEqual({
+      status: "open",
+      achieved_on: null,
+    });
+  });
+
+  it("アーカイブでは達成日を触らない", () => {
+    expect(buildThemeStatusInput("archived", "2026-08-03")).toEqual({
+      status: "archived",
+    });
+  });
+});

--- a/app/(app)/themes/_components/ThemeFormModal.tsx
+++ b/app/(app)/themes/_components/ThemeFormModal.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import type {
+  ImprovementTheme,
+  ImprovementThemeInput,
+} from "@app/types/improvementTheme";
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Textarea,
+} from "@heroui/react";
+import { useState } from "react";
+import { THEME_CATEGORIES } from "@app/constants/improvementTheme";
+import { TITLE_REQUIRED_ERROR } from "./themeCopy";
+
+interface ThemeFormModalProps {
+  /** 編集対象。null なら新規作成。 */
+  theme: ImprovementTheme | null;
+  isSaving: boolean;
+  /** 保存に失敗したときにフォーム内へ出すサーバー由来のメッセージ。 */
+  serverErrors: string[];
+  onClose: () => void;
+  onSubmit: (input: ImprovementThemeInput) => void;
+}
+
+const TITLE_MAX_LENGTH = 100;
+
+/**
+ * 課題の作成・編集フォーム。
+ *
+ * 入力値の保持と必須チェックだけを担い、API 呼び出し・上限判定は呼び出し元に委ねる。
+ * 開くたびに呼び出し元が key を変えて再マウントするため、初期値の同期に useEffect を使わない。
+ */
+export default function ThemeFormModal({
+  theme,
+  isSaving,
+  serverErrors,
+  onClose,
+  onSubmit,
+}: ThemeFormModalProps) {
+  const [title, setTitle] = useState(theme?.title ?? "");
+  const [category, setCategory] = useState<string>(
+    theme?.category ?? THEME_CATEGORIES[0].value,
+  );
+  const [purpose, setPurpose] = useState(theme?.purpose ?? "");
+  const [titleError, setTitleError] = useState<string | null>(null);
+
+  const handleSubmit = () => {
+    const trimmedTitle = title.trim();
+    if (trimmedTitle === "") {
+      setTitleError(TITLE_REQUIRED_ERROR);
+      return;
+    }
+    setTitleError(null);
+    onSubmit({
+      title: trimmedTitle,
+      category,
+      // 空欄は「目的なし」を意味するため null で送る（空文字だと back に空文字が保存される）。
+      purpose: purpose.trim() === "" ? null : purpose.trim(),
+    });
+  };
+
+  return (
+    <Modal isOpen onClose={onClose} placement="center" className="buzz-dark">
+      <ModalContent>
+        <ModalHeader className="text-white">
+          {theme ? "課題を編集" : "課題を決める"}
+        </ModalHeader>
+        <ModalBody className="gap-4">
+          <Input
+            isRequired
+            label="いま取り組む課題"
+            labelPlacement="outside"
+            placeholder="例: 肩の開きを抑える"
+            maxLength={TITLE_MAX_LENGTH}
+            value={title}
+            onValueChange={setTitle}
+            isInvalid={titleError !== null}
+            errorMessage={titleError}
+          />
+
+          <div>
+            <p className="mb-2 text-sm text-zinc-300">カテゴリ</p>
+            <div className="flex flex-wrap gap-2" role="group">
+              {THEME_CATEGORIES.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  aria-pressed={category === item.value}
+                  onClick={() => setCategory(item.value)}
+                  className={`rounded-full px-3.5 py-2 text-xs font-bold transition-colors ${
+                    category === item.value
+                      ? "bg-[#d08000] text-white"
+                      : "bg-sub text-zinc-400 hover:text-white"
+                  }`}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <Textarea
+            label="目的・メモ（任意）"
+            labelPlacement="outside"
+            placeholder="何のために取り組むか。克服の基準など"
+            minRows={3}
+            value={purpose}
+            onValueChange={setPurpose}
+          />
+
+          {serverErrors.length > 0 ? (
+            <div role="alert" className="text-xs text-red-400">
+              {serverErrors.map((message) => (
+                <p key={message}>{message}</p>
+              ))}
+            </div>
+          ) : null}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="flat" onPress={onClose} isDisabled={isSaving}>
+            キャンセル
+          </Button>
+          <Button
+            color="primary"
+            onPress={handleSubmit}
+            isDisabled={isSaving}
+            isLoading={isSaving}
+          >
+            {theme ? "更新" : "この課題に取り組む"}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/app/(app)/themes/_components/ThemeList.tsx
+++ b/app/(app)/themes/_components/ThemeList.tsx
@@ -1,0 +1,62 @@
+import type { ImprovementTheme } from "@app/types/improvementTheme";
+import Link from "next/link";
+import { themeCategoryLabel } from "@app/constants/improvementTheme";
+
+interface ThemeListProps {
+  themes: ImprovementTheme[];
+  /** 0件のときに出す文言。タブごとに異なるため呼び出し元から渡す。 */
+  emptyMessage: string;
+}
+
+/**
+ * 課題カードの一覧。
+ * 統計（取組日数・練習・ノート）は back が集計した値をそのまま表示する
+ * （紐づく記録の件数から数え直すと、一覧に載せていない記録の分だけずれる）。
+ */
+export default function ThemeList({ themes, emptyMessage }: ThemeListProps) {
+  if (themes.length === 0) {
+    return (
+      <p className="rounded-lg bg-sub p-4 text-sm text-zinc-400">
+        {emptyMessage}
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-3">
+      {themes.map((theme) => (
+        <li key={theme.id}>
+          <Link
+            href={`/themes/${theme.id}`}
+            className="block rounded-xl bg-sub p-4 transition-colors hover:bg-zinc-700"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <p className="font-bold text-white">{theme.title}</p>
+                <span className="mt-1.5 inline-block rounded bg-main px-2 py-0.5 text-[11px] font-semibold text-zinc-400">
+                  {themeCategoryLabel(theme.category)}
+                </span>
+              </div>
+              {theme.status === "achieved" ? (
+                <span className="shrink-0 rounded-full bg-[#d08000] px-2.5 py-1 text-[11px] font-bold text-white">
+                  克服
+                </span>
+              ) : null}
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2 text-xs font-semibold text-zinc-300">
+              <span className="rounded-lg bg-main px-2.5 py-1.5">
+                取組 {theme.active_days}日
+              </span>
+              <span className="rounded-lg bg-main px-2.5 py-1.5">
+                練習 {theme.practice_logs_count}件
+              </span>
+              <span className="rounded-lg bg-main px-2.5 py-1.5">
+                ノート {theme.notes_count}件
+              </span>
+            </div>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/app/(app)/themes/_components/ThemesContent.tsx
+++ b/app/(app)/themes/_components/ThemesContent.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import type {
+  ImprovementTheme,
+  ImprovementThemeInput,
+  ImprovementThemeStatus,
+} from "@app/types/improvementTheme";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import { Button } from "@heroui/react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { createImprovementTheme } from "@app/services/v2/improvementThemeService";
+import {
+  THEME_TABS,
+  groupThemesByStatus,
+  isAtThemeFreeLimit,
+} from "../_utils/themeList";
+import {
+  EMPTY_MESSAGE,
+  FREE_LIMIT_DESCRIPTION,
+  FREE_LIMIT_SERVER_ERROR,
+  FREE_LIMIT_TITLE,
+} from "./themeCopy";
+import ThemeFormModal from "./ThemeFormModal";
+import ThemeList from "./ThemeList";
+
+interface ThemesContentProps {
+  initialThemes: ImprovementTheme[];
+}
+
+/**
+ * 課題一覧画面の Container。
+ * タブの状態保持・Server Action 呼び出し・無料枠の判定を担い、表示は子コンポーネントへ委ねる。
+ */
+export default function ThemesContent({ initialThemes }: ThemesContentProps) {
+  const [themes, setThemes] = useState<ImprovementTheme[]>(initialThemes);
+  const [tab, setTab] = useState<ImprovementThemeStatus>("open");
+  const [formToken, setFormToken] = useState<number | null>(null);
+  const [formErrors, setFormErrors] = useState<string[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const { hasEntitlement, isLoading: isEntitlementLoading } = useEntitlement();
+  const { open: openProUpgradeModal } = useProUpgradeModal();
+
+  const themesByStatus = groupThemesByStatus(themes);
+  const isAtFreeLimit = isAtThemeFreeLimit({
+    themes,
+    hasUnlimited: hasEntitlement("unlimited_improvement_themes"),
+    isEntitlementLoading,
+  });
+
+  const handleAdd = () => {
+    if (isAtFreeLimit) {
+      openProUpgradeModal({ trigger: "unlimited_improvement_themes" });
+      return;
+    }
+    setFormErrors([]);
+    setFormToken(Date.now());
+  };
+
+  const handleSubmit = async (input: ImprovementThemeInput) => {
+    setIsSaving(true);
+    setFormErrors([]);
+    const result = await createImprovementTheme(input);
+    setIsSaving(false);
+
+    if (result.ok) {
+      setThemes((prev) => [...prev, result.data]);
+      setFormToken(null);
+      // 作成した課題は必ず取組中なので、そのタブへ寄せて追加結果を見せる。
+      setTab("open");
+      toast.success("課題を作成しました");
+      return;
+    }
+
+    // 作成時の 403 は Pro 限定機能ではなく無料枠の超過を意味する。
+    if (result.reason === "forbidden") {
+      setFormErrors([FREE_LIMIT_SERVER_ERROR]);
+      openProUpgradeModal({ trigger: "unlimited_improvement_themes" });
+      return;
+    }
+    setFormErrors(result.errors);
+  };
+
+  return (
+    <>
+      <h2 className="text-2xl font-bold">課題</h2>
+      <p className="mt-2 text-sm text-zinc-300">
+        いま集中して取り組むテーマを決めると、練習記録やノートをその課題に束ねて振り返れます。
+      </p>
+
+      <div className="my-5 flex gap-2" role="tablist" aria-label="課題の状態">
+        {THEME_TABS.map((item) => {
+          const isActive = item.key === tab;
+          return (
+            <button
+              key={item.key}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => setTab(item.key)}
+              className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg py-2.5 text-sm font-bold transition-colors ${
+                isActive ? "bg-[#d08000] text-white" : "bg-sub text-zinc-400"
+              }`}
+            >
+              {item.label}
+              <span className="text-xs">{themesByStatus[item.key].length}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mb-6">
+        <ThemeList
+          themes={themesByStatus[tab]}
+          emptyMessage={EMPTY_MESSAGE[tab]}
+        />
+      </div>
+
+      {isAtFreeLimit ? (
+        <ProUpsellCard
+          feature="unlimited_improvement_themes"
+          title={FREE_LIMIT_TITLE}
+          description={FREE_LIMIT_DESCRIPTION}
+          ctaLabel="Pro プランを見る"
+          className="mb-4"
+        />
+      ) : null}
+
+      <Button
+        color="primary"
+        fullWidth
+        radius="sm"
+        className="font-bold"
+        startContent={<PlusIcon className="h-5 w-5" aria-hidden />}
+        isDisabled={isEntitlementLoading}
+        onPress={handleAdd}
+      >
+        新しい課題に取り組む
+      </Button>
+
+      {formToken === null ? null : (
+        <ThemeFormModal
+          key={formToken}
+          theme={null}
+          isSaving={isSaving}
+          serverErrors={formErrors}
+          onClose={() => setFormToken(null)}
+          onSubmit={handleSubmit}
+        />
+      )}
+    </>
+  );
+}

--- a/app/(app)/themes/_components/themeCopy.ts
+++ b/app/(app)/themes/_components/themeCopy.ts
@@ -1,0 +1,34 @@
+import type { ImprovementThemeStatus } from "@app/types/improvementTheme";
+import { IMPROVEMENT_THEME_FREE_LIMIT } from "@app/constants/improvementTheme";
+
+export const FREE_LIMIT_TITLE = `無料プランで同時に取り組める課題は${IMPROVEMENT_THEME_FREE_LIMIT}件までです`;
+
+export const FREE_LIMIT_DESCRIPTION =
+  "克服・アーカイブした課題は件数に含まれません。Pro プランなら取組中の課題を無制限に持てます。";
+
+/**
+ * 作成が 403 で弾かれたときにフォームへ出す文言。
+ * 別端末での追加などでクライアント側の件数判定がサーバーとずれた場合にここへ入る。
+ */
+export const FREE_LIMIT_SERVER_ERROR = `${FREE_LIMIT_TITLE}。${FREE_LIMIT_DESCRIPTION}`;
+
+export const EMPTY_MESSAGE: Record<ImprovementThemeStatus, string> = {
+  open: "いま取り組む課題を決めると、練習やノートがその課題に束ねられます。",
+  achieved: "克服した課題はまだありません。",
+  archived: "アーカイブした課題はありません。",
+};
+
+export const LOAD_ERROR_MESSAGE =
+  "課題を取得できませんでした。時間を置いて再度お試しください。";
+
+export const NOT_FOUND_MESSAGE = "課題が見つかりません。";
+
+export const DELETE_CONFIRM_NOTICE =
+  "削除しても、紐付いていた練習記録・ノートは残ります。";
+
+export const TITLE_REQUIRED_ERROR = "課題のタイトルを入力してください。";
+
+export const LINKED_SESSIONS_LOAD_ERROR =
+  "紐づく練習記録を取得できませんでした。";
+
+export const LINKED_NOTES_LOAD_ERROR = "紐づくノートを取得できませんでした。";

--- a/app/(app)/themes/_utils/themeList.ts
+++ b/app/(app)/themes/_utils/themeList.ts
@@ -1,0 +1,95 @@
+import type {
+  ImprovementTheme,
+  ImprovementThemeInput,
+  ImprovementThemeStatus,
+} from "@app/types/improvementTheme";
+import { IMPROVEMENT_THEME_FREE_LIMIT } from "@app/constants/improvementTheme";
+
+/** タブは back の status enum（open / achieved / archived）と1対1で対応する。 */
+export const THEME_TABS: ReadonlyArray<{
+  key: ImprovementThemeStatus;
+  label: string;
+}> = [
+  { key: "open", label: "取組中" },
+  { key: "achieved", label: "克服" },
+  { key: "archived", label: "アーカイブ" },
+];
+
+/** 課題を status ごとに振り分ける。件数バッジと一覧表示の両方がこの結果を使う。 */
+export function groupThemesByStatus(
+  themes: ImprovementTheme[],
+): Record<ImprovementThemeStatus, ImprovementTheme[]> {
+  const buckets: Record<ImprovementThemeStatus, ImprovementTheme[]> = {
+    open: [],
+    achieved: [],
+    archived: [],
+  };
+  themes.forEach((theme) => buckets[theme.status].push(theme));
+  return buckets;
+}
+
+/**
+ * 無料枠を消費している課題の件数。
+ * back の PlanLimits#open_improvement_themes_count と同じく **取組中（open）だけ** を数える
+ * （克服・アーカイブ済みは何件あっても枠を消費しない）。
+ */
+export function countOpenThemes(themes: ImprovementTheme[]): number {
+  return themes.filter((theme) => theme.status === "open").length;
+}
+
+interface FreeLimitParams {
+  themes: ImprovementTheme[];
+  hasUnlimited: boolean;
+  isEntitlementLoading: boolean;
+}
+
+/**
+ * 課題を新規作成できないか（無料枠が埋まっているか）。
+ *
+ * back は新規作成だけを弾き、既に上限を超えている課題の編集・状態変更は許す。
+ * Pro 判定が未確定の間は上限扱いにしない（Pro 加入者へ誤って上限を告知しないため）。
+ */
+export function isAtThemeFreeLimit({
+  themes,
+  hasUnlimited,
+  isEntitlementLoading,
+}: FreeLimitParams): boolean {
+  if (isEntitlementLoading || hasUnlimited) return false;
+  return countOpenThemes(themes) >= IMPROVEMENT_THEME_FREE_LIMIT;
+}
+
+/** 詳細画面に出す状態遷移の操作。mobile の課題詳細と同じ組み合わせにする。 */
+export interface ThemeTransitions {
+  /** 「克服した」を出すか。取組中の課題にだけ出す。 */
+  canAchieve: boolean;
+  /** 「取組中に戻す」を出すか。克服・アーカイブ済みの課題に出す。 */
+  canReopen: boolean;
+  /** 「アーカイブ」を出すか。既にアーカイブ済みなら出さない。 */
+  canArchive: boolean;
+}
+
+export function themeTransitions(
+  status: ImprovementThemeStatus,
+): ThemeTransitions {
+  return {
+    canAchieve: status === "open",
+    canReopen: status !== "open",
+    canArchive: status !== "archived",
+  };
+}
+
+/**
+ * 状態遷移で送る更新パラメータ。
+ *
+ * 克服時は達成日を記録し、取組中へ戻すときは達成日を消す（克服していないのに
+ * 克服日が残ると詳細の表示が実態とずれる）。back は status の遷移に制約を持たず、
+ * 送った値をそのまま保存する。
+ */
+export function buildThemeStatusInput(
+  status: ImprovementThemeStatus,
+  today: string,
+): ImprovementThemeInput {
+  if (status === "achieved") return { status, achieved_on: today };
+  if (status === "open") return { status, achieved_on: null };
+  return { status };
+}

--- a/app/(app)/themes/page.tsx
+++ b/app/(app)/themes/page.tsx
@@ -1,0 +1,39 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getImprovementThemes } from "@app/services/v2/improvementThemeService";
+import { LOAD_ERROR_MESSAGE } from "./_components/themeCopy";
+import ThemesContent from "./_components/ThemesContent";
+
+export const metadata = {
+  title: "課題",
+};
+
+export default async function ThemesPage() {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const result = await getImprovementThemes();
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            {result.status === "ok" ? (
+              <ThemesContent initialThemes={result.data} />
+            ) : (
+              // 取得失敗を空配列に丸めると「課題が未設定」と誤表示し、同じ課題の重複作成を招く。
+              <p className="py-8 text-center text-sm text-zinc-400">
+                {LOAD_ERROR_MESSAGE}
+              </p>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/components/header/HeaderRight.tsx
+++ b/app/components/header/HeaderRight.tsx
@@ -67,6 +67,16 @@ export default function HeaderRight() {
                   振り返りテンプレ
                 </DropdownItem>
                 <DropdownItem
+                  key="themes"
+                  as={Link}
+                  href="/themes"
+                  startContent={
+                    <BallIcon fill="currentColor" width="18" height="18" />
+                  }
+                >
+                  課題
+                </DropdownItem>
+                <DropdownItem
                   key="goals"
                   as={Link}
                   href="/goals"

--- a/app/components/note/NoteGameResultSection.tsx
+++ b/app/components/note/NoteGameResultSection.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import type { GameResultLinkOption } from "@app/types/gameResultLink";
+import { useState } from "react";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+import { useGameResultSearch } from "@app/hooks/note/useGameResultSearch";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { formatJaFullDate } from "@app/utils/formatDate";
+import { canLinkMore } from "@app/utils/noteLinks";
+
+interface NoteGameResultSectionProps {
+  selectedIds: number[];
+  onChange: (ids: number[]) => void;
+  /**
+   * 更新前にノートへ紐付いていた件数（新規作成は 0）。
+   * back のグランドファザリング（既存件数以下なら無料でも維持できる）に合わせるために必要。
+   */
+  initialCount: number;
+  /** 既に紐付いている試合の表示情報。ノート詳細でサーバー取得したものを渡す。 */
+  linkedOptions: GameResultLinkOption[];
+}
+
+function gameLabel(option: GameResultLinkOption): string {
+  const opponent = option.opponent_team_name || "対戦相手未登録";
+  return `${formatJaFullDate(option.date)} vs ${opponent}`;
+}
+
+/**
+ * ノートに紐付ける試合記録のピッカー。対戦相手名でのデバウンス検索付き。
+ *
+ * 複数紐付けは Pro 限定だが、無料判定は「1件まで」と決め打ちしない。
+ * back は既存件数を超えて増やすときだけ弾くため、既存の複数紐付けはそのまま維持できる。
+ */
+export default function NoteGameResultSection({
+  selectedIds,
+  onChange,
+  initialCount,
+  linkedOptions,
+}: NoteGameResultSectionProps) {
+  const [isPickerOpen, setPickerOpen] = useState(false);
+  const { hasEntitlement, isLoading } = useEntitlement();
+  const { open: openProUpgradeModal } = useProUpgradeModal();
+  const { query, result, isSearching, changeQuery, loadOnce } =
+    useGameResultSearch();
+
+  const searched = result?.status === "ok" ? result.data : [];
+  // 選択済みの表示名はサーバー取得分と検索結果の両方から引く（検索語を変えても名前が消えないように）。
+  const knownOptions = [...linkedOptions, ...searched];
+  const selectableOptions = searched.filter(
+    (option) => !selectedIds.includes(option.game_result_id),
+  );
+
+  const handleOpenPicker = () => {
+    if (
+      !canLinkMore({
+        nextCount: selectedIds.length + 1,
+        initialCount,
+        // Pro 判定が未確定の間は権利なしとして扱う（確定後に開き直せる）。
+        hasMultiLink: !isLoading && hasEntitlement("multi_game_result_notes"),
+      })
+    ) {
+      openProUpgradeModal({ trigger: "multi_game_result_notes" });
+      return;
+    }
+    const next = !isPickerOpen;
+    setPickerOpen(next);
+    if (next) loadOnce();
+  };
+
+  const handleSelect = (id: number) => {
+    onChange(selectedIds.includes(id) ? selectedIds : [...selectedIds, id]);
+    setPickerOpen(false);
+  };
+
+  const handleRemove = (id: number) =>
+    onChange(selectedIds.filter((selected) => selected !== id));
+
+  return (
+    <section aria-labelledby="note-game-section-heading" className="mt-8">
+      <h3
+        id="note-game-section-heading"
+        className="text-sm font-bold text-zinc-400"
+      >
+        試合記録との紐付け（任意）
+      </h3>
+
+      <ul className="mt-2 flex flex-col gap-2">
+        {selectedIds.map((id) => {
+          const option = knownOptions.find(
+            (item) => item.game_result_id === id,
+          );
+          return (
+            <li
+              key={id}
+              className="flex items-center gap-2 rounded-lg bg-sub px-3 py-3"
+            >
+              <span className="min-w-0 flex-1 truncate text-sm text-white">
+                {option ? gameLabel(option) : "試合に紐付け済み"}
+              </span>
+              <button
+                type="button"
+                aria-label="試合の紐付けを外す"
+                onClick={() => handleRemove(id)}
+                className="shrink-0 text-xs font-bold text-zinc-400 hover:text-white"
+              >
+                外す
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <button
+        type="button"
+        aria-expanded={isPickerOpen}
+        onClick={handleOpenPicker}
+        className="mt-2 flex w-full items-center justify-between rounded-lg bg-sub px-3 py-3 text-sm text-white"
+      >
+        {selectedIds.length > 0 ? "試合をもう1件追加" : "試合記録に紐付け"}
+        <span aria-hidden className="text-zinc-400">
+          {isPickerOpen ? "▲" : "▼"}
+        </span>
+      </button>
+
+      {isPickerOpen ? (
+        <div className="mt-2 overflow-hidden rounded-lg bg-sub">
+          <input
+            type="search"
+            aria-label="対戦相手で検索"
+            placeholder="対戦相手で検索"
+            value={query}
+            onChange={(event) => changeQuery(event.target.value)}
+            className="w-full bg-sub px-3 py-2.5 text-sm text-white placeholder:text-zinc-500"
+          />
+          {isSearching ? (
+            <p className="border-t border-main px-3 py-3 text-xs text-zinc-400">
+              検索中...
+            </p>
+          ) : result === null ? null : result.status !== "ok" ? (
+            <p className="border-t border-main px-3 py-3 text-xs text-zinc-400">
+              試合記録を取得できませんでした。
+            </p>
+          ) : selectableOptions.length === 0 ? (
+            <p className="border-t border-main px-3 py-3 text-xs text-zinc-400">
+              該当する試合記録がありません
+            </p>
+          ) : (
+            <ul>
+              {selectableOptions.map((option) => (
+                <li
+                  key={option.game_result_id}
+                  className="border-t border-main"
+                >
+                  <button
+                    type="button"
+                    onClick={() => handleSelect(option.game_result_id)}
+                    className="w-full px-3 py-3 text-left text-sm text-white hover:bg-zinc-700"
+                  >
+                    {gameLabel(option)}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/app/components/note/NoteThemeSection.tsx
+++ b/app/components/note/NoteThemeSection.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import type { FetchResult } from "@app/services/v2/requests";
+import type { ImprovementTheme } from "@app/types/improvementTheme";
+import { useState } from "react";
+import { themeCategoryLabel } from "@app/constants/improvementTheme";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { canLinkMore } from "@app/utils/noteLinks";
+
+interface NoteThemeSectionProps {
+  /**
+   * 課題一覧の取得結果。失敗を空配列に丸めると「課題未設定」と誤表示するため結果ごと受け取る。
+   * 選択候補は取組中（open）のみに絞るが、既に紐付いている克服済みの課題も名前を出すため
+   * 全ステータスを渡すこと。
+   */
+  themesResult: FetchResult<ImprovementTheme[]>;
+  selectedIds: number[];
+  onChange: (ids: number[]) => void;
+  /**
+   * 更新前にノートへ紐付いていた件数（新規作成は 0）。
+   * back のグランドファザリング（既存件数以下なら無料でも維持できる）に合わせるために必要。
+   */
+  initialCount: number;
+}
+
+/**
+ * ノートに紐付ける課題のピッカー（mobile の ThemePickerField 相当）。
+ *
+ * 複数紐付けは Pro 限定だが、無料判定は「1件まで」と決め打ちしない。
+ * back は既存件数を超えて増やすときだけ弾くため、既存の複数紐付けはそのまま維持できる。
+ */
+export default function NoteThemeSection({
+  themesResult,
+  selectedIds,
+  onChange,
+  initialCount,
+}: NoteThemeSectionProps) {
+  const [isPickerOpen, setPickerOpen] = useState(false);
+  const { hasEntitlement, isLoading } = useEntitlement();
+  const { open: openProUpgradeModal } = useProUpgradeModal();
+
+  const themes = themesResult.status === "ok" ? themesResult.data : null;
+  const selectedThemes = selectedIds.map((id) => ({
+    id,
+    theme: themes?.find((item) => item.id === id) ?? null,
+  }));
+  const selectableThemes = (themes ?? []).filter(
+    (theme) => theme.status === "open" && !selectedIds.includes(theme.id),
+  );
+
+  const handleOpenPicker = () => {
+    if (
+      !canLinkMore({
+        nextCount: selectedIds.length + 1,
+        initialCount,
+        // Pro 判定が未確定の間は権利なしとして扱う（確定後に開き直せる）。
+        hasMultiLink:
+          !isLoading && hasEntitlement("multi_improvement_theme_links"),
+      })
+    ) {
+      openProUpgradeModal({ trigger: "multi_improvement_theme_links" });
+      return;
+    }
+    setPickerOpen((prev) => !prev);
+  };
+
+  const handleSelect = (id: number) => {
+    onChange([...selectedIds, id]);
+    setPickerOpen(false);
+  };
+
+  const handleRemove = (id: number) =>
+    onChange(selectedIds.filter((selected) => selected !== id));
+
+  return (
+    <section aria-labelledby="note-theme-section-heading" className="mt-8">
+      <h3
+        id="note-theme-section-heading"
+        className="text-sm font-bold text-zinc-400"
+      >
+        取り組む課題（任意）
+      </h3>
+
+      {themes === null ? (
+        <p className="mt-2 text-xs text-zinc-400">
+          課題を取得できませんでした。メモはそのまま入力できます。
+        </p>
+      ) : (
+        <div className="mt-2">
+          <ul className="flex flex-col gap-2">
+            {selectedThemes.map(({ id, theme }) => (
+              <li
+                key={id}
+                className="flex items-center gap-2 rounded-lg bg-sub px-3 py-3"
+              >
+                <span className="min-w-0 flex-1 truncate text-sm text-white">
+                  {theme ? theme.title : "課題に紐付け済み"}
+                </span>
+                {theme ? (
+                  <span className="shrink-0 rounded bg-main px-2 py-0.5 text-[11px] text-zinc-400">
+                    {themeCategoryLabel(theme.category)}
+                  </span>
+                ) : null}
+                <button
+                  type="button"
+                  aria-label="課題の紐付けを外す"
+                  onClick={() => handleRemove(id)}
+                  className="shrink-0 text-xs font-bold text-zinc-400 hover:text-white"
+                >
+                  外す
+                </button>
+              </li>
+            ))}
+          </ul>
+
+          <button
+            type="button"
+            aria-expanded={isPickerOpen}
+            onClick={handleOpenPicker}
+            className="mt-2 flex w-full items-center justify-between rounded-lg bg-sub px-3 py-3 text-sm text-white"
+          >
+            {selectedIds.length > 0
+              ? "課題をもう1件追加"
+              : "取り組む課題に紐付け"}
+            <span aria-hidden className="text-zinc-400">
+              {isPickerOpen ? "▲" : "▼"}
+            </span>
+          </button>
+
+          {isPickerOpen ? (
+            <ul className="mt-2 overflow-hidden rounded-lg bg-sub">
+              {selectableThemes.length === 0 ? (
+                <li className="px-3 py-3 text-xs text-zinc-400">
+                  取組中の課題がありません
+                </li>
+              ) : (
+                selectableThemes.map((theme) => (
+                  <li
+                    key={theme.id}
+                    className="border-t border-main first:border-t-0"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => handleSelect(theme.id)}
+                      className="w-full px-3 py-3 text-left text-sm text-white hover:bg-zinc-700"
+                    >
+                      {theme.title}
+                    </button>
+                  </li>
+                ))
+              )}
+            </ul>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/components/note/__tests__/NoteGameResultSection.test.tsx
+++ b/app/components/note/__tests__/NoteGameResultSection.test.tsx
@@ -1,0 +1,321 @@
+const mockOpenProUpgradeModal = jest.fn();
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({
+    open: mockOpenProUpgradeModal,
+    close: jest.fn(),
+  }),
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+jest.mock("@app/services/v2/gameResultLinkService", () => ({
+  searchGameResultOptions: jest.fn(),
+}));
+
+import type { FetchResult } from "@app/services/v2/requests";
+import type { GameResultLinkOption } from "@app/types/gameResultLink";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { searchGameResultOptions } from "@app/services/v2/gameResultLinkService";
+import NoteGameResultSection from "../NoteGameResultSection";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+const mockSearch = searchGameResultOptions as jest.MockedFunction<
+  typeof searchGameResultOptions
+>;
+
+function buildOption(
+  overrides: Partial<GameResultLinkOption> = {},
+): GameResultLinkOption {
+  return {
+    game_result_id: 101,
+    date: "2026-07-20",
+    opponent_team_name: "青空高校",
+    ...overrides,
+  };
+}
+
+function mockEntitlement({
+  granted = false,
+  isLoading = false,
+}: { granted?: boolean; isLoading?: boolean } = {}) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: granted,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading,
+    hasEntitlement: () => granted,
+  } as unknown as ReturnType<typeof useEntitlement>);
+}
+
+function renderSection(
+  props: Partial<React.ComponentProps<typeof NoteGameResultSection>> = {},
+) {
+  const onChange = jest.fn();
+  render(
+    <NoteGameResultSection
+      selectedIds={[]}
+      onChange={onChange}
+      initialCount={0}
+      linkedOptions={[]}
+      {...props}
+    />,
+  );
+  return { onChange };
+}
+
+function openPicker() {
+  fireEvent.click(screen.getByRole("button", { name: /試合記録に紐付け/ }));
+}
+
+function searchInput() {
+  return screen.getByLabelText("対戦相手で検索");
+}
+
+describe("試合記録の紐付け", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEntitlement();
+    mockSearch.mockResolvedValue({ status: "ok", data: [] });
+  });
+
+  describe("紐付け先の表示", () => {
+    it("紐付け済みの試合を日付と対戦相手で表示する", () => {
+      renderSection({
+        selectedIds: [101],
+        initialCount: 1,
+        linkedOptions: [buildOption()],
+      });
+
+      expect(screen.getByText("2026年7月20日 vs 青空高校")).toBeInTheDocument();
+    });
+
+    it("表示情報が取得できなかった紐付けも消さずに残す", () => {
+      renderSection({ selectedIds: [999], initialCount: 1 });
+
+      expect(screen.getByText("試合に紐付け済み")).toBeInTheDocument();
+    });
+
+    it("紐付けを外せる", () => {
+      const { onChange } = renderSection({
+        selectedIds: [101, 102],
+        initialCount: 2,
+        linkedOptions: [buildOption()],
+      });
+
+      fireEvent.click(
+        screen.getAllByRole("button", { name: "試合の紐付けを外す" })[0],
+      );
+
+      expect(onChange).toHaveBeenCalledWith([102]);
+    });
+  });
+
+  describe("複数紐付けの Pro 判定（グランドファザリング）", () => {
+    it("無料でも1件目は紐付けられる", async () => {
+      renderSection({ selectedIds: [], initialCount: 0 });
+
+      openPicker();
+
+      await waitFor(() => expect(mockSearch).toHaveBeenCalled());
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+      expect(searchInput()).toBeInTheDocument();
+    });
+
+    it("無料は既存が無い状態から2件目を足そうとすると Pro 訴求を出す", () => {
+      renderSection({ selectedIds: [101], initialCount: 0 });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /試合をもう1件追加/ }),
+      );
+
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "multi_game_result_notes",
+      });
+      expect(screen.queryByLabelText("対戦相手で検索")).not.toBeInTheDocument();
+    });
+
+    it("無料でも既存件数の範囲内なら追加し直せる（Pro 解約後の維持）", async () => {
+      renderSection({ selectedIds: [101, 102], initialCount: 3 });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /試合をもう1件追加/ }),
+      );
+
+      await waitFor(() => expect(mockSearch).toHaveBeenCalled());
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+      expect(searchInput()).toBeInTheDocument();
+    });
+
+    it("無料は既存件数を超えて増やそうとすると Pro 訴求を出す", () => {
+      renderSection({ selectedIds: [101, 102, 103], initialCount: 3 });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /試合をもう1件追加/ }),
+      );
+
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "multi_game_result_notes",
+      });
+    });
+
+    it("Pro は既存が無くても複数紐付けできる", async () => {
+      mockEntitlement({ granted: true });
+      renderSection({ selectedIds: [101], initialCount: 0 });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /試合をもう1件追加/ }),
+      );
+
+      await waitFor(() => expect(mockSearch).toHaveBeenCalled());
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+
+    it("Pro 判定が未確定の間は権利なしとして扱う", () => {
+      mockEntitlement({ granted: true, isLoading: true });
+      renderSection({ selectedIds: [101], initialCount: 0 });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /試合をもう1件追加/ }),
+      );
+
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "multi_game_result_notes",
+      });
+    });
+  });
+
+  describe("検索結果の表示", () => {
+    it("候補を選ぶと紐付けに加える", async () => {
+      mockSearch.mockResolvedValue({ status: "ok", data: [buildOption()] });
+      const { onChange } = renderSection();
+
+      openPicker();
+
+      const candidate = await screen.findByRole("button", {
+        name: "2026年7月20日 vs 青空高校",
+      });
+      fireEvent.click(candidate);
+
+      expect(onChange).toHaveBeenCalledWith([101]);
+    });
+
+    it("0件は「該当する試合記録がありません」と伝える", async () => {
+      mockSearch.mockResolvedValue({ status: "ok", data: [] });
+      renderSection();
+
+      openPicker();
+
+      expect(
+        await screen.findByText("該当する試合記録がありません"),
+      ).toBeInTheDocument();
+    });
+
+    it("取得失敗は0件と区別して伝える", async () => {
+      mockSearch.mockResolvedValue({ status: "error" });
+      renderSection();
+
+      openPicker();
+
+      expect(
+        await screen.findByText("試合記録を取得できませんでした。"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("該当する試合記録がありません"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("デバウンス検索", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("連続入力ではリクエストを1回にまとめ、最後の入力で検索する", async () => {
+      renderSection();
+      openPicker();
+      await act(async () => {});
+      mockSearch.mockClear();
+
+      fireEvent.change(searchInput(), { target: { value: "あ" } });
+      fireEvent.change(searchInput(), { target: { value: "あお" } });
+      fireEvent.change(searchInput(), { target: { value: "あおぞら" } });
+      expect(mockSearch).not.toHaveBeenCalled();
+
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+      });
+
+      expect(mockSearch).toHaveBeenCalledTimes(1);
+      expect(mockSearch).toHaveBeenCalledWith("あおぞら");
+    });
+
+    it("応答が前後しても古い結果で新しい結果を上書きしない", async () => {
+      renderSection();
+      openPicker();
+      await act(async () => {});
+
+      const resolvers: Array<
+        (value: FetchResult<GameResultLinkOption[]>) => void
+      > = [];
+      mockSearch.mockImplementation(
+        () =>
+          new Promise<FetchResult<GameResultLinkOption[]>>((resolve) => {
+            resolvers.push(resolve);
+          }),
+      );
+
+      fireEvent.change(searchInput(), { target: { value: "青" } });
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+      });
+      fireEvent.change(searchInput(), { target: { value: "赤" } });
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+      });
+      expect(resolvers).toHaveLength(2);
+
+      // 新しい検索（赤）が先に返り、古い検索（青）が後から返る。
+      await act(async () => {
+        resolvers[1]({
+          status: "ok",
+          data: [
+            buildOption({
+              game_result_id: 202,
+              opponent_team_name: "赤星高校",
+            }),
+          ],
+        });
+      });
+      await act(async () => {
+        resolvers[0]({
+          status: "ok",
+          data: [
+            buildOption({
+              game_result_id: 101,
+              opponent_team_name: "青空高校",
+            }),
+          ],
+        });
+      });
+
+      expect(screen.getByText(/赤星高校/)).toBeInTheDocument();
+      expect(screen.queryByText(/青空高校/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/app/components/note/__tests__/NoteThemeSection.test.tsx
+++ b/app/components/note/__tests__/NoteThemeSection.test.tsx
@@ -1,0 +1,209 @@
+const mockOpenProUpgradeModal = jest.fn();
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({
+    open: mockOpenProUpgradeModal,
+    close: jest.fn(),
+  }),
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+import type { ImprovementTheme } from "@app/types/improvementTheme";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import NoteThemeSection from "../NoteThemeSection";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+
+function buildTheme(
+  overrides: Partial<ImprovementTheme> = {},
+): ImprovementTheme {
+  return {
+    id: 1,
+    title: "肩の開きを抑える",
+    category: "batting",
+    purpose: null,
+    status: "open",
+    started_on: "2026-07-01",
+    achieved_on: null,
+    sort_order: 0,
+    practice_logs_count: 0,
+    notes_count: 0,
+    active_days: 0,
+    created_at: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function mockEntitlement({
+  granted = false,
+  isLoading = false,
+}: { granted?: boolean; isLoading?: boolean } = {}) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: granted,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading,
+    hasEntitlement: () => granted,
+  } as unknown as ReturnType<typeof useEntitlement>);
+}
+
+function renderSection(
+  props: Partial<React.ComponentProps<typeof NoteThemeSection>> = {},
+) {
+  const onChange = jest.fn();
+  render(
+    <NoteThemeSection
+      themesResult={{ status: "ok", data: [buildTheme()] }}
+      selectedIds={[]}
+      onChange={onChange}
+      initialCount={0}
+      {...props}
+    />,
+  );
+  return { onChange };
+}
+
+describe("課題の紐付けピッカー", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEntitlement();
+  });
+
+  it("取組中の課題だけを候補に出す", () => {
+    renderSection({
+      themesResult: {
+        status: "ok",
+        data: [
+          buildTheme({ id: 1, title: "取組中の課題", status: "open" }),
+          buildTheme({ id: 2, title: "克服した課題", status: "achieved" }),
+          buildTheme({ id: 3, title: "アーカイブ課題", status: "archived" }),
+        ],
+      },
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /取り組む課題に紐付け/ }),
+    );
+
+    expect(
+      screen.getByRole("button", { name: "取組中の課題" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "克服した課題" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("候補が0件なら取組中の課題が無いと伝える", () => {
+    renderSection({ themesResult: { status: "ok", data: [] } });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /取り組む課題に紐付け/ }),
+    );
+
+    expect(screen.getByText("取組中の課題がありません")).toBeInTheDocument();
+  });
+
+  it("取得失敗は0件と区別して伝える", () => {
+    renderSection({ themesResult: { status: "error" } });
+
+    expect(screen.getByText(/課題を取得できませんでした/)).toBeInTheDocument();
+    expect(
+      screen.queryByText("取組中の課題がありません"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("候補を選ぶと紐付けに加える", () => {
+    const { onChange } = renderSection();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /取り組む課題に紐付け/ }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "肩の開きを抑える" }));
+
+    expect(onChange).toHaveBeenCalledWith([1]);
+  });
+
+  it("克服済みの課題が紐付いていても名前を表示する", () => {
+    renderSection({
+      themesResult: {
+        status: "ok",
+        data: [
+          buildTheme({ id: 2, title: "克服した課題", status: "achieved" }),
+        ],
+      },
+      selectedIds: [2],
+      initialCount: 1,
+    });
+
+    expect(screen.getByText("克服した課題")).toBeInTheDocument();
+  });
+
+  it("紐付けを外せる", () => {
+    const { onChange } = renderSection({
+      selectedIds: [1, 2],
+      initialCount: 2,
+    });
+
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "課題の紐付けを外す" })[0],
+    );
+
+    expect(onChange).toHaveBeenCalledWith([2]);
+  });
+
+  describe("複数紐付けの Pro 判定（グランドファザリング）", () => {
+    it("無料は既存が無い状態から2件目を足そうとすると Pro 訴求を出す", () => {
+      renderSection({ selectedIds: [1], initialCount: 0 });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /課題をもう1件追加/ }),
+      );
+
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "multi_improvement_theme_links",
+      });
+      expect(
+        screen.queryByText("取組中の課題がありません"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("無料でも既存件数の範囲内なら追加し直せる（Pro 解約後の維持）", () => {
+      renderSection({ selectedIds: [1], initialCount: 2 });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /課題をもう1件追加/ }),
+      );
+
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+
+    it("無料は既存件数を超えて増やそうとすると Pro 訴求を出す", () => {
+      renderSection({ selectedIds: [1, 2], initialCount: 2 });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /課題をもう1件追加/ }),
+      );
+
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "multi_improvement_theme_links",
+      });
+    });
+
+    it("Pro は既存が無くても複数紐付けできる", () => {
+      mockEntitlement({ granted: true });
+      renderSection({ selectedIds: [1], initialCount: 0 });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /課題をもう1件追加/ }),
+      );
+
+      expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/constants/improvementTheme.ts
+++ b/app/constants/improvementTheme.ts
@@ -1,0 +1,38 @@
+import type { ImprovementThemeStatus } from "@app/types/improvementTheme";
+
+/**
+ * 無料プランで同時に取り組める課題の上限。
+ * back/app/models/concerns/plan_limits.rb の IMPROVEMENT_THEME_FREE_LIMIT と一致させる。
+ * back は `status: "open"` の課題だけを数えるため、克服・アーカイブ済みは枠を消費しない。
+ */
+export const IMPROVEMENT_THEME_FREE_LIMIT = 2;
+
+/** 課題のカテゴリ選択肢。back の ImprovementTheme::CATEGORIES と順序まで揃える。 */
+export const THEME_CATEGORIES: ReadonlyArray<{
+  value: string;
+  label: string;
+}> = [
+  { value: "batting", label: "打撃" },
+  { value: "pitching", label: "投球" },
+  { value: "defense", label: "守備" },
+  { value: "baserunning", label: "走塁" },
+  { value: "training", label: "トレーニング" },
+  { value: "strength", label: "筋トレ" },
+  { value: "care", label: "ケア" },
+  { value: "other", label: "その他" },
+];
+
+/** カテゴリ値の表示ラベル。未設定・未知の値は mobile と同じく「その他」に寄せる。 */
+export function themeCategoryLabel(value: string | null): string {
+  return (
+    THEME_CATEGORIES.find((category) => category.value === value)?.label ??
+    "その他"
+  );
+}
+
+/** 課題の取組状況の表示ラベル。 */
+export const THEME_STATUS_LABELS: Record<ImprovementThemeStatus, string> = {
+  open: "取組中",
+  achieved: "克服",
+  archived: "アーカイブ",
+};

--- a/app/hooks/note/useGameResultSearch.ts
+++ b/app/hooks/note/useGameResultSearch.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import type { FetchResult } from "@app/services/v2/requests";
+import type { GameResultLinkOption } from "@app/types/gameResultLink";
+import { useRef, useState } from "react";
+import { searchGameResultOptions } from "@app/services/v2/gameResultLinkService";
+
+/** 入力が止まってから検索するまでの待ち時間。1文字打つたびにリクエストを飛ばさないために置く。 */
+export const GAME_SEARCH_DEBOUNCE_MS = 300;
+
+interface UseGameResultSearchReturn {
+  query: string;
+  /**
+   * 直近の検索結果。まだ一度も検索していない間は null。
+   * 「未検索」「取得失敗」「0件」を取り違えないよう、FetchResult のまま返す。
+   */
+  result: FetchResult<GameResultLinkOption[]> | null;
+  isSearching: boolean;
+  /** 検索語の更新。デバウンス後に検索が走る。 */
+  changeQuery: (value: string) => void;
+  /** ピッカーを開いたときの初回取得。すでに取得済みなら何もしない。 */
+  loadOnce: () => void;
+}
+
+/**
+ * 対戦相手名による試合記録の絞り込み検索。
+ *
+ * 検索そのものは back（`search_by_opponent`）に任せ、ここでは
+ * 「入力のたびに投げない（デバウンス）」「古いレスポンスで新しい結果を上書きしない
+ * （順序逆転対策）」の2点を担保する。
+ */
+export function useGameResultSearch(): UseGameResultSearchReturn {
+  const [query, setQuery] = useState("");
+  const [result, setResult] = useState<FetchResult<
+    GameResultLinkOption[]
+  > | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 発行した検索の連番。応答時に最新の連番と一致しなければ破棄する。
+  const latestRequestIdRef = useRef(0);
+  const hasLoadedRef = useRef(false);
+
+  const runSearch = async (value: string) => {
+    const requestId = latestRequestIdRef.current + 1;
+    latestRequestIdRef.current = requestId;
+    hasLoadedRef.current = true;
+    setIsSearching(true);
+
+    const response = await searchGameResultOptions(value || undefined);
+
+    // 後から投げた検索が先に返っている場合、この結果はもう古い。表示を巻き戻さない。
+    if (requestId !== latestRequestIdRef.current) return;
+    setIsSearching(false);
+    setResult(response);
+  };
+
+  const changeQuery = (value: string) => {
+    setQuery(value);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      void runSearch(value);
+    }, GAME_SEARCH_DEBOUNCE_MS);
+  };
+
+  const loadOnce = () => {
+    if (hasLoadedRef.current) return;
+    void runSearch(query);
+  };
+
+  return { query, result, isSearching, changeQuery, loadOnce };
+}

--- a/app/services/v2/__tests__/improvementThemeService.test.ts
+++ b/app/services/v2/__tests__/improvementThemeService.test.ts
@@ -1,0 +1,256 @@
+const mockGet = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(() => Promise.resolve({ get: mockGet })),
+}));
+
+jest.mock("next/cache", () => ({
+  revalidatePath: jest.fn(),
+}));
+
+jest.mock("@app/constants/api", () => ({
+  RAILS_API_URL: "http://back:3000",
+}));
+
+jest.mock("../../../../lib/sentry-helpers", () => ({
+  captureServerActionError: jest.fn(),
+}));
+
+import {
+  getGameResultOption,
+  searchGameResultOptions,
+} from "../gameResultLinkService";
+import {
+  createImprovementTheme,
+  deleteImprovementTheme,
+  getImprovementThemes,
+  updateImprovementTheme,
+} from "../improvementThemeService";
+
+function setupAuthCookies() {
+  mockGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: "test-uid" },
+    };
+    return values[key];
+  });
+}
+
+function mockResponse(status: number, body: unknown) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+function requestedUrl(): string {
+  return (global.fetch as jest.Mock).mock.calls[0][0] as string;
+}
+
+function requestedInit(): RequestInit {
+  return (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+}
+
+const theme = {
+  id: 5,
+  title: "肩の開きを抑える",
+  category: "batting",
+  purpose: null,
+  status: "open",
+  started_on: "2026-07-01",
+  achieved_on: null,
+  sort_order: 0,
+  practice_logs_count: 3,
+  notes_count: 2,
+  active_days: 4,
+  created_at: "2026-07-01T00:00:00.000Z",
+};
+
+describe("課題の v2 Server Actions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    setupAuthCookies();
+  });
+
+  describe("getImprovementThemes", () => {
+    it("GET /api/v2/improvement_themes を叩く", async () => {
+      mockResponse(200, [theme]);
+
+      const result = await getImprovementThemes();
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/improvement_themes");
+      expect(result).toEqual({ status: "ok", data: [theme] });
+    });
+
+    it("status で絞り込める", async () => {
+      mockResponse(200, [theme]);
+
+      await getImprovementThemes({ status: "open" });
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/improvement_themes?status=open",
+      );
+    });
+
+    it("0件は取得成功として空配列を返す", async () => {
+      mockResponse(200, []);
+
+      expect(await getImprovementThemes()).toEqual({ status: "ok", data: [] });
+    });
+
+    it("取得失敗は 0件と区別して error を返す", async () => {
+      mockResponse(500, {});
+
+      expect(await getImprovementThemes()).toEqual({ status: "error" });
+    });
+  });
+
+  describe("createImprovementTheme", () => {
+    it("POST で improvement_theme を包んで送る", async () => {
+      mockResponse(201, theme);
+
+      const result = await createImprovementTheme({
+        title: "肩の開きを抑える",
+        category: "batting",
+        purpose: null,
+      });
+
+      expect(requestedUrl()).toBe("http://back:3000/api/v2/improvement_themes");
+      expect(requestedInit().method).toBe("POST");
+      expect(JSON.parse(requestedInit().body as string)).toEqual({
+        improvement_theme: {
+          title: "肩の開きを抑える",
+          category: "batting",
+          purpose: null,
+        },
+      });
+      expect(result).toEqual({ ok: true, data: theme });
+    });
+
+    it("無料枠超過の 403 は forbidden として返す", async () => {
+      mockResponse(403, { error: "取組中の課題は無料プランで2つまでです" });
+
+      const result = await createImprovementTheme({ title: "3つ目" });
+
+      expect(result).toEqual({
+        ok: false,
+        reason: "forbidden",
+        errors: ["取組中の課題は無料プランで2つまでです"],
+      });
+    });
+  });
+
+  describe("updateImprovementTheme", () => {
+    it("PATCH で状態遷移を送る", async () => {
+      mockResponse(200, { ...theme, status: "achieved" });
+
+      await updateImprovementTheme(5, {
+        status: "achieved",
+        achieved_on: "2026-08-03",
+      });
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/improvement_themes/5",
+      );
+      expect(requestedInit().method).toBe("PATCH");
+      expect(JSON.parse(requestedInit().body as string)).toEqual({
+        improvement_theme: { status: "achieved", achieved_on: "2026-08-03" },
+      });
+    });
+  });
+
+  describe("deleteImprovementTheme", () => {
+    it("DELETE を叩く", async () => {
+      mockResponse(200, { message: "削除しました" });
+
+      const result = await deleteImprovementTheme(5);
+
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/improvement_themes/5",
+      );
+      expect(requestedInit().method).toBe("DELETE");
+      expect(result).toEqual({ ok: true, data: { message: "削除しました" } });
+    });
+  });
+});
+
+describe("試合記録の紐付け候補", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    setupAuthCookies();
+  });
+
+  const rawGameResult = {
+    game_result_id: 101,
+    match_result: {
+      date_and_time: "2026-07-20T13:00:00.000+09:00",
+      opponent_team_name: "青空高校",
+    },
+  };
+
+  it("対戦相手の検索はサーバー側の filtered_index に委ねる", async () => {
+    mockResponse(200, { data: [rawGameResult] });
+
+    const result = await searchGameResultOptions("青空");
+
+    expect(requestedUrl()).toBe(
+      "http://back:3000/api/v2/game_results/filtered_index?search=%E9%9D%92%E7%A9%BA&per_page=20",
+    );
+    expect(result).toEqual({
+      status: "ok",
+      data: [
+        {
+          game_result_id: 101,
+          date: "2026-07-20",
+          opponent_team_name: "青空高校",
+        },
+      ],
+    });
+  });
+
+  it("検索語が無ければ search を送らない", async () => {
+    mockResponse(200, { data: [] });
+
+    await searchGameResultOptions(undefined);
+
+    expect(requestedUrl()).toBe(
+      "http://back:3000/api/v2/game_results/filtered_index?per_page=20",
+    );
+  });
+
+  it("0件は取得成功として空配列を返す", async () => {
+    mockResponse(200, { data: [] });
+
+    expect(await searchGameResultOptions("該当なし")).toEqual({
+      status: "ok",
+      data: [],
+    });
+  });
+
+  it("取得失敗は 0件と区別して error を返す", async () => {
+    mockResponse(500, {});
+
+    expect(await searchGameResultOptions("青空")).toEqual({ status: "error" });
+  });
+
+  it("紐付け済みの1件は show エンドポイントから引く", async () => {
+    mockResponse(200, rawGameResult);
+
+    const result = await getGameResultOption(101);
+
+    expect(requestedUrl()).toBe("http://back:3000/api/v2/game_results/101");
+    expect(result).toEqual({
+      status: "ok",
+      data: {
+        game_result_id: 101,
+        date: "2026-07-20",
+        opponent_team_name: "青空高校",
+      },
+    });
+  });
+});

--- a/app/services/v2/gameResultLinkService.ts
+++ b/app/services/v2/gameResultLinkService.ts
@@ -1,0 +1,65 @@
+"use server";
+
+import type { GameResultLinkOption } from "@app/types/gameResultLink";
+import { type FetchResult, buildQuery, fetchV2 } from "./requests";
+
+const BASE_PATH = "/api/v2/game_results";
+
+/** 候補リストの取得件数。ピッカーは検索して絞り込む前提なので先頭ページだけを見る。 */
+const SEARCH_PER_PAGE = 20;
+
+/** back の V2::GameResultSerializer のうち、紐付け UI が参照する部分だけの形。 */
+interface RawGameResult {
+  game_result_id: number;
+  match_result: {
+    date_and_time: string | null;
+    opponent_team_name: string | null;
+  } | null;
+}
+
+interface PaginatedGameResults {
+  data: RawGameResult[];
+}
+
+function toOption(raw: RawGameResult): GameResultLinkOption {
+  return {
+    game_result_id: raw.game_result_id,
+    // date_and_time は ISO 8601 で返るため、日付部分だけを取り出す。
+    date: raw.match_result?.date_and_time?.slice(0, 10) ?? "",
+    opponent_team_name: raw.match_result?.opponent_team_name ?? "",
+  };
+}
+
+/**
+ * 対戦相手名で試合記録を検索する（GET /api/v2/game_results/filtered_index）。
+ * 検索は back の `search_by_opponent`（teams.name の部分一致）が担うため、
+ * 全件を取得してクライアントで絞り込むことはしない。
+ *
+ * @param search 対戦相手名の部分一致キーワード。空なら直近の試合を新しい順で返す。
+ */
+export async function searchGameResultOptions(
+  search?: string,
+): Promise<FetchResult<GameResultLinkOption[]>> {
+  const query = buildQuery({ search, per_page: SEARCH_PER_PAGE });
+  const result = await fetchV2<PaginatedGameResults>(
+    `${BASE_PATH}/filtered_index${query}`,
+    "searchGameResultOptions",
+  );
+  if (result.status !== "ok") return result;
+  return { status: "ok", data: result.data.data.map(toOption) };
+}
+
+/**
+ * 試合記録を1件取得する（GET /api/v2/game_results/:id）。
+ * ノート詳細で紐付け先カードを描くために使う。
+ */
+export async function getGameResultOption(
+  id: number,
+): Promise<FetchResult<GameResultLinkOption>> {
+  const result = await fetchV2<RawGameResult>(
+    `${BASE_PATH}/${id}`,
+    "getGameResultOption",
+  );
+  if (result.status !== "ok") return result;
+  return { status: "ok", data: toOption(result.data) };
+}

--- a/app/services/v2/improvementThemeService.ts
+++ b/app/services/v2/improvementThemeService.ts
@@ -2,15 +2,30 @@
 
 import type {
   ImprovementTheme,
+  ImprovementThemeInput,
   ImprovementThemeStatus,
 } from "@app/types/improvementTheme";
-import { type FetchResult, buildQuery, fetchV2 } from "./requests";
+import { revalidatePath } from "next/cache";
+import {
+  type DeletedResponse,
+  type FetchResult,
+  type MutationResult,
+  buildQuery,
+  fetchV2,
+  mutateV2,
+} from "./requests";
 
 const BASE_PATH = "/api/v2/improvement_themes";
 
 interface GetImprovementThemesParams {
   /** 取組状況で絞り込む。記録画面の紐付け候補は "open" のみを使う。 */
   status?: ImprovementThemeStatus;
+}
+
+/** 課題一覧・詳細を表示する画面の再検証。作成・更新・削除の後に呼ぶ。 */
+async function revalidateThemes(id?: number): Promise<void> {
+  revalidatePath("/themes");
+  if (id) revalidatePath(`/themes/${id}`);
 }
 
 /**
@@ -24,4 +39,57 @@ export async function getImprovementThemes(
     `${BASE_PATH}${buildQuery({ status: params.status })}`,
     "getImprovementThemes",
   );
+}
+
+/**
+ * 課題を新規作成する（POST /api/v2/improvement_themes）。
+ * 無料プランは取組中（open）が IMPROVEMENT_THEME_FREE_LIMIT 件を超えると 403 になるため、
+ * reason:"forbidden" を Pro 訴求の分岐に使う。
+ */
+export async function createImprovementTheme(
+  input: ImprovementThemeInput,
+): Promise<MutationResult<ImprovementTheme>> {
+  const result = await mutateV2<ImprovementTheme>(BASE_PATH, {
+    method: "POST",
+    body: { improvement_theme: input },
+    action: "createImprovementTheme",
+    fallbackMessage: "課題の作成に失敗しました",
+  });
+  if (result.ok) await revalidateThemes();
+  return result;
+}
+
+/**
+ * 課題を更新する（PATCH /api/v2/improvement_themes/:id）。
+ * 状態遷移（克服 / 取組中へ戻す / アーカイブ）もこのエンドポイントで行う。
+ * back に遷移の制約は無く、送った status がそのまま保存される。
+ */
+export async function updateImprovementTheme(
+  id: number,
+  input: ImprovementThemeInput,
+): Promise<MutationResult<ImprovementTheme>> {
+  const result = await mutateV2<ImprovementTheme>(`${BASE_PATH}/${id}`, {
+    method: "PATCH",
+    body: { improvement_theme: input },
+    action: "updateImprovementTheme",
+    fallbackMessage: "課題の更新に失敗しました",
+  });
+  if (result.ok) await revalidateThemes(id);
+  return result;
+}
+
+/**
+ * 課題を削除する（DELETE /api/v2/improvement_themes/:id）。
+ * 紐付いていた練習・ノートは中間テーブルごと外れるだけで、記録自体は残る。
+ */
+export async function deleteImprovementTheme(
+  id: number,
+): Promise<MutationResult<DeletedResponse>> {
+  const result = await mutateV2<DeletedResponse>(`${BASE_PATH}/${id}`, {
+    method: "DELETE",
+    action: "deleteImprovementTheme",
+    fallbackMessage: "課題の削除に失敗しました",
+  });
+  if (result.ok) await revalidateThemes(id);
+  return result;
 }

--- a/app/types/gameResultLink.ts
+++ b/app/types/gameResultLink.ts
@@ -1,0 +1,12 @@
+/**
+ * ノートへ紐付ける試合記録の候補・紐付け先カードで使う最小限の情報。
+ * back の V2::GameResultSerializer は打席結果や投球成績まで含む重いレスポンスを返すため、
+ * 紐付け UI では日付と対戦相手だけに絞って扱う。
+ */
+export interface GameResultLinkOption {
+  game_result_id: number;
+  /** YYYY-MM-DD。back の match_result.date_and_time から日付部分だけを取り出したもの。 */
+  date: string;
+  /** 対戦相手のチーム名。未登録・取得できない場合は空文字。 */
+  opponent_team_name: string;
+}

--- a/app/types/improvementTheme.ts
+++ b/app/types/improvementTheme.ts
@@ -16,8 +16,25 @@ export interface ImprovementTheme {
   started_on: string;
   achieved_on: string | null;
   sort_order: number;
+  /** 紐づく練習セッション配下の練習ログ件数。back が集計して返す。 */
   practice_logs_count: number;
+  /** 紐づくノート件数。back が集計して返す。 */
   notes_count: number;
+  /** 練習セッションのある日の distinct 日数。back が集計して返す。 */
   active_days: number;
   created_at: string;
+}
+
+/**
+ * 課題の作成・更新パラメータ。
+ * back の Strong Parameters（title / category / purpose / status / achieved_on / sort_order）に対応する。
+ * 更新時は変更したいキーだけを含める。
+ */
+export interface ImprovementThemeInput {
+  title?: string;
+  category?: string | null;
+  purpose?: string | null;
+  status?: ImprovementThemeStatus;
+  achieved_on?: string | null;
+  sort_order?: number;
 }

--- a/app/utils/__tests__/noteLinks.test.ts
+++ b/app/utils/__tests__/noteLinks.test.ts
@@ -1,0 +1,103 @@
+import {
+  buildGameResultIdsPayload,
+  buildGameResultIdsUpdate,
+  buildImprovementThemeIdsPayload,
+  buildImprovementThemeIdsUpdate,
+  canLinkMore,
+} from "../noteLinks";
+
+describe("複数紐付けの可否（グランドファザリング）", () => {
+  it("1件までは無料でも紐付けられる", () => {
+    expect(
+      canLinkMore({ nextCount: 1, initialCount: 0, hasMultiLink: false }),
+    ).toBe(true);
+  });
+
+  it("無料は既存が無い状態から2件目を増やせない", () => {
+    expect(
+      canLinkMore({ nextCount: 2, initialCount: 0, hasMultiLink: false }),
+    ).toBe(false);
+  });
+
+  it("Pro は既存が無くても複数紐付けできる", () => {
+    expect(
+      canLinkMore({ nextCount: 3, initialCount: 0, hasMultiLink: true }),
+    ).toBe(true);
+  });
+
+  it("無料でも既存件数と同じ件数なら維持できる", () => {
+    expect(
+      canLinkMore({ nextCount: 3, initialCount: 3, hasMultiLink: false }),
+    ).toBe(true);
+  });
+
+  it("無料でも既存件数より減らす分には通る", () => {
+    expect(
+      canLinkMore({ nextCount: 2, initialCount: 3, hasMultiLink: false }),
+    ).toBe(true);
+  });
+
+  it("無料は既存件数を超えて増やそうとすると弾く", () => {
+    expect(
+      canLinkMore({ nextCount: 4, initialCount: 3, hasMultiLink: false }),
+    ).toBe(false);
+  });
+});
+
+describe("作成時の紐付けペイロード", () => {
+  it("紐付けが無ければキーを生やさない", () => {
+    expect(buildImprovementThemeIdsPayload([])).toEqual({});
+    expect(buildGameResultIdsPayload([])).toEqual({});
+  });
+
+  it("重複を除いた ID を送る", () => {
+    expect(buildImprovementThemeIdsPayload([3, 3, 5])).toEqual({
+      improvement_theme_ids: [3, 5],
+    });
+    expect(buildGameResultIdsPayload([7, 7])).toEqual({
+      game_result_ids: [7],
+    });
+  });
+});
+
+describe("更新時の紐付けペイロード", () => {
+  it("変更が無ければ試合のキーを生やさない", () => {
+    expect(
+      buildGameResultIdsUpdate({ initialIds: [1, 2], ids: [2, 1] }),
+    ).toEqual({});
+  });
+
+  it("変更があれば試合のキーを送る", () => {
+    expect(buildGameResultIdsUpdate({ initialIds: [1], ids: [1, 2] })).toEqual({
+      game_result_ids: [1, 2],
+    });
+  });
+
+  it("全解除は空配列を明示して送る", () => {
+    expect(buildGameResultIdsUpdate({ initialIds: [1], ids: [] })).toEqual({
+      game_result_ids: [],
+    });
+  });
+
+  it("元から紐付けが無ければ空配列でもキーを生やさない", () => {
+    expect(buildGameResultIdsUpdate({ initialIds: [], ids: [] })).toEqual({});
+  });
+
+  it("変更が無ければ課題のキーを生やさない", () => {
+    expect(
+      buildImprovementThemeIdsUpdate({ initialIds: [7], ids: [7] }),
+    ).toEqual({});
+  });
+
+  it("課題の全解除も空配列を明示して送る", () => {
+    expect(
+      buildImprovementThemeIdsUpdate({ initialIds: [7], ids: [] }),
+    ).toEqual({ improvement_theme_ids: [] });
+  });
+
+  it("課題の差し替えはそのまま送る", () => {
+    expect(
+      buildImprovementThemeIdsUpdate({ initialIds: [7], ids: [8] }),
+    ).toEqual({ improvement_theme_ids: [8] });
+  });
+});

--- a/app/utils/formatDate.ts
+++ b/app/utils/formatDate.ts
@@ -1,0 +1,16 @@
+/**
+ * "YYYY-MM-DD" を "YYYY年M月D日" 表記に変換する。
+ * 月・日はゼロ埋めしない。パースできない文字列はそのまま返す（mobile の formatJaFullDate と同じ挙動）。
+ */
+export function formatJaFullDate(iso: string): string {
+  const [year, month, day] = iso.split("-").map(Number);
+  if (!year || !month || !day) return iso;
+  return `${year}年${month}月${day}日`;
+}
+
+/** 日付入力（`type="date"`）が要求する `YYYY-MM-DD` をローカル時刻で組み立てる。 */
+export function todayString(now: Date = new Date()): string {
+  const month = (now.getMonth() + 1).toString().padStart(2, "0");
+  const day = now.getDate().toString().padStart(2, "0");
+  return `${now.getFullYear()}-${month}-${day}`;
+}

--- a/app/utils/noteLinks.ts
+++ b/app/utils/noteLinks.ts
@@ -1,0 +1,105 @@
+import type { BaseballNoteInput } from "@app/interface/baseballNoteV2";
+
+interface LinkCapacityParams {
+  /** 紐付けを追加した後の件数。 */
+  nextCount: number;
+  /**
+   * 更新前にノートへ紐付いていた件数。新規作成は 0。
+   * Pro 解約後も既存の複数紐付けを維持・削減できるようにするため（グランドファザリング）に使う。
+   */
+  initialCount: number;
+  /** 複数紐付けの entitlement を持ち、かつ Pro 判定が確定しているか。未確定の間は false を渡す。 */
+  hasMultiLink: boolean;
+}
+
+/**
+ * その件数まで紐付けてよいか。
+ *
+ * back の `valid_game_results?` / `valid_improvement_themes?` と同じ判定にする。
+ * back は「1件以下」「entitlement あり」「既存件数以下」のいずれかなら通し、
+ * **既存件数を超えて2件以上に増やすときだけ** 403 を返す。
+ * フロントで「無料は1件まで」と決め打ちすると、Pro 解約後のユーザーが既存の複数紐付けを
+ * 維持したまま保存できなくなるため、必ず initialCount を見る。
+ */
+export function canLinkMore({
+  nextCount,
+  initialCount,
+  hasMultiLink,
+}: LinkCapacityParams): boolean {
+  if (nextCount <= 1) return true;
+  if (hasMultiLink) return true;
+  return nextCount <= initialCount;
+}
+
+/**
+ * 作成時に送る `improvement_theme_ids` を組み立てる。
+ * 紐付けが無いときはキーを生やさない（back は blank を「紐付け無し」として扱う）。
+ */
+export function buildImprovementThemeIdsPayload(
+  ids: number[],
+): Pick<BaseballNoteInput, "improvement_theme_ids"> {
+  const next = dedupe(ids);
+  return next.length === 0 ? {} : { improvement_theme_ids: next };
+}
+
+/**
+ * 作成時に送る `game_result_ids` を組み立てる。
+ * 紐付けが無いときはキーを生やさない（back は blank を「紐付け無し」として扱う）。
+ */
+export function buildGameResultIdsPayload(
+  ids: number[],
+): Pick<BaseballNoteInput, "game_result_ids"> {
+  const next = dedupe(ids);
+  return next.length === 0 ? {} : { game_result_ids: next };
+}
+
+interface LinkUpdateParams {
+  /** 更新前にノートへ紐付いていた ID。 */
+  initialIds: number[];
+  /** 画面で選択されている ID。 */
+  ids: number[];
+}
+
+/**
+ * 更新時に送る `game_result_ids` を組み立てる。
+ *
+ * 変更が無ければキーを生やさない（back は未送信を「変更なし」として扱う）。
+ * 全解除は `[]` を明示して送る必要があるため、空配列をキー未送信へ丸めてはならない。
+ */
+export function buildGameResultIdsUpdate({
+  initialIds,
+  ids,
+}: LinkUpdateParams): Pick<BaseballNoteInput, "game_result_ids"> {
+  const changed = changedIds(initialIds, ids);
+  return changed === null ? {} : { game_result_ids: changed };
+}
+
+/**
+ * 更新時に送る `improvement_theme_ids` を組み立てる。
+ * セマンティクスは `buildGameResultIdsUpdate` と同じ（未送信＝変更なし、`[]`＝全解除）。
+ */
+export function buildImprovementThemeIdsUpdate({
+  initialIds,
+  ids,
+}: LinkUpdateParams): Pick<BaseballNoteInput, "improvement_theme_ids"> {
+  const changed = changedIds(initialIds, ids);
+  return changed === null ? {} : { improvement_theme_ids: changed };
+}
+
+/** 変更後の ID 配列。変更が無ければ null（キーを生やさないことを表す）。 */
+function changedIds(initialIds: number[], ids: number[]): number[] | null {
+  const next = dedupe(ids);
+  return isSameIdSet(next, dedupe(initialIds)) ? null : next;
+}
+
+function dedupe(ids: number[]): number[] {
+  return Array.from(new Set(ids));
+}
+
+/** 並び順は保存時に意味を持たないため、集合として比較する。 */
+function isSameIdSet(a: number[], b: number[]): boolean {
+  if (a.length !== b.length) return false;
+  const left = [...a].sort((x, y) => x - y);
+  const right = [...b].sort((x, y) => x - y);
+  return left.every((value, index) => value === right[index]);
+}


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#478

## 概要

取組中/克服/アーカイブの3状態で課題を管理し、練習記録・ノートと紐付けて取り組み状況を可視化します。front に全く存在しませんでした。

## ⚠️ Pro のグランドファザリングに対応しました（mobile と意図的に変えた点）

back の紐付け判定は `ids.size > 1 && ids.size > existing_ids.size && !entitlement` のときだけ 403 です。つまり**既存件数以下なら無料でも維持・削減できます**。

**mobile の `ThemePickerField` / `NoteForm` は「無料は1件まで」と決め打ちしています**が、それだと **Pro を解約した既存ユーザーが自分のノートを編集できなくなります**。front は back と同じ式にしました。

```ts
canLinkMore({ nextCount, initialCount, hasMultiLink })
// nextCount <= 1 || hasMultiLink || nextCount <= initialCount
```

**Pro 判定が未確定の間は `hasMultiLink: false` に倒しています。**

## 部分更新セマンティクスの厳守

`buildGameResultIdsUpdate` / `buildImprovementThemeIdsUpdate` が集合比較し、**変化なし＝キーを生やさない / 変化あり＝`[]` でも必ず送る**。フォームの state を丸ごと送ると既存の紐付けが消えるため、ミューテーション（常にキーを送る2種、`[]` を未送信扱い、順序比較化、フォームが常送信）で固定しています。

## back の契約で判明した点

- **status に遷移の制約はありません。** `update` は Strong Params の `status` をそのまま保存するだけで、状態機械もバリデーションもありません
- **`show` が無い**ため詳細は index から1件取り出しています
- **統計（`practice_logs_count` / `notes_count` / `active_days`）はサーバー算出**なので、紐づく一覧の件数から数え直していません
- **無料枠は `open` のみ数えます**（克服・アーカイブは枠を消費しない）。作成時のみ判定
- **対戦相手検索はサーバー側にあります**（`GET /api/v2/game_results/filtered_index?search=` → `teams.name ILIKE`）。#476 / #471 と違い、ここはクライアント実装が不要でした

## デバウンスと順序逆転対策

`useGameResultSearch` が 300ms のタイマーを積み直し（連続入力でリクエスト1回）、発行ごとに連番を採番して応答時に最新でなければ**破棄**します。`useEffect` を使わずイベントハンドラ内で完結。検索結果は `FetchResult` のまま保持し、**未検索(null) / 失敗 / 0件を区別**します。

## レビューで確認いただきたい点

1. **再開時に `achieved_on: null` を送って克服日を消しています**（mobile は残す）。克服していない課題に克服日が表示されるのは実態とずれるためですが、mobile と挙動が異なります
2. **試合候補の整形を Server Action 側で行っています。** `filtered_index` は打席結果まで含む重いレスポンスなので `{game_result_id, date, opponent_team_name}` に落としました。「変換はクライアントで」の原則よりペイロード削減を優先しています（理由はコード内にも記載）
3. **紐づく練習記録を非リンクの行にしています。** 実装時点で front に練習セッション詳細のルートが無かったためですが、**#471（PR #427）が `/practice/records/[id]` を追加する**ので、そちらのマージ後にリンク化できます
4. **紐付け先カードの取得**は、ノート本体取得後にしか ID が分からないためそこだけ直列に並列取得しています。取得できなかった分は落とすだけでノート表示は止めず、ID の紐付け自体は保持します

## チェックリスト

- [x] `yarn typecheck` / `yarn lint` / `yarn format:check` が通る
- [x] `yarn test` が通る（**150 suites / 1791 tests**。新規 6 ファイル / 93 tests）
- [x] `yarn build` が通る（ローカルで実行済み）
- [x] ミューテーションテスト **33 設計 / 33 KILLED / 0 SURVIVED**

### ルート表

base（`86ba8e1`）も同条件でビルドして diff を取得しました。

- base: 静的 87 / 動的 50 → head: 静的 87 / 動的 52
- **追加は `/themes`・`/themes/[id]` の2件のみ。既存ルートの分類変更なし**

<details>
<summary>ミューテーションテスト詳細</summary>

更新で常にキーを送る2種 / `[]` を未送信扱い / 順序比較化 / フォームが常送信 / **グランドファザリング無視・境界改変・Pro判定消し・未確定を権利あり扱い・既存件数無視** / 無料枠の数え方（`open` 以外も数える）・上限値・境界・未確定扱い / 遷移の許容改変2種 / 達成日の付け外し2種 / 3タブ分類・タブ順 / 統計の算出改変2種 / デバウンス除去・タイマー非再設定・順序逆転対策除去 / 0件と取得失敗の取り違え4種 / API パス・メソッド・検索パラメータ・エンドポイント改変4種 — 全 KILLED。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_