### PR TITLE
Add: 練習メニュー別の積み上げサマリーと推移グラフ（Pro）を実装

### DIFF
--- a/app/(app)/practice/summary/[menuId]/__tests__/MenuTrendContent.test.tsx
+++ b/app/(app)/practice/summary/[menuId]/__tests__/MenuTrendContent.test.tsx
@@ -1,0 +1,233 @@
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: jest.fn(), close: jest.fn() }),
+}));
+
+jest.mock("@app/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+import type { MenuTrend, MenuTrendBucket } from "@app/types/practice";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import MenuTrendContent from "../_components/MenuTrendContent";
+
+const SAMPLE_LABEL = "サンプルデータ（実際の記録ではありません）";
+const DAY_LIMIT_NOTICE = "日別は記録のある直近60日分までの表示です";
+
+const pad2 = (value: number) => String(value).padStart(2, "0");
+
+const monthBuckets = (count: number): MenuTrendBucket[] =>
+  Array.from({ length: count }, (_, index) => ({
+    period: `2026-${pad2(12 - index)}`,
+    total_amount: 100 + index,
+    total_volume: 1000 + index,
+    days_count: 3,
+  }));
+
+const dayBuckets = (count: number): MenuTrendBucket[] =>
+  Array.from({ length: count }, (_, index) => ({
+    period: `2026-08-${pad2(30 - index)}`,
+    total_amount: 10 + index,
+    total_volume: 100 + index,
+    days_count: 1,
+  }));
+
+const buildTrend = (overrides: Partial<MenuTrend> = {}): MenuTrend => ({
+  menu: {
+    id: 1,
+    name: "素振り",
+    unit: "count",
+    unit_label: "本",
+    is_weight_reps: false,
+  },
+  by_year: [
+    { period: "2026", total_amount: 1200, total_volume: 0, days_count: 40 },
+    { period: "2025", total_amount: 900, total_volume: 0, days_count: 30 },
+    { period: "2024", total_amount: 600, total_volume: 0, days_count: 20 },
+    { period: "2023", total_amount: 300, total_volume: 0, days_count: 10 },
+  ],
+  by_month: monthBuckets(12),
+  by_day: dayBuckets(20),
+  ...overrides,
+});
+
+const renderTrend = (trend: MenuTrend = buildTrend()) =>
+  render(<MenuTrendContent view={{ kind: "trend", trend }} />);
+
+const rangeGroup = () => screen.getByRole("group", { name: "表示レンジ" });
+
+const activeRangeLabel = () =>
+  within(rangeGroup())
+    .getAllByRole("button")
+    .find((button) => button.getAttribute("aria-pressed") === "true")
+    ?.textContent;
+
+const rangeLabels = () =>
+  within(rangeGroup())
+    .getAllByRole("button")
+    .map((button) => button.textContent);
+
+const bucketRows = () => screen.getAllByRole("listitem");
+
+describe("粒度タブ", () => {
+  it("既定は月別で、直近1年ぶんを表示する", async () => {
+    renderTrend();
+
+    expect(screen.getByRole("button", { name: "月別" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(activeRangeLabel()).toBe("1年");
+    expect(bucketRows()).toHaveLength(12);
+  });
+
+  it("年別へ切り替えるとレンジの選択肢と既定が年のものになる", async () => {
+    const user = userEvent.setup();
+    renderTrend();
+
+    await user.click(screen.getByRole("button", { name: "年別" }));
+
+    expect(rangeLabels()).toEqual(["3年", "5年", "全期間"]);
+    expect(activeRangeLabel()).toBe("全期間");
+    expect(bucketRows()).toHaveLength(4);
+    expect(within(bucketRows()[0]).getByText("2026年")).toBeInTheDocument();
+  });
+
+  it("日別へ切り替えるとレンジの選択肢と既定が日のものになる", async () => {
+    const user = userEvent.setup();
+    renderTrend();
+
+    await user.click(screen.getByRole("button", { name: "日別" }));
+
+    expect(rangeLabels()).toEqual(["2週間", "1ヶ月", "3ヶ月", "全期間"]);
+    expect(activeRangeLabel()).toBe("1ヶ月");
+    expect(within(bucketRows()[0]).getByText("8/30")).toBeInTheDocument();
+  });
+
+  it("月別のレンジは 6ヶ月 / 1年 / 2年 / 全期間", async () => {
+    renderTrend();
+
+    expect(rangeLabels()).toEqual(["6ヶ月", "1年", "2年", "全期間"]);
+  });
+});
+
+describe("表示レンジ", () => {
+  it("選んだレンジの件数だけ新しい順に表示する", async () => {
+    const user = userEvent.setup();
+    renderTrend();
+
+    await user.click(screen.getByRole("button", { name: "6ヶ月" }));
+
+    expect(bucketRows()).toHaveLength(6);
+    expect(within(bucketRows()[0]).getByText("2026/12")).toBeInTheDocument();
+  });
+
+  it("年別の3年は直近3件に絞る", async () => {
+    const user = userEvent.setup();
+    renderTrend();
+
+    await user.click(screen.getByRole("button", { name: "年別" }));
+    await user.click(screen.getByRole("button", { name: "3年" }));
+
+    expect(bucketRows()).toHaveLength(3);
+    expect(within(bucketRows()[2]).getByText("2024年")).toBeInTheDocument();
+  });
+});
+
+describe("日別の上限", () => {
+  it("60件返ってきたら上限の注記を出す", async () => {
+    const user = userEvent.setup();
+    renderTrend(buildTrend({ by_day: dayBuckets(60) }));
+
+    await user.click(screen.getByRole("button", { name: "日別" }));
+
+    expect(screen.getByText(DAY_LIMIT_NOTICE)).toBeInTheDocument();
+  });
+
+  it("上限未満なら注記を出さない", async () => {
+    const user = userEvent.setup();
+    renderTrend(buildTrend({ by_day: dayBuckets(59) }));
+
+    await user.click(screen.getByRole("button", { name: "日別" }));
+
+    expect(screen.queryByText(DAY_LIMIT_NOTICE)).not.toBeInTheDocument();
+  });
+
+  it("月別では日別の注記を出さない", () => {
+    renderTrend(buildTrend({ by_day: dayBuckets(60) }));
+
+    expect(screen.queryByText(DAY_LIMIT_NOTICE)).not.toBeInTheDocument();
+  });
+});
+
+describe("表示単位", () => {
+  it("通常メニューは量を単位ラベル付きで出す", () => {
+    renderTrend();
+
+    expect(within(bucketRows()[0]).getByText("100本")).toBeInTheDocument();
+    expect(within(bucketRows()[0]).getByText("3日")).toBeInTheDocument();
+  });
+
+  it("weight_reps は総挙上重量で出す", () => {
+    renderTrend(
+      buildTrend({
+        menu: {
+          id: 2,
+          name: "ベンチプレス",
+          unit: "weight_reps",
+          unit_label: "回",
+          is_weight_reps: true,
+        },
+        by_month: [
+          {
+            period: "2026-08",
+            total_amount: 620,
+            total_volume: 8200,
+            days_count: 12,
+          },
+        ],
+      }),
+    );
+
+    expect(within(bucketRows()[0]).getByText("8.2t")).toBeInTheDocument();
+    expect(screen.queryByText("620回")).not.toBeInTheDocument();
+  });
+});
+
+describe("サンプル表示", () => {
+  it("サンプルには SampleDataLabel と Pro 訴求を添える", () => {
+    render(<MenuTrendContent view={{ kind: "sample", trend: buildTrend() }} />);
+
+    expect(screen.getByText(SAMPLE_LABEL)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "メニューごとの推移を詳しく見る" }),
+    ).toBeInTheDocument();
+  });
+
+  it("実データにはサンプルの断り書きを付けない", () => {
+    renderTrend();
+
+    expect(screen.queryByText(SAMPLE_LABEL)).not.toBeInTheDocument();
+  });
+});
+
+describe("0件と取得失敗", () => {
+  it("バケットが空なら記録なしの案内を出し、レンジ切替は出さない", () => {
+    renderTrend(buildTrend({ by_year: [], by_month: [], by_day: [] }));
+
+    expect(screen.getByText("まだ記録がありません")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("group", { name: "表示レンジ" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("取得失敗は記録なしと別の文言にする", () => {
+    render(<MenuTrendContent view={{ kind: "error" }} />);
+
+    expect(screen.getByText(/推移を取得できませんでした/)).toBeInTheDocument();
+    expect(screen.queryByText("まだ記録がありません")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("group", { name: "集計の粒度" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/(app)/practice/summary/[menuId]/__tests__/page.test.tsx
+++ b/app/(app)/practice/summary/[menuId]/__tests__/page.test.tsx
@@ -1,0 +1,282 @@
+const mockCookieGet = jest.fn();
+const mockRedirect = jest.fn((path: string) => {
+  throw new Error(`NEXT_REDIRECT:${path}`);
+});
+const mockNotFound = jest.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+const mockGetCachedProStatus = jest.fn();
+const mockGetMenuTrend = jest.fn();
+const mockGetShadowSwingTrend = jest.fn();
+const mockGetPracticeMenus = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: () => Promise.resolve({ get: mockCookieGet }),
+}));
+
+jest.mock("next/navigation", () => ({
+  redirect: (path: string) => mockRedirect(path),
+  notFound: () => mockNotFound(),
+}));
+
+jest.mock("@app/(app)/pro/proStatus", () => ({
+  getCachedProStatus: () => mockGetCachedProStatus(),
+}));
+
+jest.mock("@app/services/v2/practiceSummaryService", () => ({
+  getMenuTrend: (menuId: number) => mockGetMenuTrend(menuId),
+  getShadowSwingTrend: () => mockGetShadowSwingTrend(),
+}));
+
+jest.mock("@app/services/v2/practiceMenuService", () => ({
+  getPracticeMenus: () => mockGetPracticeMenus(),
+}));
+
+jest.mock("@app/components/header/Header", () => ({
+  __esModule: true,
+  default: () => <header />,
+}));
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: jest.fn(), close: jest.fn() }),
+}));
+
+jest.mock("@app/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+import type { MenuTrend } from "@app/types/practice";
+import { render, screen } from "@testing-library/react";
+import { DEFAULT_PRO_STATUS } from "@app/types/pro";
+import PracticeMenuTrendPage from "../page";
+
+const FEATURE = "practice_menu_trend_detail";
+const SAMPLE_LABEL = "サンプルデータ（実際の記録ではありません）";
+
+const buildTrend = (overrides: Partial<MenuTrend> = {}): MenuTrend => ({
+  menu: {
+    id: 3,
+    name: "ベンチプレス",
+    unit: "weight_reps",
+    unit_label: "回",
+    is_weight_reps: true,
+  },
+  by_year: [
+    { period: "2026", total_amount: 620, total_volume: 8200, days_count: 40 },
+  ],
+  by_month: [
+    {
+      period: "2026-08",
+      total_amount: 80,
+      total_volume: 640,
+      days_count: 4,
+    },
+  ],
+  by_day: [
+    {
+      period: "2026-08-03",
+      total_amount: 20,
+      total_volume: 160,
+      days_count: 1,
+    },
+  ],
+  ...overrides,
+});
+
+function setAuthCookies() {
+  mockCookieGet.mockImplementation((key: string) =>
+    key === "access-token" ? { value: "test-access-token" } : undefined,
+  );
+}
+
+function setPro(isPro: boolean) {
+  mockGetCachedProStatus.mockResolvedValue({
+    ...DEFAULT_PRO_STATUS,
+    entitlements: isPro
+      ? [...DEFAULT_PRO_STATUS.entitlements, FEATURE]
+      : DEFAULT_PRO_STATUS.entitlements,
+  });
+}
+
+async function renderPage({
+  menuId = "3",
+  source,
+}: { menuId?: string; source?: string } = {}) {
+  render(
+    await PracticeMenuTrendPage({
+      params: Promise.resolve({ menuId }),
+      searchParams: Promise.resolve(source ? { source } : {}),
+    }),
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setAuthCookies();
+  mockGetPracticeMenus.mockResolvedValue({
+    status: "ok",
+    data: [
+      {
+        id: 3,
+        name: "ベンチプレス",
+        category: "strength",
+        unit: "weight_reps",
+        unit_label: "回",
+        default_value: null,
+        is_favorite: false,
+        sort_order: 0,
+      },
+    ],
+  });
+});
+
+describe("認証", () => {
+  it("未ログインはサインアップへ送る", async () => {
+    mockCookieGet.mockReturnValue(undefined);
+
+    await expect(
+      PracticeMenuTrendPage({
+        params: Promise.resolve({ menuId: "3" }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).rejects.toThrow("NEXT_REDIRECT");
+    expect(mockGetMenuTrend).not.toHaveBeenCalled();
+  });
+});
+
+describe("無料ユーザー", () => {
+  beforeEach(() => {
+    setPro(false);
+  });
+
+  it("推移 API を一度も叩かずサンプルを表示する", async () => {
+    await renderPage();
+
+    expect(mockGetMenuTrend).not.toHaveBeenCalled();
+    expect(mockGetShadowSwingTrend).not.toHaveBeenCalled();
+    expect(screen.getByText(SAMPLE_LABEL)).toBeInTheDocument();
+  });
+
+  it("Pro 限定機能である旨を伝える（無料枠の超過ではない）", async () => {
+    await renderPage();
+
+    expect(
+      screen.getByText(
+        /メニューごとの推移の詳細表示は Pro プラン限定の機能です/,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/件まで/)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "メニューごとの推移を詳しく見る" }),
+    ).toBeInTheDocument();
+  });
+
+  it("サンプルでも対象メニューの単位で表示する", async () => {
+    await renderPage();
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: "ベンチプレス" }),
+    ).toBeInTheDocument();
+    // weight_reps のサンプルは総挙上重量（kg / t）で出す。
+    expect(screen.getAllByText(/kg|t$/).length).toBeGreaterThan(0);
+  });
+
+  it("素振りはメニュー一覧を引かずに素振りとして見せる", async () => {
+    await renderPage({ menuId: "shadow_swing", source: "shadow_swing" });
+
+    expect(mockGetShadowSwingTrend).not.toHaveBeenCalled();
+    expect(mockGetPracticeMenus).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("heading", { level: 2, name: "素振り" }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Pro ユーザー", () => {
+  beforeEach(() => {
+    setPro(true);
+  });
+
+  it("メニュー推移をメニュー id で取得する", async () => {
+    mockGetMenuTrend.mockResolvedValue({ status: "ok", data: buildTrend() });
+
+    await renderPage({ menuId: "3" });
+
+    expect(mockGetMenuTrend).toHaveBeenCalledWith(3);
+    expect(mockGetShadowSwingTrend).not.toHaveBeenCalled();
+    expect(screen.queryByText(SAMPLE_LABEL)).not.toBeInTheDocument();
+    expect(screen.getByText("640kg")).toBeInTheDocument();
+  });
+
+  it("source=shadow_swing は素振り専用エンドポイントを叩く", async () => {
+    mockGetShadowSwingTrend.mockResolvedValue({
+      status: "ok",
+      data: buildTrend({
+        menu: {
+          id: null,
+          name: "素振り",
+          unit: "count",
+          unit_label: "本",
+          is_weight_reps: false,
+        },
+      }),
+    });
+
+    await renderPage({ menuId: "shadow_swing", source: "shadow_swing" });
+
+    expect(mockGetShadowSwingTrend).toHaveBeenCalledTimes(1);
+    expect(mockGetMenuTrend).not.toHaveBeenCalled();
+    expect(screen.getByText("80本")).toBeInTheDocument();
+  });
+
+  it("記録 0 件は空の案内を出す", async () => {
+    mockGetMenuTrend.mockResolvedValue({
+      status: "ok",
+      data: buildTrend({ by_year: [], by_month: [], by_day: [] }),
+    });
+
+    await renderPage();
+
+    expect(screen.getByText("まだ記録がありません")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/推移を取得できませんでした/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("取得失敗は 0 件と区別してエラーを出す", async () => {
+    mockGetMenuTrend.mockResolvedValue({ status: "error" });
+
+    await renderPage();
+
+    expect(screen.getByText(/推移を取得できませんでした/)).toBeInTheDocument();
+    expect(screen.queryByText("まだ記録がありません")).not.toBeInTheDocument();
+    expect(screen.queryByText(SAMPLE_LABEL)).not.toBeInTheDocument();
+  });
+
+  it("403 は Pro 限定の文脈でサンプルへ倒す", async () => {
+    mockGetMenuTrend.mockResolvedValue({ status: "forbidden" });
+
+    await renderPage();
+
+    expect(screen.getByText(SAMPLE_LABEL)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /メニューごとの推移の詳細表示は Pro プラン限定の機能です/,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/推移を取得できませんでした/),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("不正なパス", () => {
+  it("数値でないメニュー id は 404（source 指定なし）", async () => {
+    setPro(true);
+
+    await expect(renderPage({ menuId: "abc" })).rejects.toThrow(
+      "NEXT_NOT_FOUND",
+    );
+    expect(mockGetMenuTrend).not.toHaveBeenCalled();
+  });
+});

--- a/app/(app)/practice/summary/[menuId]/_components/MenuTrendChart.tsx
+++ b/app/(app)/practice/summary/[menuId]/_components/MenuTrendChart.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import type { MenuTrend, MenuTrendBucket } from "@app/types/practice";
+import { Fragment, useId, useState } from "react";
+import {
+  type TrendPeriod,
+  bucketValue,
+  bucketValueText,
+  periodLabel,
+} from "../_utils/menuTrendRange";
+
+interface MenuTrendChartProps {
+  trend: MenuTrend;
+  period: TrendPeriod;
+  /** 表示対象のバケット（新しい順）。内部で古い→新しいへ並べ替えて描画する。 */
+  buckets: MenuTrendBucket[];
+}
+
+const CHART_WIDTH = 320;
+const CHART_HEIGHT = 180;
+const PADDING_LEFT = 34;
+const PADDING_RIGHT = 12;
+const PADDING_TOP = 14;
+const PADDING_BOTTOM = 24;
+const PLOT_WIDTH = CHART_WIDTH - PADDING_LEFT - PADDING_RIGHT;
+const PLOT_HEIGHT = CHART_HEIGHT - PADDING_TOP - PADDING_BOTTOM;
+const PLOT_RIGHT = CHART_WIDTH - PADDING_RIGHT;
+const PLOT_BOTTOM = PADDING_TOP + PLOT_HEIGHT;
+
+// X 軸ラベルは混雑回避のため間引く。日別の全期間（最大60件）でも読める本数にする。
+const MAX_X_LABELS = 6;
+
+const LINE_COLOR = "#d08000";
+
+/** Y 軸の目盛り。1万以上は k 表記にして軸幅に収める。 */
+const axisLabel = (value: number): string =>
+  value >= 10_000
+    ? `${Math.round(value / 1000).toLocaleString("ja-JP")}k`
+    : Math.round(value).toLocaleString("ja-JP");
+
+/**
+ * メニューの積み上げ推移の折れ線グラフ（グラデーションの面付き）。
+ * 点をクリックすると値と期間のツールチップを出す（成績の推移グラフと同じ操作感）。
+ */
+export default function MenuTrendChart({
+  trend,
+  period,
+  buckets,
+}: MenuTrendChartProps) {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const gradientId = useId();
+
+  // 古い→新しいで描き、最新を右端に置く。
+  const shown = [...buckets].reverse();
+  if (shown.length === 0) return null;
+
+  const values = shown.map((bucket) => bucketValue(trend, bucket));
+  const max = Math.max(...values, 1);
+  const yTicks = [0, max];
+
+  const getX = (index: number) =>
+    PADDING_LEFT +
+    (shown.length === 1
+      ? PLOT_WIDTH / 2
+      : (index / (shown.length - 1)) * PLOT_WIDTH);
+  const getY = (value: number) =>
+    PADDING_TOP + PLOT_HEIGHT - (value / max) * PLOT_HEIGHT;
+
+  // タップ領域の縦帯。隣接点との X 中点で分割し、両端はプロット境界にクランプする。
+  const getBandX = (index: number) =>
+    index === 0 ? PADDING_LEFT : (getX(index - 1) + getX(index)) / 2;
+  const getBandRight = (index: number) =>
+    index === shown.length - 1
+      ? PLOT_RIGHT
+      : (getX(index) + getX(index + 1)) / 2;
+
+  const linePath = values
+    .map(
+      (value, index) =>
+        `${index === 0 ? "M" : "L"} ${getX(index)},${getY(value)}`,
+    )
+    .join(" ");
+  const areaPath = `${linePath} L ${getX(shown.length - 1)},${PLOT_BOTTOM} L ${getX(0)},${PLOT_BOTTOM} Z`;
+
+  const labelStride = Math.max(1, Math.ceil(shown.length / MAX_X_LABELS));
+
+  return (
+    <div className="flex justify-center">
+      <svg
+        width="100%"
+        viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+        className="max-w-[460px]"
+        role="img"
+        aria-label="積み上げの推移グラフ"
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={LINE_COLOR} stopOpacity={0.28} />
+            <stop offset="100%" stopColor={LINE_COLOR} stopOpacity={0.02} />
+          </linearGradient>
+        </defs>
+
+        {/* 余白のクリックでツールチップを閉じる。点の帯は後から描くので前面に来る。 */}
+        <rect
+          x={0}
+          y={0}
+          width={CHART_WIDTH}
+          height={CHART_HEIGHT}
+          fill="transparent"
+          onClick={() => setSelectedIndex(null)}
+        />
+
+        {yTicks.map((tick) => (
+          <Fragment key={`y-${tick}`}>
+            <line
+              x1={PADDING_LEFT}
+              y1={getY(tick)}
+              x2={PLOT_RIGHT}
+              y2={getY(tick)}
+              stroke="#424242"
+              strokeWidth={0.5}
+            />
+            <text
+              x={PADDING_LEFT - 5}
+              y={getY(tick) + 3}
+              textAnchor="end"
+              fill="#71717A"
+              fontSize={9}
+            >
+              {axisLabel(tick)}
+            </text>
+          </Fragment>
+        ))}
+
+        <path d={areaPath} fill={`url(#${gradientId})`} />
+        <path
+          d={linePath}
+          fill="none"
+          stroke={LINE_COLOR}
+          strokeWidth={1.8}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+
+        {shown.map((bucket, index) => {
+          const isSelected = selectedIndex === index;
+          const bandX = getBandX(index);
+          const bandY = Math.max(PADDING_TOP, getY(values[index]) - 8);
+          return (
+            <Fragment key={`pt-${bucket.period}`}>
+              <rect
+                x={bandX}
+                y={bandY}
+                width={getBandRight(index) - bandX}
+                height={PLOT_BOTTOM - bandY}
+                fill="transparent"
+                className="cursor-pointer"
+                onClick={() =>
+                  setSelectedIndex((prev) => (prev === index ? null : index))
+                }
+              />
+              <circle
+                cx={getX(index)}
+                cy={getY(values[index])}
+                r={isSelected ? 4 : 2.4}
+                fill={LINE_COLOR}
+                stroke={isSelected ? "#F4F4F4" : "none"}
+                strokeWidth={isSelected ? 1.5 : 0}
+              />
+            </Fragment>
+          );
+        })}
+
+        {selectedIndex !== null
+          ? (() => {
+              const bucket = shown[selectedIndex];
+              if (!bucket) return null;
+              const valueText = bucketValueText(trend, bucket);
+              const labelText = periodLabel(period, bucket.period);
+              const cx = getX(selectedIndex);
+              const cy = getY(values[selectedIndex]);
+              const tooltipWidth = Math.max(
+                64,
+                valueText.length * 8 + 20,
+                labelText.length * 7 + 20,
+              );
+              const tooltipHeight = 32;
+              // 端で見切れないよう位置を寄せる。
+              let tx = cx - tooltipWidth / 2;
+              if (tx < 2) tx = 2;
+              if (tx + tooltipWidth > CHART_WIDTH - 2)
+                tx = CHART_WIDTH - tooltipWidth - 2;
+              let ty = cy - tooltipHeight - 8;
+              if (ty < 2) ty = cy + 10;
+              return (
+                <g>
+                  <rect
+                    x={tx}
+                    y={ty}
+                    width={tooltipWidth}
+                    height={tooltipHeight}
+                    rx={5}
+                    fill="#27272A"
+                    stroke={LINE_COLOR}
+                    strokeWidth={1}
+                  />
+                  <text
+                    x={tx + tooltipWidth / 2}
+                    y={ty + 13}
+                    textAnchor="middle"
+                    fill="#F4F4F4"
+                    fontSize={11}
+                    fontWeight={700}
+                  >
+                    {valueText}
+                  </text>
+                  <text
+                    x={tx + tooltipWidth / 2}
+                    y={ty + 25}
+                    textAnchor="middle"
+                    fill="#A1A1AA"
+                    fontSize={9}
+                  >
+                    {labelText}
+                  </text>
+                </g>
+              );
+            })()
+          : null}
+
+        {shown.map((bucket, index) =>
+          index % labelStride === 0 || index === shown.length - 1 ? (
+            <text
+              key={`xl-${bucket.period}`}
+              x={getX(index)}
+              y={CHART_HEIGHT - 5}
+              textAnchor="middle"
+              fill="#A1A1AA"
+              fontSize={9}
+            >
+              {periodLabel(period, bucket.period)}
+            </text>
+          ) : null,
+        )}
+      </svg>
+    </div>
+  );
+}

--- a/app/(app)/practice/summary/[menuId]/_components/MenuTrendContent.tsx
+++ b/app/(app)/practice/summary/[menuId]/_components/MenuTrendContent.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import type { MenuTrend } from "@app/types/practice";
+import { useState } from "react";
+import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
+import { SampleDataLabel } from "@app/components/pro/SampleDataLabel";
+import {
+  TREND_DEFAULT_RANGE_INDEX,
+  TREND_PERIOD_TABS,
+  TREND_RANGE_OPTIONS,
+  type TrendPeriod,
+  bucketValueText,
+  bucketsForPeriod,
+  isDayLimitReached,
+  periodLabel,
+  sliceByRange,
+} from "../_utils/menuTrendRange";
+import MenuTrendChart from "./MenuTrendChart";
+import {
+  TREND_DAY_LIMIT_NOTICE,
+  TREND_EMPTY,
+  TREND_EMPTY_HINT,
+  TREND_LOAD_ERROR,
+  TREND_PAGE_TITLE,
+  TREND_PRO_ONLY_NOTE,
+} from "./menuTrendCopy";
+
+/**
+ * サーバーで決めた表示内容。
+ * 記録 0 件（trend だがバケットが空）と取得失敗（error）は別物として扱う。
+ * sample は Pro 限定機能のため実データを取得していない状態を表す。
+ */
+export type MenuTrendView =
+  | { kind: "trend"; trend: MenuTrend }
+  | { kind: "sample"; trend: MenuTrend }
+  | { kind: "error" };
+
+const FEATURE = "practice_menu_trend_detail" as const;
+
+const INITIAL_PERIOD: TrendPeriod = "month";
+
+/**
+ * 推移グラフの Container。粒度タブとレンジ切替の状態を持ち、描画は子へ委ねる。
+ * データ取得はサーバー側で完了しているため、ここでは API を叩かない
+ * （無料ユーザーには Pro 限定 API を一度も叩かせない）。
+ */
+export default function MenuTrendContent({ view }: { view: MenuTrendView }) {
+  const [period, setPeriod] = useState<TrendPeriod>(INITIAL_PERIOD);
+  const [rangeIndex, setRangeIndex] = useState(
+    TREND_DEFAULT_RANGE_INDEX[INITIAL_PERIOD],
+  );
+
+  if (view.kind === "error") {
+    return (
+      <>
+        <h2 className="text-2xl font-bold">{TREND_PAGE_TITLE}</h2>
+        <p className="py-8 text-center text-sm text-zinc-400">
+          {TREND_LOAD_ERROR}
+        </p>
+      </>
+    );
+  }
+
+  const { trend } = view;
+  const isSample = view.kind === "sample";
+  const rangeOptions = TREND_RANGE_OPTIONS[period];
+  const rangeOption = rangeOptions[rangeIndex] ?? rangeOptions[0];
+  const buckets = bucketsForPeriod(trend, period);
+  const rangedBuckets = sliceByRange(buckets, rangeOption.limit);
+
+  // 粒度ごとに選択肢が違うため、切り替えたらレンジも既定へ戻す。
+  const handlePeriodChange = (next: TrendPeriod) => {
+    setPeriod(next);
+    setRangeIndex(TREND_DEFAULT_RANGE_INDEX[next]);
+  };
+
+  return (
+    <>
+      <h2 className="text-2xl font-bold">{trend.menu.name}</h2>
+      <p className="mt-2 text-sm text-zinc-300">
+        {isSample ? TREND_PRO_ONLY_NOTE : TREND_PAGE_TITLE}
+      </p>
+
+      {isSample ? (
+        <div className="mt-4">
+          <ProUpsellCard feature={FEATURE} />
+        </div>
+      ) : null}
+
+      <div
+        role="group"
+        aria-label="集計の粒度"
+        className="mt-5 flex rounded-md bg-[#27272A] p-0.5"
+      >
+        {TREND_PERIOD_TABS.map((tab) => {
+          const isActive = tab.key === period;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => handlePeriodChange(tab.key)}
+              className={`flex-1 rounded px-3 py-1.5 text-xs font-semibold ${
+                isActive ? "bg-[#52525B] text-[#F4F4F4]" : "text-zinc-400"
+              }`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {buckets.length === 0 ? (
+        <div className="py-10 text-center">
+          <p className="text-sm font-semibold text-zinc-400">{TREND_EMPTY}</p>
+          <p className="mt-1 text-xs text-zinc-500">{TREND_EMPTY_HINT}</p>
+        </div>
+      ) : (
+        <>
+          <div
+            role="group"
+            aria-label="表示レンジ"
+            className="mt-3 flex flex-wrap gap-2"
+          >
+            {rangeOptions.map((option, index) => {
+              const isActive = index === rangeIndex;
+              return (
+                <button
+                  key={option.label}
+                  type="button"
+                  aria-pressed={isActive}
+                  onClick={() => setRangeIndex(index)}
+                  className={`rounded-full border px-3 py-1 text-xs font-semibold ${
+                    isActive
+                      ? "border-[#d08000] bg-[#d08000] text-main"
+                      : "border-zinc-600 bg-sub text-zinc-400"
+                  }`}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+
+          {isSample ? <SampleDataLabel className="mt-3" /> : null}
+
+          <div
+            className={
+              isSample
+                ? "mt-2 rounded-[14px] border border-dashed border-zinc-600 p-3"
+                : "mt-3"
+            }
+          >
+            <div className="rounded-xl bg-sub p-4">
+              <MenuTrendChart
+                trend={trend}
+                period={period}
+                buckets={rangedBuckets}
+              />
+            </div>
+
+            {isDayLimitReached(period, buckets) ? (
+              <p className="mt-2 text-center text-[11px] text-zinc-500">
+                {TREND_DAY_LIMIT_NOTICE}
+              </p>
+            ) : null}
+
+            <ul className="mt-3 rounded-xl bg-sub px-3.5">
+              {rangedBuckets.map((bucket) => (
+                <li
+                  key={bucket.period}
+                  className="flex items-center justify-between border-b border-main py-3 last:border-b-0"
+                >
+                  <span className="text-sm font-semibold text-white">
+                    {periodLabel(period, bucket.period)}
+                  </span>
+                  <span className="flex items-baseline gap-2">
+                    <span className="text-base font-extrabold text-[#d08000]">
+                      {bucketValueText(trend, bucket)}
+                    </span>
+                    {/* 日別は 1 バケット = 1 日で記録日数が自明なため出さない。 */}
+                    {period === "day" ? null : (
+                      <span className="text-xs text-zinc-400">
+                        {bucket.days_count}日
+                      </span>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/app/(app)/practice/summary/[menuId]/_components/menuTrendCopy.ts
+++ b/app/(app)/practice/summary/[menuId]/_components/menuTrendCopy.ts
@@ -1,0 +1,33 @@
+/**
+ * メニュー推移ページの文言。
+ * 推移詳細の 403 は「無料枠の超過」ではなく「Pro プラン限定機能」を意味するため、
+ * 件数ではなくプランで開放される機能として伝える。
+ */
+
+export const TREND_PAGE_TITLE = "メニューの推移";
+
+export const TREND_PAGE_DESCRIPTION =
+  "年別・月別・日別で積み上げの推移を確認できます。";
+
+/** 取得失敗。バケットが 0 件（まだ記録がない）と必ず区別して出す。 */
+export const TREND_LOAD_ERROR =
+  "推移を取得できませんでした。時間を置いて再度お試しください。";
+
+/** 取得はできたが集計対象の記録が無い状態。 */
+export const TREND_EMPTY = "まだ記録がありません";
+
+export const TREND_EMPTY_HINT =
+  "このメニューを記録すると、ここに推移が表示されます。";
+
+/** Pro 限定機能であることの説明（無料枠を使い切ったという意味ではない）。 */
+export const TREND_PRO_ONLY_NOTE =
+  "メニューごとの推移の詳細表示は Pro プラン限定の機能です。下のグラフはサンプルです。";
+
+/**
+ * back（Practices::MenuTrend / ShadowSwingTrend）の DAY_LIMIT と一致させる。
+ * 日別は記録のある日を新しい順に 60 件までしか返さない。
+ */
+export const TREND_DAY_LIMIT = 60;
+
+/** 日別が上限に達したときの注記。全期間を選んでも 60 件で頭打ちになることを伝える。 */
+export const TREND_DAY_LIMIT_NOTICE = `日別は記録のある直近${TREND_DAY_LIMIT}日分までの表示です`;

--- a/app/(app)/practice/summary/[menuId]/_components/menuTrendSampleData.ts
+++ b/app/(app)/practice/summary/[menuId]/_components/menuTrendSampleData.ts
@@ -1,0 +1,83 @@
+import type { MenuTrend, MenuTrendBucket } from "@app/types/practice";
+
+const pad2 = (value: number): string => String(value).padStart(2, "0");
+
+const yearPeriod = (base: Date, offsetFromNow: number): string =>
+  String(base.getFullYear() - offsetFromNow);
+
+const monthPeriod = (base: Date, offsetFromNow: number): string => {
+  const date = new Date(base.getFullYear(), base.getMonth() - offsetFromNow, 1);
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}`;
+};
+
+const dayPeriod = (base: Date, offsetFromNow: number): string => {
+  const date = new Date(
+    base.getFullYear(),
+    base.getMonth(),
+    base.getDate() - offsetFromNow,
+  );
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+};
+
+interface SampleShape {
+  count: number;
+  base: number;
+  step: number;
+  periodFor: (base: Date, offsetFromNow: number) => string;
+  daysCountFor: (offsetFromNow: number, count: number) => number;
+}
+
+// メニュー・単位によらず同じ右肩上がりの例を見せる（mobile のサンプルと同じ形）。
+const SAMPLE_SHAPES: Readonly<Record<"year" | "month" | "day", SampleShape>> = {
+  year: {
+    count: 3,
+    base: 800,
+    step: 700,
+    periodFor: yearPeriod,
+    daysCountFor: (offset, count) => 30 + (count - 1 - offset) * 15,
+  },
+  month: {
+    count: 6,
+    base: 80,
+    step: 40,
+    periodFor: monthPeriod,
+    daysCountFor: (offset, count) => 8 + (count - 1 - offset),
+  },
+  day: {
+    count: 14,
+    base: 8,
+    step: 4,
+    periodFor: dayPeriod,
+    daysCountFor: () => 1,
+  },
+};
+
+// offsetFromNow=0 が最新。古いほど値を小さくして右肩上がりに見せる。
+const buildBuckets = (shape: SampleShape, now: Date): MenuTrendBucket[] =>
+  Array.from({ length: shape.count }, (_, offsetFromNow) => {
+    const value = shape.base + shape.step * (shape.count - 1 - offsetFromNow);
+    return {
+      period: shape.periodFor(now, offsetFromNow),
+      total_amount: value,
+      total_volume: value,
+      days_count: shape.daysCountFor(offsetFromNow, shape.count),
+    };
+  });
+
+/**
+ * 無料ユーザーへ見せるサンプル推移を組み立てる。
+ * 推移詳細 API は Pro 限定なので叩かず、その場で一般的な例を生成する。
+ * 表示単位（t / 本 など）だけは対象メニューに合わせ、加入後の見え方を正しく伝える。
+ *
+ * @param menu 対象メニューの表示情報（名称・単位）
+ * @param now 期間ラベルの基準日
+ */
+export const buildSampleMenuTrend = (
+  menu: MenuTrend["menu"],
+  now: Date = new Date(),
+): MenuTrend => ({
+  menu,
+  by_year: buildBuckets(SAMPLE_SHAPES.year, now),
+  by_month: buildBuckets(SAMPLE_SHAPES.month, now),
+  by_day: buildBuckets(SAMPLE_SHAPES.day, now),
+});

--- a/app/(app)/practice/summary/[menuId]/_utils/__tests__/menuTrendRange.test.ts
+++ b/app/(app)/practice/summary/[menuId]/_utils/__tests__/menuTrendRange.test.ts
@@ -1,0 +1,131 @@
+import type { MenuTrend, MenuTrendBucket } from "@app/types/practice";
+import { buildSampleMenuTrend } from "../../_components/menuTrendSampleData";
+import {
+  TREND_RANGE_OPTIONS,
+  bucketValue,
+  bucketValueText,
+  bucketsForPeriod,
+  isDayLimitReached,
+  periodLabel,
+  sliceByRange,
+} from "../menuTrendRange";
+
+const bucket = (overrides: Partial<MenuTrendBucket> = {}): MenuTrendBucket => ({
+  period: "2026-08",
+  total_amount: 620,
+  total_volume: 8200,
+  days_count: 4,
+  ...overrides,
+});
+
+const trend = (isWeightReps: boolean): MenuTrend => ({
+  menu: {
+    id: 1,
+    name: "メニュー",
+    unit: isWeightReps ? "weight_reps" : "count",
+    unit_label: isWeightReps ? "回" : "本",
+    is_weight_reps: isWeightReps,
+  },
+  by_year: [bucket({ period: "2026" })],
+  by_month: [bucket()],
+  by_day: [bucket({ period: "2026-08-03" })],
+});
+
+describe("バケットの取り出し", () => {
+  it("粒度に対応する配列を返す", () => {
+    const data = trend(false);
+
+    expect(bucketsForPeriod(data, "year")[0].period).toBe("2026");
+    expect(bucketsForPeriod(data, "month")[0].period).toBe("2026-08");
+    expect(bucketsForPeriod(data, "day")[0].period).toBe("2026-08-03");
+  });
+
+  it("レンジは新しい順の先頭から取る。全期間は絞らない", () => {
+    const buckets = [bucket(), bucket(), bucket()];
+
+    expect(sliceByRange(buckets, 2)).toHaveLength(2);
+    expect(sliceByRange(buckets, null)).toHaveLength(3);
+  });
+});
+
+describe("値の読み替え", () => {
+  it("weight_reps は総挙上重量、それ以外は量を使う", () => {
+    expect(bucketValue(trend(true), bucket())).toBe(8200);
+    expect(bucketValue(trend(false), bucket())).toBe(620);
+    expect(bucketValueText(trend(true), bucket())).toBe("8.2t");
+    expect(bucketValueText(trend(false), bucket())).toBe("620本");
+  });
+});
+
+describe("期間ラベル", () => {
+  it("粒度ごとに読みやすい形にする", () => {
+    expect(periodLabel("year", "2026")).toBe("2026年");
+    expect(periodLabel("month", "2026-08")).toBe("2026/8");
+    expect(periodLabel("day", "2026-08-03")).toBe("8/3");
+  });
+});
+
+describe("レンジの選択肢", () => {
+  it("粒度ごとに mobile と同じ選択肢を持つ", () => {
+    expect(TREND_RANGE_OPTIONS.year.map((option) => option.label)).toEqual([
+      "3年",
+      "5年",
+      "全期間",
+    ]);
+    expect(TREND_RANGE_OPTIONS.month.map((option) => option.label)).toEqual([
+      "6ヶ月",
+      "1年",
+      "2年",
+      "全期間",
+    ]);
+    expect(TREND_RANGE_OPTIONS.day.map((option) => option.label)).toEqual([
+      "2週間",
+      "1ヶ月",
+      "3ヶ月",
+      "全期間",
+    ]);
+  });
+});
+
+describe("日別の上限判定", () => {
+  const buckets = (count: number) =>
+    Array.from({ length: count }, () => bucket());
+
+  it("日別が60件に達したときだけ true", () => {
+    expect(isDayLimitReached("day", buckets(60))).toBe(true);
+    expect(isDayLimitReached("day", buckets(59))).toBe(false);
+    expect(isDayLimitReached("month", buckets(60))).toBe(false);
+  });
+});
+
+describe("サンプル推移", () => {
+  const menu = trend(false).menu;
+
+  it("年3件・月6件・日14件を新しい順に組み立てる", () => {
+    const sample = buildSampleMenuTrend(menu, new Date(2026, 7, 3));
+
+    expect(sample.by_year.map((item) => item.period)).toEqual([
+      "2026",
+      "2025",
+      "2024",
+    ]);
+    expect(sample.by_month).toHaveLength(6);
+    expect(sample.by_month[0].period).toBe("2026-08");
+    expect(sample.by_day).toHaveLength(14);
+    expect(sample.by_day[0].period).toBe("2026-08-03");
+  });
+
+  it("古いほど値が小さい右肩上がりの例にする", () => {
+    const sample = buildSampleMenuTrend(menu, new Date(2026, 7, 3));
+
+    expect(sample.by_year[0].total_amount).toBeGreaterThan(
+      sample.by_year[2].total_amount,
+    );
+  });
+
+  it("表示単位を決めるメニュー情報はそのまま引き継ぐ", () => {
+    const weightRepsMenu = trend(true).menu;
+
+    expect(buildSampleMenuTrend(weightRepsMenu).menu.is_weight_reps).toBe(true);
+  });
+});

--- a/app/(app)/practice/summary/[menuId]/_utils/menuTrendRange.ts
+++ b/app/(app)/practice/summary/[menuId]/_utils/menuTrendRange.ts
@@ -1,0 +1,104 @@
+import type { MenuTrend, MenuTrendBucket } from "@app/types/practice";
+import { formatTotalAmount, formatVolume } from "@app/constants/practice";
+import { TREND_DAY_LIMIT } from "../_components/menuTrendCopy";
+
+/** 集計の粒度。back のレスポンス（by_year / by_month / by_day）に1対1で対応する。 */
+export type TrendPeriod = "year" | "month" | "day";
+
+export const TREND_PERIOD_TABS: ReadonlyArray<{
+  key: TrendPeriod;
+  label: string;
+}> = [
+  { key: "year", label: "年別" },
+  { key: "month", label: "月別" },
+  { key: "day", label: "日別" },
+];
+
+export interface TrendRangeOption {
+  label: string;
+  /** 表示するバケット数（新しい順）。null は全期間。 */
+  limit: number | null;
+}
+
+/** 粒度ごとの表示レンジ。mobile の推移画面と同じ選択肢に揃える。 */
+export const TREND_RANGE_OPTIONS: Readonly<
+  Record<TrendPeriod, readonly TrendRangeOption[]>
+> = {
+  year: [
+    { label: "3年", limit: 3 },
+    { label: "5年", limit: 5 },
+    { label: "全期間", limit: null },
+  ],
+  month: [
+    { label: "6ヶ月", limit: 6 },
+    { label: "1年", limit: 12 },
+    { label: "2年", limit: 24 },
+    { label: "全期間", limit: null },
+  ],
+  day: [
+    { label: "2週間", limit: 14 },
+    { label: "1ヶ月", limit: 30 },
+    { label: "3ヶ月", limit: 90 },
+    { label: "全期間", limit: null },
+  ],
+};
+
+/** 粒度を切り替えたときに選ばれるレンジ。粒度ごとに選択肢が違うため個別に持つ。 */
+export const TREND_DEFAULT_RANGE_INDEX: Readonly<Record<TrendPeriod, number>> =
+  {
+    year: 2,
+    month: 1,
+    day: 1,
+  };
+
+/** 粒度に対応するバケット配列（新しい順）を取り出す。 */
+export const bucketsForPeriod = (
+  trend: MenuTrend,
+  period: TrendPeriod,
+): MenuTrendBucket[] => {
+  if (period === "year") return trend.by_year ?? [];
+  if (period === "month") return trend.by_month ?? [];
+  return trend.by_day ?? [];
+};
+
+/**
+ * レンジで直近 limit 件に絞る。バケットは新しい順で届くため先頭から取る。
+ * @param limit null なら絞り込まない（全期間）
+ */
+export const sliceByRange = (
+  buckets: MenuTrendBucket[],
+  limit: number | null,
+): MenuTrendBucket[] => (limit === null ? buckets : buckets.slice(0, limit));
+
+/** グラフに描く値。筋トレは総挙上重量、それ以外は量そのもの。 */
+export const bucketValue = (
+  trend: MenuTrend,
+  bucket: MenuTrendBucket,
+): number =>
+  trend.menu.is_weight_reps ? bucket.total_volume : bucket.total_amount;
+
+/** 一覧・ツールチップに出す値。筋トレは「8.2t」、それ以外は「200本」。 */
+export const bucketValueText = (
+  trend: MenuTrend,
+  bucket: MenuTrendBucket,
+): string =>
+  trend.menu.is_weight_reps
+    ? formatVolume(bucket.total_volume)
+    : formatTotalAmount(bucket.total_amount, trend.menu.unit_label);
+
+/** back の period（"2026" / "2026-08" / "2026-08-03"）を表示ラベルにする。 */
+export const periodLabel = (period: TrendPeriod, value: string): string => {
+  const [year, month, day] = value.split("-");
+  if (period === "year") return `${year}年`;
+  if (period === "month") return `${Number(year)}/${Number(month)}`;
+  return `${Number(month)}/${Number(day)}`;
+};
+
+/**
+ * 日別が back の上限（60 件）に達しているか。
+ * 上限に達していると、より広いレンジを選んでも表示件数が増えないため注記を出す。
+ */
+export const isDayLimitReached = (
+  period: TrendPeriod,
+  buckets: MenuTrendBucket[],
+): boolean => period === "day" && buckets.length >= TREND_DAY_LIMIT;

--- a/app/(app)/practice/summary/[menuId]/page.tsx
+++ b/app/(app)/practice/summary/[menuId]/page.tsx
@@ -1,0 +1,153 @@
+import type { MenuTrendView } from "./_components/MenuTrendContent";
+import type { MenuTrend } from "@app/types/practice";
+import type { Feature } from "@app/types/pro";
+import ArrowLeftIcon from "@heroicons/react/24/outline/ArrowLeftIcon";
+import { cookies } from "next/headers";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { getCachedProStatus } from "@app/(app)/pro/proStatus";
+import Header from "@app/components/header/Header";
+import { getPracticeMenus } from "@app/services/v2/practiceMenuService";
+import {
+  getMenuTrend,
+  getShadowSwingTrend,
+} from "@app/services/v2/practiceSummaryService";
+import { DEFAULT_PRO_STATUS } from "@app/types/pro";
+import {
+  SHADOW_SWING_MENU_NAME,
+  SHADOW_SWING_SOURCE,
+} from "../_utils/menuSummaryDisplay";
+import MenuTrendContent from "./_components/MenuTrendContent";
+import { TREND_PAGE_TITLE } from "./_components/menuTrendCopy";
+import { buildSampleMenuTrend } from "./_components/menuTrendSampleData";
+
+/** 推移詳細を開くのに必要な entitlement。back の 403 と同じキー。 */
+const FEATURE = "practice_menu_trend_detail";
+
+/** 素振りはメニューに紐付かないことがあるため、back も別エンドポイントで集計する。 */
+const SHADOW_SWING_MENU: MenuTrend["menu"] = {
+  id: null,
+  name: SHADOW_SWING_MENU_NAME,
+  unit: "count",
+  unit_label: "本",
+  is_weight_reps: false,
+};
+
+/** メニューを引けないとき（削除済みなど）にサンプルの見出しへ使う名前。 */
+const UNKNOWN_MENU_NAME = "メニュー";
+
+export const metadata = {
+  title: TREND_PAGE_TITLE,
+  robots: { index: false },
+};
+
+interface PracticeMenuTrendPageProps {
+  params: Promise<{ menuId: string }>;
+  searchParams: Promise<{ source?: string }>;
+}
+
+/**
+ * サンプル表示用のメニュー情報を組み立てる。
+ * 推移 API は Pro 限定なので叩けない。単位だけは合わせたいので、
+ * Pro 限定ではないメニュー一覧から名称・単位を引く。
+ */
+async function resolveSampleMenu(menuId: number): Promise<MenuTrend["menu"]> {
+  const menusResult = await getPracticeMenus();
+  const menu =
+    menusResult.status === "ok"
+      ? menusResult.data.find((item) => item.id === menuId)
+      : undefined;
+
+  return {
+    id: menu?.id ?? menuId,
+    name: menu?.name ?? UNKNOWN_MENU_NAME,
+    unit: menu?.unit ?? "count",
+    unit_label: menu?.unit_label ?? null,
+    is_weight_reps: menu?.unit === "weight_reps",
+  };
+}
+
+async function buildSampleView(
+  isShadowSwing: boolean,
+  menuId: number,
+): Promise<MenuTrendView> {
+  const menu = isShadowSwing
+    ? SHADOW_SWING_MENU
+    : await resolveSampleMenu(menuId);
+  return { kind: "sample", trend: buildSampleMenuTrend(menu) };
+}
+
+/**
+ * 表示すべき内容を決める。
+ * entitlement を持たないうちは推移 API を一切叩かず、サンプルだけを組み立てる。
+ *
+ * @param entitlements サーバーで解決した閲覧権限（未認証・取得失敗時は無料相当）
+ */
+async function resolveView(
+  isShadowSwing: boolean,
+  menuId: number,
+  entitlements: readonly Feature[],
+): Promise<MenuTrendView> {
+  if (!entitlements.includes(FEATURE)) {
+    return buildSampleView(isShadowSwing, menuId);
+  }
+
+  const result = isShadowSwing
+    ? await getShadowSwingTrend()
+    : await getMenuTrend(menuId);
+
+  if (result.status === "ok") return { kind: "trend", trend: result.data };
+  // entitlement の判定とサーバーの判定がずれた場合の 403。取得失敗とは区別する。
+  if (result.status === "forbidden") {
+    return buildSampleView(isShadowSwing, menuId);
+  }
+  return { kind: "error" };
+}
+
+export default async function PracticeMenuTrendPage({
+  params,
+  searchParams,
+}: PracticeMenuTrendPageProps) {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const [{ menuId }, { source }] = await Promise.all([params, searchParams]);
+  const isShadowSwing = source === SHADOW_SWING_SOURCE;
+  const numericMenuId = Number(menuId);
+  if (!isShadowSwing && !Number.isInteger(numericMenuId)) {
+    notFound();
+  }
+
+  // 推移詳細は Pro 限定。無料ユーザーには 403 を踏ませず、そもそも API を叩かない。
+  const proStatus = await getCachedProStatus();
+  const view = await resolveView(
+    isShadowSwing,
+    numericMenuId,
+    proStatus?.entitlements ?? DEFAULT_PRO_STATUS.entitlements,
+  );
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            <Link
+              href="/practice/summary"
+              className="inline-flex items-center gap-1 text-xs font-semibold text-zinc-400"
+            >
+              <ArrowLeftIcon className="h-3.5 w-3.5" aria-hidden />
+              積み上げサマリー
+            </Link>
+
+            <div className="mt-3 mb-10">
+              <MenuTrendContent view={view} />
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/(app)/practice/summary/__tests__/page.test.tsx
+++ b/app/(app)/practice/summary/__tests__/page.test.tsx
@@ -1,0 +1,263 @@
+const mockCookieGet = jest.fn();
+const mockRedirect = jest.fn((path: string) => {
+  throw new Error(`NEXT_REDIRECT:${path}`);
+});
+const mockGetMenuSummaries = jest.fn();
+const mockGetPracticeMenus = jest.fn();
+const mockGetPracticeOverview = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: () => Promise.resolve({ get: mockCookieGet }),
+}));
+
+jest.mock("next/navigation", () => ({
+  redirect: (path: string) => mockRedirect(path),
+}));
+
+jest.mock("@app/services/v2/practiceSummaryService", () => ({
+  getMenuSummaries: () => mockGetMenuSummaries(),
+  getPracticeOverview: () => mockGetPracticeOverview(),
+}));
+
+jest.mock("@app/services/v2/practiceMenuService", () => ({
+  getPracticeMenus: () => mockGetPracticeMenus(),
+}));
+
+jest.mock("@app/components/header/Header", () => ({
+  __esModule: true,
+  default: () => <header />,
+}));
+
+import type { MenuSummary, PracticeMenu } from "@app/types/practice";
+import { render, screen, within } from "@testing-library/react";
+import PracticeSummaryPage from "../page";
+
+const buildSummary = (overrides: Partial<MenuSummary> = {}): MenuSummary => ({
+  practice_menu_id: 1,
+  menu_name: "素振り",
+  unit: "count",
+  unit_label: "本",
+  total_amount: 12400,
+  total_volume: null,
+  this_month_amount: 800,
+  this_month_volume: null,
+  days_count: 40,
+  last_logged_on: "2026-08-03",
+  ...overrides,
+});
+
+const buildMenu = (overrides: Partial<PracticeMenu> = {}): PracticeMenu => ({
+  id: 1,
+  name: "素振り",
+  category: "batting",
+  unit: "count",
+  unit_label: "本",
+  default_value: null,
+  is_favorite: false,
+  sort_order: 0,
+  ...overrides,
+});
+
+function setAuthCookies() {
+  mockCookieGet.mockImplementation((key: string) =>
+    key === "access-token" ? { value: "test-access-token" } : undefined,
+  );
+}
+
+async function renderPage({
+  summaries = [buildSummary()],
+  menus = [buildMenu()],
+  summariesStatus = "ok",
+  overview = null as unknown,
+}: {
+  summaries?: MenuSummary[];
+  menus?: PracticeMenu[];
+  summariesStatus?: "ok" | "error";
+  overview?: unknown;
+} = {}) {
+  setAuthCookies();
+  mockGetMenuSummaries.mockResolvedValue(
+    summariesStatus === "ok"
+      ? { status: "ok", data: summaries }
+      : { status: "error" },
+  );
+  mockGetPracticeMenus.mockResolvedValue({ status: "ok", data: menus });
+  mockGetPracticeOverview.mockResolvedValue(
+    overview === null ? { status: "error" } : { status: "ok", data: overview },
+  );
+  render(await PracticeSummaryPage());
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("認証", () => {
+  it("未ログインはサインアップへ送り、API を叩かない", async () => {
+    mockCookieGet.mockReturnValue(undefined);
+
+    await expect(PracticeSummaryPage()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mockRedirect).toHaveBeenCalledWith("/signup?auth_required=true");
+    expect(mockGetMenuSummaries).not.toHaveBeenCalled();
+  });
+});
+
+describe("カードの並び", () => {
+  it("最終記録日が新しい順に並べ、未記録のメニューを末尾に置く", async () => {
+    await renderPage({
+      summaries: [
+        buildSummary({
+          practice_menu_id: 1,
+          menu_name: "ティー",
+          last_logged_on: "2026-07-01",
+        }),
+        buildSummary({
+          practice_menu_id: 2,
+          menu_name: "素振り",
+          last_logged_on: "2026-08-03",
+        }),
+      ],
+      menus: [
+        buildMenu({ id: 1, name: "ティー" }),
+        buildMenu({ id: 2, name: "素振り" }),
+        buildMenu({ id: 3, name: "ランニング", unit: "distance" }),
+      ],
+    });
+
+    const links = screen.getAllByRole("link");
+    expect(links.map((link) => link.getAttribute("aria-label"))).toEqual([
+      "素振りの推移を見る",
+      "ティーの推移を見る",
+      "ランニングの推移を見る",
+    ]);
+    expect(screen.getByText("まだ記録がありません")).toBeInTheDocument();
+  });
+});
+
+describe("表示単位", () => {
+  it("通常メニューは累計と今月を本数で出す", async () => {
+    await renderPage();
+
+    expect(screen.getByText("累計")).toBeInTheDocument();
+    expect(screen.getByText("12,400本")).toBeInTheDocument();
+    expect(screen.getByText("800本")).toBeInTheDocument();
+    expect(screen.queryByText("総挙上重量")).not.toBeInTheDocument();
+  });
+
+  it("weight_reps は総挙上重量を t / kg で出し、回数は補足に回す", async () => {
+    await renderPage({
+      summaries: [
+        buildSummary({
+          practice_menu_id: 5,
+          menu_name: "ベンチプレス",
+          unit: "weight_reps",
+          unit_label: "回",
+          total_amount: 620,
+          total_volume: 8200,
+          this_month_amount: 80,
+          this_month_volume: 640,
+          days_count: 12,
+        }),
+      ],
+      menus: [buildMenu({ id: 5, name: "ベンチプレス", category: "strength" })],
+    });
+
+    expect(screen.getByText("総挙上重量")).toBeInTheDocument();
+    expect(screen.getByText("8.2t")).toBeInTheDocument();
+    expect(screen.getByText("640kg")).toBeInTheDocument();
+    expect(screen.getByText(/累計 620回/)).toBeInTheDocument();
+    expect(screen.queryByText("8,200本")).not.toBeInTheDocument();
+  });
+});
+
+describe("推移への導線", () => {
+  it("メニューに紐付く記録は推移ページへリンクする", async () => {
+    await renderPage({
+      summaries: [buildSummary({ practice_menu_id: 4, menu_name: "ティー" })],
+      menus: [buildMenu({ id: 4, name: "ティー" })],
+    });
+
+    expect(
+      screen.getByRole("link", { name: "ティーの推移を見る" }),
+    ).toHaveAttribute("href", "/practice/summary/4");
+  });
+
+  it("メニュー未紐付けの素振りは source 付きのリンクにする", async () => {
+    await renderPage({
+      summaries: [
+        buildSummary({ practice_menu_id: null, menu_name: "素振り" }),
+      ],
+      menus: [],
+    });
+
+    expect(
+      screen.getByRole("link", { name: "素振りの推移を見る" }),
+    ).toHaveAttribute(
+      "href",
+      "/practice/summary/shadow_swing?source=shadow_swing",
+    );
+  });
+
+  it("削除済みメニューの記録はリンクにせず、その旨を添える", async () => {
+    await renderPage({
+      summaries: [
+        buildSummary({ practice_menu_id: null, menu_name: "消したメニュー" }),
+      ],
+      menus: [],
+    });
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("削除したメニューの記録")).toBeInTheDocument();
+  });
+});
+
+describe("0件と取得失敗", () => {
+  it("記録も未記録メニューも無ければ空の案内を出す", async () => {
+    await renderPage({ summaries: [], menus: [] });
+
+    expect(screen.getByText("まだ練習の記録がありません")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/積み上げサマリーを取得できませんでした/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("取得失敗は 0 件と区別してエラーを出す", async () => {
+    await renderPage({ summariesStatus: "error" });
+
+    expect(
+      screen.getByText(/積み上げサマリーを取得できませんでした/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("まだ練習の記録がありません"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("KPI ヘッダ", () => {
+  it("取得できた全体 KPI を表示する", async () => {
+    await renderPage({
+      overview: {
+        total_practice_days: 120,
+        this_month_practice_days: 12,
+        total_swing_count: 4800,
+        total_volume: 8200,
+        total_menus: 5,
+      },
+    });
+
+    const header = screen.getByRole("region", { name: "練習全体の積み上げ" });
+    expect(within(header).getByText("120日")).toBeInTheDocument();
+    expect(within(header).getByText("12日")).toBeInTheDocument();
+    expect(within(header).getByText("8.2t")).toBeInTheDocument();
+    expect(within(header).getByText("4,800本")).toBeInTheDocument();
+  });
+
+  it("KPI の取得に失敗してもカードは表示する", async () => {
+    await renderPage();
+
+    expect(
+      screen.queryByRole("region", { name: "練習全体の積み上げ" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("12,400本")).toBeInTheDocument();
+  });
+});

--- a/app/(app)/practice/summary/__tests__/page.test.tsx
+++ b/app/(app)/practice/summary/__tests__/page.test.tsx
@@ -141,6 +141,7 @@ describe("表示単位", () => {
     expect(screen.getByText("累計")).toBeInTheDocument();
     expect(screen.getByText("12,400本")).toBeInTheDocument();
     expect(screen.getByText("800本")).toBeInTheDocument();
+    expect(screen.getByText("記録 40日 ・ 最終 8/3")).toBeInTheDocument();
     expect(screen.queryByText("総挙上重量")).not.toBeInTheDocument();
   });
 
@@ -165,7 +166,9 @@ describe("表示単位", () => {
     expect(screen.getByText("総挙上重量")).toBeInTheDocument();
     expect(screen.getByText("8.2t")).toBeInTheDocument();
     expect(screen.getByText("640kg")).toBeInTheDocument();
-    expect(screen.getByText(/累計 620回/)).toBeInTheDocument();
+    expect(
+      screen.getByText("累計 620回 ・ 記録 12日 ・ 最終 8/3"),
+    ).toBeInTheDocument();
     expect(screen.queryByText("8,200本")).not.toBeInTheDocument();
   });
 });

--- a/app/(app)/practice/summary/_components/MenuSummaryCard.tsx
+++ b/app/(app)/practice/summary/_components/MenuSummaryCard.tsx
@@ -1,0 +1,99 @@
+import type { MenuSummaryCard as MenuSummaryCardData } from "../_utils/menuSummaryDisplay";
+import ChevronRightIcon from "@heroicons/react/24/outline/ChevronRightIcon";
+import Link from "next/link";
+import {
+  PRACTICE_CATEGORY_ICONS,
+  SHADOW_SWING_ICON,
+  formatTotalAmount,
+} from "@app/constants/practice";
+import {
+  formatLastLoggedOn,
+  isWeightRepsSummary,
+  summaryMonthText,
+  summaryTotalLabel,
+  summaryTotalText,
+} from "../_utils/menuSummaryDisplay";
+import { ARCHIVED_MENU_NOTE, NOT_RECORDED_LABEL } from "./practiceSummaryCopy";
+
+interface MenuSummaryCardProps {
+  card: MenuSummaryCardData;
+}
+
+function StatTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex-1 rounded-[10px] bg-main px-3 py-2.5">
+      <p className="text-[11px] font-semibold text-zinc-400">{label}</p>
+      <p className="mt-1 text-xl font-extrabold text-[#d08000]">{value}</p>
+    </div>
+  );
+}
+
+/**
+ * メニュー1件の積み上げカード（累計 / 今月 + 補足）。
+ * 筋トレ（重さ×回数）は総挙上重量を主役にし、補足へ累計回数を回す。
+ * それ以外は量そのもの（本 / 分 / km など）を主役にする。
+ */
+export default function MenuSummaryCard({ card }: MenuSummaryCardProps) {
+  const { summary, category, href, isShadowSwing } = card;
+  const Icon = isShadowSwing
+    ? SHADOW_SWING_ICON
+    : (PRACTICE_CATEGORY_ICONS[category ?? "other"] ??
+      PRACTICE_CATEGORY_ICONS.other);
+  const isWeightReps = isWeightRepsSummary(summary);
+  const hasRecords = summary.days_count > 0;
+
+  const body = (
+    <>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Icon className="h-5 w-5 shrink-0 text-[#d08000]" aria-hidden />
+          <span className="truncate text-[15px] font-bold text-white">
+            {summary.menu_name}
+          </span>
+        </div>
+        {href ? (
+          <ChevronRightIcon
+            className="h-4 w-4 shrink-0 text-zinc-400"
+            aria-hidden
+          />
+        ) : null}
+      </div>
+
+      <div className="mt-3 flex gap-2.5">
+        <StatTile
+          label={summaryTotalLabel(summary)}
+          value={summaryTotalText(summary)}
+        />
+        <StatTile label="今月" value={summaryMonthText(summary)} />
+      </div>
+
+      {hasRecords ? (
+        <p className="mt-2.5 text-xs text-zinc-400">
+          {isWeightReps
+            ? `累計 ${formatTotalAmount(summary.total_amount, "回")} ・ 記録 ${summary.days_count}日 ・ 最終 ${formatLastLoggedOn(summary.last_logged_on)}`
+            : `記録 ${summary.days_count}日 ・ 最終 ${formatLastLoggedOn(summary.last_logged_on)}`}
+        </p>
+      ) : (
+        <p className="mt-2.5 text-xs text-zinc-400">{NOT_RECORDED_LABEL}</p>
+      )}
+
+      {href === null ? (
+        <p className="mt-1 text-[11px] text-zinc-500">{ARCHIVED_MENU_NOTE}</p>
+      ) : null}
+    </>
+  );
+
+  if (!href) {
+    return <div className="rounded-xl bg-sub p-3.5">{body}</div>;
+  }
+
+  return (
+    <Link
+      href={href}
+      aria-label={`${summary.menu_name}の推移を見る`}
+      className="block rounded-xl bg-sub p-3.5 transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000]"
+    >
+      {body}
+    </Link>
+  );
+}

--- a/app/(app)/practice/summary/_components/PracticeOverviewHeader.tsx
+++ b/app/(app)/practice/summary/_components/PracticeOverviewHeader.tsx
@@ -1,0 +1,53 @@
+import type { PracticeOverview } from "@app/types/practice";
+import { formatTotalAmount, formatVolume } from "@app/constants/practice";
+
+interface PracticeOverviewHeaderProps {
+  overview: PracticeOverview;
+}
+
+function KpiTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[10px] bg-main px-3 py-2.5">
+      <p className="text-[11px] font-semibold text-zinc-400">{label}</p>
+      <p className="mt-1 text-lg font-extrabold text-white">{value}</p>
+    </div>
+  );
+}
+
+/**
+ * 練習全体の KPI ヘッダ（GET /api/v2/practice_overview）。
+ * メニュー別カードの前に「全体でどれだけ積み上がったか」を置き、
+ * カードは個々のメニューの内訳として読めるようにする。
+ */
+export default function PracticeOverviewHeader({
+  overview,
+}: PracticeOverviewHeaderProps) {
+  return (
+    <section
+      aria-label="練習全体の積み上げ"
+      className="rounded-xl bg-sub p-3.5"
+    >
+      <div className="grid grid-cols-2 gap-2.5">
+        <KpiTile
+          label="累計練習日数"
+          value={`${overview.total_practice_days.toLocaleString("ja-JP")}日`}
+        />
+        <KpiTile
+          label="今月の練習日数"
+          value={`${overview.this_month_practice_days.toLocaleString("ja-JP")}日`}
+        />
+        <KpiTile
+          label="総挙上重量"
+          value={formatVolume(overview.total_volume)}
+        />
+        <KpiTile
+          label="素振り累計"
+          value={formatTotalAmount(overview.total_swing_count, "本")}
+        />
+      </div>
+      <p className="mt-2.5 text-xs text-zinc-400">
+        登録中のメニュー {overview.total_menus}件
+      </p>
+    </section>
+  );
+}

--- a/app/(app)/practice/summary/_components/practiceSummaryCopy.ts
+++ b/app/(app)/practice/summary/_components/practiceSummaryCopy.ts
@@ -1,0 +1,24 @@
+/**
+ * 積み上げサマリー / 推移グラフ画面の文言。
+ * 「Pro 限定機能」と「無料枠の超過」は back の 403 でも意味が違うため、
+ * 推移詳細まわりの文言は必ず Pro 限定（プランで開放される機能）の文脈で書く。
+ */
+
+export const SUMMARY_PAGE_TITLE = "積み上げサマリー";
+
+export const SUMMARY_PAGE_DESCRIPTION =
+  "メニューごとの累計と今月の積み上げをまとめて確認できます。カードを開くと推移グラフを見られます。";
+
+/** 取得失敗。0 件（まだ記録がない）と取り違えないよう別文言にする。 */
+export const SUMMARY_LOAD_ERROR =
+  "積み上げサマリーを取得できませんでした。時間を置いて再度お試しください。";
+
+export const SUMMARY_EMPTY = "まだ練習の記録がありません";
+
+export const SUMMARY_EMPTY_HINT =
+  "練習を記録すると、メニューごとの累計がここに積み上がります。";
+
+/** 削除済みメニューの記録。推移は practice_menu の id 単位で集計するため開けない。 */
+export const ARCHIVED_MENU_NOTE = "削除したメニューの記録";
+
+export const NOT_RECORDED_LABEL = "まだ記録がありません";

--- a/app/(app)/practice/summary/_utils/__tests__/menuSummaryDisplay.test.ts
+++ b/app/(app)/practice/summary/_utils/__tests__/menuSummaryDisplay.test.ts
@@ -1,0 +1,174 @@
+import type { MenuSummary, PracticeMenu } from "@app/types/practice";
+import {
+  buildMenuSummaryCards,
+  formatLastLoggedOn,
+  isWeightRepsSummary,
+  summaryMonthText,
+  summaryTotalLabel,
+  summaryTotalText,
+} from "../menuSummaryDisplay";
+
+const buildSummary = (overrides: Partial<MenuSummary> = {}): MenuSummary => ({
+  practice_menu_id: 1,
+  menu_name: "素振り",
+  unit: "count",
+  unit_label: "本",
+  total_amount: 12400,
+  total_volume: null,
+  this_month_amount: 800,
+  this_month_volume: null,
+  days_count: 40,
+  last_logged_on: "2026-08-03",
+  ...overrides,
+});
+
+const buildMenu = (overrides: Partial<PracticeMenu> = {}): PracticeMenu => ({
+  id: 1,
+  name: "素振り",
+  category: "batting",
+  unit: "count",
+  unit_label: "本",
+  default_value: null,
+  is_favorite: false,
+  sort_order: 0,
+  ...overrides,
+});
+
+const weightRepsSummary = buildSummary({
+  practice_menu_id: 2,
+  menu_name: "ベンチプレス",
+  unit: "weight_reps",
+  unit_label: "回",
+  total_amount: 620,
+  total_volume: 8200,
+  this_month_amount: 80,
+  this_month_volume: 640,
+});
+
+describe("表示単位の出し分け", () => {
+  it("通常メニューは累計を本数で出す", () => {
+    const summary = buildSummary();
+
+    expect(summaryTotalLabel(summary)).toBe("累計");
+    expect(summaryTotalText(summary)).toBe("12,400本");
+    expect(summaryMonthText(summary)).toBe("800本");
+  });
+
+  it("weight_reps は総挙上重量（t / kg）で出す", () => {
+    expect(isWeightRepsSummary(weightRepsSummary)).toBe(true);
+    expect(summaryTotalLabel(weightRepsSummary)).toBe("総挙上重量");
+    expect(summaryTotalText(weightRepsSummary)).toBe("8.2t");
+    expect(summaryMonthText(weightRepsSummary)).toBe("640kg");
+  });
+
+  it("unit が weight_reps でなくても重さ付きの記録があれば重量で出す", () => {
+    const summary = buildSummary({
+      unit: "count",
+      total_volume: 1500,
+      this_month_volume: 300,
+    });
+
+    expect(isWeightRepsSummary(summary)).toBe(true);
+    expect(summaryTotalText(summary)).toBe("1.5t");
+  });
+
+  it("単位ラベルが無いメニューは数値だけを出す", () => {
+    expect(summaryTotalText(buildSummary({ unit_label: null }))).toBe("12,400");
+  });
+
+  it("最終記録日は月/日にし、未記録は - にする", () => {
+    expect(formatLastLoggedOn("2026-08-03")).toBe("8/3");
+    expect(formatLastLoggedOn(null)).toBe("-");
+  });
+});
+
+describe("カードの並び", () => {
+  it("最終記録日が新しい順に並べる", () => {
+    const cards = buildMenuSummaryCards(
+      [
+        buildSummary({
+          practice_menu_id: 1,
+          menu_name: "古い",
+          last_logged_on: "2026-07-01",
+        }),
+        buildSummary({
+          practice_menu_id: 2,
+          menu_name: "新しい",
+          last_logged_on: "2026-08-03",
+        }),
+      ],
+      [],
+    );
+
+    expect(cards.map((card) => card.summary.menu_name)).toEqual([
+      "新しい",
+      "古い",
+    ]);
+  });
+
+  it("未記録のメニューを補い、記録済みより後ろに置く", () => {
+    const cards = buildMenuSummaryCards(
+      [
+        buildSummary({
+          practice_menu_id: 1,
+          menu_name: "記録あり",
+          last_logged_on: "2026-01-05",
+        }),
+      ],
+      [
+        buildMenu({ id: 1, name: "記録あり" }),
+        buildMenu({ id: 9, name: "未記録" }),
+      ],
+    );
+
+    expect(cards.map((card) => card.summary.menu_name)).toEqual([
+      "記録あり",
+      "未記録",
+    ]);
+    expect(cards[1].summary.days_count).toBe(0);
+    expect(cards[1].summary.last_logged_on).toBeNull();
+  });
+
+  it("メニューのカテゴリをカードに載せる", () => {
+    const cards = buildMenuSummaryCards(
+      [buildSummary({ practice_menu_id: 3 })],
+      [buildMenu({ id: 3, category: "strength" })],
+    );
+
+    expect(cards[0].category).toBe("strength");
+  });
+});
+
+describe("推移ページへのリンク", () => {
+  it("メニューに紐付く記録はメニュー id のパスへ送る", () => {
+    const [card] = buildMenuSummaryCards(
+      [buildSummary({ practice_menu_id: 7 })],
+      [],
+    );
+
+    expect(card.href).toBe("/practice/summary/7");
+  });
+
+  it("メニュー未紐付けの素振りは source=shadow_swing 付きのパスへ送る", () => {
+    const [card] = buildMenuSummaryCards(
+      [buildSummary({ practice_menu_id: null, menu_name: "素振り" })],
+      [],
+    );
+
+    expect(card.isShadowSwing).toBe(true);
+    expect(card.href).toBe(
+      "/practice/summary/shadow_swing?source=shadow_swing",
+    );
+  });
+
+  it("削除済みメニューの記録は推移を開けない", () => {
+    const [card] = buildMenuSummaryCards(
+      [buildSummary({ practice_menu_id: null, menu_name: "消したメニュー" })],
+      [],
+    );
+
+    expect(card.isShadowSwing).toBe(false);
+    expect(card.href).toBeNull();
+    expect(card.summary.menu_name).toBe("消したメニュー");
+  });
+});

--- a/app/(app)/practice/summary/_utils/__tests__/menuSummaryDisplay.test.ts
+++ b/app/(app)/practice/summary/_utils/__tests__/menuSummaryDisplay.test.ts
@@ -125,6 +125,8 @@ describe("カードの並び", () => {
       "記録あり",
       "未記録",
     ]);
+    // 記録日が古くても、未記録より前に並ぶ（未記録は必ず末尾）。
+    expect(cards[0].summary.last_logged_on).toBe("2026-01-05");
     expect(cards[1].summary.days_count).toBe(0);
     expect(cards[1].summary.last_logged_on).toBeNull();
   });

--- a/app/(app)/practice/summary/_utils/menuSummaryDisplay.ts
+++ b/app/(app)/practice/summary/_utils/menuSummaryDisplay.ts
@@ -1,0 +1,136 @@
+import type {
+  MenuSummary,
+  PracticeCategory,
+  PracticeMenu,
+} from "@app/types/practice";
+import { formatTotalAmount, formatVolume } from "@app/constants/practice";
+
+/**
+ * 素振り自動ログのメニュー名。back の ShadowSwingSession::MENU_NAME と一致させる。
+ * 素振りは練習メニューに紐付かないことがあり、その場合サマリーの practice_menu_id が
+ * null になるため、名前で素振りだと見分ける。
+ */
+export const SHADOW_SWING_MENU_NAME = "素振り";
+
+/** 素振りの推移は別エンドポイントを叩くため、パスではなく source で切り替える。 */
+export const SHADOW_SWING_SOURCE = "shadow_swing";
+
+/** 素振りの推移ページのパス。メニュー id を持たないので固定のセグメントを使う。 */
+export const SHADOW_SWING_TREND_HREF = `/practice/summary/${SHADOW_SWING_SOURCE}?source=${SHADOW_SWING_SOURCE}`;
+
+/** 1枚のカードに必要な表示情報。 */
+export interface MenuSummaryCard {
+  /** リストの key。メニュー削除後は id が無いので名前で代用する。 */
+  key: string;
+  summary: MenuSummary;
+  /** アイコン選択に使うカテゴリ。メニューが引けない（削除済み）場合は null。 */
+  category: PracticeCategory | null;
+  /** 推移ページへのリンク。開けない記録（削除済みメニュー）は null。 */
+  href: string | null;
+  /** 素振り自動ログの積み上げかどうか。 */
+  isShadowSwing: boolean;
+}
+
+/**
+ * 筋トレ（重さ×回数）の積み上げかどうか。
+ * back は unit が weight_reps でなくても重さ付きのログがあれば total_volume を返すため、
+ * unit だけでなく total_volume の有無も見る（mobile の判定と揃える）。
+ */
+export const isWeightRepsSummary = (summary: MenuSummary): boolean =>
+  summary.unit === "weight_reps" || summary.total_volume != null;
+
+/**
+ * カードのメイン数値のラベル。
+ * 筋トレは重さの積み上げ（総挙上重量）、それ以外は量の累計を主役にする。
+ */
+export const summaryTotalLabel = (summary: MenuSummary): string =>
+  isWeightRepsSummary(summary) ? "総挙上重量" : "累計";
+
+/** 累計の表示値。筋トレは「8.2t」、それ以外は「12,400本」。 */
+export const summaryTotalText = (summary: MenuSummary): string =>
+  isWeightRepsSummary(summary)
+    ? formatVolume(summary.total_volume ?? 0)
+    : formatTotalAmount(summary.total_amount, summary.unit_label);
+
+/** 今月の表示値。累計と同じ単位で出す（筋トレは「640kg」のように kg 表記になる）。 */
+export const summaryMonthText = (summary: MenuSummary): string =>
+  isWeightRepsSummary(summary)
+    ? formatVolume(summary.this_month_volume ?? 0)
+    : formatTotalAmount(summary.this_month_amount, summary.unit_label);
+
+/** 最終記録日を「8/3」の形にする。未記録は "-"。 */
+export const formatLastLoggedOn = (isoDate: string | null): string => {
+  if (!isoDate) return "-";
+  const [, month, day] = isoDate.split("-");
+  if (!month || !day) return "-";
+  return `${Number(month)}/${Number(day)}`;
+};
+
+/** まだ一度も記録していないメニューの空サマリー。 */
+const emptySummary = (menu: PracticeMenu): MenuSummary => ({
+  practice_menu_id: menu.id,
+  menu_name: menu.name,
+  unit: menu.unit,
+  unit_label: menu.unit_label,
+  total_amount: 0,
+  total_volume: menu.unit === "weight_reps" ? 0 : null,
+  this_month_amount: 0,
+  this_month_volume: menu.unit === "weight_reps" ? 0 : null,
+  days_count: 0,
+  last_logged_on: null,
+});
+
+const buildCard = (
+  summary: MenuSummary,
+  categoryById: Map<number, PracticeCategory>,
+): MenuSummaryCard => {
+  const menuId = summary.practice_menu_id;
+  const isShadowSwing =
+    menuId === null && summary.menu_name === SHADOW_SWING_MENU_NAME;
+
+  return {
+    key: menuId === null ? `name:${summary.menu_name}` : `menu:${menuId}`,
+    summary,
+    category: menuId === null ? null : (categoryById.get(menuId) ?? null),
+    // 削除済みメニューの記録は practice_menu_id が null になり、推移を集計できない。
+    href:
+      menuId !== null
+        ? `/practice/summary/${menuId}`
+        : isShadowSwing
+          ? SHADOW_SWING_TREND_HREF
+          : null,
+    isShadowSwing,
+  };
+};
+
+/**
+ * サマリーと登録メニューを突き合わせ、カードの表示順を決める。
+ *
+ * 並びは最終記録日の新しい順。まだ記録していないメニューは日付を持たないため末尾に置く。
+ * back のサマリーは記録のあるメニューしか含まないので、未記録のメニューはここで補う。
+ *
+ * @param summaries back のメニュー別サマリー（記録のあるものだけ）
+ * @param menus 登録中の練習メニュー。カテゴリアイコンと未記録メニューの補完に使う
+ */
+export const buildMenuSummaryCards = (
+  summaries: MenuSummary[],
+  menus: PracticeMenu[],
+): MenuSummaryCard[] => {
+  const categoryById = new Map(menus.map((menu) => [menu.id, menu.category]));
+  const recordedMenuIds = new Set(
+    summaries
+      .map((summary) => summary.practice_menu_id)
+      .filter((id): id is number => id !== null),
+  );
+  const unrecorded = menus
+    .filter((menu) => !recordedMenuIds.has(menu.id))
+    .map(emptySummary);
+
+  return [...summaries, ...unrecorded]
+    .map((summary) => buildCard(summary, categoryById))
+    .sort((a, b) =>
+      (b.summary.last_logged_on ?? "").localeCompare(
+        a.summary.last_logged_on ?? "",
+      ),
+    );
+};

--- a/app/(app)/practice/summary/page.tsx
+++ b/app/(app)/practice/summary/page.tsx
@@ -1,0 +1,89 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getPracticeMenus } from "@app/services/v2/practiceMenuService";
+import {
+  getMenuSummaries,
+  getPracticeOverview,
+} from "@app/services/v2/practiceSummaryService";
+import MenuSummaryCard from "./_components/MenuSummaryCard";
+import PracticeOverviewHeader from "./_components/PracticeOverviewHeader";
+import {
+  SUMMARY_EMPTY,
+  SUMMARY_EMPTY_HINT,
+  SUMMARY_LOAD_ERROR,
+  SUMMARY_PAGE_DESCRIPTION,
+  SUMMARY_PAGE_TITLE,
+} from "./_components/practiceSummaryCopy";
+import { buildMenuSummaryCards } from "./_utils/menuSummaryDisplay";
+
+export const metadata = {
+  title: SUMMARY_PAGE_TITLE,
+  robots: { index: false },
+};
+
+export default async function PracticeSummaryPage() {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  // 3つは互いに依存しないため並列で取得する。KPI は落ちても本体（カード）は出す。
+  const [summariesResult, menusResult, overviewResult] = await Promise.all([
+    getMenuSummaries(),
+    getPracticeMenus(),
+    getPracticeOverview(),
+  ]);
+
+  // メニュー一覧は未記録メニューの補完とカテゴリアイコンにだけ使うので、
+  // 取得できなくてもサマリーは表示する。
+  const menus = menusResult.status === "ok" ? menusResult.data : [];
+  const cards =
+    summariesResult.status === "ok"
+      ? buildMenuSummaryCards(summariesResult.data, menus)
+      : [];
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            <h2 className="text-2xl font-bold">{SUMMARY_PAGE_TITLE}</h2>
+            <p className="mt-2 text-sm text-zinc-300">
+              {SUMMARY_PAGE_DESCRIPTION}
+            </p>
+
+            {overviewResult.status === "ok" ? (
+              <div className="mt-6">
+                <PracticeOverviewHeader overview={overviewResult.data} />
+              </div>
+            ) : null}
+
+            <div className="my-6 flex flex-col gap-3">
+              {summariesResult.status !== "ok" ? (
+                // 取得失敗を 0 件に丸めると「まだ記録がない」と誤って伝えてしまう。
+                <p className="py-8 text-center text-sm text-zinc-400">
+                  {SUMMARY_LOAD_ERROR}
+                </p>
+              ) : cards.length === 0 ? (
+                <div className="py-8 text-center">
+                  <p className="text-sm font-semibold text-zinc-400">
+                    {SUMMARY_EMPTY}
+                  </p>
+                  <p className="mt-1 text-xs text-zinc-500">
+                    {SUMMARY_EMPTY_HINT}
+                  </p>
+                </div>
+              ) : (
+                cards.map((card) => (
+                  <MenuSummaryCard key={card.key} card={card} />
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/services/v2/__tests__/practiceServices.test.ts
+++ b/app/services/v2/__tests__/practiceServices.test.ts
@@ -41,6 +41,7 @@ import {
   getMenuSummaries,
   getMenuTrend,
   getPracticeOverview,
+  getShadowSwingTrend,
 } from "../practiceSummaryService";
 import { buildQuery } from "../requests";
 
@@ -495,6 +496,39 @@ describe("練習ドメインの v2 Server Actions", () => {
       });
 
       expect(await getMenuTrend(3)).toEqual({ status: "forbidden" });
+    });
+
+    it("素振りの推移はメニュー推移とは別のエンドポイントを叩く", async () => {
+      const trend = {
+        menu: {
+          id: null,
+          name: "素振り",
+          unit: "count",
+          unit_label: "本",
+          is_weight_reps: false,
+        },
+        by_year: [],
+        by_month: [],
+        by_day: [],
+      };
+      mockResponse(200, trend);
+
+      expect(await getShadowSwingTrend()).toEqual({
+        status: "ok",
+        data: trend,
+      });
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/shadow_swing_sessions/trend",
+      );
+      expect(requestedInit().method).toBeUndefined();
+    });
+
+    it("無料ユーザーの素振り推移（403）は forbidden を返す", async () => {
+      mockResponse(403, {
+        error: "メニュー推移の詳細表示は Pro プラン限定です",
+      });
+
+      expect(await getShadowSwingTrend()).toEqual({ status: "forbidden" });
     });
   });
 

--- a/app/services/v2/practiceSummaryService.ts
+++ b/app/services/v2/practiceSummaryService.ts
@@ -43,3 +43,17 @@ export async function getMenuTrend(
     "getMenuTrend",
   );
 }
+
+/**
+ * 素振り（source: shadow_swing）の推移を取得する
+ * （GET /api/v2/shadow_swing_sessions/trend）。
+ * 素振りログは practice_menu に紐付かないことがあるため、メニュー推移とは別系統になる。
+ * 推移詳細と同じ entitlement（practice_menu_trend_detail）で守られており、
+ * 無料プランでは status:"forbidden" が返る。
+ */
+export async function getShadowSwingTrend(): Promise<FetchResult<MenuTrend>> {
+  return fetchV2<MenuTrend>(
+    "/api/v2/shadow_swing_sessions/trend",
+    "getShadowSwingTrend",
+  );
+}

--- a/app/types/practice.ts
+++ b/app/types/practice.ts
@@ -119,7 +119,8 @@ export interface MenuTrendBucket {
  */
 export interface MenuTrend {
   menu: {
-    id: number;
+    /** 素振りの推移（shadow_swing_sessions/trend）はメニューに紐付かないため null。 */
+    id: number | null;
     name: string;
     unit: PracticeUnit;
     unit_label: string | null;


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#473

## 概要

メニューごとの累計・今月・記録日数と、年別/月別/日別の推移グラフです。mobile の `app/(records)/summary.tsx` / `trend.tsx` 相当。

**#471（PR #427）の一覧から `/practice/summary` へのリンクが既にあり現在リンク切れなので、本 PR がそれを解消します。**

## 無料ユーザーには API を叩きません

issue の明示要件です。403 を食らってからサンプルを出すのではなく、**Server Component の時点で entitlement を解決し、`practice_menu_trend_detail` を持たない場合は `getMenuTrend` / `getShadowSwingTrend` を一度も呼びません**。クライアントからも取得しません（`MenuTrendContent` は API を持たない純粋な Container）。

サンプルの単位を実メニューに合わせるため、無料ユーザーのみ Pro 非依存の `getPracticeMenus()` を引いています。Pro 判定とサーバー判定がずれて 403 が返った場合も「取得失敗」ではなくサンプル＋Pro 訴求に倒します。

## back の契約で判明した点

- **`by_day` は 60 件上限**（`DAY_LIMIT = 60`）。`logged_on` 降順にソート後 `first(60)` なので**記録のある直近60日**です。`by_year` / `by_month` に上限はありません
- **素振りは別エンドポイント**（`shadow_swing_sessions/trend`）。`menu.id` が **null** で返るため、`app/types/practice.ts` の型を `number | null` に修正しました（既存型の変更はこれだけです）
- `practice_menu_trends` の 403 は**「Pro 限定機能」**（無料枠超過ではない）。文言をその文脈に合わせています

## mobile のバグを1件回避しています

**削除済みメニュー（`practice_menu_id: null` かつ名前が素振り以外）を mobile は素振り扱いにして誤ったリンクを張ります。** front では `menu_name` のスナップショットで表示しつつ**リンクを張らず「削除したメニューの記録」と明示**しました。

## 変更内容

- `practiceSummaryService.ts` に `getShadowSwingTrend()` を追加（他は既存を利用）
- `/practice/summary` — 認証＋3件の並列取得（サマリー/メニュー/KPI）
- `_utils/menuSummaryDisplay.ts` — 並び替え・未記録補完・単位出し分け・リンク解決
- `/practice/summary/[menuId]` — `?source` 判定・entitlement 判定・取得またはサンプル生成
- `MenuTrendChart.tsx` — **既存の成績推移（`BattingTrendChart`）と同じ素の inline SVG**。新規グラフライブラリは追加していません

`formatVolume`（「8.2t」）/ `formatTotalAmount`（「12,400本」）は #467 の既存実装をそのまま利用し、再実装していません。

## レビューで確認いただきたい点

1. **未記録メニューをメニュー一覧から補完して末尾に置いています。** back のサマリーは記録済みのみ返すため、issue の「未記録は末尾」を満たすには突き合わせが必要でした。**mobile にはない挙動**です
2. **素振りのパスを `/practice/summary/shadow_swing?source=shadow_swing` にしました**（メニュー id を持たないため固定セグメント＋クエリ。`[menuId]` は無視し source を優先）
3. **KPI ヘッダに `practice_overview` を使いました**（issue が「検討」としていた点。mobile は未使用）
4. **導線は追加していません。** `/practice/records`（#471 / PR #427）からのリンクが本ページを指すため、ヘッダー衝突を避けて追加を見送りました

## チェックリスト

- [x] `yarn typecheck` / `yarn lint` / `yarn format:check` が通る
- [x] `yarn test` が通る（**160 suites / 1888 tests**。新規 62 tests）
- [x] `yarn build` が通る（ローカルで実行済み）
- [x] ミューテーションテスト **22 設計 / 22 KILLED / 0 SURVIVED**

### ルート表

base（`9d15b12`）も同条件でビルドして diff を取得しました。**追加は `/practice/summary`・`/practice/summary/[menuId]`（ともに動的）の2件のみ、削除0、既存ルートの分類変更なし**。

<details>
<summary>ミューテーションテスト詳細</summary>

無改変での全通過を確認後に実施。**初回 20/22 検出、生存2件を潰して最終 22/22**。

検出: 無料でも API を叩く / 403 文言を「無料枠超過」に / `weight_reps` と通常の取り違え / `formatVolume`・`formatTotalAmount` 不使用 / 並び順反転 / レンジ選択肢の削除 / 年・月バケットの取り違え / `?source` 無視 / 60件上限の扱い除去 / 取得失敗を0件扱い2種 / `SampleDataLabel` 除去 / API パス改変2種 / 素振りリンク削除 / レンジ既定の改変 / サンプルの単位 / KPI の単位 / 粒度変更時にレンジを戻さない。

**生存2件への対処**: ①「未記録を先頭に」は連結順を変えるだけでは**ソートが吸収する等価変異**だったため、null を最大値扱いにする実質的な変異に置き換えて撃墜 ②「記録日数を累計量に取り違える」は補足行を部分一致で見ていたため**全文一致に変更**して撃墜。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_