### PR TITLE
Add: 週の練習プランと「今日のやること」を実装

### DIFF
--- a/app/(app)/dashboard/_components/TodayTasksSection.tsx
+++ b/app/(app)/dashboard/_components/TodayTasksSection.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import type { FetchResult } from "@app/services/v2/requests";
+import type { Plan, PlanMenu } from "@app/types/plan";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import CheckCircleIcon from "@heroicons/react/24/solid/CheckCircleIcon";
+import Link from "next/link";
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import { buildPracticeRecordHref } from "@app/(app)/practice/schedules/_utils/scheduleRecord";
+import { eventTypeMeta } from "@app/constants/schedule";
+import {
+  createPracticeLog,
+  deletePracticeLog,
+  getPracticeLogs,
+} from "@app/services/v2/practiceLogService";
+import {
+  doneLogIdsOf,
+  donePresetMenus,
+  planMenuKey,
+  setMenuDone,
+} from "../_utils/todayPlans";
+import {
+  ADD_PLAN_LABEL,
+  CALENDAR_LABEL,
+  EMPTY_MESSAGE,
+  LOAD_ERROR,
+  RECORD_GAME_LABEL,
+  RECORD_PRACTICE_HELPER,
+  RECORD_PRACTICE_LABEL,
+  SECTION_TITLE,
+  TOGGLE_DONE_ERROR,
+  TOGGLE_UNDONE_ERROR,
+  WEEKLY_PLAN_LABEL,
+  menuSetHint,
+} from "./todayTasksCopy";
+
+interface TodayTasksSectionProps {
+  /** Asia/Tokyo の今日（YYYY-MM-DD）。練習ログの logged_on と記録画面への引き継ぎに使う。 */
+  today: string;
+  result: FetchResult<Plan[]>;
+}
+
+/**
+ * ダッシュボードの「今日のやること」。
+ *
+ * 当日の予定（繰り返し ∪ 単発）は back が by_date で展開済みのものを受け取る。
+ * メニューの「済」は練習ログ（practice_log）の作成／削除で表し、通信の往復を待たずに
+ * 手元の状態を先に反転させる。失敗したら必ず元の値へ戻し、「済にしたのに保存されていない」
+ * 状態を残さない。
+ */
+export default function TodayTasksSection({
+  today,
+  result,
+}: TodayTasksSectionProps) {
+  const [plans, setPlans] = useState<Plan[]>(
+    result.status === "ok" ? result.data : [],
+  );
+  const [pendingKeys, setPendingKeys] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+
+  // state の反映を待たずに 2 回目のクリックが走るのを防ぐ。
+  // 同じメニューを素早く 2 回押しても、作成と削除が交錯して「済」表示と実データがずれない。
+  const pendingRef = useRef<Set<string>>(new Set());
+
+  const syncPending = () => setPendingKeys(new Set(pendingRef.current));
+
+  /** 「済」にする。量を伴わない完了マークなので amount は送らない。 */
+  const markDone = async (
+    scheduleId: number,
+    practiceMenuId: number,
+  ): Promise<boolean> => {
+    // schedule_id を送らないと back が予定単位の「済」として数えず、済にならない。
+    const created = await createPracticeLog({
+      practice_menu_id: practiceMenuId,
+      schedule_id: scheduleId,
+      logged_on: today,
+    });
+    return created.ok;
+  };
+
+  /** 「済」を解除する。その予定・その日に作られたログだけを消す。 */
+  const markUndone = async (
+    scheduleId: number,
+    practiceMenuId: number,
+  ): Promise<boolean> => {
+    const logs = await getPracticeLogs({ from: today, to: today });
+    if (logs.status !== "ok") return false;
+
+    const targetIds = doneLogIdsOf(logs.data, scheduleId, practiceMenuId);
+    const deleted = await Promise.all(
+      targetIds.map((logId) => deletePracticeLog(logId)),
+    );
+    return deleted.every((response) => response.ok);
+  };
+
+  const handleToggle = async (plan: Plan, menu: PlanMenu) => {
+    const key = planMenuKey(plan.id, menu.practice_menu_id);
+    if (pendingRef.current.has(key)) return;
+
+    pendingRef.current.add(key);
+    syncPending();
+
+    const wasDone = menu.done;
+    setPlans((previous) =>
+      setMenuDone(previous, plan.id, menu.practice_menu_id, !wasDone),
+    );
+
+    const succeeded = wasDone
+      ? await markUndone(plan.id, menu.practice_menu_id)
+      : await markDone(plan.id, menu.practice_menu_id);
+
+    pendingRef.current.delete(key);
+    syncPending();
+
+    if (!succeeded) {
+      setPlans((previous) =>
+        setMenuDone(previous, plan.id, menu.practice_menu_id, wasDone),
+      );
+      toast.error(wasDone ? TOGGLE_UNDONE_ERROR : TOGGLE_DONE_ERROR);
+    }
+  };
+
+  const presetMenus = donePresetMenus(plans);
+
+  return (
+    <section>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-lg font-bold">{SECTION_TITLE}</h3>
+        <Link
+          href="/practice/schedules/week"
+          className="text-sm text-yellow-500 hover:underline"
+        >
+          {WEEKLY_PLAN_LABEL}
+        </Link>
+      </div>
+
+      {result.status !== "ok" ? (
+        // 取得失敗を「予定なし」と同じ見た目にすると、予定があるのに無いと誤読される。
+        <p
+          role="alert"
+          className="rounded-lg border border-zinc-700 p-6 text-center text-sm text-zinc-400"
+        >
+          {LOAD_ERROR}
+        </p>
+      ) : plans.length === 0 ? (
+        <div className="rounded-lg border border-zinc-700 p-6 text-center">
+          <p className="text-zinc-400">{EMPTY_MESSAGE}</p>
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {plans.map((plan) => {
+            const meta = eventTypeMeta(plan.event_type);
+            return (
+              <li
+                key={plan.id}
+                data-testid={`today-plan-${plan.id}`}
+                className="rounded-lg border border-zinc-700 p-3"
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    className="shrink-0 rounded-full px-2 py-0.5 text-[11px] font-bold"
+                    style={{
+                      backgroundColor: `${meta.color}22`,
+                      color: meta.color,
+                    }}
+                  >
+                    {meta.label}
+                  </span>
+                  {plan.scheduled_time ? (
+                    <span className="shrink-0 text-xs text-zinc-400">
+                      {plan.scheduled_time}
+                    </span>
+                  ) : null}
+                  <Link
+                    href={`/practice/schedules/${plan.id}?date=${today}`}
+                    className="min-w-0 flex-1 truncate text-sm font-bold text-white hover:underline"
+                  >
+                    {plan.title ?? meta.label}
+                  </Link>
+                  {plan.done ? (
+                    <CheckCircleIcon
+                      data-testid={`today-plan-done-${plan.id}`}
+                      className="h-4 w-4 shrink-0 text-[#4a8e32]"
+                      aria-label="この予定は完了しています"
+                    />
+                  ) : null}
+                </div>
+
+                {plan.event_type === "game" ? (
+                  <Link
+                    href="/game-result/record"
+                    className="mt-2 inline-block rounded-lg bg-[#EF4444]/10 px-3 py-1.5 text-xs font-bold text-[#EF4444] transition-opacity hover:opacity-90"
+                  >
+                    {RECORD_GAME_LABEL}
+                  </Link>
+                ) : null}
+
+                {plan.menus.length > 0 ? (
+                  <ul className="mt-2 flex flex-col gap-1">
+                    {plan.menus.map((menu) => {
+                      const key = planMenuKey(plan.id, menu.practice_menu_id);
+                      return (
+                        <li key={key}>
+                          <label className="flex items-center gap-2.5 py-1 text-sm text-white">
+                            <input
+                              type="checkbox"
+                              checked={menu.done}
+                              disabled={pendingKeys.has(key)}
+                              onChange={() => handleToggle(plan, menu)}
+                              className="h-4 w-4 accent-[#d08000] disabled:opacity-50"
+                            />
+                            <span
+                              className={
+                                menu.done ? "text-zinc-400 line-through" : ""
+                              }
+                            >
+                              {menu.name ?? "メニュー"}
+                              {menu.target_value !== null
+                                ? ` ${menu.target_value}${menu.unit_label ?? ""}`
+                                : ""}
+                            </span>
+                          </label>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ) : null}
+
+                {plan.menu_set_id !== null && plan.title !== null ? (
+                  <p className="mt-1 text-[11px] text-zinc-500">
+                    {menuSetHint(plan.title)}
+                  </p>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="mt-3 flex flex-col gap-2">
+        {presetMenus.length > 0 ? (
+          <>
+            <Link
+              href={buildPracticeRecordHref(today, presetMenus)}
+              className="flex w-full items-center justify-center rounded-[10px] bg-[#d08000] px-5 py-3 text-sm font-bold text-white transition-opacity hover:opacity-90"
+            >
+              {RECORD_PRACTICE_LABEL}
+            </Link>
+            <p className="text-xs text-zinc-400">{RECORD_PRACTICE_HELPER}</p>
+          </>
+        ) : null}
+
+        <div className="flex gap-2">
+          <Link
+            href={`/practice/schedules/new?date=${today}`}
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-[10px] border border-[#d08000] px-3 py-2.5 text-xs font-bold text-[#d08000] transition-colors hover:bg-[#d08000]/10"
+          >
+            <PlusIcon className="h-4 w-4 shrink-0" aria-hidden />
+            {ADD_PLAN_LABEL}
+          </Link>
+          <Link
+            href="/practice/schedules/calendar"
+            className="flex flex-1 items-center justify-center rounded-[10px] border border-zinc-600 px-3 py-2.5 text-xs font-bold text-zinc-200 transition-colors hover:border-[#d08000] hover:text-[#d08000]"
+          >
+            {CALENDAR_LABEL}
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/(app)/dashboard/_components/__tests__/TodayTasksSection.test.tsx
+++ b/app/(app)/dashboard/_components/__tests__/TodayTasksSection.test.tsx
@@ -1,0 +1,331 @@
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@app/services/v2/practiceLogService", () => ({
+  createPracticeLog: jest.fn(),
+  deletePracticeLog: jest.fn(),
+  getPracticeLogs: jest.fn(),
+}));
+
+import type { FetchResult } from "@app/services/v2/requests";
+import type { Plan, PlanMenu } from "@app/types/plan";
+import type { PracticeLog } from "@app/types/practice";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  createPracticeLog,
+  deletePracticeLog,
+  getPracticeLogs,
+} from "@app/services/v2/practiceLogService";
+import {
+  EMPTY_MESSAGE,
+  LOAD_ERROR,
+  RECORD_PRACTICE_LABEL,
+} from "../todayTasksCopy";
+import TodayTasksSection from "../TodayTasksSection";
+
+const mockCreateLog = createPracticeLog as jest.MockedFunction<
+  typeof createPracticeLog
+>;
+const mockDeleteLog = deletePracticeLog as jest.MockedFunction<
+  typeof deletePracticeLog
+>;
+const mockGetLogs = getPracticeLogs as jest.MockedFunction<
+  typeof getPracticeLogs
+>;
+
+const TODAY = "2026-08-03";
+
+function buildMenu(overrides: Partial<PlanMenu> = {}): PlanMenu {
+  return {
+    practice_menu_id: 1,
+    name: "素振り",
+    unit_label: "本",
+    target_value: 200,
+    sort_order: 0,
+    done: false,
+    ...overrides,
+  };
+}
+
+function buildPlan(overrides: Partial<Plan> = {}): Plan {
+  return {
+    id: 10,
+    title: "朝練",
+    event_type: "self_practice",
+    scheduled_time: "06:00",
+    recurring: true,
+    menu_set_id: null,
+    game_result_id: null,
+    note: null,
+    menus: [buildMenu()],
+    done: false,
+    ...overrides,
+  };
+}
+
+function buildLog(overrides: Partial<PracticeLog> = {}): PracticeLog {
+  return {
+    id: 100,
+    practice_menu_id: 1,
+    schedule_id: 10,
+    logged_on: TODAY,
+    amount: null,
+    weight: null,
+    menu_name: "素振り",
+    unit_label: "本",
+    source: "manual",
+    memo: null,
+    created_at: `${TODAY}T00:00:00Z`,
+    ...overrides,
+  };
+}
+
+const ok = (plans: Plan[]): FetchResult<Plan[]> => ({
+  status: "ok",
+  data: plans,
+});
+
+const createdLog = (id: number) =>
+  ({ ok: true, data: buildLog({ id }) }) as const;
+
+function renderSection(result: FetchResult<Plan[]>) {
+  return render(<TodayTasksSection today={TODAY} result={result} />);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetLogs.mockResolvedValue({ status: "ok", data: [] });
+});
+
+describe("表示", () => {
+  it("繰り返しと単発が同じ日に並ぶ", () => {
+    renderSection(
+      ok([
+        buildPlan({ id: 10, title: "朝練", recurring: true }),
+        buildPlan({
+          id: 11,
+          title: "練習試合",
+          recurring: false,
+          event_type: "game",
+          menus: [],
+        }),
+      ]),
+    );
+
+    expect(screen.getByRole("link", { name: "朝練" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "練習試合" })).toBeInTheDocument();
+  });
+
+  it("予定 0 件は「予定なし」を出す", () => {
+    renderSection(ok([]));
+
+    expect(screen.getByText(EMPTY_MESSAGE)).toBeInTheDocument();
+    expect(screen.queryByText(LOAD_ERROR)).toBeNull();
+  });
+
+  it("取得失敗は 0 件と区別して案内する", () => {
+    renderSection({ status: "error" });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(LOAD_ERROR);
+    expect(screen.queryByText(EMPTY_MESSAGE)).toBeNull();
+  });
+});
+
+describe("「済」トグル", () => {
+  it("通信を待たずにチェックが入り、schedule_id つきでログを作る", async () => {
+    const user = userEvent.setup();
+    mockCreateLog.mockResolvedValue(createdLog(100));
+    renderSection(ok([buildPlan()]));
+
+    const checkbox = screen.getByRole("checkbox", { name: /素振り/ });
+    await user.click(checkbox);
+
+    expect(checkbox).toBeChecked();
+    expect(mockCreateLog).toHaveBeenCalledWith({
+      practice_menu_id: 1,
+      schedule_id: 10,
+      logged_on: TODAY,
+    });
+  });
+
+  it("済のメニューを外すと、その予定・その日のログだけ削除する", async () => {
+    const user = userEvent.setup();
+    mockGetLogs.mockResolvedValue({
+      status: "ok",
+      data: [
+        buildLog({ id: 100 }),
+        buildLog({ id: 101, schedule_id: 11 }),
+        buildLog({ id: 102, schedule_id: null }),
+      ],
+    });
+    mockDeleteLog.mockResolvedValue({
+      ok: true,
+      data: { message: "削除しました" },
+    });
+    renderSection(ok([buildPlan({ menus: [buildMenu({ done: true })] })]));
+
+    await user.click(screen.getByRole("checkbox", { name: /素振り/ }));
+
+    await waitFor(() => expect(mockDeleteLog).toHaveBeenCalledTimes(1));
+    expect(mockDeleteLog).toHaveBeenCalledWith(100);
+  });
+
+  it("作成に失敗したらチェックを元に戻す", async () => {
+    const user = userEvent.setup();
+    mockCreateLog.mockResolvedValue({
+      ok: false,
+      reason: "error",
+      errors: ["保存に失敗しました"],
+    });
+    renderSection(ok([buildPlan()]));
+
+    const checkbox = screen.getByRole("checkbox", { name: /素振り/ });
+    await user.click(checkbox);
+
+    await waitFor(() => expect(checkbox).not.toBeChecked());
+  });
+
+  it("解除に失敗したらチェックを戻す（済のまま残す）", async () => {
+    const user = userEvent.setup();
+    mockGetLogs.mockResolvedValue({
+      status: "ok",
+      data: [buildLog({ id: 100 })],
+    });
+    mockDeleteLog.mockResolvedValue({
+      ok: false,
+      reason: "error",
+      errors: ["削除に失敗しました"],
+    });
+    renderSection(ok([buildPlan({ menus: [buildMenu({ done: true })] })]));
+
+    const checkbox = screen.getByRole("checkbox", { name: /素振り/ });
+    await user.click(checkbox);
+
+    await waitFor(() => expect(checkbox).toBeChecked());
+  });
+
+  it("当日ログの取得に失敗したら解除せず元に戻す", async () => {
+    const user = userEvent.setup();
+    mockGetLogs.mockResolvedValue({ status: "error" });
+    renderSection(ok([buildPlan({ menus: [buildMenu({ done: true })] })]));
+
+    const checkbox = screen.getByRole("checkbox", { name: /素振り/ });
+    await user.click(checkbox);
+
+    await waitFor(() => expect(checkbox).toBeChecked());
+    expect(mockDeleteLog).not.toHaveBeenCalled();
+  });
+
+  it("連打しても作成は 1 回しか走らない", async () => {
+    const user = userEvent.setup();
+    let resolveCreate: (
+      value: ReturnType<typeof createdLog>,
+    ) => void = () => {};
+    mockCreateLog.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+    renderSection(ok([buildPlan()]));
+
+    const checkbox = screen.getByRole("checkbox", { name: /素振り/ });
+    await user.click(checkbox);
+    await user.click(checkbox);
+    await user.click(checkbox);
+
+    expect(mockCreateLog).toHaveBeenCalledTimes(1);
+    expect(mockDeleteLog).not.toHaveBeenCalled();
+
+    resolveCreate(createdLog(100));
+    await waitFor(() => expect(checkbox).toBeChecked());
+  });
+
+  it("同じメニューでも別の予定なら独立してトグルできる", async () => {
+    const user = userEvent.setup();
+    mockCreateLog.mockResolvedValue(createdLog(100));
+    renderSection(
+      ok([
+        buildPlan({ id: 10, title: "朝練" }),
+        buildPlan({ id: 11, title: "夕練" }),
+      ]),
+    );
+
+    const checkboxes = screen.getAllByRole("checkbox", { name: /素振り/ });
+    await user.click(checkboxes[0]);
+
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+    expect(mockCreateLog).toHaveBeenCalledWith(
+      expect.objectContaining({ schedule_id: 10 }),
+    );
+  });
+
+  it("全メニューが済になると予定に完了マークが付く", async () => {
+    const user = userEvent.setup();
+    mockCreateLog.mockResolvedValue(createdLog(100));
+    renderSection(
+      ok([
+        buildPlan({
+          menus: [
+            buildMenu({ practice_menu_id: 1, name: "素振り", done: true }),
+            buildMenu({ practice_menu_id: 2, name: "ランニング" }),
+          ],
+        }),
+      ]),
+    );
+
+    expect(screen.queryByTestId("today-plan-done-10")).toBeNull();
+
+    await user.click(screen.getByRole("checkbox", { name: /ランニング/ }));
+
+    expect(screen.getByTestId("today-plan-done-10")).toBeInTheDocument();
+  });
+});
+
+describe("練習記録への引き継ぎ", () => {
+  it("済のメニューが無ければ記録ボタンを出さない", () => {
+    renderSection(ok([buildPlan()]));
+
+    expect(
+      screen.queryByRole("link", { name: RECORD_PRACTICE_LABEL }),
+    ).toBeNull();
+  });
+
+  it("date と presetMenus の両方を渡す", () => {
+    renderSection(
+      ok([
+        buildPlan({
+          menus: [buildMenu({ target_value: 200, done: true })],
+        }),
+      ]),
+    );
+
+    const href = screen
+      .getByRole("link", { name: RECORD_PRACTICE_LABEL })
+      .getAttribute("href") as string;
+    const query = new URLSearchParams(href.split("?")[1]);
+
+    expect(query.get("date")).toBe(TODAY);
+    expect(JSON.parse(query.get("presetMenus") as string)).toEqual([
+      { practice_menu_id: 1, target_value: 200 },
+    ]);
+  });
+
+  it("済にした直後のメニューが引き継ぎ対象に入る", async () => {
+    const user = userEvent.setup();
+    mockCreateLog.mockResolvedValue(createdLog(100));
+    renderSection(ok([buildPlan()]));
+
+    await user.click(screen.getByRole("checkbox", { name: /素振り/ }));
+
+    const href = screen
+      .getByRole("link", { name: RECORD_PRACTICE_LABEL })
+      .getAttribute("href") as string;
+    expect(new URLSearchParams(href.split("?")[1]).get("presetMenus")).toBe(
+      JSON.stringify([{ practice_menu_id: 1, target_value: 200 }]),
+    );
+  });
+});

--- a/app/(app)/dashboard/_components/__tests__/TodayTasksSection.test.tsx
+++ b/app/(app)/dashboard/_components/__tests__/TodayTasksSection.test.tsx
@@ -11,7 +11,13 @@ jest.mock("@app/services/v2/practiceLogService", () => ({
 import type { FetchResult } from "@app/services/v2/requests";
 import type { Plan, PlanMenu } from "@app/types/plan";
 import type { PracticeLog } from "@app/types/practice";
-import { render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   createPracticeLog,
@@ -218,8 +224,9 @@ describe("「済」トグル", () => {
     expect(mockDeleteLog).not.toHaveBeenCalled();
   });
 
-  it("連打しても作成は 1 回しか走らない", async () => {
-    const user = userEvent.setup();
+  // 再描画（disabled の反映）を挟まずに連続でクリックが届く状況を作り、
+  // 表示だけでなくトグル処理自体が二重送信を弾くことを確かめる。
+  it("再描画を挟まない連打でも作成は 1 回しか走らない", async () => {
     let resolveCreate: (
       value: ReturnType<typeof createdLog>,
     ) => void = () => {};
@@ -232,15 +239,19 @@ describe("「済」トグル", () => {
     renderSection(ok([buildPlan()]));
 
     const checkbox = screen.getByRole("checkbox", { name: /素振り/ });
-    await user.click(checkbox);
-    await user.click(checkbox);
-    await user.click(checkbox);
+    await act(async () => {
+      fireEvent.click(checkbox);
+      fireEvent.click(checkbox);
+      fireEvent.click(checkbox);
+    });
 
     expect(mockCreateLog).toHaveBeenCalledTimes(1);
     expect(mockDeleteLog).not.toHaveBeenCalled();
 
-    resolveCreate(createdLog(100));
-    await waitFor(() => expect(checkbox).toBeChecked());
+    await act(async () => {
+      resolveCreate(createdLog(100));
+    });
+    expect(checkbox).toBeChecked();
   });
 
   it("同じメニューでも別の予定なら独立してトグルできる", async () => {

--- a/app/(app)/dashboard/_components/todayTasksCopy.ts
+++ b/app/(app)/dashboard/_components/todayTasksCopy.ts
@@ -1,0 +1,24 @@
+/** 「今日のやること」セクションの文言。表示のゆれを避けるため 1 箇所に集約する。 */
+
+export const SECTION_TITLE = "今日のやること";
+
+/** 0 件と取得失敗を同じ見た目にすると「予定なし」と誤読され、重複登録を招く。 */
+export const EMPTY_MESSAGE = "今日の予定はありません";
+export const LOAD_ERROR =
+  "今日の予定を取得できませんでした。時間を置いて再度お試しください。";
+
+export const ADD_PLAN_LABEL = "今日やることを登録";
+export const RECORD_PRACTICE_LABEL = "今日の練習を記録する";
+export const RECORD_GAME_LABEL = "試合結果を記録する";
+export const WEEKLY_PLAN_LABEL = "週の練習プラン";
+export const CALENDAR_LABEL = "カレンダー";
+
+/** 引き継がれるのが「済」にしたメニューだけであることを明示する。 */
+export const RECORD_PRACTICE_HELPER =
+  "「済」にしたメニューを選択済みの状態で練習記録画面を開きます。";
+
+export const TOGGLE_DONE_ERROR = "「済」にできませんでした";
+export const TOGGLE_UNDONE_ERROR = "「済」を解除できませんでした";
+
+/** メニューセット由来の予定であることを示す補足。 */
+export const menuSetHint = (title: string): string => `「${title}」より`;

--- a/app/(app)/dashboard/_utils/__tests__/todayPlans.test.ts
+++ b/app/(app)/dashboard/_utils/__tests__/todayPlans.test.ts
@@ -1,0 +1,183 @@
+import type { Plan, PlanMenu } from "@app/types/plan";
+import type { PracticeLog } from "@app/types/practice";
+import {
+  doneLogIdsOf,
+  donePresetMenus,
+  planMenuKey,
+  setMenuDone,
+} from "../todayPlans";
+
+function buildMenu(overrides: Partial<PlanMenu> = {}): PlanMenu {
+  return {
+    practice_menu_id: 1,
+    name: "素振り",
+    unit_label: "本",
+    target_value: 200,
+    sort_order: 0,
+    done: false,
+    ...overrides,
+  };
+}
+
+function buildPlan(overrides: Partial<Plan> = {}): Plan {
+  return {
+    id: 10,
+    title: "朝練",
+    event_type: "self_practice",
+    scheduled_time: "06:00",
+    recurring: true,
+    menu_set_id: null,
+    game_result_id: null,
+    note: null,
+    menus: [buildMenu()],
+    done: false,
+    ...overrides,
+  };
+}
+
+function buildLog(overrides: Partial<PracticeLog> = {}): PracticeLog {
+  return {
+    id: 100,
+    practice_menu_id: 1,
+    schedule_id: 10,
+    logged_on: "2026-08-03",
+    amount: null,
+    weight: null,
+    menu_name: "素振り",
+    unit_label: "本",
+    source: "manual",
+    memo: null,
+    created_at: "2026-08-03T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("planMenuKey", () => {
+  it("同じメニューでも予定が違えば別のキーになる", () => {
+    expect(planMenuKey(10, 1)).not.toBe(planMenuKey(11, 1));
+  });
+});
+
+describe("setMenuDone", () => {
+  it("対象メニューの done を指定値にする", () => {
+    const plans = [buildPlan()];
+
+    const next = setMenuDone(plans, 10, 1, true);
+
+    expect(next[0].menus[0].done).toBe(true);
+  });
+
+  it("同じ値をもう一度指定しても反転しない（ロールバックが元に戻せる）", () => {
+    const plans = setMenuDone([buildPlan()], 10, 1, true);
+
+    expect(setMenuDone(plans, 10, 1, true)[0].menus[0].done).toBe(true);
+  });
+
+  it("同じメニューを持つ別の予定には波及しない", () => {
+    const plans = [buildPlan({ id: 10 }), buildPlan({ id: 11 })];
+
+    const next = setMenuDone(plans, 10, 1, true);
+
+    expect(next[0].menus[0].done).toBe(true);
+    expect(next[1].menus[0].done).toBe(false);
+  });
+
+  it("全メニューが済になったら予定全体も済にする", () => {
+    const plans = [
+      buildPlan({
+        menus: [
+          buildMenu({ practice_menu_id: 1, done: true }),
+          buildMenu({ practice_menu_id: 2, done: false }),
+        ],
+      }),
+    ];
+
+    expect(setMenuDone(plans, 10, 2, true)[0].done).toBe(true);
+  });
+
+  it("1 つでも未済に戻れば予定全体の済も外れる", () => {
+    const plans = [
+      buildPlan({
+        done: true,
+        menus: [
+          buildMenu({ practice_menu_id: 1, done: true }),
+          buildMenu({ practice_menu_id: 2, done: true }),
+        ],
+      }),
+    ];
+
+    expect(setMenuDone(plans, 10, 2, false)[0].done).toBe(false);
+  });
+
+  it("元の配列を書き換えない", () => {
+    const plans = [buildPlan()];
+
+    setMenuDone(plans, 10, 1, true);
+
+    expect(plans[0].menus[0].done).toBe(false);
+  });
+});
+
+describe("donePresetMenus", () => {
+  it("済のメニューだけを目標量つきで返す", () => {
+    const plans = [
+      buildPlan({
+        menus: [
+          buildMenu({ practice_menu_id: 1, target_value: 200, done: true }),
+          buildMenu({ practice_menu_id: 2, target_value: 5, done: false }),
+        ],
+      }),
+    ];
+
+    expect(donePresetMenus(plans)).toEqual([
+      { practice_menu_id: 1, target_value: 200 },
+    ]);
+  });
+
+  it("複数の予定に同じメニューがあっても 1 件にまとめる", () => {
+    const plans = [
+      buildPlan({
+        id: 10,
+        menus: [buildMenu({ practice_menu_id: 1, done: true })],
+      }),
+      buildPlan({
+        id: 11,
+        menus: [
+          buildMenu({ practice_menu_id: 1, target_value: 50, done: true }),
+        ],
+      }),
+    ];
+
+    expect(donePresetMenus(plans)).toEqual([
+      { practice_menu_id: 1, target_value: 200 },
+    ]);
+  });
+
+  it("済が無ければ空配列", () => {
+    expect(donePresetMenus([buildPlan()])).toEqual([]);
+  });
+});
+
+describe("doneLogIdsOf", () => {
+  it("その予定・そのメニューのログ ID だけを返す", () => {
+    const logs = [
+      buildLog({ id: 100 }),
+      buildLog({ id: 101, schedule_id: 11 }),
+      buildLog({ id: 102, practice_menu_id: 2 }),
+    ];
+
+    expect(doneLogIdsOf(logs, 10, 1)).toEqual([100]);
+  });
+
+  it("予定に紐づかないログ（schedule_id が null）は対象にしない", () => {
+    const logs = [buildLog({ id: 200, schedule_id: null })];
+
+    expect(doneLogIdsOf(logs, 10, 1)).toEqual([]);
+  });
+
+  it("同じメニューのログが複数あればすべて返す", () => {
+    const logs = [buildLog({ id: 100 }), buildLog({ id: 103 })];
+
+    expect(doneLogIdsOf(logs, 10, 1)).toEqual([100, 103]);
+  });
+});

--- a/app/(app)/dashboard/_utils/todayPlans.ts
+++ b/app/(app)/dashboard/_utils/todayPlans.ts
@@ -1,0 +1,82 @@
+import type { Plan } from "@app/types/plan";
+import type { PracticeLog, PresetMenu } from "@app/types/practice";
+
+/**
+ * 「今日のやること」の状態計算。すべて純粋関数で、楽観的更新とロールバックの両方から使う。
+ */
+
+/**
+ * 予定 × メニューを一意に指すキー。
+ * 同じ練習メニューが複数の予定に含まれることがあり、practice_menu_id だけでは
+ * どの予定のトグルなのか特定できない（「済」は予定単位で独立している）。
+ */
+export function planMenuKey(
+  scheduleId: number,
+  practiceMenuId: number,
+): string {
+  return `${scheduleId}:${practiceMenuId}`;
+}
+
+/**
+ * 対象メニューの done を指定値に揃えた plans を返す。
+ *
+ * 反転ではなく「値を指定する」形にしているのは、失敗時のロールバックで
+ * 元の状態へ確実に戻すため。反転を 2 回重ねる方式は、途中で別の更新が挟まると
+ * 元に戻らない。予定全体の done も付随して計算し直す。
+ */
+export function setMenuDone(
+  plans: Plan[],
+  scheduleId: number,
+  practiceMenuId: number,
+  done: boolean,
+): Plan[] {
+  return plans.map((plan) => {
+    if (plan.id !== scheduleId) return plan;
+    const menus = plan.menus.map((menu) =>
+      menu.practice_menu_id === practiceMenuId ? { ...menu, done } : menu,
+    );
+    return {
+      ...plan,
+      menus,
+      done: menus.length > 0 && menus.every((menu) => menu.done),
+    };
+  });
+}
+
+/**
+ * 「済」にしたメニューを練習記録のプリセットへ変換する。
+ * 同じメニューが複数の予定で済になっていても記録先は 1 件なので、
+ * practice_menu_id で重複を除く（先に現れた予定の目標量を採る）。
+ */
+export function donePresetMenus(plans: Plan[]): PresetMenu[] {
+  const byMenuId = new Map<number, PresetMenu>();
+  plans.forEach((plan) =>
+    plan.menus.forEach((menu) => {
+      if (!menu.done || byMenuId.has(menu.practice_menu_id)) return;
+      byMenuId.set(menu.practice_menu_id, {
+        practice_menu_id: menu.practice_menu_id,
+        target_value: menu.target_value,
+      });
+    }),
+  );
+  return Array.from(byMenuId.values());
+}
+
+/**
+ * 「済」を解除するために削除すべき練習ログの ID。
+ * schedule_id が一致するログだけを対象にする。フル記録など予定に紐づかないログ
+ * （schedule_id が null）まで消すと、予定と無関係な実績が失われる。
+ */
+export function doneLogIdsOf(
+  logs: PracticeLog[],
+  scheduleId: number,
+  practiceMenuId: number,
+): number[] {
+  return logs
+    .filter(
+      (log) =>
+        log.schedule_id === scheduleId &&
+        log.practice_menu_id === practiceMenuId,
+    )
+    .map((log) => log.id);
+}

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,11 +1,14 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { todayInTokyo } from "@app/(app)/practice/schedules/calendar/_utils/calendarDate";
 import { adSlots } from "@app/components/ad/adConfig";
 import AdInFeed from "@app/components/ad/AdInFeed";
 import Header from "@app/components/header/Header";
 import { getPeriodicReviews } from "@app/services/v2/periodicReviewService";
+import { getDayPlan } from "@app/services/v2/planService";
 import DashboardContent from "./_components/DashboardContent";
 import PeriodicReviewBanner from "./_components/PeriodicReviewBanner";
+import TodayTasksSection from "./_components/TodayTasksSection";
 import { getAvailableSeasons, getDashboardData } from "./actions";
 
 export const metadata = {
@@ -18,10 +21,14 @@ export default async function DashboardPage() {
     redirect("/signup?auth_required=true");
   }
 
-  const [data, seasons, reviews] = await Promise.all([
+  // 「今日」は back の集計と同じ Asia/Tokyo 基準で決める。実行環境のタイムゾーンに任せると
+  // 日付が 1 日ずれ、当日の予定と「済」の判定日が食い違う。
+  const today = todayInTokyo();
+  const [data, seasons, reviews, todayPlans] = await Promise.all([
     getDashboardData(),
     getAvailableSeasons(),
     getPeriodicReviews(),
+    getDayPlan(today),
   ]);
 
   return (
@@ -34,6 +41,7 @@ export default async function DashboardPage() {
               <h2 className="text-2xl font-bold">ダッシュボード</h2>
               <div className="my-6 flex flex-col gap-6">
                 <PeriodicReviewBanner result={reviews} />
+                <TodayTasksSection today={today} result={todayPlans} />
                 <DashboardContent data={data} seasons={seasons} />
                 <AdInFeed
                   slot={adSlots.dashboardInFeed}

--- a/app/(app)/practice/schedules/_components/scheduleCopy.ts
+++ b/app/(app)/practice/schedules/_components/scheduleCopy.ts
@@ -8,6 +8,7 @@ export const PAGE_DESCRIPTION =
 
 export const CREATE_LABEL = "予定を作る";
 export const CALENDAR_LABEL = "カレンダー";
+export const WEEKLY_PLAN_LABEL = "週プラン";
 export const EMPTY_MESSAGE = "まだ予定がありません";
 export const RECURRING_SECTION_TITLE = "毎週の予定";
 export const SINGLE_SECTION_TITLE = "この日だけの予定";

--- a/app/(app)/practice/schedules/page.tsx
+++ b/app/(app)/practice/schedules/page.tsx
@@ -11,6 +11,7 @@ import {
   LOAD_ERROR,
   PAGE_DESCRIPTION,
   PAGE_TITLE,
+  WEEKLY_PLAN_LABEL,
 } from "./_components/scheduleCopy";
 import ScheduleList from "./_components/ScheduleList";
 
@@ -34,13 +35,21 @@ export default async function SchedulesPage() {
           <div className="pt-20 px-4 lg:px-6">
             <div className="flex items-start justify-between gap-3">
               <h2 className="text-2xl font-bold">{PAGE_TITLE}</h2>
-              <Link
-                href="/practice/schedules/calendar"
-                className="mt-1 inline-flex shrink-0 items-center gap-1 rounded-full border border-zinc-600 px-3 py-1.5 text-xs font-bold text-zinc-200 transition-colors hover:border-[#d08000] hover:text-[#d08000]"
-              >
-                <CalendarIcon fill="currentColor" width="14" height="14" />
-                {CALENDAR_LABEL}
-              </Link>
+              <div className="mt-1 flex shrink-0 items-center gap-2">
+                <Link
+                  href="/practice/schedules/week"
+                  className="inline-flex shrink-0 items-center gap-1 rounded-full border border-zinc-600 px-3 py-1.5 text-xs font-bold text-zinc-200 transition-colors hover:border-[#d08000] hover:text-[#d08000]"
+                >
+                  {WEEKLY_PLAN_LABEL}
+                </Link>
+                <Link
+                  href="/practice/schedules/calendar"
+                  className="inline-flex shrink-0 items-center gap-1 rounded-full border border-zinc-600 px-3 py-1.5 text-xs font-bold text-zinc-200 transition-colors hover:border-[#d08000] hover:text-[#d08000]"
+                >
+                  <CalendarIcon fill="currentColor" width="14" height="14" />
+                  {CALENDAR_LABEL}
+                </Link>
+              </div>
             </div>
             <p className="mt-2 text-sm text-zinc-300">{PAGE_DESCRIPTION}</p>
 

--- a/app/(app)/practice/schedules/week/__tests__/WeeklyPlanContent.test.tsx
+++ b/app/(app)/practice/schedules/week/__tests__/WeeklyPlanContent.test.tsx
@@ -29,7 +29,14 @@ jest.mock("@app/services/v2/scheduleService", () => ({
 
 import type { FetchResult } from "@app/services/v2/requests";
 import type { Schedule } from "@app/types/schedule";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { copyScheduleWeekToNext } from "@app/services/v2/scheduleService";
 import WeeklyPlanContent from "../_components/WeeklyPlanContent";
@@ -277,8 +284,9 @@ describe("来週にコピー", () => {
     expect(screen.queryByTestId("copy-lock-icon")).toBeNull();
   });
 
-  it("連打しても 1 回しか送らない", async () => {
-    const user = userEvent.setup();
+  // 再描画（disabled の反映）を挟まずに連続でクリックが届く状況を作り、
+  // 表示だけでなく送信処理自体が二重送信を弾くことを確かめる。
+  it("再描画を挟まない連打でも 1 回しか送らない", async () => {
     let resolveCopy: (value: { ok: true; data: Schedule[] }) => void = () => {};
     mockCopy.mockImplementation(
       () =>
@@ -289,20 +297,22 @@ describe("来週にコピー", () => {
     renderContent(ok([buildSchedule()]));
 
     const button = screen.getByRole("button", { name: new RegExp(COPY_LABEL) });
-    await user.click(button);
-    await user.click(button);
-    await user.click(button);
+    await act(async () => {
+      fireEvent.click(button);
+      fireEvent.click(button);
+      fireEvent.click(button);
+    });
 
     expect(mockCopy).toHaveBeenCalledTimes(1);
 
-    resolveCopy({
-      ok: true,
-      data: [buildSchedule({ id: 20, planned_on: "2026-08-10" })],
+    await act(async () => {
+      resolveCopy({
+        ok: true,
+        data: [buildSchedule({ id: 20, planned_on: "2026-08-10" })],
+      });
     });
-    await waitFor(() =>
-      expect(screen.getByTestId("week-range-label")).toHaveTextContent(
-        "8/10〜8/16",
-      ),
+    expect(screen.getByTestId("week-range-label")).toHaveTextContent(
+      "8/10〜8/16",
     );
   });
 });

--- a/app/(app)/practice/schedules/week/__tests__/WeeklyPlanContent.test.tsx
+++ b/app/(app)/practice/schedules/week/__tests__/WeeklyPlanContent.test.tsx
@@ -1,0 +1,308 @@
+const mockHasEntitlement = jest.fn();
+const mockIsEntitlementLoading = jest.fn(() => false);
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: () => ({
+    isPro: mockHasEntitlement("schedule_copy_next_week"),
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading: mockIsEntitlementLoading(),
+    hasEntitlement: mockHasEntitlement,
+  }),
+}));
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: jest.fn(), close: jest.fn() }),
+}));
+
+jest.mock("@app/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@app/services/v2/scheduleService", () => ({
+  copyScheduleWeekToNext: jest.fn(),
+}));
+
+import type { FetchResult } from "@app/services/v2/requests";
+import type { Schedule } from "@app/types/schedule";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { copyScheduleWeekToNext } from "@app/services/v2/scheduleService";
+import WeeklyPlanContent from "../_components/WeeklyPlanContent";
+import {
+  COPY_EMPTY_MESSAGE,
+  COPY_FORBIDDEN_MESSAGE,
+  COPY_LABEL,
+  COPY_PAYWALL_TITLE,
+  LOAD_ERROR,
+  NEXT_WEEK_LABEL,
+  PREV_WEEK_LABEL,
+} from "../_components/weeklyPlanCopy";
+
+const mockCopy = copyScheduleWeekToNext as jest.MockedFunction<
+  typeof copyScheduleWeekToNext
+>;
+
+// 2026-08-05 は水曜。その週は 2026-08-03(月) 〜 2026-08-09(日)。
+const TODAY = "2026-08-05";
+const MONDAY = "2026-08-03";
+
+function buildSchedule(overrides: Partial<Schedule> = {}): Schedule {
+  return {
+    id: 1,
+    title: "朝練",
+    days_of_week: null,
+    planned_on: MONDAY,
+    scheduled_time: "06:00",
+    event_type: "self_practice",
+    recurring: false,
+    menu_set_id: null,
+    game_result_id: null,
+    note: null,
+    notification_enabled: false,
+    active: true,
+    notification_message: null,
+    menus: [],
+    logged_practice_menu_ids: [],
+    ...overrides,
+  };
+}
+
+const ok = (schedules: Schedule[]): FetchResult<Schedule[]> => ({
+  status: "ok",
+  data: schedules,
+});
+
+function renderContent(result: FetchResult<Schedule[]> = ok([])) {
+  return render(<WeeklyPlanContent today={TODAY} result={result} />);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockHasEntitlement.mockReturnValue(true);
+  mockIsEntitlementLoading.mockReturnValue(false);
+});
+
+describe("週の表示", () => {
+  it("週始まりは月曜で、月〜日の 7 日を並べる", () => {
+    renderContent();
+
+    expect(screen.getByTestId(`week-day-${MONDAY}`)).toBeInTheDocument();
+    expect(screen.getByTestId("week-day-2026-08-09")).toBeInTheDocument();
+    // 前週の日曜・翌週の月曜は含まない。
+    expect(screen.queryByTestId("week-day-2026-08-02")).toBeNull();
+    expect(screen.queryByTestId("week-day-2026-08-10")).toBeNull();
+    expect(screen.getByTestId("week-range-label")).toHaveTextContent(
+      "8/3〜8/9",
+    );
+  });
+
+  it("その週の単発予定を曜日の行に出す", () => {
+    renderContent(
+      ok([
+        buildSchedule({ id: 1, title: "朝練", planned_on: MONDAY }),
+        buildSchedule({ id: 2, title: "練習試合", planned_on: "2026-08-09" }),
+      ]),
+    );
+
+    expect(
+      within(screen.getByTestId(`week-day-${MONDAY}`)).getByText("朝練"),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("week-day-2026-08-09")).getByText("練習試合"),
+    ).toBeInTheDocument();
+  });
+
+  it("前へ・次へで週が 7 日ずつ動く", async () => {
+    const user = userEvent.setup();
+    renderContent();
+
+    await user.click(screen.getByRole("button", { name: NEXT_WEEK_LABEL }));
+    expect(screen.getByTestId("week-range-label")).toHaveTextContent(
+      "8/10〜8/16",
+    );
+
+    await user.click(screen.getByRole("button", { name: PREV_WEEK_LABEL }));
+    await user.click(screen.getByRole("button", { name: PREV_WEEK_LABEL }));
+    expect(screen.getByTestId("week-range-label")).toHaveTextContent(
+      "7/27〜8/2",
+    );
+  });
+
+  it("日ごとの「＋」は、その日を初期値にした予定作成へ送る", () => {
+    renderContent();
+
+    const addLinks = screen.getAllByRole("link", { name: /予定を追加/ });
+    expect(addLinks[0]).toHaveAttribute(
+      "href",
+      `/practice/schedules/new?date=${MONDAY}`,
+    );
+  });
+
+  it("予定のチップは日付つきの詳細へ送る（済の判定日を引き継ぐ）", () => {
+    renderContent(ok([buildSchedule({ id: 7, planned_on: "2026-08-06" })]));
+
+    expect(screen.getByRole("link", { name: /朝練/ })).toHaveAttribute(
+      "href",
+      "/practice/schedules/7?date=2026-08-06",
+    );
+  });
+
+  it("取得失敗は「予定なし」と区別して案内する", () => {
+    renderContent({ status: "error" });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(LOAD_ERROR);
+    expect(screen.queryByTestId(`week-day-${MONDAY}`)).toBeNull();
+  });
+
+  it("0 件のときは曜日の枠は出したまま、エラーは出さない", () => {
+    renderContent(ok([]));
+
+    expect(screen.getByTestId(`week-day-${MONDAY}`)).toBeInTheDocument();
+    expect(screen.queryByText(LOAD_ERROR)).toBeNull();
+  });
+});
+
+describe("来週にコピー", () => {
+  it("成功したら表示週が翌週へ移動する", async () => {
+    const user = userEvent.setup();
+    mockCopy.mockResolvedValue({
+      ok: true,
+      data: [buildSchedule({ id: 20, planned_on: "2026-08-10" })],
+    });
+    renderContent(ok([buildSchedule({ id: 1, planned_on: MONDAY })]));
+
+    await user.click(
+      screen.getByRole("button", { name: new RegExp(COPY_LABEL) }),
+    );
+
+    expect(mockCopy).toHaveBeenCalledWith(MONDAY);
+    await waitFor(() =>
+      expect(screen.getByTestId("week-range-label")).toHaveTextContent(
+        "8/10〜8/16",
+      ),
+    );
+  });
+
+  it("コピーされた予定が移動先の週に並ぶ", async () => {
+    const user = userEvent.setup();
+    mockCopy.mockResolvedValue({
+      ok: true,
+      data: [
+        buildSchedule({ id: 20, title: "朝練", planned_on: "2026-08-10" }),
+      ],
+    });
+    renderContent(ok([buildSchedule({ id: 1, planned_on: MONDAY })]));
+
+    await user.click(
+      screen.getByRole("button", { name: new RegExp(COPY_LABEL) }),
+    );
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("week-day-2026-08-10")).getByText("朝練"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("コピー対象が 0 件なら案内を出し、週は動かさない", async () => {
+    const user = userEvent.setup();
+    mockCopy.mockResolvedValue({ ok: true, data: [] });
+    renderContent(ok([]));
+
+    await user.click(
+      screen.getByRole("button", { name: new RegExp(COPY_LABEL) }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(COPY_EMPTY_MESSAGE),
+    );
+    expect(screen.getByTestId("week-range-label")).toHaveTextContent(
+      "8/3〜8/9",
+    );
+  });
+
+  it("403 は「Pro 限定」として案内する（無料枠の超過ではない）", async () => {
+    const user = userEvent.setup();
+    // front の Pro 判定が古く、back だけが未加入と判断したケース。
+    mockHasEntitlement.mockReturnValue(true);
+    mockCopy.mockResolvedValue({
+      ok: false,
+      reason: "forbidden",
+      errors: ["来週にコピーは Pro プラン限定です"],
+    });
+    renderContent(ok([buildSchedule()]));
+
+    await user.click(
+      screen.getByRole("button", { name: new RegExp(COPY_LABEL) }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(
+        COPY_FORBIDDEN_MESSAGE,
+      ),
+    );
+    expect(screen.getByText(COPY_PAYWALL_TITLE)).toBeInTheDocument();
+    expect(screen.getByRole("status")).not.toHaveTextContent("上限");
+    expect(screen.getByTestId("week-range-label")).toHaveTextContent(
+      "8/3〜8/9",
+    );
+  });
+
+  it("entitlement が無ければ API を叩かずにペイウォールを出す", async () => {
+    const user = userEvent.setup();
+    mockHasEntitlement.mockReturnValue(false);
+    renderContent(ok([buildSchedule()]));
+
+    await user.click(
+      screen.getByRole("button", { name: new RegExp(COPY_LABEL) }),
+    );
+
+    expect(mockCopy).not.toHaveBeenCalled();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      COPY_FORBIDDEN_MESSAGE,
+    );
+    expect(screen.getByText(COPY_PAYWALL_TITLE)).toBeInTheDocument();
+  });
+
+  it("Pro 判定が未確定の間は鍵アイコンを出さない", () => {
+    mockIsEntitlementLoading.mockReturnValue(true);
+    mockHasEntitlement.mockReturnValue(false);
+    renderContent(ok([]));
+
+    expect(screen.queryByTestId("copy-lock-icon")).toBeNull();
+  });
+
+  it("連打しても 1 回しか送らない", async () => {
+    const user = userEvent.setup();
+    let resolveCopy: (value: { ok: true; data: Schedule[] }) => void = () => {};
+    mockCopy.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCopy = resolve;
+        }),
+    );
+    renderContent(ok([buildSchedule()]));
+
+    const button = screen.getByRole("button", { name: new RegExp(COPY_LABEL) });
+    await user.click(button);
+    await user.click(button);
+    await user.click(button);
+
+    expect(mockCopy).toHaveBeenCalledTimes(1);
+
+    resolveCopy({
+      ok: true,
+      data: [buildSchedule({ id: 20, planned_on: "2026-08-10" })],
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("week-range-label")).toHaveTextContent(
+        "8/10〜8/16",
+      ),
+    );
+  });
+});

--- a/app/(app)/practice/schedules/week/_components/WeeklyPlanContent.tsx
+++ b/app/(app)/practice/schedules/week/_components/WeeklyPlanContent.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import type { FetchResult } from "@app/services/v2/requests";
+import type { Schedule } from "@app/types/schedule";
+import ArrowPathIcon from "@heroicons/react/24/outline/ArrowPathIcon";
+import ChevronLeftIcon from "@heroicons/react/24/outline/ChevronLeftIcon";
+import ChevronRightIcon from "@heroicons/react/24/outline/ChevronRightIcon";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import LockClosedIcon from "@heroicons/react/24/solid/LockClosedIcon";
+import Link from "next/link";
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+  addDays,
+  startOfWeek,
+  weekdayNumber,
+} from "@app/(app)/practice/schedules/calendar/_utils/calendarDate";
+import { ProUpsellCard } from "@app/components/pro/ProUpsellCard";
+import { WEEK_DAYS, eventTypeMeta } from "@app/constants/schedule";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import { copyScheduleWeekToNext } from "@app/services/v2/scheduleService";
+import { formatDayLabel } from "../../calendar/_components/CalendarDaySection";
+import {
+  addPlanHref,
+  entryHref,
+} from "../../calendar/_components/CalendarEntryRow";
+import {
+  mergeSchedules,
+  nextWeekStart,
+  singleSchedulesByDate,
+  weekDates,
+  weekRangeLabel,
+} from "../_utils/weeklyPlan";
+import {
+  ADD_PLAN_LABEL,
+  COPY_EMPTY_MESSAGE,
+  COPY_FORBIDDEN_MESSAGE,
+  COPY_LABEL,
+  COPY_PAYWALL_DESCRIPTION,
+  COPY_PAYWALL_TITLE,
+  COPY_RUNNING_LABEL,
+  EMPTY_DAY_LABEL,
+  LOAD_ERROR,
+  NEXT_WEEK_LABEL,
+  PREV_WEEK_LABEL,
+  RECURRING_NOTICE,
+  THIS_WEEK_LABEL,
+  copiedMessage,
+} from "./weeklyPlanCopy";
+
+const FEATURE = "schedule_copy_next_week" as const;
+
+/** 曜日の短いラベル（月〜日）。番号は月=1〜日=7 で、JS の getDay（日=0）とは別体系。 */
+function shortWeekdayLabel(iso: string): string {
+  return WEEK_DAYS.find((day) => day.num === weekdayNumber(iso))?.label ?? "";
+}
+
+interface WeeklyPlanContentProps {
+  /** Asia/Tokyo の今日。「今週」への復帰と当日の強調に使う。 */
+  today: string;
+  /** Server Component が取得した予定一覧（繰り返し・単発が混在）。 */
+  result: FetchResult<Schedule[]>;
+}
+
+/**
+ * 週の練習プランの Container。
+ *
+ * 予定一覧は Server Component が一度に取得済みなので、週の前後移動では再取得しない。
+ * 「来週にコピー」は Pro 限定（schedule_copy_next_week）で、成功して 1 件以上作られたときだけ
+ * 表示週を翌週へ送る。0 件のときに週を送ると「コピーされた」と誤解させるため送らない。
+ */
+export default function WeeklyPlanContent({
+  today,
+  result,
+}: WeeklyPlanContentProps) {
+  const { hasEntitlement, isLoading: isEntitlementLoading } = useEntitlement();
+
+  const [weekStart, setWeekStart] = useState(() => startOfWeek(today));
+  const [schedules, setSchedules] = useState<Schedule[]>(
+    result.status === "ok" ? result.data : [],
+  );
+  const [isCopying, setIsCopying] = useState(false);
+  const [copyNotice, setCopyNotice] = useState<string | null>(null);
+  const [isPaywallVisible, setIsPaywallVisible] = useState(false);
+
+  // isCopying の反映を待たずに 2 回目の送信が走るのを防ぐ（連打で予定が二重に増えないように）。
+  const isCopyingRef = useRef(false);
+
+  const dates = weekDates(weekStart);
+  const byDate = singleSchedulesByDate(schedules, weekStart);
+
+  // Pro 判定が未確定の間はロック表示にしない。先に無料前提で描くと、
+  // 加入済みユーザーに一瞬だけ鍵アイコンが見えてしまう。
+  const isCopyLocked = !isEntitlementLoading && !hasEntitlement(FEATURE);
+
+  const moveWeek = (nextStart: string) => {
+    setWeekStart(nextStart);
+    setCopyNotice(null);
+  };
+
+  const showPaywall = (message: string) => {
+    setCopyNotice(message);
+    setIsPaywallVisible(true);
+  };
+
+  const handleCopy = async () => {
+    if (isCopyingRef.current) return;
+    if (isCopyLocked) {
+      showPaywall(COPY_FORBIDDEN_MESSAGE);
+      return;
+    }
+
+    isCopyingRef.current = true;
+    setIsCopying(true);
+    setCopyNotice(null);
+    const copied = await copyScheduleWeekToNext(weekStart);
+    isCopyingRef.current = false;
+    setIsCopying(false);
+
+    if (!copied.ok) {
+      // back の entitlement 判定が正。front の Pro 判定が古くても、403 は Pro 限定として案内する。
+      if (copied.reason === "forbidden") {
+        showPaywall(COPY_FORBIDDEN_MESSAGE);
+        return;
+      }
+      toast.error(copied.errors[0]);
+      return;
+    }
+
+    // 201 でも作成 0 件のことがある（コピー元が空、または既にコピー済み）。
+    if (copied.data.length === 0) {
+      setCopyNotice(COPY_EMPTY_MESSAGE);
+      return;
+    }
+
+    setSchedules((previous) => mergeSchedules(previous, copied.data));
+    toast.success(copiedMessage(copied.data.length));
+    moveWeek(nextWeekStart(weekStart));
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          aria-label={PREV_WEEK_LABEL}
+          onClick={() => moveWeek(addDays(weekStart, -7))}
+          className="rounded-full p-1.5 text-zinc-200 transition-colors hover:bg-white/10"
+        >
+          <ChevronLeftIcon className="h-5 w-5" aria-hidden />
+        </button>
+        <p
+          data-testid="week-range-label"
+          aria-live="polite"
+          className="text-base font-bold text-white"
+        >
+          {weekRangeLabel(weekStart)}
+        </p>
+        <button
+          type="button"
+          aria-label={NEXT_WEEK_LABEL}
+          onClick={() => moveWeek(addDays(weekStart, 7))}
+          className="rounded-full p-1.5 text-zinc-200 transition-colors hover:bg-white/10"
+        >
+          <ChevronRightIcon className="h-5 w-5" aria-hidden />
+        </button>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => moveWeek(startOfWeek(today))}
+          className="rounded-lg border border-zinc-600 px-3 py-1.5 text-xs font-bold text-zinc-200 transition-colors hover:border-[#d08000] hover:text-[#d08000]"
+        >
+          {THIS_WEEK_LABEL}
+        </button>
+      </div>
+
+      {result.status !== "ok" ? (
+        // 取得失敗を空表示に丸めると「予定なし」と誤読され、重複登録を招く。
+        <p role="alert" className="py-8 text-center text-sm text-zinc-400">
+          {LOAD_ERROR}
+        </p>
+      ) : (
+        <ul className="flex flex-col">
+          {dates.map((date) => {
+            const dayLabel = formatDayLabel(date);
+            const entries = byDate.get(date) ?? [];
+            return (
+              <li
+                key={date}
+                data-testid={`week-day-${date}`}
+                className="flex items-start gap-3 border-b border-zinc-700 py-2.5 last:border-b-0"
+              >
+                <div className="w-9 shrink-0 text-center">
+                  <p
+                    className={`text-sm font-bold ${date === today ? "text-[#d08000]" : "text-white"}`}
+                  >
+                    {shortWeekdayLabel(date)}
+                  </p>
+                  <p className="mt-0.5 text-[11px] text-zinc-500">
+                    {Number(date.slice(8, 10))}
+                  </p>
+                </div>
+                <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+                  {entries.length === 0 ? (
+                    <span aria-hidden className="text-xs text-zinc-600">
+                      {EMPTY_DAY_LABEL}
+                    </span>
+                  ) : (
+                    entries.map((schedule) => {
+                      const meta = eventTypeMeta(schedule.event_type);
+                      return (
+                        <Link
+                          key={schedule.id}
+                          href={entryHref({
+                            date,
+                            event_type: schedule.event_type,
+                            title: schedule.title,
+                            schedule_id: schedule.id,
+                          })}
+                          className="inline-flex max-w-full items-center gap-1.5 rounded-full bg-sub px-3 py-1.5 text-xs text-white transition-opacity hover:opacity-90"
+                        >
+                          <span
+                            aria-hidden
+                            data-testid="week-chip-dot"
+                            data-event-type={schedule.event_type}
+                            className="h-1.5 w-1.5 shrink-0 rounded-full"
+                            style={{ backgroundColor: meta.color }}
+                          />
+                          <span className="truncate">
+                            {schedule.title ?? meta.label}
+                          </span>
+                        </Link>
+                      );
+                    })
+                  )}
+                  <Link
+                    href={addPlanHref(date)}
+                    aria-label={`${dayLabel} ${ADD_PLAN_LABEL}`}
+                    className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[#d08000] text-[#d08000] transition-colors hover:bg-[#d08000]/10"
+                  >
+                    <PlusIcon className="h-4 w-4" aria-hidden />
+                  </Link>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <button
+        type="button"
+        onClick={handleCopy}
+        disabled={isCopying}
+        className="flex w-full items-center justify-center gap-1.5 rounded-[10px] bg-sub px-5 py-3 text-sm font-bold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+      >
+        <ArrowPathIcon className="h-4 w-4 shrink-0" aria-hidden />
+        {isCopying ? COPY_RUNNING_LABEL : COPY_LABEL}
+        {isCopyLocked ? (
+          <LockClosedIcon
+            data-testid="copy-lock-icon"
+            className="h-3.5 w-3.5 shrink-0 text-zinc-400"
+            aria-hidden
+          />
+        ) : null}
+      </button>
+
+      {copyNotice ? (
+        <p role="status" className="text-xs text-zinc-300">
+          {copyNotice}
+        </p>
+      ) : null}
+
+      {isPaywallVisible ? (
+        <ProUpsellCard
+          feature={FEATURE}
+          title={COPY_PAYWALL_TITLE}
+          description={COPY_PAYWALL_DESCRIPTION}
+        />
+      ) : null}
+
+      <p className="text-xs text-zinc-500">{RECURRING_NOTICE}</p>
+    </div>
+  );
+}

--- a/app/(app)/practice/schedules/week/_components/weeklyPlanCopy.ts
+++ b/app/(app)/practice/schedules/week/_components/weeklyPlanCopy.ts
@@ -1,0 +1,38 @@
+/** 週の練習プラン画面の文言。表示のゆれを避けるため 1 箇所に集約する。 */
+
+export const PAGE_TITLE = "週の練習プラン";
+export const PAGE_DESCRIPTION =
+  "月曜はじまりの1週間で、その日だけの予定を並べて確認できます。「＋」から曜日ごとに予定を足せます。";
+
+export const PREV_WEEK_LABEL = "前の週";
+export const NEXT_WEEK_LABEL = "次の週";
+export const THIS_WEEK_LABEL = "今週";
+export const ADD_PLAN_LABEL = "予定を追加";
+
+/** 0 件と取得失敗を同じ見た目にすると「予定なし」と誤読させるため、文言を分ける。 */
+export const LOAD_ERROR =
+  "予定を取得できませんでした。時間を置いて再度お試しください。";
+export const EMPTY_DAY_LABEL = "―";
+
+export const COPY_LABEL = "来週にコピー";
+export const COPY_RUNNING_LABEL = "コピー中";
+
+/** 週プランに並ぶのが単発予定だけであることと、繰り返しの登録先を示す。 */
+export const RECURRING_NOTICE =
+  "毎週くり返す予定はここには並びません。カレンダーや予定一覧から登録・確認できます。";
+
+/** コピー元が 0 件、または既にコピー済みで新しく作られなかったとき。 */
+export const COPY_EMPTY_MESSAGE =
+  "この週にはコピーできる予定がありません（毎週くり返す予定はコピーされません）。";
+export const copiedMessage = (count: number): string =>
+  `${count}件の予定を来週にコピーしました`;
+
+/**
+ * 「来週にコピー」の 403 は Pro 限定機能を指す。
+ * 予定の作成自体は無料プランでも無制限なので、無料枠の超過と読ませない。
+ */
+export const COPY_FORBIDDEN_MESSAGE =
+  "「来週にコピー」は Pro プラン限定の機能です。";
+export const COPY_PAYWALL_TITLE = "今週のプランを来週にまるごとコピー";
+export const COPY_PAYWALL_DESCRIPTION =
+  "予定の作成は無料プランでも無制限です。Pro プランなら、その週の予定をまとめて来週へコピーして、毎週のプラン作りをそのまま繰り返せます。";

--- a/app/(app)/practice/schedules/week/_utils/__tests__/weeklyPlan.test.ts
+++ b/app/(app)/practice/schedules/week/_utils/__tests__/weeklyPlan.test.ts
@@ -1,0 +1,147 @@
+import type { Schedule } from "@app/types/schedule";
+import {
+  mergeSchedules,
+  nextWeekStart,
+  singleSchedulesByDate,
+  weekDates,
+  weekEnd,
+  weekRangeLabel,
+} from "../weeklyPlan";
+
+function buildSchedule(overrides: Partial<Schedule> = {}): Schedule {
+  return {
+    id: 1,
+    title: "朝練",
+    days_of_week: null,
+    planned_on: "2026-08-03",
+    scheduled_time: "06:00",
+    event_type: "self_practice",
+    recurring: false,
+    menu_set_id: null,
+    game_result_id: null,
+    note: null,
+    notification_enabled: false,
+    active: true,
+    notification_message: null,
+    menus: [],
+    logged_practice_menu_ids: [],
+    ...overrides,
+  };
+}
+
+// 2026-08-03 は月曜、2026-08-09 は日曜。
+const MONDAY = "2026-08-03";
+
+describe("weekDates", () => {
+  it("月曜から日曜までの 7 日を返す", () => {
+    expect(weekDates(MONDAY)).toEqual([
+      "2026-08-03",
+      "2026-08-04",
+      "2026-08-05",
+      "2026-08-06",
+      "2026-08-07",
+      "2026-08-08",
+      "2026-08-09",
+    ]);
+  });
+
+  it("週の途中の日を渡しても、その週の月曜から始まる", () => {
+    expect(weekDates("2026-08-06")[0]).toBe(MONDAY);
+  });
+
+  it("日曜を渡したときは前の月曜から始まる（週始まりは日曜ではない）", () => {
+    expect(weekDates("2026-08-09")[0]).toBe(MONDAY);
+    expect(weekDates("2026-08-09")[6]).toBe("2026-08-09");
+  });
+});
+
+describe("weekEnd / nextWeekStart", () => {
+  it("週末は日曜", () => {
+    expect(weekEnd(MONDAY)).toBe("2026-08-09");
+  });
+
+  it("翌週の起点は 7 日後", () => {
+    expect(nextWeekStart(MONDAY)).toBe("2026-08-10");
+  });
+
+  it("月をまたぐ週でも 7 日後になる", () => {
+    expect(nextWeekStart("2026-08-31")).toBe("2026-09-07");
+  });
+});
+
+describe("weekRangeLabel", () => {
+  it("月/日〜月/日 で表示する", () => {
+    expect(weekRangeLabel(MONDAY)).toBe("8/3〜8/9");
+  });
+
+  it("月をまたぐ週は両方の月を出す", () => {
+    expect(weekRangeLabel("2026-08-31")).toBe("8/31〜9/6");
+  });
+});
+
+describe("singleSchedulesByDate", () => {
+  it("その週の単発予定だけを日付ごとにまとめる", () => {
+    const inWeek = buildSchedule({ id: 1, planned_on: "2026-08-05" });
+    const beforeWeek = buildSchedule({ id: 2, planned_on: "2026-08-02" });
+    const afterWeek = buildSchedule({ id: 3, planned_on: "2026-08-10" });
+
+    const grouped = singleSchedulesByDate(
+      [inWeek, beforeWeek, afterWeek],
+      MONDAY,
+    );
+
+    expect(grouped.get("2026-08-05")).toEqual([inWeek]);
+    expect(grouped.get("2026-08-02")).toBeUndefined();
+    expect(grouped.get("2026-08-10")).toBeUndefined();
+  });
+
+  it("週の両端（月曜・日曜）を含む", () => {
+    const monday = buildSchedule({ id: 1, planned_on: MONDAY });
+    const sunday = buildSchedule({ id: 2, planned_on: "2026-08-09" });
+
+    const grouped = singleSchedulesByDate([monday, sunday], MONDAY);
+
+    expect(grouped.get(MONDAY)).toEqual([monday]);
+    expect(grouped.get("2026-08-09")).toEqual([sunday]);
+  });
+
+  it("毎週くり返す予定は含めない（コピー対象と揃える）", () => {
+    const recurring = buildSchedule({
+      id: 9,
+      planned_on: null,
+      days_of_week: "1,3,5",
+      recurring: true,
+    });
+
+    const grouped = singleSchedulesByDate([recurring], MONDAY);
+
+    expect(grouped.size).toBe(0);
+  });
+
+  it("同じ日の予定は時刻順（未設定は末尾）に並ぶ", () => {
+    const afternoon = buildSchedule({ id: 1, scheduled_time: "15:00" });
+    const allDay = buildSchedule({ id: 2, scheduled_time: null });
+    const morning = buildSchedule({ id: 3, scheduled_time: "06:00" });
+
+    const grouped = singleSchedulesByDate([afternoon, allDay, morning], MONDAY);
+
+    expect(grouped.get(MONDAY)?.map((item) => item.id)).toEqual([3, 1, 2]);
+  });
+});
+
+describe("mergeSchedules", () => {
+  it("既存に無い予定だけを足す", () => {
+    const existing = buildSchedule({ id: 1 });
+    const added = buildSchedule({ id: 2, planned_on: "2026-08-10" });
+
+    expect(mergeSchedules([existing], [added])).toEqual([existing, added]);
+  });
+
+  it("同じ id は重複させない", () => {
+    const existing = buildSchedule({ id: 1 });
+
+    expect(mergeSchedules([existing], [buildSchedule({ id: 1 })])).toEqual([
+      existing,
+    ]);
+  });
+});

--- a/app/(app)/practice/schedules/week/_utils/weeklyPlan.ts
+++ b/app/(app)/practice/schedules/week/_utils/weeklyPlan.ts
@@ -1,0 +1,85 @@
+import type { Schedule } from "@app/types/schedule";
+import {
+  addDays,
+  weekDays,
+} from "@app/(app)/practice/schedules/calendar/_utils/calendarDate";
+
+/**
+ * 週プランの日付・並び替えロジック。
+ *
+ * 週の起点（月曜）や日付の加算は #483 の calendarDate.ts に実装済みのものを使う。
+ * ここで独自に曜日計算を持つと、カレンダーと週プランで週の切れ目がずれる。
+ */
+
+/** その週の月曜〜日曜（7日分）。週始まりは月曜（曜日マスタの月=1〜日=7 に合わせる）。 */
+export function weekDates(weekStart: string): string[] {
+  return weekDays(weekStart);
+}
+
+/** その週の最終日（日曜）。 */
+export function weekEnd(weekStart: string): string {
+  return addDays(weekStart, 6);
+}
+
+/** 翌週の同じ曜日。「来週にコピー」後の表示週の移動に使う。 */
+export function nextWeekStart(weekStart: string): string {
+  return addDays(weekStart, 7);
+}
+
+/** "2026-08-03" と "2026-08-09" → "8/3〜8/9"。 */
+export function weekRangeLabel(weekStart: string): string {
+  const end = weekEnd(weekStart);
+  const short = (iso: string) =>
+    `${Number(iso.slice(5, 7))}/${Number(iso.slice(8, 10))}`;
+  return `${short(weekStart)}〜${short(end)}`;
+}
+
+/** 時刻順（未設定は末尾）。back の plans#by_date と同じ並びにする。 */
+function byScheduledTime(a: Schedule, b: Schedule): number {
+  return (a.scheduled_time ?? "99:99").localeCompare(
+    b.scheduled_time ?? "99:99",
+  );
+}
+
+/**
+ * その週に入る単発予定（planned_on 持ち）を日付ごとにまとめる。
+ *
+ * 毎週の繰り返し予定は含めない。週プランで扱うのは「その日だけの予定」で、
+ * 「来週にコピー」の対象（back の schedules.single）と一致させるため。
+ * 繰り返し予定まで並べると、コピーされないものがコピー対象に見えてしまう。
+ */
+export function singleSchedulesByDate(
+  schedules: Schedule[],
+  weekStart: string,
+): Map<string, Schedule[]> {
+  const end = weekEnd(weekStart);
+  const grouped = new Map<string, Schedule[]>();
+
+  schedules.forEach((schedule) => {
+    const date = schedule.planned_on;
+    if (date === null || date < weekStart || date > end) return;
+    const list = grouped.get(date);
+    if (list) list.push(schedule);
+    else grouped.set(date, [schedule]);
+  });
+
+  grouped.forEach((list) => list.sort(byScheduledTime));
+  return grouped;
+}
+
+/**
+ * コピーで作成された予定を手元の一覧へ取り込む。
+ *
+ * back は同一内容の予定を作り直さない（冪等）ため、連続実行でも重複は増えない想定だが、
+ * 取り込み側でも id で重ねて防ぐ。サーバー再取得を待たずに移動先の週へ反映するために使う。
+ */
+export function mergeSchedules(
+  current: Schedule[],
+  added: Schedule[],
+): Schedule[] {
+  const existingIds = new Set(current.map((schedule) => schedule.id));
+  return [
+    ...current,
+    ...added.filter((schedule) => !existingIds.has(schedule.id)),
+  ];
+}

--- a/app/(app)/practice/schedules/week/page.tsx
+++ b/app/(app)/practice/schedules/week/page.tsx
@@ -1,0 +1,61 @@
+import { cookies } from "next/headers";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { CalendarIcon } from "@app/components/icon/CalendarIcon";
+import { getSchedules } from "@app/services/v2/scheduleService";
+import {
+  CALENDAR_LABEL,
+  PAGE_TITLE as SCHEDULES_PAGE_TITLE,
+} from "../_components/scheduleCopy";
+import { todayInTokyo } from "../calendar/_utils/calendarDate";
+import WeeklyPlanContent from "./_components/WeeklyPlanContent";
+import { PAGE_DESCRIPTION, PAGE_TITLE } from "./_components/weeklyPlanCopy";
+
+export const metadata = {
+  title: PAGE_TITLE,
+};
+
+export default async function WeeklyPlanPage() {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  // 予定は件数が少なく全件返るため、週の前後移動のたびに取り直さず一度で読み込む。
+  const result = await getSchedules();
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            <div className="flex items-start justify-between gap-3">
+              <h2 className="text-2xl font-bold">{PAGE_TITLE}</h2>
+              <Link
+                href="/practice/schedules/calendar"
+                className="mt-1 inline-flex shrink-0 items-center gap-1 rounded-full border border-zinc-600 px-3 py-1.5 text-xs font-bold text-zinc-200 transition-colors hover:border-[#d08000] hover:text-[#d08000]"
+              >
+                <CalendarIcon fill="currentColor" width="14" height="14" />
+                {CALENDAR_LABEL}
+              </Link>
+            </div>
+            <p className="mt-2 text-sm text-zinc-300">{PAGE_DESCRIPTION}</p>
+
+            <div className="my-6">
+              <WeeklyPlanContent today={todayInTokyo()} result={result} />
+            </div>
+
+            <Link
+              href="/practice/schedules"
+              className="inline-block text-sm font-bold text-[#d08000] hover:opacity-80"
+            >
+              {SCHEDULES_PAGE_TITLE}へ
+            </Link>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/services/v2/__tests__/planService.test.ts
+++ b/app/services/v2/__tests__/planService.test.ts
@@ -12,7 +12,8 @@ jest.mock("../../../../lib/sentry-helpers", () => ({
   captureServerActionError: jest.fn(),
 }));
 
-import { getPlanCalendar } from "../planService";
+import type { Plan } from "@app/types/plan";
+import { getDayPlan, getPlanCalendar } from "../planService";
 
 function setupAuthCookies() {
   mockGet.mockImplementation((key: string) => {
@@ -40,6 +41,71 @@ beforeEach(() => {
   jest.clearAllMocks();
   global.fetch = jest.fn();
   setupAuthCookies();
+});
+
+describe("getDayPlan", () => {
+  const plan: Plan = {
+    id: 3,
+    title: "朝練",
+    event_type: "self_practice",
+    scheduled_time: "06:00",
+    recurring: true,
+    menu_set_id: null,
+    game_result_id: null,
+    note: null,
+    menus: [
+      {
+        practice_menu_id: 1,
+        name: "素振り",
+        unit_label: "本",
+        target_value: 200,
+        sort_order: 0,
+        done: false,
+      },
+    ],
+    done: false,
+  };
+
+  it("date をクエリに付けて by_date を叩く", async () => {
+    mockResponse(200, []);
+
+    await getDayPlan("2026-08-03");
+
+    expect(requestedUrl()).toBe(
+      "http://back:3000/api/v2/plans/by_date?date=2026-08-03",
+    );
+  });
+
+  it("繰り返しと単発が同じ日付に集約されて返る", async () => {
+    const single: Plan = {
+      ...plan,
+      id: 4,
+      title: "練習試合",
+      event_type: "game",
+      recurring: false,
+      menus: [],
+    };
+    mockResponse(200, [plan, single]);
+
+    const result = await getDayPlan("2026-08-03");
+
+    expect(result).toEqual({ status: "ok", data: [plan, single] });
+  });
+
+  it("予定 0 件は空配列の ok として返す（取得失敗と区別する）", async () => {
+    mockResponse(200, []);
+
+    await expect(getDayPlan("2026-08-03")).resolves.toEqual({
+      status: "ok",
+      data: [],
+    });
+  });
+
+  it("date が不正で back が 422 を返したら error にする", async () => {
+    mockResponse(422, { error: "date が不正です" });
+
+    await expect(getDayPlan("invalid")).resolves.toEqual({ status: "error" });
+  });
 });
 
 describe("getPlanCalendar", () => {

--- a/app/services/v2/__tests__/scheduleService.test.ts
+++ b/app/services/v2/__tests__/scheduleService.test.ts
@@ -14,6 +14,7 @@ jest.mock("../../../../lib/sentry-helpers", () => ({
 
 import type { Schedule } from "@app/types/schedule";
 import {
+  copyScheduleWeekToNext,
   createSchedule,
   deleteSchedule,
   getSchedules,
@@ -120,6 +121,40 @@ describe("scheduleService", () => {
     expect(requestedUrl()).toBe("http://back:3000/api/v2/schedules/10");
     expect(requestedInit().method).toBe("DELETE");
     expect(result).toEqual({ ok: true, data: { message: "削除しました" } });
+  });
+
+  it("来週へのコピーは POST /api/v2/schedules/week_copy に week_start を送る", async () => {
+    const copied = { ...schedule, id: 11, planned_on: "2026-08-10" };
+    mockResponse(201, [copied]);
+
+    const result = await copyScheduleWeekToNext("2026-08-03");
+
+    expect(requestedUrl()).toBe("http://back:3000/api/v2/schedules/week_copy");
+    const init = requestedInit();
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      week_start: "2026-08-03",
+    });
+    expect(result).toEqual({ ok: true, data: [copied] });
+  });
+
+  it("コピー元が0件でも 201 + 空配列を成功として返す", async () => {
+    mockResponse(201, []);
+
+    await expect(copyScheduleWeekToNext("2026-08-03")).resolves.toEqual({
+      ok: true,
+      data: [],
+    });
+  });
+
+  it("無料プランの 403 は forbidden として返す（Pro 限定機能）", async () => {
+    mockResponse(403, { error: "来週にコピーは Pro プラン限定です" });
+
+    await expect(copyScheduleWeekToNext("2026-08-03")).resolves.toEqual({
+      ok: false,
+      reason: "forbidden",
+      errors: ["来週にコピーは Pro プラン限定です"],
+    });
   });
 
   it("422 のバリデーションエラーはメッセージを取り出して返す", async () => {

--- a/app/services/v2/planService.ts
+++ b/app/services/v2/planService.ts
@@ -1,9 +1,26 @@
 "use server";
 
-import type { CalendarResponse } from "@app/types/plan";
+import type { CalendarResponse, Plan } from "@app/types/plan";
 import { type FetchResult, buildQuery, fetchV2 } from "./requests";
 
 const BASE_PATH = "/api/v2/plans";
+
+/**
+ * 指定日の予定を取得する（GET /api/v2/plans/by_date）。
+ *
+ * 繰り返し（曜日）と単発（planned_on）を back がその日付へ集約し、時刻順（未設定は末尾）で返す。
+ * メニューの done は「その日・その予定で作られた練習ログの有無」で、予定単位に独立している。
+ *
+ * 予定が 1 件も無い日は 200 + 空配列が返る。取得失敗（status:"error"）と区別して扱うこと。
+ *
+ * @param date 対象日（YYYY-MM-DD）。不正な形式は back が 422 を返し error になる。
+ */
+export async function getDayPlan(date: string): Promise<FetchResult<Plan[]>> {
+  return fetchV2<Plan[]>(
+    `${BASE_PATH}/by_date${buildQuery({ date })}`,
+    "getDayPlan",
+  );
+}
 
 /**
  * 期間内の予定を日別エントリで取得する（GET /api/v2/plans/calendar）。

--- a/app/services/v2/scheduleService.ts
+++ b/app/services/v2/scheduleService.ts
@@ -53,6 +53,31 @@ export async function updateSchedule(
 }
 
 /**
+ * 週の単発予定を翌週へ一括コピーする（POST /api/v2/schedules/week_copy）。
+ *
+ * Pro 限定（entitlement: schedule_copy_next_week）。無料プランでは 403 が返るため、
+ * 呼び出し側は reason:"forbidden" を「無料枠の超過」ではなく Pro 限定機能の案内へ倒す。
+ *
+ * コピー対象はその週（week_start 〜 +6日）の単発予定だけで、毎週の繰り返し予定は含まれない。
+ * コピー元が 0 件でも、コピー先に同じ予定が既にあってスキップされた場合も 201 + 空配列が返る
+ * （back は冪等になるよう同一内容の予定を作り直さない）。「成功したのに何も増えていない」
+ * ケースがあるため、data.length を見て案内を出し分けること。
+ *
+ * @param weekStart コピー元の週の開始日（YYYY-MM-DD、月曜）
+ * @returns 実際に作成された予定の配列（0 件なら空配列）
+ */
+export async function copyScheduleWeekToNext(
+  weekStart: string,
+): Promise<MutationResult<Schedule[]>> {
+  return mutateV2<Schedule[]>(`${BASE_PATH}/week_copy`, {
+    method: "POST",
+    body: { week_start: weekStart },
+    action: "copyScheduleWeekToNext",
+    fallbackMessage: "来週へのコピーに失敗しました",
+  });
+}
+
+/**
  * 予定を削除する（DELETE /api/v2/schedules/:id）。
  * 予定に紐づいた練習ログは実績として残り、schedule_id だけが外れる。
  */

--- a/app/types/plan.ts
+++ b/app/types/plan.ts
@@ -1,10 +1,45 @@
 /**
  * 予定（schedule）を日付軸に展開したビュー用の型。
- * back/app/controllers/api/v2/plans_controller.rb の calendar レスポンスに対応する。
+ * back/app/controllers/api/v2/plans_controller.rb の by_date / calendar レスポンスに対応する。
  * キー名は back の JSON をそのまま使う（snake_case のまま扱い、変換しない）。
  */
 
 import type { ScheduleEventType } from "@app/types/schedule";
+
+/**
+ * 予定に紐づく練習メニュー1件（by_date）。
+ * done は「その日・その予定（schedule_id）で練習ログが作られているか」。
+ * 同じメニューが複数の予定にあっても予定ごとに独立して判定される
+ * （back の done_menu_ids_by_schedule_on が schedule_id 単位で畳み込むため）。
+ */
+export interface PlanMenu {
+  practice_menu_id: number;
+  name: string | null;
+  unit_label: string | null;
+  target_value: number | null;
+  sort_order: number;
+  done: boolean;
+}
+
+/**
+ * 特定日に展開された予定。「今日のやること」1ブロックに対応する。
+ * 繰り返し（days_of_week）と単発（planned_on）は back が同じ日付へ集約して返すため、
+ * front で曜日展開はしない。
+ */
+export interface Plan {
+  id: number;
+  title: string | null;
+  event_type: ScheduleEventType;
+  /** "06:00"。終日（時刻未設定）は null。 */
+  scheduled_time: string | null;
+  recurring: boolean;
+  menu_set_id: number | null;
+  game_result_id: number | null;
+  note: string | null;
+  menus: PlanMenu[];
+  /** 予定内の全メニューが当日ログ済みか。メニュー未設定の予定は false。 */
+  done: boolean;
+}
 
 /**
  * カレンダー1マスに並ぶ予定 1 件。


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#484

## 概要

mobile の `WeeklyPlanView` と `TodayTasksSection` 相当です。週次の予定俯瞰と、当日の予定をメニュー単位で消化していく導線を実装します。

## back の契約で判明した点

**`week_copy` は 0件のときも 201 + `[]` を返します。** しかも「コピー元が空」と「既に同一内容がコピー済み（`already_copied?` でスキップ）」を**区別しません**。どちらも 201 + `[]` になるため、文言は両方を包含する形にしました。

**Pro ゲートは日付パースより先に評価されます。** つまり無料ユーザーは `week_start` が何であれ常に 403 です。

**コピー対象は単発予定のみ**（`schedules.active.single`）で、繰り返し予定はコピーされません。そのため**週プランの表示も単発のみ**にし、「コピーされない予定がコピー対象に見える」状態を避けています（注記で補足）。

**`by_date` の `done` は schedule_id 単位**で判定されるため、同じメニューが別予定にあっても独立判定です。

## 楽観的更新のロールバックと連打対策

`setMenuDone(plans, scheduleId, menuId, done)` は**反転ではなく値指定**です。楽観更新 = `!wasDone`、失敗時 = `wasDone` を明示セットするため確実に元へ戻ります（反転2回方式だと途中に別更新が挟まると戻りません）。

失敗は3経路すべてでロールバックします: 作成失敗 / 削除失敗 / **当日ログ取得失敗**（`getPracticeLogs` が error のとき削除に進まず巻き戻す）。

連打対策は `useRef<Set<string>>` の同期ガード＋ `disabled` の二段です。**再描画を挟まない連打**でも1回しか送らないことをテストで固定しています。

## #483 の日付ユーティリティを再利用しました

`calendarDate.ts` の `startOfWeek` / `weekDays` / `addDays` / `weekdayNumber` / `todayInTokyo` をそのまま使い、**新規の日付ユーティリティは一切書いていません**。`week/_utils/weeklyPlan.ts` は薄いラッパとグルーピングのみで曜日計算を持ちません。

## レビューで確認いただきたい点

1. **プリセットを「済メニューのみ」にしました**（mobile は全メニューを渡す）。issue 本文が「済メニューをプリセットとして引き継ぎ」であり、#482 の予定詳細も済のみのため、front 内の一貫性を優先しています
2. **「済」トグル後に `router.refresh()` を呼んでいません。** ダッシュボードの他セクション（試合成績・グループランキング）は練習ログに依存せず、毎チェックで全面再取得は高コストなためです。**`ScheduleDetailContent`（#482）は呼んでいるので挙動が揃っていません**
3. **`calendarDate.ts` を共有場所へ移していません。** `app/utils/` へ移すのが理想ですが、並行ブランチとの衝突リスクを避けて据え置き、既存のクロスルート import で再利用しています

## チェックリスト

- [x] `yarn typecheck` / `yarn lint` / `yarn format:check` が通る
- [x] `yarn test` が通る（**184 suites / 2198 tests**。新規49件）
- [x] `yarn build` が通る（ローカルで実行済み）
- [x] ミューテーションテスト **20 設計 / 20 KILLED / 0 SURVIVED**

### ルート表

base（`fa48eea`）も同条件でビルドして比較しました。

- base: 静的 87 / 動的 61
- branch: 静的 87 / 動的 62
- **追加は `/practice/schedules/week` の1件のみ。静的の増減0、既存ルートの分類変更0**

<details>
<summary>ミューテーションテスト詳細</summary>

週始まりを日曜に / 曜日変換を日=0体系に / **失敗時ロールバックしない** / 済トグルの連打抑止を外す / コピーの連打抑止を外す / **`schedule_id` を送らない** / プリセットで `date` を渡さない / コピー後に週を移動しない / 403文言を「無料枠超過」に / 0件の案内を出さない / TZ を UTC に / 0件と取得失敗の取り違え2種 / API パス・メソッド改変3種 / 削除対象の `schedule_id` 絞り込みを外す / `setMenuDone` を反転に / 繰り返し予定も週プランに含める / 週の移動幅 7→1 — 全 KILLED。

**初回に2件 SURVIVED**（連打抑止2種）。`disabled` 属性がテスト上でクリックを吸収し ref ガードの寄与が見えなかったため、**再描画を挟まない連打を再現するようテストを強化**して KILLED を確認しています。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_