### PR TITLE
Add: 予定カレンダー（月/週/日ビュー）を実装

### DIFF
--- a/app/(app)/practice/schedules/_components/scheduleCopy.ts
+++ b/app/(app)/practice/schedules/_components/scheduleCopy.ts
@@ -7,6 +7,7 @@ export const PAGE_DESCRIPTION =
   "この日だけの予定と、毎週くり返す予定を登録できます。メニューを紐付けておくと、その日の練習記録にそのまま引き継げます。";
 
 export const CREATE_LABEL = "予定を作る";
+export const CALENDAR_LABEL = "カレンダー";
 export const EMPTY_MESSAGE = "まだ予定がありません";
 export const RECURRING_SECTION_TITLE = "毎週の予定";
 export const SINGLE_SECTION_TITLE = "この日だけの予定";

--- a/app/(app)/practice/schedules/calendar/__tests__/PlanCalendarContent.test.tsx
+++ b/app/(app)/practice/schedules/calendar/__tests__/PlanCalendarContent.test.tsx
@@ -1,0 +1,536 @@
+const mockHasEntitlement = jest.fn();
+const mockIsEntitlementLoading = jest.fn(() => false);
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: () => ({
+    isPro: mockHasEntitlement("schedule_calendar_full_history"),
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading: mockIsEntitlementLoading(),
+    hasEntitlement: mockHasEntitlement,
+  }),
+}));
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: jest.fn(), close: jest.fn() }),
+}));
+
+jest.mock("@app/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("@app/services/v2/planService", () => ({
+  getPlanCalendar: jest.fn(),
+}));
+
+import type { FetchResult } from "@app/services/v2/requests";
+import type { CalendarEntry, CalendarResponse } from "@app/types/plan";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EVENT_TYPES } from "@app/constants/schedule";
+import { getPlanCalendar } from "@app/services/v2/planService";
+import {
+  ADD_PLAN_LABEL,
+  EMPTY_MESSAGE,
+  LOAD_ERROR,
+  PAYWALL_RANGE_NOTICE,
+  PAYWALL_TITLE,
+} from "../_components/calendarCopy";
+import PlanCalendarContent from "../_components/PlanCalendarContent";
+import { fetchRange } from "../_utils/calendarDate";
+
+const mockGetPlanCalendar = getPlanCalendar as jest.MockedFunction<
+  typeof getPlanCalendar
+>;
+
+// 2026-08-03 は月曜。無料枠は 2026-05-03 〜 2026-11-03 になる。
+const TODAY = "2026-08-03";
+const INITIAL_RANGE = fetchRange(TODAY);
+
+const entry = (overrides: Partial<CalendarEntry> = {}): CalendarEntry => ({
+  date: TODAY,
+  event_type: "self_practice",
+  title: "朝練",
+  schedule_id: 1,
+  ...overrides,
+});
+
+const ok = (entries: CalendarEntry[]): FetchResult<CalendarResponse> => ({
+  status: "ok",
+  data: { entries },
+});
+
+const colorOf = (value: string): string =>
+  EVENT_TYPES.find((item) => item.value === value)?.color ?? "";
+
+const toRgb = (hex: string): string => {
+  const value = hex.replace("#", "");
+  return `rgb(${parseInt(value.slice(0, 2), 16)}, ${parseInt(value.slice(2, 4), 16)}, ${parseInt(value.slice(4, 6), 16)})`;
+};
+
+// matchMedia は jsdom に無いため、ブレークポイントの変化を発火できるモックを用意する。
+let isNarrowViewport = false;
+const mediaListeners = new Set<() => void>();
+
+const setNarrowViewport = (narrow: boolean) => {
+  isNarrowViewport = narrow;
+  act(() => {
+    mediaListeners.forEach((listener) => listener());
+  });
+};
+
+const renderCalendar = (
+  initialResult: FetchResult<CalendarResponse> = ok([]),
+) =>
+  render(
+    <PlanCalendarContent
+      today={TODAY}
+      initialRange={INITIAL_RANGE}
+      initialResult={initialResult}
+    />,
+  );
+
+/** 月モードで「次へ」を count 回押す。 */
+const clickNext = async (
+  user: ReturnType<typeof userEvent.setup>,
+  count = 1,
+) => {
+  for (let index = 0; index < count; index += 1) {
+    await user.click(screen.getByRole("button", { name: "次へ" }));
+  }
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      media: query,
+      get matches() {
+        return isNarrowViewport;
+      },
+      addEventListener: (_type: string, listener: () => void) => {
+        mediaListeners.add(listener);
+      },
+      removeEventListener: (_type: string, listener: () => void) => {
+        mediaListeners.delete(listener);
+      },
+    }),
+  });
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  isNarrowViewport = false;
+  mediaListeners.clear();
+  mockIsEntitlementLoading.mockReturnValue(false);
+  mockHasEntitlement.mockReturnValue(true);
+  mockGetPlanCalendar.mockResolvedValue(ok([]));
+});
+
+describe("PlanCalendarContent", () => {
+  describe("表示モードの切り替え", () => {
+    it("デスクトップ幅では月グリッドを表示する", () => {
+      renderCalendar();
+
+      expect(screen.getByRole("button", { name: "月" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(screen.getByTestId(`calendar-day-${TODAY}`)).toBeInTheDocument();
+      expect(screen.getByTestId("calendar-range-label")).toHaveTextContent(
+        "2026年8月",
+      );
+    });
+
+    it("週に切り替えると月曜から日曜の7日が並ぶ", async () => {
+      const user = userEvent.setup();
+      renderCalendar();
+
+      await user.click(screen.getByRole("button", { name: "週" }));
+
+      expect(
+        screen.queryByTestId(`calendar-day-${TODAY}`),
+      ).not.toBeInTheDocument();
+      [
+        "2026-08-03",
+        "2026-08-04",
+        "2026-08-05",
+        "2026-08-06",
+        "2026-08-07",
+        "2026-08-08",
+        "2026-08-09",
+      ].forEach((date) => {
+        expect(
+          screen.getByTestId(`calendar-day-section-${date}`),
+        ).toBeInTheDocument();
+      });
+      expect(screen.getByTestId("calendar-range-label")).toHaveTextContent(
+        "8月3日(月) - 8月9日(日)",
+      );
+    });
+
+    it("日に切り替えるとその日だけを表示する", async () => {
+      const user = userEvent.setup();
+      renderCalendar();
+
+      await user.click(screen.getByRole("button", { name: "日" }));
+
+      expect(
+        screen.getByTestId(`calendar-day-section-${TODAY}`),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("calendar-day-section-2026-08-04"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("calendar-range-label")).toHaveTextContent(
+        "2026年8月3日(月)",
+      );
+    });
+
+    it("SP 幅では週表示を既定にする", () => {
+      isNarrowViewport = true;
+      renderCalendar();
+
+      expect(screen.getByRole("button", { name: "週" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    it("明示的に選んだモードは画面幅の変化で上書きしない", async () => {
+      const user = userEvent.setup();
+      renderCalendar();
+
+      await user.click(screen.getByRole("button", { name: "日" }));
+      setNarrowViewport(true);
+
+      expect(screen.getByRole("button", { name: "日" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(
+        screen.queryByTestId("calendar-day-section-2026-08-04"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("モード未選択なら画面幅の変化に追従する", () => {
+      renderCalendar();
+
+      setNarrowViewport(true);
+
+      expect(screen.getByRole("button", { name: "週" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+  });
+
+  describe("前後移動", () => {
+    it("次へで翌月の範囲を取得する", async () => {
+      const user = userEvent.setup();
+      renderCalendar();
+
+      await clickNext(user);
+
+      expect(screen.getByTestId("calendar-range-label")).toHaveTextContent(
+        "2026年9月",
+      );
+      await waitFor(() =>
+        expect(mockGetPlanCalendar).toHaveBeenCalledWith(
+          "2026-08-31",
+          "2026-10-04",
+        ),
+      );
+    });
+
+    it("前へで前月の範囲を取得する", async () => {
+      const user = userEvent.setup();
+      renderCalendar();
+
+      await user.click(screen.getByRole("button", { name: "前へ" }));
+
+      expect(screen.getByTestId("calendar-range-label")).toHaveTextContent(
+        "2026年7月",
+      );
+      await waitFor(() =>
+        expect(mockGetPlanCalendar).toHaveBeenCalledWith(
+          "2026-06-29",
+          "2026-08-02",
+        ),
+      );
+    });
+
+    it("週モードの次へは7日進む", async () => {
+      const user = userEvent.setup();
+      renderCalendar();
+
+      await user.click(screen.getByRole("button", { name: "週" }));
+      await clickNext(user);
+
+      expect(screen.getByTestId("calendar-range-label")).toHaveTextContent(
+        "8月10日(月) - 8月16日(日)",
+      );
+    });
+
+    it("日モードの次へは1日進む", async () => {
+      const user = userEvent.setup();
+      renderCalendar();
+
+      await user.click(screen.getByRole("button", { name: "日" }));
+      await clickNext(user);
+
+      expect(screen.getByTestId("calendar-range-label")).toHaveTextContent(
+        "2026年8月4日(火)",
+      );
+    });
+
+    it("モードを切り替えただけでは再取得しない", async () => {
+      const user = userEvent.setup();
+      renderCalendar();
+
+      await user.click(screen.getByRole("button", { name: "週" }));
+      await user.click(screen.getByRole("button", { name: "日" }));
+
+      expect(mockGetPlanCalendar).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("予定の表示", () => {
+    it("繰り返し予定は back が展開した日付ぶんすべて表示する", () => {
+      renderCalendar(
+        ok([
+          entry({ date: "2026-08-03" }),
+          entry({ date: "2026-08-10" }),
+          entry({ date: "2026-08-17" }),
+        ]),
+      );
+
+      ["2026-08-03", "2026-08-10", "2026-08-17"].forEach((date) => {
+        expect(
+          within(screen.getByTestId(`calendar-day-${date}`)).getByText("朝練"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("event_type ごとに色を分ける", () => {
+      renderCalendar(
+        ok([
+          entry({ date: "2026-08-03", event_type: "self_practice" }),
+          entry({
+            date: "2026-08-04",
+            event_type: "game",
+            title: "練習試合",
+            schedule_id: 2,
+          }),
+          entry({
+            date: "2026-08-05",
+            event_type: "practice",
+            title: "全体練",
+            schedule_id: 3,
+          }),
+          entry({
+            date: "2026-08-06",
+            event_type: "other",
+            title: "ミーティング",
+            schedule_id: 4,
+          }),
+        ]),
+      );
+
+      const chips = screen.getAllByTestId("calendar-month-chip");
+      const colorByType = new Map(
+        chips.map((chip) => [
+          chip.getAttribute("data-event-type"),
+          chip.style.backgroundColor,
+        ]),
+      );
+
+      expect(colorByType.get("self_practice")).toBe(
+        toRgb(colorOf("self_practice")),
+      );
+      expect(colorByType.get("game")).toBe(toRgb(colorOf("game")));
+      expect(colorByType.get("practice")).toBe(toRgb(colorOf("practice")));
+      expect(colorByType.get("other")).toBe(toRgb(colorOf("other")));
+      expect(new Set(colorByType.values()).size).toBe(4);
+    });
+
+    it("日付を選ぶとその日の詳細に切り替わる", async () => {
+      const user = userEvent.setup();
+      renderCalendar(
+        ok([entry({ date: "2026-08-12", title: "居残り", schedule_id: 9 })]),
+      );
+
+      await user.click(screen.getByTestId("calendar-day-2026-08-12"));
+
+      expect(
+        screen.getByTestId("calendar-day-section-2026-08-12"),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /居残り/ })).toHaveAttribute(
+        "href",
+        "/practice/schedules/9?date=2026-08-12",
+      );
+    });
+
+    it("その日の予定追加ボタンは日付付きの作成画面へ遷移する", () => {
+      renderCalendar(ok([]));
+
+      expect(
+        screen.getByRole("link", { name: `8月3日(月) ${ADD_PLAN_LABEL}` }),
+      ).toHaveAttribute("href", "/practice/schedules/new?date=2026-08-03");
+    });
+
+    it("週モードでは各日に予定追加ボタンが並ぶ", async () => {
+      const user = userEvent.setup();
+      renderCalendar(ok([]));
+
+      await user.click(screen.getByRole("button", { name: "週" }));
+
+      expect(
+        screen.getByRole("link", { name: `8月5日(水) ${ADD_PLAN_LABEL}` }),
+      ).toHaveAttribute("href", "/practice/schedules/new?date=2026-08-05");
+    });
+  });
+
+  describe("0件と取得失敗の区別", () => {
+    it("0件なら予定なしと伝える", () => {
+      renderCalendar(ok([]));
+
+      expect(screen.getByText(EMPTY_MESSAGE)).toBeInTheDocument();
+      expect(screen.queryByText(LOAD_ERROR)).not.toBeInTheDocument();
+    });
+
+    it("取得失敗なら予定なしではなくエラーを出す", () => {
+      renderCalendar({ status: "error" });
+
+      expect(screen.getByText(LOAD_ERROR)).toBeInTheDocument();
+      expect(screen.queryByText(EMPTY_MESSAGE)).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId(`calendar-day-${TODAY}`),
+      ).not.toBeInTheDocument();
+    });
+
+    it("移動先の取得に失敗したときもエラーを出す", async () => {
+      const user = userEvent.setup();
+      mockGetPlanCalendar.mockResolvedValue({ status: "error" });
+      renderCalendar(ok([]));
+
+      await clickNext(user);
+
+      expect(await screen.findByText(LOAD_ERROR)).toBeInTheDocument();
+    });
+  });
+
+  describe("無料プランの閲覧範囲", () => {
+    it("前後3ヶ月を超える月へ移動するとペイウォールを出す（空カレンダーにしない）", async () => {
+      const user = userEvent.setup();
+      mockHasEntitlement.mockReturnValue(false);
+      renderCalendar(ok([]));
+
+      await clickNext(user, 4);
+
+      expect(screen.getByTestId("calendar-range-label")).toHaveTextContent(
+        "2026年12月",
+      );
+      expect(screen.getByText(PAYWALL_TITLE)).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("calendar-day-2026-12-01"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(EMPTY_MESSAGE)).not.toBeInTheDocument();
+    });
+
+    it("一部だけ範囲外の月は境界の日だけロック表示する", async () => {
+      const user = userEvent.setup();
+      mockHasEntitlement.mockReturnValue(false);
+      renderCalendar(ok([]));
+
+      await clickNext(user, 3);
+
+      expect(screen.getByTestId("calendar-range-label")).toHaveTextContent(
+        "2026年11月",
+      );
+      expect(screen.queryByText(PAYWALL_TITLE)).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("calendar-day-locked-2026-11-03"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId("calendar-day-locked-2026-11-04"),
+      ).toBeInTheDocument();
+    });
+
+    it("ロックした日は予定0件ではなく閲覧範囲外だと伝える", async () => {
+      const user = userEvent.setup();
+      mockHasEntitlement.mockReturnValue(false);
+      renderCalendar(ok([]));
+
+      await clickNext(user, 3);
+      await user.click(screen.getByTestId("calendar-day-2026-11-30"));
+
+      expect(screen.getByText(PAYWALL_RANGE_NOTICE)).toBeInTheDocument();
+      expect(screen.queryByText(EMPTY_MESSAGE)).not.toBeInTheDocument();
+    });
+
+    it("閲覧範囲外の日でも予定の追加はできる", async () => {
+      const user = userEvent.setup();
+      mockHasEntitlement.mockReturnValue(false);
+      renderCalendar(ok([]));
+
+      await clickNext(user, 3);
+      await user.click(screen.getByTestId("calendar-day-2026-11-30"));
+
+      expect(
+        screen.getByRole("link", { name: `11月30日(月) ${ADD_PLAN_LABEL}` }),
+      ).toHaveAttribute("href", "/practice/schedules/new?date=2026-11-30");
+    });
+
+    it("Pro ユーザーは範囲外へ移動してもペイウォールを出さない", async () => {
+      const user = userEvent.setup();
+      mockHasEntitlement.mockReturnValue(true);
+      renderCalendar(ok([]));
+
+      await clickNext(user, 4);
+
+      expect(screen.queryByText(PAYWALL_TITLE)).not.toBeInTheDocument();
+      expect(
+        await screen.findByTestId("calendar-day-2026-12-01"),
+      ).toBeInTheDocument();
+    });
+
+    it("Pro 判定が未確定の間は範囲外扱いにしない", async () => {
+      const user = userEvent.setup();
+      mockIsEntitlementLoading.mockReturnValue(true);
+      mockHasEntitlement.mockReturnValue(false);
+      renderCalendar(ok([]));
+
+      await clickNext(user, 4);
+
+      expect(screen.queryByText(PAYWALL_TITLE)).not.toBeInTheDocument();
+      expect(
+        await screen.findByTestId("calendar-day-2026-12-01"),
+      ).toBeInTheDocument();
+    });
+
+    it("Pro 判定が未確定の間は境界の日もロックしない", () => {
+      mockIsEntitlementLoading.mockReturnValue(true);
+      mockHasEntitlement.mockReturnValue(false);
+      renderCalendar(ok([]));
+
+      expect(
+        screen.queryByTestId("calendar-day-locked-2026-08-03"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("範囲外でも取得は行い、back がクランプした結果を使う", async () => {
+      const user = userEvent.setup();
+      mockHasEntitlement.mockReturnValue(false);
+      renderCalendar(ok([]));
+
+      await clickNext(user, 4);
+
+      await waitFor(() =>
+        expect(mockGetPlanCalendar).toHaveBeenLastCalledWith(
+          "2026-11-30",
+          "2027-01-03",
+        ),
+      );
+    });
+  });
+});

--- a/app/(app)/practice/schedules/calendar/_components/CalendarDaySection.tsx
+++ b/app/(app)/practice/schedules/calendar/_components/CalendarDaySection.tsx
@@ -1,0 +1,83 @@
+import type { CalendarEntry } from "@app/types/plan";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import LockClosedIcon from "@heroicons/react/24/solid/LockClosedIcon";
+import Link from "next/link";
+import { WEEK_DAYS } from "@app/constants/schedule";
+import { weekdayNumber } from "../_utils/calendarDate";
+import {
+  ADD_PLAN_LABEL,
+  EMPTY_MESSAGE,
+  PAYWALL_RANGE_NOTICE,
+} from "./calendarCopy";
+import CalendarEntryRow, { addPlanHref } from "./CalendarEntryRow";
+
+interface CalendarDaySectionProps {
+  date: string;
+  entries: CalendarEntry[];
+  today: string;
+  /** 無料プランの閲覧範囲外で、そもそも back からエントリが返らない日か。 */
+  locked: boolean;
+}
+
+/** "2026-07-06" → "7月6日(月)"。曜日ラベルは月=1〜日=7 のマスタから引く。 */
+export function formatDayLabel(iso: string): string {
+  const month = Number(iso.slice(5, 7));
+  const day = Number(iso.slice(8, 10));
+  const weekday = WEEK_DAYS.find((item) => item.num === weekdayNumber(iso));
+  return `${month}月${day}日(${weekday?.label ?? ""})`;
+}
+
+/**
+ * 1 日分の予定リスト。週表示・日表示・月表示の選択日の詳細で共用する。
+ *
+ * 予定の作成自体は無料プランでも無制限なので、閲覧範囲外の日でも追加ボタンは残す。
+ * 一方で「予定が 0 件」と「Pro でないため取得できていない」は意味が違うため、
+ * 空表示と閲覧範囲外の案内は文言を分ける。
+ */
+export default function CalendarDaySection({
+  date,
+  entries,
+  today,
+  locked,
+}: CalendarDaySectionProps) {
+  return (
+    <section
+      data-testid={`calendar-day-section-${date}`}
+      className="border-b border-zinc-700 py-3 last:border-b-0"
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <h3
+          className={`text-sm font-bold ${date === today ? "text-[#d08000]" : "text-zinc-200"}`}
+        >
+          {formatDayLabel(date)}
+        </h3>
+        <Link
+          href={addPlanHref(date)}
+          aria-label={`${formatDayLabel(date)} ${ADD_PLAN_LABEL}`}
+          className="inline-flex shrink-0 items-center gap-1 rounded-full border border-zinc-600 px-2.5 py-1 text-xs font-bold text-zinc-200 transition-colors hover:border-[#d08000] hover:text-[#d08000]"
+        >
+          <PlusIcon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+          {ADD_PLAN_LABEL}
+        </Link>
+      </div>
+
+      {locked ? (
+        <p className="flex items-center gap-1.5 py-1 text-xs text-zinc-400">
+          <LockClosedIcon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+          {PAYWALL_RANGE_NOTICE}
+        </p>
+      ) : entries.length === 0 ? (
+        <p className="py-1 text-xs text-zinc-500">{EMPTY_MESSAGE}</p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {entries.map((entry, index) => (
+            <CalendarEntryRow
+              key={`${entry.schedule_id}-${index}`}
+              entry={entry}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/app/(app)/practice/schedules/calendar/_components/CalendarEntryRow.tsx
+++ b/app/(app)/practice/schedules/calendar/_components/CalendarEntryRow.tsx
@@ -1,0 +1,47 @@
+import type { CalendarEntry } from "@app/types/plan";
+import Link from "next/link";
+import { eventTypeMeta } from "@app/constants/schedule";
+
+/**
+ * カレンダーから開く予定詳細のリンク先。
+ * 毎週の予定は「どの日として開いたか」で「済」の判定日が変わるため、date を必ず引き継ぐ。
+ */
+export function entryHref(entry: CalendarEntry): string {
+  return `/practice/schedules/${entry.schedule_id}?date=${entry.date}`;
+}
+
+/** 予定を追加する画面へのリンク先。日付が確定した文脈から開くので初期日付を渡す。 */
+export function addPlanHref(date: string): string {
+  return `/practice/schedules/new?date=${date}`;
+}
+
+/** 予定 1 件の行（種別色のバー + タイトル）。週表示・日表示・月表示の詳細欄で共用する。 */
+export default function CalendarEntryRow({ entry }: { entry: CalendarEntry }) {
+  const meta = eventTypeMeta(entry.event_type);
+
+  return (
+    <li>
+      <Link
+        href={entryHref(entry)}
+        className="flex items-center gap-2.5 rounded-lg bg-sub px-3 py-2.5 transition-opacity hover:opacity-90"
+      >
+        <span
+          aria-hidden
+          data-testid="calendar-entry-bar"
+          data-event-type={entry.event_type}
+          className="h-5 w-1 shrink-0 rounded-full"
+          style={{ backgroundColor: meta.color }}
+        />
+        <span className="min-w-0 flex-1 truncate text-sm text-white">
+          {entry.title ?? meta.label}
+        </span>
+        <span
+          className="shrink-0 rounded-full px-2 py-0.5 text-[11px] font-bold"
+          style={{ backgroundColor: `${meta.color}22`, color: meta.color }}
+        >
+          {meta.label}
+        </span>
+      </Link>
+    </li>
+  );
+}

--- a/app/(app)/practice/schedules/calendar/_components/CalendarMonthGrid.tsx
+++ b/app/(app)/practice/schedules/calendar/_components/CalendarMonthGrid.tsx
@@ -1,0 +1,123 @@
+import type { CalendarEntry } from "@app/types/plan";
+import LockClosedIcon from "@heroicons/react/24/solid/LockClosedIcon";
+import { WEEK_DAYS, eventTypeMeta } from "@app/constants/schedule";
+import { isSameMonth, monthGridWeeks } from "../_utils/calendarDate";
+import { LOCKED_DAY_LABEL } from "./calendarCopy";
+
+interface CalendarMonthGridProps {
+  /** 表示する月を含む日付。 */
+  cursor: string;
+  selected: string;
+  today: string;
+  entriesByDate: Map<string, CalendarEntry[]>;
+  /** 無料プランの閲覧範囲外で、back からエントリが返らない日か。 */
+  isDayLocked: (iso: string) => boolean;
+  onSelect: (iso: string) => void;
+}
+
+/** 1 マスに並べる予定の最大数。溢れた分は件数だけ出す。 */
+const MAX_CHIPS_PER_CELL = 3;
+
+const CELL_BASE =
+  "flex min-h-[76px] flex-col gap-0.5 border-b border-r border-zinc-700 px-1 pt-1 pb-1.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#d08000] md:min-h-[104px] lg:min-h-[124px]";
+
+function dayNumber(iso: string): string {
+  return String(Number(iso.slice(8, 10)));
+}
+
+/**
+ * 月グリッド。前後の月からはみ出す日も含めて必ず週単位（7 の倍数）で並べる。
+ * 日付の算出は _utils/calendarDate に閉じ込め、ここは並べるだけにしている。
+ */
+export default function CalendarMonthGrid({
+  cursor,
+  selected,
+  today,
+  entriesByDate,
+  isDayLocked,
+  onSelect,
+}: CalendarMonthGridProps) {
+  const weeks = monthGridWeeks(cursor);
+
+  return (
+    <div className="overflow-hidden rounded-[10px] border-l border-t border-zinc-700">
+      <div className="grid grid-cols-7">
+        {WEEK_DAYS.map((day) => (
+          <div
+            key={day.num}
+            className="border-b border-r border-zinc-700 py-1.5 text-center text-[11px] font-bold text-zinc-400"
+          >
+            {day.label}
+          </div>
+        ))}
+      </div>
+
+      {weeks.map((week) => (
+        <div key={week[0]} className="grid grid-cols-7">
+          {week.map((iso) => {
+            const entries = entriesByDate.get(iso) ?? [];
+            const locked = isDayLocked(iso);
+            const isSelected = iso === selected;
+            const inMonth = isSameMonth(iso, cursor);
+            const isToday = iso === today;
+
+            return (
+              <button
+                key={iso}
+                type="button"
+                data-testid={`calendar-day-${iso}`}
+                aria-pressed={isSelected}
+                aria-current={isToday ? "date" : undefined}
+                onClick={() => onSelect(iso)}
+                className={`${CELL_BASE} ${isSelected ? "bg-[#d08000]/15" : "hover:bg-white/5"}`}
+              >
+                <span
+                  className={`text-center text-[11px] ${isToday ? "font-bold text-[#d08000]" : inMonth ? "text-zinc-100" : "text-zinc-500"}`}
+                >
+                  {dayNumber(iso)}
+                </span>
+
+                {locked ? (
+                  <span
+                    data-testid={`calendar-day-locked-${iso}`}
+                    className="mx-auto inline-flex items-center gap-0.5 rounded-full bg-zinc-700/80 px-1.5 py-0.5 text-[9px] font-bold text-zinc-300"
+                  >
+                    <LockClosedIcon
+                      className="h-2.5 w-2.5 shrink-0"
+                      aria-hidden
+                    />
+                    {LOCKED_DAY_LABEL}
+                  </span>
+                ) : (
+                  <>
+                    {entries
+                      .slice(0, MAX_CHIPS_PER_CELL)
+                      .map((entry, index) => {
+                        const meta = eventTypeMeta(entry.event_type);
+                        return (
+                          <span
+                            key={`${entry.schedule_id}-${index}`}
+                            data-testid="calendar-month-chip"
+                            data-event-type={entry.event_type}
+                            className="truncate rounded px-1 py-px text-[10px] font-bold text-white"
+                            style={{ backgroundColor: meta.color }}
+                          >
+                            {entry.title ?? meta.label}
+                          </span>
+                        );
+                      })}
+                    {entries.length > MAX_CHIPS_PER_CELL ? (
+                      <span className="px-1 text-[10px] text-zinc-400">
+                        +{entries.length - MAX_CHIPS_PER_CELL}
+                      </span>
+                    ) : null}
+                  </>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/(app)/practice/schedules/calendar/_components/PlanCalendarContent.tsx
+++ b/app/(app)/practice/schedules/calendar/_components/PlanCalendarContent.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import type { CalendarRange, CalendarViewMode } from "../_utils/calendarDate";
+import type { FetchResult } from "@app/services/v2/requests";
+import type { CalendarEntry, CalendarResponse } from "@app/types/plan";
+import ChevronLeftIcon from "@heroicons/react/24/outline/ChevronLeftIcon";
+import ChevronRightIcon from "@heroicons/react/24/outline/ChevronRightIcon";
+import { useState } from "react";
+import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { useIsNarrowViewport } from "@app/hooks/useIsNarrowViewport";
+import { getPlanCalendar } from "@app/services/v2/planService";
+import {
+  fetchRange,
+  isRangeOutsideFreeCalendarWindow,
+  isWithinFreeCalendarWindow,
+  shiftCursor,
+  visibleRange,
+  weekDays,
+} from "../_utils/calendarDate";
+import {
+  LOADING_MESSAGE,
+  LOAD_ERROR,
+  MODE_DAY_LABEL,
+  MODE_GROUP_LABEL,
+  MODE_MONTH_LABEL,
+  MODE_WEEK_LABEL,
+  NEXT_LABEL,
+  PAYWALL_DESCRIPTION,
+  PAYWALL_TITLE,
+  PREV_LABEL,
+  TODAY_LABEL,
+} from "./calendarCopy";
+import CalendarDaySection, { formatDayLabel } from "./CalendarDaySection";
+import CalendarMonthGrid from "./CalendarMonthGrid";
+
+const FEATURE = "schedule_calendar_full_history" as const;
+
+const VIEW_MODES: ReadonlyArray<{ value: CalendarViewMode; label: string }> = [
+  { value: "month", label: MODE_MONTH_LABEL },
+  { value: "week", label: MODE_WEEK_LABEL },
+  { value: "day", label: MODE_DAY_LABEL },
+];
+
+const rangeKey = (range: CalendarRange): string => `${range.from}_${range.to}`;
+
+/** 前後移動のヘッダーに出す表示中の期間。 */
+function rangeLabel(mode: CalendarViewMode, cursor: string): string {
+  const year = cursor.slice(0, 4);
+  if (mode === "month") return `${year}年${Number(cursor.slice(5, 7))}月`;
+  if (mode === "week") {
+    const days = weekDays(cursor);
+    return `${formatDayLabel(days[0])} - ${formatDayLabel(days[6])}`;
+  }
+  return `${year}年${formatDayLabel(cursor)}`;
+}
+
+function groupByDate(entries: CalendarEntry[]): Map<string, CalendarEntry[]> {
+  const grouped = new Map<string, CalendarEntry[]>();
+  entries.forEach((entry) => {
+    const list = grouped.get(entry.date);
+    if (list) list.push(entry);
+    else grouped.set(entry.date, [entry]);
+  });
+  return grouped;
+}
+
+interface PlanCalendarContentProps {
+  /** Asia/Tokyo の今日。無料プランの閲覧範囲の基準になる。 */
+  today: string;
+  /** Server Component が先に取得した初期表示範囲。 */
+  initialRange: CalendarRange;
+  initialResult: FetchResult<CalendarResponse>;
+}
+
+/**
+ * 予定カレンダーの Container。
+ *
+ * - 表示モード（月/週/日）と基準日を持ち、前後移動のたびに Server Action で取得する。
+ * - 取得範囲はモードに依らず基準日の月グリッド全体にしているため、モード切り替えでは
+ *   再取得が起きない（週・日は必ず月グリッドの内側に入る）。
+ * - 無料プランの閲覧範囲は back がクランプする。front は同じ幅で「その日は取得できていない」
+ *   ことを明示するだけで、範囲判定の正はあくまで back に置く。
+ */
+export default function PlanCalendarContent({
+  today,
+  initialRange,
+  initialResult,
+}: PlanCalendarContentProps) {
+  const { hasEntitlement, isLoading: isEntitlementLoading } = useEntitlement();
+  const isNarrowViewport = useIsNarrowViewport();
+
+  // 明示的に切り替えるまでは画面幅に合わせた既定モード（SP は週、デスクトップは月）。
+  // 一度でも選んだら以降は画面幅で上書きしない。
+  const [selectedMode, setSelectedMode] = useState<CalendarViewMode | null>(
+    null,
+  );
+  const mode: CalendarViewMode =
+    selectedMode ?? (isNarrowViewport ? "week" : "month");
+
+  const [cursor, setCursor] = useState(today);
+  const [selectedDate, setSelectedDate] = useState(today);
+  const [resultsByRange, setResultsByRange] = useState<
+    Record<string, FetchResult<CalendarResponse>>
+  >({ [rangeKey(initialRange)]: initialResult });
+
+  const currentKey = rangeKey(fetchRange(cursor));
+  const result = resultsByRange[currentKey];
+
+  const loadRange = (nextCursor: string) => {
+    const range = fetchRange(nextCursor);
+    const key = rangeKey(range);
+    if (resultsByRange[key]) return;
+    // 範囲外でも取得はする。back がクランプした実データを持っておくことで、
+    // Pro 判定が後から確定しても取得済みの内容をそのまま出せる。
+    void getPlanCalendar(range.from, range.to).then((fetched) => {
+      setResultsByRange((previous) => ({ ...previous, [key]: fetched }));
+    });
+  };
+
+  const moveTo = (nextCursor: string) => {
+    setCursor(nextCursor);
+    // 月をまたぐ移動では選択日が画面外になるため、移動先の先頭日へ寄せる。
+    setSelectedDate(nextCursor);
+    loadRange(nextCursor);
+  };
+
+  const shift = (direction: 1 | -1) =>
+    moveTo(shiftCursor(mode, cursor, direction));
+
+  // Pro 判定が未確定の間は範囲外扱いにしない。先に無料前提でロックすると、
+  // 加入済みユーザーに一瞬ペイウォールが見えてしまう。
+  const isRangeLimited = !isEntitlementLoading && !hasEntitlement(FEATURE);
+  const isDayLocked = (iso: string): boolean =>
+    isRangeLimited && !isWithinFreeCalendarWindow(iso, today);
+  const isWholeViewLocked =
+    isRangeLimited &&
+    isRangeOutsideFreeCalendarWindow(visibleRange(mode, cursor), today);
+
+  const entriesByDate = groupByDate(
+    result?.status === "ok" ? result.data.entries : [],
+  );
+  const entriesOf = (iso: string): CalendarEntry[] =>
+    entriesByDate.get(iso) ?? [];
+
+  const agendaDates = mode === "week" ? weekDays(cursor) : [cursor];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div
+          role="group"
+          aria-label={MODE_GROUP_LABEL}
+          className="flex rounded-lg bg-sub p-0.5"
+        >
+          {VIEW_MODES.map((item) => (
+            <button
+              key={item.value}
+              type="button"
+              aria-pressed={mode === item.value}
+              onClick={() => setSelectedMode(item.value)}
+              className={`w-12 rounded-md py-1.5 text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000] ${
+                mode === item.value
+                  ? "bg-[#d08000] text-white"
+                  : "text-zinc-400 hover:text-zinc-200"
+              }`}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => moveTo(today)}
+          className="rounded-lg border border-zinc-600 px-3 py-1.5 text-xs font-bold text-zinc-200 transition-colors hover:border-[#d08000] hover:text-[#d08000]"
+        >
+          {TODAY_LABEL}
+        </button>
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          aria-label={PREV_LABEL}
+          onClick={() => shift(-1)}
+          className="rounded-full p-1.5 text-zinc-200 transition-colors hover:bg-white/10"
+        >
+          <ChevronLeftIcon className="h-5 w-5" aria-hidden />
+        </button>
+        <p
+          data-testid="calendar-range-label"
+          aria-live="polite"
+          className="text-base font-bold text-white"
+        >
+          {rangeLabel(mode, cursor)}
+        </p>
+        <button
+          type="button"
+          aria-label={NEXT_LABEL}
+          onClick={() => shift(1)}
+          className="rounded-full p-1.5 text-zinc-200 transition-colors hover:bg-white/10"
+        >
+          <ChevronRightIcon className="h-5 w-5" aria-hidden />
+        </button>
+      </div>
+
+      {isWholeViewLocked ? (
+        <ProUpsellCard
+          feature={FEATURE}
+          title={PAYWALL_TITLE}
+          description={PAYWALL_DESCRIPTION}
+        />
+      ) : result === undefined ? (
+        <div
+          aria-busy="true"
+          className="h-64 animate-pulse rounded-[10px] bg-sub"
+        >
+          <p className="sr-only">{LOADING_MESSAGE}</p>
+        </div>
+      ) : result.status !== "ok" ? (
+        // 取得失敗を空表示に丸めると「予定なし」と誤読され、重複登録を招く。
+        <p className="py-8 text-center text-sm text-zinc-400">{LOAD_ERROR}</p>
+      ) : mode === "month" ? (
+        <>
+          <CalendarMonthGrid
+            cursor={cursor}
+            selected={selectedDate}
+            today={today}
+            entriesByDate={entriesByDate}
+            isDayLocked={isDayLocked}
+            onSelect={setSelectedDate}
+          />
+          <CalendarDaySection
+            date={selectedDate}
+            entries={entriesOf(selectedDate)}
+            today={today}
+            locked={isDayLocked(selectedDate)}
+          />
+        </>
+      ) : (
+        <div>
+          {agendaDates.map((date) => (
+            <CalendarDaySection
+              key={date}
+              date={date}
+              entries={entriesOf(date)}
+              today={today}
+              locked={isDayLocked(date)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/practice/schedules/calendar/_components/calendarCopy.ts
+++ b/app/(app)/practice/schedules/calendar/_components/calendarCopy.ts
@@ -1,0 +1,29 @@
+import { FREE_CALENDAR_WINDOW_MONTHS } from "@app/constants/schedule";
+
+/** 予定カレンダー画面の文言。表示のゆれを避けるため 1 箇所に集約する。 */
+
+export const PAGE_TITLE = "予定カレンダー";
+export const PAGE_DESCRIPTION =
+  "登録した予定を月・週・日の3つの見え方で確認できます。毎週くり返す予定も、その週の日付に展開して表示します。";
+
+export const MODE_MONTH_LABEL = "月";
+export const MODE_WEEK_LABEL = "週";
+export const MODE_DAY_LABEL = "日";
+export const MODE_GROUP_LABEL = "表示の切り替え";
+
+export const PREV_LABEL = "前へ";
+export const NEXT_LABEL = "次へ";
+export const TODAY_LABEL = "今日";
+
+export const ADD_PLAN_LABEL = "この日の予定を追加";
+export const EMPTY_MESSAGE = "予定はありません";
+export const LOADING_MESSAGE = "予定を読み込み中";
+
+/** 0 件と取得失敗を同じ見た目にすると「予定なし」と誤読させるため、文言を分ける。 */
+export const LOAD_ERROR =
+  "予定を取得できませんでした。時間を置いて再度お試しください。";
+
+export const LOCKED_DAY_LABEL = "Pro限定";
+export const PAYWALL_TITLE = "カレンダーを全期間で見る";
+export const PAYWALL_DESCRIPTION = `無料プランで見られるのは今日の前後${FREE_CALENDAR_WINDOW_MONTHS}ヶ月までです。Pro プランなら先々の予定も過去の練習プランも、月を遡らず確認できます。`;
+export const PAYWALL_RANGE_NOTICE = `無料プランでは今日の前後${FREE_CALENDAR_WINDOW_MONTHS}ヶ月を超える日の予定は表示されません。`;

--- a/app/(app)/practice/schedules/calendar/_utils/__tests__/calendarDate.test.ts
+++ b/app/(app)/practice/schedules/calendar/_utils/__tests__/calendarDate.test.ts
@@ -1,0 +1,295 @@
+import {
+  addDays,
+  addMonths,
+  daysInMonth,
+  endOfMonth,
+  fetchRange,
+  freeCalendarWindow,
+  isRangeOutsideFreeCalendarWindow,
+  isSameMonth,
+  isWithinFreeCalendarWindow,
+  monthGridDays,
+  monthGridRange,
+  monthGridWeeks,
+  shiftCursor,
+  startOfMonth,
+  startOfWeek,
+  todayInTokyo,
+  visibleRange,
+  weekDays,
+  weekdayNumber,
+} from "../calendarDate";
+
+// 2026-08-03 は月曜。この日を「今日」とすると無料枠は 2026-05-03 〜 2026-11-03 になる。
+const TODAY = "2026-08-03";
+
+describe("todayInTokyo", () => {
+  it("UTC では前日でも Asia/Tokyo の日付を返す", () => {
+    expect(todayInTokyo(new Date("2026-08-03T15:30:00Z"))).toBe("2026-08-04");
+  });
+
+  it("UTC の日付が変わる直前でも Asia/Tokyo の日付を返す", () => {
+    expect(todayInTokyo(new Date("2026-08-03T23:59:59Z"))).toBe("2026-08-04");
+  });
+
+  it("Asia/Tokyo の日付が変わる直前は当日のまま", () => {
+    expect(todayInTokyo(new Date("2026-08-03T14:59:59Z"))).toBe("2026-08-03");
+  });
+});
+
+describe("addDays", () => {
+  it("月をまたいで加算できる", () => {
+    expect(addDays("2026-07-31", 1)).toBe("2026-08-01");
+  });
+
+  it("年をまたいで減算できる", () => {
+    expect(addDays("2027-01-01", -1)).toBe("2026-12-31");
+  });
+
+  it("うるう年の2月末を正しく越える", () => {
+    expect(addDays("2024-02-28", 1)).toBe("2024-02-29");
+    expect(addDays("2024-02-29", 1)).toBe("2024-03-01");
+  });
+
+  it("平年の2月末を正しく越える", () => {
+    expect(addDays("2026-02-28", 1)).toBe("2026-03-01");
+  });
+});
+
+describe("daysInMonth", () => {
+  it("うるう年の2月は29日", () => {
+    expect(daysInMonth(2024, 1)).toBe(29);
+  });
+
+  it("平年の2月は28日", () => {
+    expect(daysInMonth(2026, 1)).toBe(28);
+  });
+
+  it("400で割り切れない100の倍数年は平年扱い", () => {
+    expect(daysInMonth(2100, 1)).toBe(28);
+    expect(daysInMonth(2000, 1)).toBe(29);
+  });
+});
+
+describe("addMonths", () => {
+  it("同じ日が無い月は月末に丸める", () => {
+    expect(addMonths("2026-01-31", 1)).toBe("2026-02-28");
+    expect(addMonths("2024-01-31", 1)).toBe("2024-02-29");
+  });
+
+  it("年をまたいで加減算できる", () => {
+    expect(addMonths("2026-11-15", 3)).toBe("2027-02-15");
+    expect(addMonths("2026-01-15", -3)).toBe("2025-10-15");
+  });
+
+  it("月末起点の3ヶ月前も丸める", () => {
+    expect(addMonths("2026-05-31", -3)).toBe("2026-02-28");
+  });
+});
+
+describe("weekdayNumber", () => {
+  it("月曜を1、日曜を7として返す（back の days_of_week と同じ体系）", () => {
+    expect(weekdayNumber("2026-07-06")).toBe(1);
+    expect(weekdayNumber("2026-07-07")).toBe(2);
+    expect(weekdayNumber("2026-07-11")).toBe(6);
+    expect(weekdayNumber("2026-07-12")).toBe(7);
+  });
+});
+
+describe("startOfWeek / weekDays", () => {
+  it("日曜は同じ週の月曜まで戻る", () => {
+    expect(startOfWeek("2026-07-12")).toBe("2026-07-06");
+  });
+
+  it("月曜はその日のまま", () => {
+    expect(startOfWeek("2026-07-06")).toBe("2026-07-06");
+  });
+
+  it("週は月曜から日曜の7日", () => {
+    expect(weekDays("2026-07-09")).toEqual([
+      "2026-07-06",
+      "2026-07-07",
+      "2026-07-08",
+      "2026-07-09",
+      "2026-07-10",
+      "2026-07-11",
+      "2026-07-12",
+    ]);
+  });
+});
+
+describe("startOfMonth / endOfMonth", () => {
+  it("月初と月末を返す", () => {
+    expect(startOfMonth("2026-07-15")).toBe("2026-07-01");
+    expect(endOfMonth("2026-07-15")).toBe("2026-07-31");
+  });
+
+  it("うるう年の2月末は29日", () => {
+    expect(endOfMonth("2024-02-10")).toBe("2024-02-29");
+  });
+
+  it("平年の2月末は28日", () => {
+    expect(endOfMonth("2026-02-10")).toBe("2026-02-28");
+  });
+});
+
+describe("monthGridRange", () => {
+  it("月初の曜日ぶんだけ前月へ、月末の曜日ぶんだけ翌月へはみ出す", () => {
+    // 2026-07-01 は水曜、2026-07-31 は金曜。
+    expect(monthGridRange("2026-07-15")).toEqual({
+      from: "2026-06-29",
+      to: "2026-08-02",
+    });
+  });
+
+  it("月初が月曜の月は前月へはみ出さない", () => {
+    // 2026-06-01 は月曜。
+    expect(monthGridRange("2026-06-10").from).toBe("2026-06-01");
+  });
+
+  it("月末が日曜の月は翌月へはみ出さない", () => {
+    // 2026-05-31 は日曜。
+    expect(monthGridRange("2026-05-10").to).toBe("2026-05-31");
+  });
+
+  it("うるう年の2月は29日を含む", () => {
+    expect(monthGridDays("2024-02-01")).toContain("2024-02-29");
+  });
+});
+
+describe("monthGridDays / monthGridWeeks", () => {
+  it("常に7の倍数の日数になる", () => {
+    ["2026-02-01", "2026-07-01", "2024-02-01", "2026-08-01"].forEach((iso) => {
+      expect(monthGridDays(iso).length % 7).toBe(0);
+    });
+  });
+
+  it("先頭は必ず月曜で、日付は連続する", () => {
+    const days = monthGridDays("2026-07-01");
+    expect(weekdayNumber(days[0])).toBe(1);
+    days.forEach((day, index) => {
+      if (index === 0) return;
+      expect(day).toBe(addDays(days[index - 1], 1));
+    });
+  });
+
+  it("週ごとに7日ずつ区切られる", () => {
+    const weeks = monthGridWeeks("2026-07-01");
+    weeks.forEach((week) => expect(week).toHaveLength(7));
+    expect(weeks.flat()).toEqual(monthGridDays("2026-07-01"));
+  });
+
+  it("月をまたぐ週は前月・翌月の日も含む", () => {
+    const firstWeek = monthGridWeeks("2026-07-01")[0];
+    expect(firstWeek).toContain("2026-06-30");
+    expect(firstWeek).toContain("2026-07-01");
+  });
+});
+
+describe("isSameMonth", () => {
+  it("同じ年月なら true", () => {
+    expect(isSameMonth("2026-07-01", "2026-07-31")).toBe(true);
+    expect(isSameMonth("2026-06-30", "2026-07-01")).toBe(false);
+    expect(isSameMonth("2025-07-01", "2026-07-01")).toBe(false);
+  });
+});
+
+describe("freeCalendarWindow / isWithinFreeCalendarWindow", () => {
+  it("今日の前後3ヶ月が閲覧範囲になる", () => {
+    expect(freeCalendarWindow(TODAY)).toEqual({
+      from: "2026-05-03",
+      to: "2026-11-03",
+    });
+  });
+
+  it("境界日は範囲内に含む", () => {
+    expect(isWithinFreeCalendarWindow("2026-05-03", TODAY)).toBe(true);
+    expect(isWithinFreeCalendarWindow("2026-11-03", TODAY)).toBe(true);
+  });
+
+  it("境界の1日外は範囲外", () => {
+    expect(isWithinFreeCalendarWindow("2026-05-02", TODAY)).toBe(false);
+    expect(isWithinFreeCalendarWindow("2026-11-04", TODAY)).toBe(false);
+  });
+});
+
+describe("isRangeOutsideFreeCalendarWindow", () => {
+  it("1日でも重なっていれば範囲外扱いにしない", () => {
+    expect(
+      isRangeOutsideFreeCalendarWindow(
+        { from: "2026-11-03", to: "2026-12-06" },
+        TODAY,
+      ),
+    ).toBe(false);
+  });
+
+  it("完全に外側なら範囲外", () => {
+    expect(
+      isRangeOutsideFreeCalendarWindow(
+        { from: "2026-11-04", to: "2026-12-06" },
+        TODAY,
+      ),
+    ).toBe(true);
+    expect(
+      isRangeOutsideFreeCalendarWindow(
+        { from: "2026-03-30", to: "2026-05-02" },
+        TODAY,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("shiftCursor", () => {
+  it("月モードは月初へ寄せてから1ヶ月動く", () => {
+    expect(shiftCursor("month", "2026-01-31", 1)).toBe("2026-02-01");
+    expect(shiftCursor("month", "2026-08-15", -1)).toBe("2026-07-01");
+  });
+
+  it("週モードは7日動く", () => {
+    expect(shiftCursor("week", "2026-07-09", 1)).toBe("2026-07-16");
+    expect(shiftCursor("week", "2026-07-09", -1)).toBe("2026-07-02");
+  });
+
+  it("日モードは1日動く", () => {
+    expect(shiftCursor("day", "2026-07-31", 1)).toBe("2026-08-01");
+    expect(shiftCursor("day", "2026-03-01", -1)).toBe("2026-02-28");
+  });
+});
+
+describe("visibleRange", () => {
+  it("月モードは月グリッド全体", () => {
+    expect(visibleRange("month", "2026-07-15")).toEqual(
+      monthGridRange("2026-07-15"),
+    );
+  });
+
+  it("週モードは月曜から日曜", () => {
+    expect(visibleRange("week", "2026-07-09")).toEqual({
+      from: "2026-07-06",
+      to: "2026-07-12",
+    });
+  });
+
+  it("日モードはその日だけ", () => {
+    expect(visibleRange("day", "2026-07-09")).toEqual({
+      from: "2026-07-09",
+      to: "2026-07-09",
+    });
+  });
+});
+
+describe("fetchRange", () => {
+  it("モードに依らず基準日の月グリッド全体を取りに行く", () => {
+    expect(fetchRange("2026-07-09")).toEqual(monthGridRange("2026-07-09"));
+  });
+
+  it("その月のどの日を含む週も取得範囲に収まる", () => {
+    const range = fetchRange("2026-07-09");
+    monthGridDays("2026-07-09").forEach((day) => {
+      weekDays(day).forEach((weekDay) => {
+        if (!isSameMonth(weekDay, "2026-07-09")) return;
+        expect(weekDay >= range.from && weekDay <= range.to).toBe(true);
+      });
+    });
+  });
+});

--- a/app/(app)/practice/schedules/calendar/_utils/calendarDate.ts
+++ b/app/(app)/practice/schedules/calendar/_utils/calendarDate.ts
@@ -1,0 +1,205 @@
+import { FREE_CALENDAR_WINDOW_MONTHS } from "@app/constants/schedule";
+
+/**
+ * カレンダーの日付計算。すべて `YYYY-MM-DD` 文字列を入出力する純粋関数で、
+ * 表示コンポーネントから切り離してテストできるようにしている。
+ */
+
+/**
+ * 「今日」の基準は back の集計（Asia/Tokyo）に合わせる。
+ * 実行環境のタイムゾーンに任せると SSR と CSR で今日がずれ、
+ * 無料プランの閲覧範囲（今日 ±3ヶ月）の境界も1日ずれる。
+ */
+const TIME_ZONE = "Asia/Tokyo";
+
+const DATE_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  timeZone: TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+/** Asia/Tokyo の今日を `YYYY-MM-DD` で返す。 */
+export function todayInTokyo(now: Date = new Date()): string {
+  return DATE_FORMATTER.format(now);
+}
+
+// 日付演算は UTC 固定の Date で行う。ローカルタイムゾーンで計算すると
+// 夏時間や UTC+X の環境で 1 日ずれることがある。
+const toDate = (iso: string): Date => new Date(`${iso}T00:00:00Z`);
+const toIso = (date: Date): string => date.toISOString().slice(0, 10);
+
+/** `YYYY-MM-DD` に日数を加算する。 */
+export function addDays(iso: string, days: number): string {
+  const date = toDate(iso);
+  date.setUTCDate(date.getUTCDate() + days);
+  return toIso(date);
+}
+
+/** その月の日数。うるう年の 2 月は 29 を返す。 */
+export function daysInMonth(year: number, monthIndex: number): number {
+  return new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate();
+}
+
+/**
+ * `YYYY-MM-DD` に月数を加算する。
+ * 加算先に同じ日が無い場合は月末に丸める（1/31 の +1ヶ月は 2/28 または 2/29）。
+ * Rails の `Date#+ n.months` と同じ丸め方にして、無料枠の境界を back と一致させる。
+ */
+export function addMonths(iso: string, months: number): string {
+  const date = toDate(iso);
+  const year = date.getUTCFullYear();
+  const monthIndex = date.getUTCMonth();
+  const day = date.getUTCDate();
+  const target = new Date(Date.UTC(year, monthIndex + months, 1));
+  const lastDay = daysInMonth(target.getUTCFullYear(), target.getUTCMonth());
+  return toIso(
+    new Date(
+      Date.UTC(
+        target.getUTCFullYear(),
+        target.getUTCMonth(),
+        Math.min(day, lastDay),
+      ),
+    ),
+  );
+}
+
+/** その日を含む月の 1 日。 */
+export function startOfMonth(iso: string): string {
+  return `${iso.slice(0, 7)}-01`;
+}
+
+/** その日を含む月の末日。 */
+export function endOfMonth(iso: string): string {
+  const date = toDate(iso);
+  const last = daysInMonth(date.getUTCFullYear(), date.getUTCMonth());
+  return `${iso.slice(0, 7)}-${String(last).padStart(2, "0")}`;
+}
+
+/**
+ * 曜日番号（月=1〜日=7）。back の Schedule#day_numbers と同じ体系。
+ * JavaScript の `Date#getUTCDay()` は日=0 なので、そのまま使うと 1 日分ずれる。
+ */
+export function weekdayNumber(iso: string): number {
+  const day = toDate(iso).getUTCDay();
+  return day === 0 ? 7 : day;
+}
+
+/** その日を含む週の月曜日。front は曜日マスタ（月=1〜日=7）に合わせて週を月曜起点にする。 */
+export function startOfWeek(iso: string): string {
+  return addDays(iso, -(weekdayNumber(iso) - 1));
+}
+
+export interface CalendarRange {
+  from: string;
+  to: string;
+}
+
+/** その日を含む週（月曜〜日曜）の 7 日分。 */
+export function weekDays(iso: string): string[] {
+  const monday = startOfWeek(iso);
+  return Array.from({ length: 7 }, (_, index) => addDays(monday, index));
+}
+
+/**
+ * 月グリッドの表示範囲。月初を含む週の月曜から、月末を含む週の日曜まで。
+ * 前後の月からはみ出す日も含むため、週表示・日表示で必要な日も必ずこの中に入る
+ * （その月のどの日を含む週も、この範囲に完全に収まる）。
+ */
+export function monthGridRange(iso: string): CalendarRange {
+  return {
+    from: startOfWeek(startOfMonth(iso)),
+    to: addDays(startOfWeek(endOfMonth(iso)), 6),
+  };
+}
+
+/** 月グリッドに並ぶ全日付（前後の月の日を含む、7 の倍数）。 */
+export function monthGridDays(iso: string): string[] {
+  const { from, to } = monthGridRange(iso);
+  const days: string[] = [];
+  for (let day = from; day <= to; day = addDays(day, 1)) days.push(day);
+  return days;
+}
+
+/** 月グリッドを週ごとに区切る。各行は必ず 7 日。 */
+export function monthGridWeeks(iso: string): string[][] {
+  const days = monthGridDays(iso);
+  const weeks: string[][] = [];
+  for (let index = 0; index < days.length; index += 7) {
+    weeks.push(days.slice(index, index + 7));
+  }
+  return weeks;
+}
+
+/** その日が iso の月に属するか（月グリッドの前後月の日を淡く出すための判定）。 */
+export function isSameMonth(iso: string, other: string): boolean {
+  return iso.slice(0, 7) === other.slice(0, 7);
+}
+
+/** カレンダーの表示モード。 */
+export type CalendarViewMode = "month" | "week" | "day";
+
+/** 前後移動したときの新しい基準日。移動幅はモードごとに変える。 */
+export function shiftCursor(
+  mode: CalendarViewMode,
+  cursor: string,
+  direction: 1 | -1,
+): string {
+  if (mode === "month") return addMonths(startOfMonth(cursor), direction);
+  return addDays(cursor, direction * (mode === "week" ? 7 : 1));
+}
+
+/** 実際に画面へ出ている日付の範囲。ペイウォールを出すかの判定に使う。 */
+export function visibleRange(
+  mode: CalendarViewMode,
+  cursor: string,
+): CalendarRange {
+  if (mode === "month") return monthGridRange(cursor);
+  if (mode === "week") {
+    const monday = startOfWeek(cursor);
+    return { from: monday, to: addDays(monday, 6) };
+  }
+  return { from: cursor, to: cursor };
+}
+
+/**
+ * API に問い合わせる範囲。モードによらず基準日の月グリッド全体を取りに行く。
+ * 月グリッドはその月のどの日を含む週も内包するため、月 → 週 → 日 の切り替えでは
+ * 追加の取得が要らず、取得のやり直しは月をまたぐ移動のときだけになる。
+ */
+export function fetchRange(cursor: string): CalendarRange {
+  return monthGridRange(cursor);
+}
+
+/**
+ * 無料プランで閲覧できる期間（今日 ±FREE_CALENDAR_WINDOW_MONTHS ヶ月）。
+ * back の plans#calendar が同じ幅で from / to をクランプする。
+ */
+export function freeCalendarWindow(today: string): CalendarRange {
+  return {
+    from: addMonths(today, -FREE_CALENDAR_WINDOW_MONTHS),
+    to: addMonths(today, FREE_CALENDAR_WINDOW_MONTHS),
+  };
+}
+
+/** その日が無料プランの閲覧範囲に入っているか。 */
+export function isWithinFreeCalendarWindow(
+  iso: string,
+  today: string,
+): boolean {
+  const { from, to } = freeCalendarWindow(today);
+  return iso >= from && iso <= to;
+}
+
+/**
+ * 表示範囲がまるごと無料プランの閲覧範囲外か。
+ * 一部でも重なっていれば back からその分のエントリは返るため、
+ * 画面全体をペイウォールで置き換えず、範囲外の日だけをロック表示する。
+ */
+export function isRangeOutsideFreeCalendarWindow(
+  range: CalendarRange,
+  today: string,
+): boolean {
+  const window = freeCalendarWindow(today);
+  return range.to < window.from || range.from > window.to;
+}

--- a/app/(app)/practice/schedules/calendar/page.tsx
+++ b/app/(app)/practice/schedules/calendar/page.tsx
@@ -1,0 +1,58 @@
+import { cookies } from "next/headers";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getPlanCalendar } from "@app/services/v2/planService";
+import { PAGE_TITLE as SCHEDULES_PAGE_TITLE } from "../_components/scheduleCopy";
+import { PAGE_DESCRIPTION, PAGE_TITLE } from "./_components/calendarCopy";
+import PlanCalendarContent from "./_components/PlanCalendarContent";
+import { fetchRange, todayInTokyo } from "./_utils/calendarDate";
+
+export const metadata = {
+  title: PAGE_TITLE,
+};
+
+export default async function PlanCalendarPage() {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  // 初期表示は「今日」を含む月。取得範囲を Container と同じ純粋関数で決めることで、
+  // ハイドレーション後に同じ範囲をもう一度取りに行かずに済む。
+  const today = todayInTokyo();
+  const initialRange = fetchRange(today);
+  const initialResult = await getPlanCalendar(
+    initialRange.from,
+    initialRange.to,
+  );
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:max-w-[900px] lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            <h2 className="text-2xl font-bold">{PAGE_TITLE}</h2>
+            <p className="mt-2 text-sm text-zinc-300">{PAGE_DESCRIPTION}</p>
+
+            <div className="my-6">
+              <PlanCalendarContent
+                today={today}
+                initialRange={initialRange}
+                initialResult={initialResult}
+              />
+            </div>
+
+            <Link
+              href="/practice/schedules"
+              className="inline-block text-sm font-bold text-[#d08000] hover:opacity-80"
+            >
+              {SCHEDULES_PAGE_TITLE}へ
+            </Link>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/(app)/practice/schedules/page.tsx
+++ b/app/(app)/practice/schedules/page.tsx
@@ -3,8 +3,10 @@ import { cookies } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import Header from "@app/components/header/Header";
+import { CalendarIcon } from "@app/components/icon/CalendarIcon";
 import { getSchedules } from "@app/services/v2/scheduleService";
 import {
+  CALENDAR_LABEL,
   CREATE_LABEL,
   LOAD_ERROR,
   PAGE_DESCRIPTION,
@@ -30,7 +32,16 @@ export default async function SchedulesPage() {
       <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
         <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
           <div className="pt-20 px-4 lg:px-6">
-            <h2 className="text-2xl font-bold">{PAGE_TITLE}</h2>
+            <div className="flex items-start justify-between gap-3">
+              <h2 className="text-2xl font-bold">{PAGE_TITLE}</h2>
+              <Link
+                href="/practice/schedules/calendar"
+                className="mt-1 inline-flex shrink-0 items-center gap-1 rounded-full border border-zinc-600 px-3 py-1.5 text-xs font-bold text-zinc-200 transition-colors hover:border-[#d08000] hover:text-[#d08000]"
+              >
+                <CalendarIcon fill="currentColor" width="14" height="14" />
+                {CALENDAR_LABEL}
+              </Link>
+            </div>
             <p className="mt-2 text-sm text-zinc-300">{PAGE_DESCRIPTION}</p>
 
             <div className="my-6">

--- a/app/components/header/HeaderRight.tsx
+++ b/app/components/header/HeaderRight.tsx
@@ -118,6 +118,16 @@ export default function HeaderRight() {
                   練習スケジュール
                 </DropdownItem>
                 <DropdownItem
+                  key="practice-schedules-calendar"
+                  as={Link}
+                  href="/practice/schedules/calendar"
+                  startContent={
+                    <CalendarIcon fill="currentColor" width="18" height="18" />
+                  }
+                >
+                  予定カレンダー
+                </DropdownItem>
+                <DropdownItem
                   key="seasons"
                   as={Link}
                   href="/seasons"

--- a/app/constants/schedule.ts
+++ b/app/constants/schedule.ts
@@ -43,3 +43,17 @@ export const EVENT_TYPES: ReadonlyArray<{
 /** 種別のメタ情報を返す。未知の値は自主練にフォールバックする。 */
 export const eventTypeMeta = (value: ScheduleEventType) =>
   EVENT_TYPES.find((event) => event.value === value) ?? EVENT_TYPES[0];
+
+/**
+ * 無料プランでカレンダーを閲覧できる、今日を中心とした前後の月数。
+ *
+ * back/app/controllers/api/v2/plans_controller.rb の同名定数と揃える。範囲の判定権は
+ * back にあり（entitlement が無ければ from / to をこの幅にクランプして返す）、front の
+ * この値は「ペイウォールをどこで出すか」という表示上の目安にすぎない。back が広げても
+ * front が狭いままだと閲覧できるはずの日をロック表示してしまうため、値を変えるときは
+ * back・mobile と同時に更新する。
+ *
+ * 本来は API が上限を返し front が受け取るのが正しい（front / back / mobile の三重定義を
+ * 解消できる）が、レスポンス形式の変更は back 側の対応が要るため現時点は定数で揃える。
+ */
+export const FREE_CALENDAR_WINDOW_MONTHS = 3;

--- a/app/hooks/useIsNarrowViewport.ts
+++ b/app/hooks/useIsNarrowViewport.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/** Tailwind の md ブレークポイント未満を「狭い画面（SP）」とみなす。 */
+const NARROW_VIEWPORT_QUERY = "(max-width: 767px)";
+
+const mediaQueryList = (): MediaQueryList | null => {
+  if (typeof window === "undefined") return null;
+  if (typeof window.matchMedia !== "function") return null;
+  return window.matchMedia(NARROW_VIEWPORT_QUERY);
+};
+
+function subscribe(onStoreChange: () => void): () => void {
+  const list = mediaQueryList();
+  if (!list?.addEventListener) return () => {};
+  list.addEventListener("change", onStoreChange);
+  return () => list.removeEventListener("change", onStoreChange);
+}
+
+const getSnapshot = (): boolean => mediaQueryList()?.matches ?? false;
+
+// サーバーには画面幅が無い。広い画面として描画しておき、ハイドレーション後に
+// 実際の幅で再評価する（狭い側を既定にすると、デスクトップで一瞬 SP 用 UI が見える）。
+const getServerSnapshot = (): boolean => false;
+
+/**
+ * 画面幅が SP 相当かを購読する。
+ * 連続的な px 幅ではなく導出済みの boolean を購読するため、リサイズのたびに
+ * 再レンダリングされるのはブレークポイントをまたいだ瞬間だけになる。
+ */
+export function useIsNarrowViewport(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/app/services/v2/__tests__/planService.test.ts
+++ b/app/services/v2/__tests__/planService.test.ts
@@ -1,0 +1,101 @@
+const mockGet = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(() => Promise.resolve({ get: mockGet })),
+}));
+
+jest.mock("@app/constants/api", () => ({
+  RAILS_API_URL: "http://back:3000",
+}));
+
+jest.mock("../../../../lib/sentry-helpers", () => ({
+  captureServerActionError: jest.fn(),
+}));
+
+import { getPlanCalendar } from "../planService";
+
+function setupAuthCookies() {
+  mockGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: "test-uid" },
+    };
+    return values[key];
+  });
+}
+
+function mockResponse(status: number, body: unknown) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+const requestedUrl = (): string =>
+  (global.fetch as jest.Mock).mock.calls[0][0] as string;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn();
+  setupAuthCookies();
+});
+
+describe("getPlanCalendar", () => {
+  it("from / to をクエリに付けて calendar を叩く", async () => {
+    mockResponse(200, { entries: [] });
+
+    await getPlanCalendar("2026-07-27", "2026-09-06");
+
+    expect(requestedUrl()).toBe(
+      "http://back:3000/api/v2/plans/calendar?from=2026-07-27&to=2026-09-06",
+    );
+  });
+
+  it("エントリをそのまま返す", async () => {
+    mockResponse(200, {
+      entries: [
+        {
+          date: "2026-08-03",
+          event_type: "game",
+          title: "練習試合",
+          schedule_id: 7,
+        },
+      ],
+    });
+
+    const result = await getPlanCalendar("2026-08-01", "2026-08-31");
+
+    expect(result).toEqual({
+      status: "ok",
+      data: {
+        entries: [
+          {
+            date: "2026-08-03",
+            event_type: "game",
+            title: "練習試合",
+            schedule_id: 7,
+          },
+        ],
+      },
+    });
+  });
+
+  it("from / to が不正で back が 422 を返したら error にする", async () => {
+    mockResponse(422, { error: "from / to が不正です" });
+
+    await expect(getPlanCalendar("2026-08-10", "2026-08-01")).resolves.toEqual({
+      status: "error",
+    });
+  });
+
+  it("認証 Cookie が無ければリクエストせず error を返す", async () => {
+    mockGet.mockReturnValue(undefined);
+
+    await expect(getPlanCalendar("2026-08-01", "2026-08-31")).resolves.toEqual({
+      status: "error",
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/app/services/v2/planService.ts
+++ b/app/services/v2/planService.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import type { CalendarResponse } from "@app/types/plan";
+import { type FetchResult, buildQuery, fetchV2 } from "./requests";
+
+const BASE_PATH = "/api/v2/plans";
+
+/**
+ * 期間内の予定を日別エントリで取得する（GET /api/v2/plans/calendar）。
+ *
+ * 繰り返し（曜日）と単発（planned_on）は back が日付ごとに展開済みで返すため、
+ * front では日付でグルーピングするだけでよい。
+ *
+ * 無料ユーザーの from / to は back が「今日 ±FREE_CALENDAR_WINDOW_MONTHS ヶ月」に
+ * クランプする。範囲外を要求しても 403 ではなく 200 + クランプ後のエントリが返るので、
+ * 「空だから予定が無い」と解釈してはいけない（呼び出し側で entitlement と突き合わせる）。
+ *
+ * @param from 期間開始日（YYYY-MM-DD）
+ * @param to 期間終了日（YYYY-MM-DD）。from より前だと back が 422 を返し error になる。
+ */
+export async function getPlanCalendar(
+  from: string,
+  to: string,
+): Promise<FetchResult<CalendarResponse>> {
+  return fetchV2<CalendarResponse>(
+    `${BASE_PATH}/calendar${buildQuery({ from, to })}`,
+    "getPlanCalendar",
+  );
+}

--- a/app/types/plan.ts
+++ b/app/types/plan.ts
@@ -1,0 +1,25 @@
+/**
+ * 予定（schedule）を日付軸に展開したビュー用の型。
+ * back/app/controllers/api/v2/plans_controller.rb の calendar レスポンスに対応する。
+ * キー名は back の JSON をそのまま使う（snake_case のまま扱い、変換しない）。
+ */
+
+import type { ScheduleEventType } from "@app/types/schedule";
+
+/**
+ * カレンダー1マスに並ぶ予定 1 件。
+ * 繰り返し予定（days_of_week）は back が日付ごとに展開して返すため、
+ * 同じ schedule_id が複数の date で現れる。front で曜日展開はしない。
+ */
+export interface CalendarEntry {
+  /** "2026-07-06"。 */
+  date: string;
+  event_type: ScheduleEventType;
+  /** back の display_title（未設定時はメニューセット名）。どちらも無ければ null。 */
+  title: string | null;
+  schedule_id: number;
+}
+
+export interface CalendarResponse {
+  entries: CalendarEntry[];
+}


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#483

※ ブランチ名は当初の割り当ての都合で `shadow-swing` ですが、実装内容は #483 の予定カレンダーです。

## 概要

`GET /api/v2/plans/calendar` を使った月/週/日の俯瞰カレンダーです。

## ⚠️ 「空カレンダー」ではなくペイウォールを出しています

back は Pro でない場合 **403 を返さず、200 + クランプ後のエントリ**を返します（`today ± 3ヶ月`）。つまり**「空 = 予定なし」と解釈すると、範囲外で「予定がありません」と誤表示**します。

そのため:

- 表示範囲が無料枠と**1日も重ならない**とき → `ProUpsellCard` でカレンダー本体を置換
- **一部だけ範囲外の月** → その日のセルに「Pro限定」ロックバッジ、詳細欄も専用文言
- **Pro 判定が未確定の間は範囲外扱いにしない**
- **範囲外でも API 取得は実行する**（叩かないと entitlement 確定のタイミング次第でローディングから抜けられない状態が作れるため）

**予定作成にはペイウォールを出しません。** `schedule_single` は無料でも無制限で、Pro なのはカレンダーの全期間閲覧だけです。

## `FREE_CALENDAR_WINDOW_MONTHS` の三重定義について（issue が提起した論点）

**今回は front にも定数を置きましたが、本来は API が返すべき**というのが結論です。

- **front に置いた理由**: 範囲の判定権は back にあり（entitlement が無ければ問答無用でクランプ）、front の値は「ペイウォールをどこで出すか」という表示上の目安にすぎません。ズレてもデータの正しさは壊れません
- **API から取るべき理由**: 3箇所（back / mobile / front）に同じ数字が散っており、**片方だけ変えると web だけ「Pro でないと見えない」と誤案内する**事故が起きえます

定数には「back と同時に更新すること」「API から返す設計が本来」というコメントを残しています。**back 側の issue 起票が必要な論点です。**

## mobile と意図的に変えた点

1. **週の起点を月曜にしました**（mobile は日曜）。front の既存資産（`WEEK_DAYS`、`goalForm.weekRange`）と back の曜日番号（月=1〜日=7）が月曜起点で統一されているためです
2. **ペイウォールを「移動をブロックしてモーダル」ではなく「移動は許してインライン表示」にしました。** back のクランプで「月の途中から空になる」ケースがあり、ブロック方式ではその状態を説明できないためです

## back の契約で判明した点

- **繰り返し予定の展開は back 側**です（`plans_on(date)` が `(from..to)` を `flat_map` して日付ごとに展開済みで返す）。front では展開せず、**同じ `schedule_id` が複数 `date` で現れる前提**で描画しています
- `from`/`to` がパース不能または `to < from` で **422**。Pro でなくても 403 は返りません

## 設計上の工夫

**取得範囲をモードに依らず「基準日の月グリッド全体」に固定**しました。月グリッドはその月のどの日を含む週も内包するため、月↔週↔日の切替で再取得が起きず、`useEffect` なしでイベント駆動のみで完結します（初期データは Server Component 側）。代償は日表示でも1ヶ月分取ることです。

レスポンシブは `selectedMode ?? (isNarrow ? "week" : "month")` とし、**一度でも明示選択したら画面幅で上書きしません**。

## チェックリスト

- [x] `yarn typecheck` / `yarn lint` / `yarn format:check` が通る
- [x] `yarn test` が通る（**158 suites / 1902 tests**。新規73件）
- [x] `yarn build` が通る（ローカルで実行済み）
- [x] ミューテーションテスト **24 設計 / 24 KILLED / 0 SURVIVED**

### ルート表

base（`9d15b12`）も同条件でビルドして diff を取得しました。**追加は `ƒ /practice/schedules/calendar` の1行のみ**。削除ゼロ、静的→動的への転落ゼロ（静的 87 で不変）。

<details>
<summary>ミューテーションテスト詳細</summary>

境界±3ヶ月（4ヶ月/2ヶ月）/ 無料枠境界の包含落ち / 範囲外判定の1日ずらし / **ペイウォール除去→空カレンダー** / **Pro判定未確定で範囲外扱い** / 月初オフセット無視 / グリッド末尾 off-by-one / 曜日変換（月=1↔日=0）/ 週頭 off-by-one / TZ を UTC に / 繰り返し展開潰し / `event_type` 色の取り違え / **画面幅によるモード上書き** / 予定追加・詳細の遷移先から日付を落とす / 取得失敗を0件表示に / API パス改変 / `from`/`to` 入替 / 取得範囲を当月のみに / **月移動の1/31問題** / 月末丸め除去 / 月日数計算破壊 / ロック判定反転 — 全 KILLED。

</details>

## 補足

`proFeatureCatalog.ts` の `schedule_calendar_full_history` は `app_only` のままにしています。web 実装済みの他機能（`unlimited_practice_menus` 等）も `app_only` のままで、ここだけ変えると比較表の整合が崩れるためです。**別途まとめて棚卸しします。**

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_