### PR TITLE
Add: 素振りカウンター（設定 → カウント → 完了）を実装

### DIFF
--- a/app/(app)/practice/shadow-swing/__tests__/ShadowSwingContent.test.tsx
+++ b/app/(app)/practice/shadow-swing/__tests__/ShadowSwingContent.test.tsx
@@ -1,0 +1,493 @@
+const mockOpenProUpgradeModal = jest.fn();
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({
+    open: mockOpenProUpgradeModal,
+    close: jest.fn(),
+  }),
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+jest.mock("@app/services/v2/shadowSwingService", () => ({
+  startShadowSwingSession: jest.fn(),
+  completeShadowSwingSession: jest.fn(),
+  getShadowSwingStats: jest.fn(),
+}));
+
+import type { FetchResult } from "@app/services/v2/requests";
+import type { ShadowSwingStats } from "@app/types/shadowSwing";
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import {
+  completeShadowSwingSession,
+  getShadowSwingStats,
+  startShadowSwingSession,
+} from "@app/services/v2/shadowSwingService";
+import ShadowSwingContent from "../_components/ShadowSwingContent";
+import {
+  AUTO_PAUSED_BY_HIDDEN,
+  NO_SWING_MESSAGE,
+  SAVE_FAILED_TITLE,
+  SAVED_MESSAGE,
+  STATS_ERROR_MESSAGE,
+} from "../_components/shadowSwingCopy";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+const mockStart = startShadowSwingSession as jest.MockedFunction<
+  typeof startShadowSwingSession
+>;
+const mockComplete = completeShadowSwingSession as jest.MockedFunction<
+  typeof completeShadowSwingSession
+>;
+const mockGetStats = getShadowSwingStats as jest.MockedFunction<
+  typeof getShadowSwingStats
+>;
+
+const SESSION_ID = 77;
+
+/* --- ブラウザ API のモック（jsdom には Web Audio / SpeechSynthesis / vibrate が無い） --- */
+
+const startedOscillators: { start: jest.Mock; stop: jest.Mock }[] = [];
+const resume = jest.fn();
+const speak = jest.fn();
+const cancel = jest.fn();
+const vibrate = jest.fn(() => true);
+
+class MockAudioContext {
+  state = "suspended";
+  currentTime = 0;
+  destination = {};
+
+  resume = async () => {
+    this.state = "running";
+    resume();
+  };
+
+  close = async () => {};
+
+  createOscillator = () => {
+    const oscillator = {
+      type: "sine",
+      frequency: { setValueAtTime: jest.fn() },
+      connect: jest.fn(),
+      start: jest.fn(),
+      stop: jest.fn(),
+    };
+    startedOscillators.push(oscillator);
+    return oscillator;
+  };
+
+  createGain = () => ({
+    gain: {
+      setValueAtTime: jest.fn(),
+      exponentialRampToValueAtTime: jest.fn(),
+    },
+    connect: jest.fn(),
+  });
+}
+
+class MockUtterance {
+  lang = "";
+  volume = 1;
+  constructor(public text: string) {}
+}
+
+function installBrowserApis({
+  vibration = true,
+}: { vibration?: boolean } = {}) {
+  (window as unknown as Record<string, unknown>).AudioContext =
+    MockAudioContext;
+  (window as unknown as Record<string, unknown>).SpeechSynthesisUtterance =
+    MockUtterance;
+  Object.defineProperty(window, "speechSynthesis", {
+    value: { speak, cancel },
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(navigator, "wakeLock", {
+    value: {
+      request: jest.fn().mockResolvedValue({
+        released: false,
+        release: jest.fn().mockResolvedValue(undefined),
+      }),
+    },
+    configurable: true,
+    writable: true,
+  });
+  if (vibration) {
+    Object.defineProperty(navigator, "vibrate", {
+      value: vibrate,
+      configurable: true,
+      writable: true,
+    });
+  }
+}
+
+function removeBrowserApis() {
+  delete (window as unknown as Record<string, unknown>).AudioContext;
+  delete (window as unknown as Record<string, unknown>)
+    .SpeechSynthesisUtterance;
+  Reflect.deleteProperty(window, "speechSynthesis");
+  Reflect.deleteProperty(navigator, "vibrate");
+  Reflect.deleteProperty(navigator, "wakeLock");
+}
+
+function setVisibility(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    value: state,
+    configurable: true,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+/* --- ヘルパー --- */
+
+const okStats = (
+  stats: Partial<ShadowSwingStats> = {},
+): FetchResult<ShadowSwingStats> => ({
+  status: "ok",
+  data: { today_count: 0, month_count: 0, total_count: 0, ...stats },
+});
+
+function mockEntitlement({ granted = false } = {}) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: granted,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading: false,
+    hasEntitlement: jest.fn(() => granted),
+  });
+}
+
+function setupUser() {
+  return userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+}
+
+/** 設定画面で設定を入れて開始し、カウント画面が出るまで待つ。 */
+async function startCounting(
+  user: ReturnType<typeof setupUser>,
+  { target = 10, speech = false, vibration = false } = {},
+) {
+  const input = screen.getByLabelText("目標本数");
+  await user.clear(input);
+  await user.type(input, String(target));
+
+  if (speech) {
+    await user.click(
+      within(screen.getByRole("group", { name: "カウント読み上げ" })).getByRole(
+        "button",
+        { name: "あり" },
+      ),
+    );
+  }
+  if (vibration) {
+    await user.click(
+      within(screen.getByRole("group", { name: "バイブレーション" })).getByRole(
+        "button",
+        { name: "あり" },
+      ),
+    );
+  }
+
+  await user.click(screen.getByRole("button", { name: "開始する" }));
+  await screen.findByRole("progressbar");
+}
+
+/** 実時間を進めて requestAnimationFrame のループを回す。 */
+async function advance(ms: number) {
+  await act(async () => {
+    jest.advanceTimersByTime(ms);
+  });
+}
+
+const swingCount = (target: number, count: number) =>
+  screen.getByRole("img", { name: `${target}本中${count}本` });
+
+/** 実際に読み上げた本数。解禁用の無音発話（空文字）は除く。 */
+const spokenCounts = (): string[] =>
+  speak.mock.calls
+    .map((call) => (call[0] as MockUtterance).text)
+    .filter((text) => text !== "");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  startedOscillators.length = 0;
+  jest.useFakeTimers();
+  installBrowserApis();
+  setVisibility("visible");
+  mockEntitlement();
+  mockStart.mockResolvedValue({
+    ok: true,
+    data: {
+      id: SESSION_ID,
+      logged_on: "2026-08-03",
+      target_count: 10,
+      swing_count: 0,
+      completed_at: null,
+      practice_log_id: null,
+    },
+  });
+  mockComplete.mockResolvedValue({
+    ok: true,
+    data: {
+      id: SESSION_ID,
+      logged_on: "2026-08-03",
+      target_count: 10,
+      swing_count: 10,
+      completed_at: "2026-08-03T10:00:00+09:00",
+      practice_log_id: 3,
+    },
+  });
+  mockGetStats.mockResolvedValue(
+    okStats({ today_count: 10, month_count: 10, total_count: 10 }),
+  );
+});
+
+afterEach(() => {
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+  jest.useRealTimers();
+  removeBrowserApis();
+});
+
+describe("カウントの進み方", () => {
+  it("インターバルごとに1本ずつ増える", async () => {
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    await startCounting(user, { target: 10 });
+    expect(swingCount(10, 0)).toBeInTheDocument();
+
+    // 既定インターバルは5秒。境界の直前では増えない。
+    await advance(4900);
+    expect(swingCount(10, 0)).toBeInTheDocument();
+
+    await advance(200);
+    expect(swingCount(10, 1)).toBeInTheDocument();
+
+    await advance(10_100);
+    expect(swingCount(10, 3)).toBeInTheDocument();
+  });
+
+  it("一時停止中は時間が進んでも増えず、再開すると続きから増える", async () => {
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    await startCounting(user, { target: 10 });
+    await advance(12_100);
+    expect(swingCount(10, 2)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "一時停止" }));
+    await advance(60_000);
+    expect(swingCount(10, 2)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "再開" }));
+    // 停止前に 2 秒ぶん進んでいるので、3 秒で 3 本目になる。
+    await advance(3000);
+    expect(swingCount(10, 3)).toBeInTheDocument();
+  });
+
+  it("タブが隠れたら自動で一時停止し、戻ってもカウントが飛ばない", async () => {
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    await startCounting(user, { target: 10 });
+    await advance(12_100);
+
+    await act(async () => {
+      setVisibility("hidden");
+    });
+    expect(screen.getByText(AUTO_PAUSED_BY_HIDDEN)).toBeInTheDocument();
+
+    // 裏で 10 分経ってもカウントは進まない（本来なら 120 本ぶんの時間）。
+    await advance(600_000);
+    await act(async () => {
+      setVisibility("visible");
+    });
+    expect(swingCount(10, 2)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "再開" }));
+    await advance(3000);
+    expect(swingCount(10, 3)).toBeInTheDocument();
+  });
+});
+
+describe("合図", () => {
+  it("開始ボタンの押下で AudioContext を解禁する", async () => {
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    await startCounting(user, { target: 10 });
+
+    expect(resume).toHaveBeenCalled();
+  });
+
+  it("笛を選ぶと1本ごとに鳴り、読み上げはしない", async () => {
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    await startCounting(user, { target: 10 });
+    await advance(15_100);
+
+    expect(startedOscillators).toHaveLength(3);
+    expect(spokenCounts()).toEqual([]);
+  });
+
+  it("読み上げを選ぶと本数を読み上げ、笛は鳴らない（排他）", async () => {
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    await startCounting(user, { target: 10, speech: true });
+    await advance(15_100);
+
+    expect(startedOscillators).toHaveLength(0);
+    expect(spokenCounts()).toEqual(["1", "2", "3"]);
+  });
+
+  it("バイブレーションを選んだ Pro ユーザーは1本ごとに振動する", async () => {
+    mockEntitlement({ granted: true });
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    await startCounting(user, { target: 10, vibration: true });
+    await advance(15_100);
+
+    expect(vibrate).toHaveBeenCalledTimes(3);
+    expect(vibrate).toHaveBeenCalledWith(40);
+  });
+
+  it("navigator.vibrate 非対応の環境では有効化できず振動もしない", async () => {
+    mockEntitlement({ granted: true });
+    removeBrowserApis();
+    installBrowserApis({ vibration: false });
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    await startCounting(user, { target: 10, vibration: true });
+    await advance(15_100);
+
+    expect(vibrate).not.toHaveBeenCalled();
+  });
+});
+
+describe("完了と保存", () => {
+  it("目標到達で自動的に完了し、本数を保存して統計を更新する", async () => {
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    await startCounting(user, { target: 3 });
+    await advance(15_100);
+
+    expect(mockComplete).toHaveBeenCalledWith(SESSION_ID, 3);
+    expect(screen.getByText("3本 達成！")).toBeInTheDocument();
+    expect(await screen.findByText(SAVED_MESSAGE)).toBeInTheDocument();
+    expect(mockGetStats).toHaveBeenCalled();
+    expect(screen.getByText("通算").nextSibling).toHaveTextContent("10本");
+  });
+
+  it("目標より手前で終了しても、その時点の本数を保存する", async () => {
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    await startCounting(user, { target: 10 });
+    await advance(12_100);
+    await user.click(screen.getByRole("button", { name: "終了する" }));
+
+    expect(mockComplete).toHaveBeenCalledWith(SESSION_ID, 2);
+    expect(screen.getByText("2本 達成！")).toBeInTheDocument();
+  });
+
+  it("保存に失敗してもカウント結果を失わず、再試行で保存できる", async () => {
+    mockComplete.mockResolvedValueOnce({
+      ok: false,
+      reason: "error",
+      errors: ["ネットワークエラー"],
+    });
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    await startCounting(user, { target: 3 });
+    await advance(15_100);
+
+    expect(screen.getByText("3本 達成！")).toBeInTheDocument();
+    expect(await screen.findByText(SAVE_FAILED_TITLE)).toBeInTheDocument();
+    expect(screen.getByText("ネットワークエラー")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "再試行" }));
+
+    expect(await screen.findByText(SAVED_MESSAGE)).toBeInTheDocument();
+    expect(mockComplete).toHaveBeenCalledTimes(2);
+    expect(mockComplete).toHaveBeenLastCalledWith(SESSION_ID, 3);
+    expect(screen.getByText("3本 達成！")).toBeInTheDocument();
+  });
+
+  it("1本もカウントせずに終了したら保存しない（0本の練習ログを作らない）", async () => {
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    await startCounting(user, { target: 10 });
+    await user.click(screen.getByRole("button", { name: "終了する" }));
+
+    expect(mockComplete).not.toHaveBeenCalled();
+    expect(screen.getByText(NO_SWING_MESSAGE)).toBeInTheDocument();
+  });
+
+  it("完了後の統計取得に失敗したら、0本ではなく取得失敗として表示する", async () => {
+    mockGetStats.mockResolvedValue({ status: "error" });
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    await startCounting(user, { target: 3 });
+    await advance(15_100);
+
+    expect(await screen.findByText(STATS_ERROR_MESSAGE)).toBeInTheDocument();
+    expect(screen.queryByText("通算")).not.toBeInTheDocument();
+  });
+});
+
+describe("開始の失敗", () => {
+  it("セッションを作れなかったらカウント画面へ進まない", async () => {
+    mockStart.mockResolvedValue({
+      ok: false,
+      reason: "error",
+      errors: ["素振りを開始できませんでした"],
+    });
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    const input = screen.getByLabelText("目標本数");
+    await user.clear(input);
+    await user.type(input, "10");
+    await user.click(screen.getByRole("button", { name: "開始する" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "素振りを開始できませんでした",
+    );
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "開始する" }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("完了画面からのやり直し", () => {
+  it("もう一度で設定画面に戻れる", async () => {
+    const user = setupUser();
+    render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    await startCounting(user, { target: 3 });
+    await advance(15_100);
+    await screen.findByText(SAVED_MESSAGE);
+
+    await user.click(screen.getByRole("button", { name: "もう一度" }));
+
+    expect(screen.getByLabelText("目標本数")).toBeInTheDocument();
+  });
+});

--- a/app/(app)/practice/shadow-swing/__tests__/ShadowSwingContent.test.tsx
+++ b/app/(app)/practice/shadow-swing/__tests__/ShadowSwingContent.test.tsx
@@ -34,6 +34,7 @@ import {
   SAVE_FAILED_TITLE,
   SAVED_MESSAGE,
   STATS_ERROR_MESSAGE,
+  VIBRATION_UNSUPPORTED_HINT,
 } from "../_components/shadowSwingCopy";
 
 const mockUseEntitlement = useEntitlement as jest.MockedFunction<
@@ -369,6 +370,15 @@ describe("合図", () => {
     installBrowserApis({ vibration: false });
     const user = setupUser();
     render(<ShadowSwingContent initialStatsResult={okStats()} />);
+
+    // 設定画面では非対応の理由を出し、「あり」を押しても有効にならない。
+    expect(screen.getByText(VIBRATION_UNSUPPORTED_HINT)).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("group", { name: "バイブレーション" })).getByRole(
+        "button",
+        { name: "なし" },
+      ),
+    ).toHaveAttribute("aria-pressed", "true");
 
     await startCounting(user, { target: 10, vibration: true });
     await advance(15_100);

--- a/app/(app)/practice/shadow-swing/__tests__/ShadowSwingSetup.test.tsx
+++ b/app/(app)/practice/shadow-swing/__tests__/ShadowSwingSetup.test.tsx
@@ -1,0 +1,374 @@
+const mockOpenProUpgradeModal = jest.fn();
+
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({
+    open: mockOpenProUpgradeModal,
+    close: jest.fn(),
+  }),
+}));
+
+jest.mock("@app/hooks/pro/useEntitlement", () => ({
+  useEntitlement: jest.fn(),
+}));
+
+import type { FetchResult } from "@app/services/v2/requests";
+import type { ShadowSwingStats } from "@app/types/shadowSwing";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import {
+  BACKGROUND_WEB_NOTICE,
+  INTERVAL_PENDING_HINT,
+  STATS_ERROR_MESSAGE,
+  VIBRATION_LOCKED_HINT,
+  VIBRATION_UNSUPPORTED_HINT,
+  WAKE_LOCK_UNSUPPORTED_NOTICE,
+} from "../_components/shadowSwingCopy";
+import ShadowSwingSetup from "../_components/ShadowSwingSetup";
+
+const mockUseEntitlement = useEntitlement as jest.MockedFunction<
+  typeof useEntitlement
+>;
+
+const OK_STATS: FetchResult<ShadowSwingStats> = {
+  status: "ok",
+  data: { today_count: 0, month_count: 0, total_count: 0 },
+};
+
+function mockEntitlement({
+  granted = false,
+  isLoading = false,
+}: { granted?: boolean; isLoading?: boolean } = {}) {
+  mockUseEntitlement.mockReturnValue({
+    isPro: granted,
+    inTrial: false,
+    inGracePeriod: false,
+    isLoading,
+    hasEntitlement: jest.fn(() => granted),
+  });
+}
+
+function renderSetup({
+  statsResult = OK_STATS,
+  isVibrationSupported = true,
+  isWakeLockSupported = true,
+}: {
+  statsResult?: FetchResult<ShadowSwingStats>;
+  isVibrationSupported?: boolean;
+  isWakeLockSupported?: boolean;
+} = {}) {
+  const onStart = jest.fn();
+  render(
+    <ShadowSwingSetup
+      statsResult={statsResult}
+      isStarting={false}
+      startError={null}
+      onStart={onStart}
+      isVibrationSupported={isVibrationSupported}
+      isWakeLockSupported={isWakeLockSupported}
+    />,
+  );
+  return { onStart, user: userEvent.setup() };
+}
+
+const intervalGroup = () => screen.getByRole("group", { name: "インターバル" });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockEntitlement();
+});
+
+describe("インターバルの制限", () => {
+  it("無料ユーザーは5〜10秒の外を選べず、Pro 訴求が開く", async () => {
+    const { onStart, user } = renderSetup();
+
+    await user.click(
+      within(intervalGroup()).getByRole("button", { name: "1.0秒" }),
+    );
+
+    expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+      trigger: "shadow_swing_custom_interval",
+    });
+    // 選択は既定値（5秒）のまま変わらない。
+    expect(
+      within(intervalGroup()).getByRole("button", { name: "5.0秒" }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(screen.getByRole("button", { name: "開始する" }));
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ intervalSeconds: 5 }),
+    );
+  });
+
+  it("無料ユーザーは10秒より長いインターバルも選べない", async () => {
+    const { onStart, user } = renderSetup();
+
+    await user.click(
+      within(intervalGroup()).getByRole("button", { name: "20.0秒" }),
+    );
+    await user.click(screen.getByRole("button", { name: "開始する" }));
+
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ intervalSeconds: 5 }),
+    );
+  });
+
+  it("無料ユーザーでも境界の10秒は選べる", async () => {
+    const { onStart, user } = renderSetup();
+
+    await user.click(
+      within(intervalGroup()).getByRole("button", { name: "10.0秒" }),
+    );
+    await user.click(screen.getByRole("button", { name: "開始する" }));
+
+    expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ intervalSeconds: 10 }),
+    );
+  });
+
+  it("Pro ユーザーは1.0〜20秒を選べる", async () => {
+    mockEntitlement({ granted: true });
+    const { onStart, user } = renderSetup();
+
+    await user.click(
+      within(intervalGroup()).getByRole("button", { name: "1.0秒" }),
+    );
+    await user.click(screen.getByRole("button", { name: "開始する" }));
+
+    expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ intervalSeconds: 1 }),
+    );
+  });
+
+  it("Pro 判定が未確定の間は Pro 前提の値を選べない", async () => {
+    mockEntitlement({ granted: true, isLoading: true });
+    const { onStart, user } = renderSetup();
+
+    expect(screen.getByText(INTERVAL_PENDING_HINT)).toBeInTheDocument();
+
+    await user.click(
+      within(intervalGroup()).getByRole("button", { name: "1.5秒" }),
+    );
+    await user.click(screen.getByRole("button", { name: "開始する" }));
+
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ intervalSeconds: 5 }),
+    );
+  });
+});
+
+describe("笛の音とカウント読み上げ", () => {
+  it("既定は笛の音のみ有効", () => {
+    renderSetup();
+
+    const whistle = screen.getByRole("group", { name: "笛の音" });
+    const speech = screen.getByRole("group", { name: "カウント読み上げ" });
+    expect(
+      within(whistle).getByRole("button", { name: "あり" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      within(speech).getByRole("button", { name: "なし" }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("読み上げを有効にすると笛が無効になる（排他）", async () => {
+    const { onStart, user } = renderSetup();
+
+    await user.click(
+      within(screen.getByRole("group", { name: "カウント読み上げ" })).getByRole(
+        "button",
+        { name: "あり" },
+      ),
+    );
+
+    expect(
+      within(screen.getByRole("group", { name: "笛の音" })).getByRole(
+        "button",
+        {
+          name: "なし",
+        },
+      ),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(screen.getByRole("button", { name: "開始する" }));
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ cue: { whistle: false, speech: true } }),
+    );
+  });
+
+  it("笛を有効に戻すと読み上げが無効になる（排他）", async () => {
+    const { onStart, user } = renderSetup();
+
+    await user.click(
+      within(screen.getByRole("group", { name: "カウント読み上げ" })).getByRole(
+        "button",
+        { name: "あり" },
+      ),
+    );
+    await user.click(
+      within(screen.getByRole("group", { name: "笛の音" })).getByRole(
+        "button",
+        {
+          name: "あり",
+        },
+      ),
+    );
+
+    await user.click(screen.getByRole("button", { name: "開始する" }));
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ cue: { whistle: true, speech: false } }),
+    );
+  });
+});
+
+describe("バイブレーション", () => {
+  const vibrationGroup = () =>
+    screen.getByRole("group", { name: "バイブレーション" });
+
+  it("navigator.vibrate 非対応の環境では有効にできず、理由を表示する", async () => {
+    mockEntitlement({ granted: true });
+    const { onStart, user } = renderSetup({ isVibrationSupported: false });
+
+    expect(screen.getByText(VIBRATION_UNSUPPORTED_HINT)).toBeInTheDocument();
+
+    await user.click(
+      within(vibrationGroup()).getByRole("button", { name: "あり" }),
+    );
+
+    expect(
+      within(vibrationGroup()).getByRole("button", { name: "なし" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    // 端末側の制約なので Pro 訴求は出さない。
+    expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "開始する" }));
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ vibration: false }),
+    );
+  });
+
+  it("対応環境の無料ユーザーは有効にできず Pro 訴求が開く", async () => {
+    const { onStart, user } = renderSetup({ isVibrationSupported: true });
+
+    expect(screen.getByText(VIBRATION_LOCKED_HINT)).toBeInTheDocument();
+
+    await user.click(
+      within(vibrationGroup()).getByRole("button", { name: "あり" }),
+    );
+
+    expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+      trigger: "shadow_swing_vibration",
+    });
+
+    await user.click(screen.getByRole("button", { name: "開始する" }));
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ vibration: false }),
+    );
+  });
+
+  it("対応環境の Pro ユーザーは有効にできる", async () => {
+    mockEntitlement({ granted: true });
+    const { onStart, user } = renderSetup({ isVibrationSupported: true });
+
+    await user.click(
+      within(vibrationGroup()).getByRole("button", { name: "あり" }),
+    );
+    await user.click(screen.getByRole("button", { name: "開始する" }));
+
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ vibration: true }),
+    );
+  });
+
+  it("Pro 判定が未確定の間は有効にできない", async () => {
+    mockEntitlement({ granted: true, isLoading: true });
+    const { onStart, user } = renderSetup({ isVibrationSupported: true });
+
+    await user.click(
+      within(vibrationGroup()).getByRole("button", { name: "あり" }),
+    );
+    await user.click(screen.getByRole("button", { name: "開始する" }));
+
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ vibration: false }),
+    );
+  });
+});
+
+describe("バックグラウンド継続実行（Web 非提供）", () => {
+  it("トグルを出さず、アプリ版のみの機能であることを明示する", () => {
+    mockEntitlement({ granted: true });
+    renderSetup();
+
+    expect(screen.getByText(BACKGROUND_WEB_NOTICE)).toBeInTheDocument();
+    expect(BACKGROUND_WEB_NOTICE).toContain("アプリ版のみ");
+
+    // 設定できる項目はインターバル・笛の音・読み上げ・バイブレーションの4つだけ。
+    expect(screen.getAllByRole("group")).toHaveLength(4);
+    expect(
+      screen.queryByRole("group", { name: /バックグラウンド/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /バックグラウンド/ }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("Screen Wake Lock", () => {
+  it("非対応環境では画面が消えることを注意書きする", () => {
+    renderSetup({ isWakeLockSupported: false });
+    expect(screen.getByText(WAKE_LOCK_UNSUPPORTED_NOTICE)).toBeInTheDocument();
+  });
+
+  it("対応環境では注意書きを出さない", () => {
+    renderSetup({ isWakeLockSupported: true });
+    expect(
+      screen.queryByText(WAKE_LOCK_UNSUPPORTED_NOTICE),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("目標本数", () => {
+  it("空欄では開始しない", async () => {
+    const { onStart, user } = renderSetup();
+
+    await user.clear(screen.getByLabelText("目標本数"));
+    await user.click(screen.getByRole("button", { name: "開始する" }));
+
+    expect(onStart).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "目標本数を入力してください",
+    );
+  });
+
+  it("入力した本数で開始する", async () => {
+    const { onStart, user } = renderSetup();
+
+    const input = screen.getByLabelText("目標本数");
+    await user.clear(input);
+    await user.type(input, "50");
+    await user.click(screen.getByRole("button", { name: "開始する" }));
+
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ targetCount: 50 }),
+    );
+  });
+});
+
+describe("積み上げ本数", () => {
+  it("0件は0本として表示する", () => {
+    renderSetup({ statsResult: OK_STATS });
+
+    expect(screen.getByText("通算").nextSibling).toHaveTextContent("0本");
+    expect(screen.queryByText(STATS_ERROR_MESSAGE)).not.toBeInTheDocument();
+  });
+
+  it("取得失敗は0本と区別して表示する", () => {
+    renderSetup({ statsResult: { status: "error" } });
+
+    expect(screen.getByText(STATS_ERROR_MESSAGE)).toBeInTheDocument();
+    expect(screen.queryByText("通算")).not.toBeInTheDocument();
+  });
+});

--- a/app/(app)/practice/shadow-swing/_components/CircularTimer.tsx
+++ b/app/(app)/practice/shadow-swing/_components/CircularTimer.tsx
@@ -1,0 +1,80 @@
+const SIZE = 260;
+const STROKE = 14;
+const RADIUS = (SIZE - STROKE) / 2;
+const CENTER = SIZE / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+const TIP_RADIUS = STROKE / 2 + 2;
+
+interface CircularTimerProps {
+  /** 現在のインターバル内の進捗（0〜1）。1 周＝素振り 1 本。 */
+  sweep: number;
+  count: number;
+  targetCount: number;
+  /** 一時停止中は針を淡くして、動いていないことを色でも示す。 */
+  isPaused: boolean;
+}
+
+/**
+ * インターバル 1 周＝1 本のテンポを可視化する円形タイマー。
+ * 進捗は SVG の弧（strokeDashoffset）と先端のドットで表し、中央に現在の本数を出す。
+ * 針の位置は毎フレーム経過時間から計算した値を受け取るだけで、内部に時間を持たない。
+ */
+export default function CircularTimer({
+  sweep,
+  count,
+  targetCount,
+  isPaused,
+}: CircularTimerProps) {
+  const clamped = Math.min(Math.max(sweep, 0), 1);
+  // 先端ドットは 12 時（-90°）を起点に時計回りへ進める。
+  const angle = clamped * 2 * Math.PI - Math.PI / 2;
+
+  return (
+    <div
+      className="relative mx-auto"
+      style={{ width: SIZE, height: SIZE }}
+      role="img"
+      aria-label={`${targetCount}本中${count}本`}
+    >
+      <svg width={SIZE} height={SIZE} aria-hidden focusable="false">
+        <g transform={`rotate(-90 ${CENTER} ${CENTER})`}>
+          <circle
+            cx={CENTER}
+            cy={CENTER}
+            r={RADIUS}
+            stroke="#424242"
+            strokeWidth={STROKE}
+            fill="none"
+          />
+          <circle
+            cx={CENTER}
+            cy={CENTER}
+            r={RADIUS}
+            stroke="#d08000"
+            strokeWidth={STROKE}
+            strokeLinecap="round"
+            fill="none"
+            strokeDasharray={CIRCUMFERENCE}
+            strokeDashoffset={CIRCUMFERENCE * (1 - clamped)}
+            opacity={isPaused ? 0.4 : 1}
+          />
+        </g>
+        <circle
+          cx={CENTER + RADIUS * Math.cos(angle)}
+          cy={CENTER + RADIUS * Math.sin(angle)}
+          r={TIP_RADIUS}
+          fill="#F4F4F4"
+          opacity={isPaused ? 0.4 : 1}
+        />
+      </svg>
+      <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+        <span className="text-[72px] font-extrabold leading-none text-white tabular-nums">
+          {count}
+        </span>
+        <span className="mt-1 text-[22px] font-semibold text-zinc-400 tabular-nums">
+          / {targetCount}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/practice/shadow-swing/_components/ShadowSwingComplete.tsx
+++ b/app/(app)/practice/shadow-swing/_components/ShadowSwingComplete.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import type { FetchResult } from "@app/services/v2/requests";
+import type { ShadowSwingStats } from "@app/types/shadowSwing";
+import CheckCircleIcon from "@heroicons/react/24/solid/CheckCircleIcon";
+import Link from "next/link";
+import {
+  NO_SWING_MESSAGE,
+  RETRY_BUTTON_LABEL,
+  SAVED_MESSAGE,
+  SAVE_FAILED_DESCRIPTION,
+  SAVE_FAILED_TITLE,
+  SAVING_MESSAGE,
+} from "./shadowSwingCopy";
+import ShadowSwingStatsCard from "./ShadowSwingStatsCard";
+
+/** 完了 API の状態。失敗しても本数は画面に残し、再送で復帰できるようにする。 */
+export type SaveState = "saving" | "saved" | "failed" | "skipped";
+
+interface ShadowSwingCompleteProps {
+  swingCount: number;
+  saveState: SaveState;
+  saveErrors: string[];
+  statsResult: FetchResult<ShadowSwingStats>;
+  onRetry: () => void;
+  onRestart: () => void;
+}
+
+const NUMBER_LOCALE = "ja-JP";
+
+/**
+ * 素振りの完了画面。達成本数と今日 / 今月 / 通算の積み上げを表示する。
+ * 保存に失敗しても本数の表示は変えず、再試行で同じ本数を送り直せるようにしている
+ * （back の complete は冪等なので、成功していた場合に再送しても二重計上されない）。
+ */
+export default function ShadowSwingComplete({
+  swingCount,
+  saveState,
+  saveErrors,
+  statsResult,
+  onRetry,
+  onRestart,
+}: ShadowSwingCompleteProps) {
+  return (
+    <div className="flex flex-col items-center gap-4 py-6">
+      <CheckCircleIcon
+        className="h-14 w-14 text-[#17C964] motion-safe:animate-swing-pop"
+        aria-hidden
+      />
+      <h2 className="text-2xl font-extrabold text-white">
+        {swingCount.toLocaleString(NUMBER_LOCALE)}本 達成！
+      </h2>
+
+      {saveState === "saving" ? (
+        <p role="status" className="text-sm text-zinc-400">
+          {SAVING_MESSAGE}
+        </p>
+      ) : null}
+      {saveState === "saved" ? (
+        <p role="status" className="text-sm text-zinc-400">
+          {SAVED_MESSAGE}
+        </p>
+      ) : null}
+      {saveState === "skipped" ? (
+        <p role="status" className="text-sm text-zinc-400">
+          {NO_SWING_MESSAGE}
+        </p>
+      ) : null}
+
+      {saveState === "failed" ? (
+        <div
+          role="alert"
+          className="w-full space-y-2 rounded-[10px] border border-red-500/60 bg-sub px-4 py-3"
+        >
+          <p className="text-sm font-bold text-red-400">{SAVE_FAILED_TITLE}</p>
+          <p className="text-xs leading-[18px] text-zinc-300">
+            {SAVE_FAILED_DESCRIPTION}
+          </p>
+          {saveErrors.length > 0 ? (
+            <ul className="space-y-1 text-xs text-zinc-400">
+              {saveErrors.map((message) => (
+                <li key={message}>{message}</li>
+              ))}
+            </ul>
+          ) : null}
+          <button
+            type="button"
+            onClick={onRetry}
+            className="mt-1 rounded-lg bg-[#d08000] px-4 py-2.5 text-sm font-bold text-white transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000] focus-visible:ring-offset-2 focus-visible:ring-offset-main"
+          >
+            {RETRY_BUTTON_LABEL}
+          </button>
+        </div>
+      ) : null}
+
+      <div className="w-full">
+        <ShadowSwingStatsCard
+          result={statsResult}
+          isRefreshing={saveState === "saving"}
+        />
+      </div>
+
+      <div className="mt-2 flex w-full flex-col gap-3 sm:flex-row">
+        <button
+          type="button"
+          onClick={onRestart}
+          className="flex-1 rounded-lg bg-sub py-3.5 text-base font-bold text-white transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000] focus-visible:ring-offset-2 focus-visible:ring-offset-main"
+        >
+          もう一度
+        </button>
+        <Link
+          href="/practice/records"
+          className="flex-1 rounded-lg bg-[#d08000] py-3.5 text-center text-base font-bold text-white transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000] focus-visible:ring-offset-2 focus-visible:ring-offset-main"
+        >
+          練習記録を見る
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/practice/shadow-swing/_components/ShadowSwingContent.tsx
+++ b/app/(app)/practice/shadow-swing/_components/ShadowSwingContent.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import type { SaveState } from "./ShadowSwingComplete";
+import type { ShadowSwingConfig } from "../_utils/shadowSwingSettings";
+import type { FetchResult } from "@app/services/v2/requests";
+import type { ShadowSwingStats } from "@app/types/shadowSwing";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import {
+  completeShadowSwingSession,
+  getShadowSwingStats,
+  startShadowSwingSession,
+} from "@app/services/v2/shadowSwingService";
+import {
+  subscribeToNothing,
+  supportsScreenWakeLock,
+  supportsVibration,
+  unsupportedOnServer,
+} from "../_utils/browserSupport";
+import { ScreenWakeLock } from "../_utils/screenWakeLock";
+import { SwingCuePlayer } from "../_utils/swingCuePlayer";
+import ShadowSwingComplete from "./ShadowSwingComplete";
+import { LEAVE_CONFIRM_MESSAGE, START_FAILED_MESSAGE } from "./shadowSwingCopy";
+import ShadowSwingCounter from "./ShadowSwingCounter";
+import ShadowSwingSetup from "./ShadowSwingSetup";
+
+/**
+ * 3 画面をルーティングではなく 1 ページ内の状態遷移で表す。
+ * ページ遷移を挟むとカウント中のコンポーネントが破棄され、経過時間も音声も失われるため、
+ * カウント中は同じツリーに留め続ける。
+ */
+type Phase =
+  | { name: "setup" }
+  | { name: "counting"; sessionId: number; config: ShadowSwingConfig }
+  | { name: "complete"; sessionId: number | null; swingCount: number };
+
+interface ShadowSwingContentProps {
+  initialStatsResult: FetchResult<ShadowSwingStats>;
+}
+
+/**
+ * 素振りカウンターの Container。
+ * セッションの開始・完了 API、統計の再取得、音声／画面ロックの寿命管理を担い、
+ * 表示は設定 / カウント / 完了の各コンポーネントへ委ねる。
+ */
+export default function ShadowSwingContent({
+  initialStatsResult,
+}: ShadowSwingContentProps) {
+  const [phase, setPhase] = useState<Phase>({ name: "setup" });
+  const [isStarting, setIsStarting] = useState(false);
+  const [startError, setStartError] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<SaveState>("saving");
+  const [saveErrors, setSaveErrors] = useState<string[]>([]);
+  const [statsResult, setStatsResult] =
+    useState<FetchResult<ShadowSwingStats>>(initialStatsResult);
+
+  // 音声とロックは画面遷移をまたいで同じインスタンスを使い続ける
+  // （設定画面の操作で解禁した AudioContext をカウント画面へ引き継ぐため）。
+  const [player] = useState(() => new SwingCuePlayer());
+  const [wakeLock] = useState(() => new ScreenWakeLock());
+
+  // SSR では navigator を見られないため、サーバー側は「非対応」として描画し、
+  // クライアントで判定し直す（属性の不一致でハイドレーションが警告になるのを避ける）。
+  const isVibrationSupported = useSyncExternalStore(
+    subscribeToNothing,
+    supportsVibration,
+    unsupportedOnServer,
+  );
+  const isWakeLockSupported = useSyncExternalStore(
+    subscribeToNothing,
+    supportsScreenWakeLock,
+    unsupportedOnServer,
+  );
+
+  useEffect(() => {
+    return () => {
+      player.dispose();
+      void wakeLock.release();
+    };
+  }, [player, wakeLock]);
+
+  // 保存に失敗した本数を持ったままの離脱を確認する。リロードすると再送できなくなるため。
+  useEffect(() => {
+    if (saveState !== "failed") return;
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = LEAVE_CONFIRM_MESSAGE;
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [saveState]);
+
+  const save = useCallback(async (sessionId: number, swingCount: number) => {
+    setSaveState("saving");
+    setSaveErrors([]);
+
+    const result = await completeShadowSwingSession(sessionId, swingCount);
+    if (!result.ok) {
+      setSaveState("failed");
+      setSaveErrors(result.errors);
+      return;
+    }
+
+    setSaveState("saved");
+    setStatsResult(await getShadowSwingStats());
+  }, []);
+
+  const handleStart = useCallback(
+    async (config: ShadowSwingConfig) => {
+      // ブラウザはユーザー操作のハンドラの中でしか音声を解禁しないため、
+      // 通信を待つ前にここで AudioContext を起こす。
+      void player.unlock();
+
+      setIsStarting(true);
+      setStartError(null);
+      const result = await startShadowSwingSession(config.targetCount);
+      setIsStarting(false);
+
+      if (!result.ok) {
+        setStartError(result.errors[0] ?? START_FAILED_MESSAGE);
+        return;
+      }
+      setPhase({ name: "counting", sessionId: result.data.id, config });
+    },
+    [player],
+  );
+
+  const handleFinish = useCallback(
+    (swingCount: number) => {
+      if (phase.name !== "counting") return;
+      const { sessionId, config } = phase;
+
+      // 保存の成否に関わらず、カウントできた本数はまず画面へ確定させる。
+      setPhase({ name: "complete", sessionId, swingCount });
+      if (config.vibration) player.vibrateCompletion();
+
+      if (swingCount <= 0) {
+        // 0 本で完了させると本数 0 の練習ログが作られ、その日を「練習した日」として
+        // 草・Streak に載せてしまう。保存せずセッションは未完了のままにする。
+        setSaveState("skipped");
+        return;
+      }
+      void save(sessionId, swingCount);
+    },
+    [phase, player, save],
+  );
+
+  const handleRetry = useCallback(() => {
+    if (phase.name !== "complete" || phase.sessionId === null) return;
+    void save(phase.sessionId, phase.swingCount);
+  }, [phase, save]);
+
+  const handleRestart = useCallback(() => {
+    setSaveState("saving");
+    setSaveErrors([]);
+    setStartError(null);
+    setPhase({ name: "setup" });
+  }, []);
+
+  if (phase.name === "counting") {
+    return (
+      <ShadowSwingCounter
+        config={phase.config}
+        player={player}
+        wakeLock={wakeLock}
+        onFinish={handleFinish}
+      />
+    );
+  }
+
+  if (phase.name === "complete") {
+    return (
+      <ShadowSwingComplete
+        swingCount={phase.swingCount}
+        saveState={saveState}
+        saveErrors={saveErrors}
+        statsResult={statsResult}
+        onRetry={handleRetry}
+        onRestart={handleRestart}
+      />
+    );
+  }
+
+  return (
+    <ShadowSwingSetup
+      statsResult={statsResult}
+      isStarting={isStarting}
+      startError={startError}
+      onStart={handleStart}
+      isVibrationSupported={isVibrationSupported}
+      isWakeLockSupported={isWakeLockSupported}
+    />
+  );
+}

--- a/app/(app)/practice/shadow-swing/_components/ShadowSwingCounter.tsx
+++ b/app/(app)/practice/shadow-swing/_components/ShadowSwingCounter.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import type { ScreenWakeLock } from "../_utils/screenWakeLock";
+import type { ShadowSwingConfig } from "../_utils/shadowSwingSettings";
+import type { TimerClock, TimerSnapshot } from "../_utils/shadowSwingTimer";
+import type { SwingCuePlayer } from "../_utils/swingCuePlayer";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  INITIAL_CLOCK,
+  cueForCountChange,
+  elapsedMsAt,
+  formatElapsed,
+  pauseClock,
+  startClock,
+  timerSnapshot,
+} from "../_utils/shadowSwingTimer";
+import CircularTimer from "./CircularTimer";
+import {
+  AUTO_PAUSED_BY_HIDDEN,
+  FINISH_BUTTON_LABEL,
+  LEAVE_CONFIRM_MESSAGE,
+  PAUSE_BUTTON_LABEL,
+  RESUME_BUTTON_LABEL,
+} from "./shadowSwingCopy";
+
+interface ShadowSwingCounterProps {
+  config: ShadowSwingConfig;
+  /** 設定画面の「開始する」押下時に解禁済みのプレイヤー。 */
+  player: SwingCuePlayer;
+  wakeLock: ScreenWakeLock;
+  /** 目標到達・手動終了のどちらでも呼ばれる。引数はカウントできた本数。 */
+  onFinish: (swingCount: number) => void;
+}
+
+const INITIAL_SNAPSHOT: TimerSnapshot = {
+  elapsedMs: 0,
+  count: 0,
+  sweep: 0,
+  isCompleted: false,
+};
+
+/**
+ * 素振りのカウント画面。
+ *
+ * 本数は `requestAnimationFrame` ごとに「開始からの経過時間」から導出する。
+ * フレームが間引かれても経過時間そのものは正しいため、本数がずれない。
+ * 一方でタブが非表示になると音・振動が止まり合図として成立しないので、
+ * 非表示を検知した時点で計測を止め（＝時間も進めず）、復帰後は明示的な再開を求める。
+ */
+export default function ShadowSwingCounter({
+  config,
+  player,
+  wakeLock,
+  onFinish,
+}: ShadowSwingCounterProps) {
+  const intervalMs = config.intervalSeconds * 1000;
+  const targetCount = config.targetCount;
+
+  const clockRef = useRef<TimerClock>(INITIAL_CLOCK);
+  const lastCountRef = useRef(0);
+  const finishedRef = useRef(false);
+  const isRunningRef = useRef(true);
+
+  const [isRunning, setIsRunningState] = useState(true);
+  const [isAutoPaused, setIsAutoPaused] = useState(false);
+  const [snapshot, setSnapshot] = useState<TimerSnapshot>(INITIAL_SNAPSHOT);
+
+  const setRunning = useCallback((next: boolean) => {
+    isRunningRef.current = next;
+    setIsRunningState(next);
+  }, []);
+
+  const finish = useCallback(
+    (swingCount: number) => {
+      if (finishedRef.current) return;
+      finishedRef.current = true;
+      clockRef.current = pauseClock(clockRef.current, performance.now());
+      setRunning(false);
+      player.stopSpeaking();
+      void wakeLock.release();
+      onFinish(swingCount);
+    },
+    [onFinish, player, setRunning, wakeLock],
+  );
+
+  const pause = useCallback(
+    (isAutomatic: boolean) => {
+      if (!isRunningRef.current || finishedRef.current) return;
+      clockRef.current = pauseClock(clockRef.current, performance.now());
+      setRunning(false);
+      setIsAutoPaused(isAutomatic);
+      player.stopSpeaking();
+      void wakeLock.release();
+    },
+    [player, setRunning, wakeLock],
+  );
+
+  const resume = useCallback(() => {
+    if (isRunningRef.current || finishedRef.current) return;
+    // 再開もユーザー操作なので、ここで音声を解禁し直す。
+    // 非表示の間に AudioContext が suspend されていると、そのままでは無音で進んでしまう。
+    void player.unlock();
+    clockRef.current = startClock(clockRef.current, performance.now());
+    setRunning(true);
+    setIsAutoPaused(false);
+    void wakeLock.acquire();
+  }, [player, setRunning, wakeLock]);
+
+  // 計測開始と画面消灯の抑止。画面を離れるときに読み上げとロックを必ず後始末する。
+  useEffect(() => {
+    clockRef.current = startClock(clockRef.current, performance.now());
+    void wakeLock.acquire();
+    return () => {
+      player.stopSpeaking();
+      void wakeLock.release();
+    };
+  }, [player, wakeLock]);
+
+  // 本数・針の更新。setInterval で刻まず、毎フレーム経過時間から導出する。
+  useEffect(() => {
+    if (!isRunning) return;
+
+    let frame = 0;
+    const tick = () => {
+      const elapsedMs = elapsedMsAt(clockRef.current, performance.now());
+      const next = timerSnapshot(elapsedMs, intervalMs, targetCount);
+
+      const cueCount = cueForCountChange(lastCountRef.current, next.count);
+      if (cueCount !== null) {
+        lastCountRef.current = next.count;
+        if (config.cue.whistle) player.playWhistle();
+        if (config.cue.speech) player.speakCount(cueCount);
+        if (config.vibration) player.vibrateSwing();
+      }
+
+      setSnapshot(next);
+      if (next.isCompleted) {
+        finish(next.count);
+        return;
+      }
+      frame = requestAnimationFrame(tick);
+    };
+
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [
+    isRunning,
+    intervalMs,
+    targetCount,
+    config.cue.whistle,
+    config.cue.speech,
+    config.vibration,
+    player,
+    finish,
+  ]);
+
+  // タブ・ウィンドウが隠れたら自動で一時停止する。
+  // ブラウザはバックグラウンドのタイマーを間引き、音声も鳴らせないため、
+  // 「カウントは進むが合図は無い」状態を作らずに時間ごと止める。
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") pause(true);
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [pause]);
+
+  // 未保存のカウントを持ったままの離脱を確認する（リロード・タブを閉じる操作向け）。
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (finishedRef.current) return;
+      event.preventDefault();
+      event.returnValue = LEAVE_CONFIRM_MESSAGE;
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, []);
+
+  const progress =
+    targetCount > 0 ? Math.min(snapshot.count / targetCount, 1) : 0;
+
+  return (
+    <div className="flex flex-col items-center gap-6 py-4">
+      <CircularTimer
+        sweep={snapshot.sweep}
+        count={snapshot.count}
+        targetCount={targetCount}
+        isPaused={!isRunning}
+      />
+
+      <div
+        className="h-2.5 w-full overflow-hidden rounded-full bg-sub"
+        role="progressbar"
+        aria-label="目標本数までの進捗"
+        aria-valuemin={0}
+        aria-valuemax={targetCount}
+        aria-valuenow={snapshot.count}
+      >
+        <div
+          className="h-full rounded-full bg-[#d08000]"
+          style={{ width: `${progress * 100}%` }}
+        />
+      </div>
+
+      <p className="text-lg text-zinc-400 tabular-nums">
+        <span className="sr-only">経過時間 </span>
+        {formatElapsed(snapshot.elapsedMs)}
+      </p>
+
+      {isAutoPaused ? (
+        <p role="status" className="text-center text-sm text-zinc-300">
+          {AUTO_PAUSED_BY_HIDDEN}
+        </p>
+      ) : null}
+
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={() => (isRunning ? pause(false) : resume())}
+          className="rounded-lg bg-sub px-8 py-3.5 text-base font-bold text-white transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000] focus-visible:ring-offset-2 focus-visible:ring-offset-main"
+        >
+          {isRunning ? PAUSE_BUTTON_LABEL : RESUME_BUTTON_LABEL}
+        </button>
+        <button
+          type="button"
+          onClick={() => finish(snapshot.count)}
+          className="rounded-lg bg-[#d08000] px-8 py-3.5 text-base font-bold text-white transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000] focus-visible:ring-offset-2 focus-visible:ring-offset-main"
+        >
+          {FINISH_BUTTON_LABEL}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/practice/shadow-swing/_components/ShadowSwingSetup.tsx
+++ b/app/(app)/practice/shadow-swing/_components/ShadowSwingSetup.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import type {
+  CueSettings,
+  ShadowSwingConfig,
+} from "../_utils/shadowSwingSettings";
+import type { FetchResult } from "@app/services/v2/requests";
+import type { ShadowSwingStats } from "@app/types/shadowSwing";
+import LockClosedIcon from "@heroicons/react/24/solid/LockClosedIcon";
+import { useState } from "react";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
+import { useEntitlement } from "@app/hooks/pro/useEntitlement";
+import {
+  DEFAULT_CUE_SETTINGS,
+  DEFAULT_INTERVAL_SECONDS,
+  DEFAULT_TARGET_COUNT,
+  INTERVAL_OPTIONS,
+  MAX_TARGET_COUNT,
+  MIN_TARGET_COUNT,
+  applyCueSelection,
+  canEnableVibration,
+  clampIntervalToAccess,
+  isIntervalAllowed,
+  resolveIntervalAccess,
+  resolveVibrationAvailability,
+  validateTargetCount,
+} from "../_utils/shadowSwingSettings";
+import {
+  BACKGROUND_WEB_NOTICE,
+  CUE_EXCLUSIVE_HINT,
+  FREE_INTERVAL_HINT,
+  INTERVAL_PENDING_HINT,
+  PAGE_DESCRIPTION,
+  START_BUTTON_LABEL,
+  VIBRATION_LOCKED_HINT,
+  VIBRATION_UNSUPPORTED_HINT,
+  WAKE_LOCK_UNSUPPORTED_NOTICE,
+} from "./shadowSwingCopy";
+import ShadowSwingStatsCard from "./ShadowSwingStatsCard";
+
+interface ShadowSwingSetupProps {
+  statsResult: FetchResult<ShadowSwingStats>;
+  isStarting: boolean;
+  startError: string | null;
+  onStart: (config: ShadowSwingConfig) => void;
+  /** `navigator.vibrate` を持つ環境か。クライアントで判定した値を受け取る。 */
+  isVibrationSupported: boolean;
+  /** Screen Wake Lock を持つ環境か。 */
+  isWakeLockSupported: boolean;
+}
+
+/** インターバルの表示ラベル。mobile と同じく小数第1位まで出して 1.5 秒刻みを読み取れるようにする。 */
+function intervalLabel(seconds: number): string {
+  return `${seconds.toFixed(1)}秒`;
+}
+
+const OPTION_BASE_CLASS =
+  "flex items-center gap-1 rounded-lg px-4 py-2.5 text-sm font-semibold transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000] focus-visible:ring-offset-2 focus-visible:ring-offset-main";
+
+/**
+ * 素振りカウンターの設定画面。
+ * 目標本数・インターバル・合図・バイブレーションを決め、確定した設定を親へ渡す。
+ * Pro 判定はここでのみ参照し、カウント画面へは解決済みの設定値だけを渡す。
+ */
+export default function ShadowSwingSetup({
+  statsResult,
+  isStarting,
+  startError,
+  onStart,
+  isVibrationSupported,
+  isWakeLockSupported,
+}: ShadowSwingSetupProps) {
+  const { hasEntitlement, isLoading: isEntitlementLoading } = useEntitlement();
+  const { open: openProUpgradeModal } = useProUpgradeModal();
+
+  const [targetInput, setTargetInput] = useState(String(DEFAULT_TARGET_COUNT));
+  const [targetError, setTargetError] = useState<string | null>(null);
+  const [intervalSeconds, setIntervalSeconds] = useState(
+    DEFAULT_INTERVAL_SECONDS,
+  );
+  const [cue, setCue] = useState<CueSettings>(DEFAULT_CUE_SETTINGS);
+  const [vibration, setVibration] = useState(false);
+
+  const intervalAccess = resolveIntervalAccess({
+    isEntitlementLoading,
+    hasCustomInterval: hasEntitlement("shadow_swing_custom_interval"),
+  });
+  const vibrationAvailability = resolveVibrationAvailability({
+    isSupported: isVibrationSupported,
+    isEntitlementLoading,
+    hasVibration: hasEntitlement("shadow_swing_vibration"),
+  });
+  const canVibrate = canEnableVibration(vibrationAvailability);
+
+  // 判定が確定して選択範囲が狭まった場合に備え、開始時の値は必ず範囲内へ丸める。
+  // 派生値なので state を持たず、レンダリング中に計算する。
+  const effectiveInterval = clampIntervalToAccess(
+    intervalSeconds,
+    intervalAccess,
+  );
+  const effectiveVibration = vibration && canVibrate;
+
+  const handleIntervalClick = (seconds: number) => {
+    if (!isIntervalAllowed(seconds, intervalAccess)) {
+      openProUpgradeModal({ trigger: "shadow_swing_custom_interval" });
+      return;
+    }
+    setIntervalSeconds(seconds);
+  };
+
+  const handleVibrationClick = (next: boolean) => {
+    if (next && !canVibrate) {
+      // 非対応ブラウザは課金しても振動しないため、Pro 訴求ではなく理由の説明だけを出す。
+      if (vibrationAvailability === "locked") {
+        openProUpgradeModal({ trigger: "shadow_swing_vibration" });
+      }
+      return;
+    }
+    setVibration(next);
+  };
+
+  const handleStart = () => {
+    const { count, error } = validateTargetCount(targetInput);
+    setTargetError(error);
+    if (count === null) return;
+
+    onStart({
+      targetCount: count,
+      intervalSeconds: effectiveInterval,
+      cue,
+      vibration: effectiveVibration,
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <p className="rounded-[10px] bg-sub px-4 py-3 text-[13px] leading-5 text-zinc-300">
+        {PAGE_DESCRIPTION}
+      </p>
+
+      <div>
+        <label
+          htmlFor="shadow-swing-target"
+          className="block text-[13px] font-semibold text-zinc-400"
+        >
+          目標本数
+        </label>
+        <div className="mt-2 flex items-center gap-2">
+          <input
+            id="shadow-swing-target"
+            type="number"
+            inputMode="numeric"
+            min={MIN_TARGET_COUNT}
+            max={MAX_TARGET_COUNT}
+            value={targetInput}
+            onChange={(event) => setTargetInput(event.target.value)}
+            aria-invalid={targetError !== null}
+            className="w-full rounded-lg bg-sub px-3 py-3 text-lg font-bold text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000]"
+          />
+          <span className="text-[15px] text-zinc-400">本</span>
+        </div>
+        {targetError ? (
+          <p role="alert" className="mt-2 text-xs text-red-400">
+            {targetError}
+          </p>
+        ) : null}
+      </div>
+
+      <div>
+        <p className="text-[13px] font-semibold text-zinc-400">インターバル</p>
+        <div
+          role="group"
+          aria-label="インターバル"
+          className="mt-2 flex flex-wrap gap-2"
+        >
+          {INTERVAL_OPTIONS.map((seconds) => {
+            const isActive = seconds === effectiveInterval;
+            const isLocked = !isIntervalAllowed(seconds, intervalAccess);
+            return (
+              <button
+                key={seconds}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => handleIntervalClick(seconds)}
+                className={`${OPTION_BASE_CLASS} ${
+                  isActive ? "bg-[#d08000] text-white" : "bg-sub text-zinc-400"
+                } ${isLocked ? "opacity-50" : ""}`}
+              >
+                {intervalLabel(seconds)}
+                {isLocked ? (
+                  <LockClosedIcon className="h-3 w-3 shrink-0" aria-hidden />
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+        {intervalAccess === "free" ? (
+          <p className="mt-2 text-xs leading-[18px] text-zinc-500">
+            {FREE_INTERVAL_HINT}
+          </p>
+        ) : null}
+        {intervalAccess === "pending" ? (
+          <p className="mt-2 text-xs leading-[18px] text-zinc-500">
+            {INTERVAL_PENDING_HINT}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="space-y-4">
+        <p className="text-xs leading-[18px] text-zinc-500">
+          {CUE_EXCLUSIVE_HINT}
+        </p>
+
+        <ChoiceGroup
+          legend="笛の音"
+          value={cue.whistle}
+          onChange={(next) =>
+            setCue((prev) => applyCueSelection(prev, "whistle", next))
+          }
+        />
+        <ChoiceGroup
+          legend="カウント読み上げ"
+          value={cue.speech}
+          onChange={(next) =>
+            setCue((prev) => applyCueSelection(prev, "speech", next))
+          }
+        />
+
+        <ChoiceGroup
+          legend="バイブレーション"
+          value={vibration && canVibrate}
+          onChange={handleVibrationClick}
+          lockedOnEnable={!canVibrate}
+        />
+        {vibrationAvailability === "unsupported" ? (
+          <p className="text-xs leading-[18px] text-zinc-500">
+            {VIBRATION_UNSUPPORTED_HINT}
+          </p>
+        ) : null}
+        {vibrationAvailability === "locked" ? (
+          <p className="text-xs leading-[18px] text-zinc-500">
+            {VIBRATION_LOCKED_HINT}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="space-y-2 rounded-[10px] border border-zinc-600 px-4 py-3">
+        <p className="text-xs leading-[18px] text-zinc-400">
+          {BACKGROUND_WEB_NOTICE}
+        </p>
+        {!isWakeLockSupported ? (
+          <p className="text-xs leading-[18px] text-zinc-400">
+            {WAKE_LOCK_UNSUPPORTED_NOTICE}
+          </p>
+        ) : null}
+      </div>
+
+      {startError ? (
+        <p role="alert" className="text-sm text-red-400">
+          {startError}
+        </p>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={handleStart}
+        disabled={isStarting}
+        className="w-full rounded-lg bg-[#d08000] py-4 text-[17px] font-bold text-white transition-opacity hover:opacity-90 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d08000] focus-visible:ring-offset-2 focus-visible:ring-offset-main"
+      >
+        {START_BUTTON_LABEL}
+      </button>
+
+      <ShadowSwingStatsCard result={statsResult} />
+    </div>
+  );
+}
+
+interface ChoiceGroupProps {
+  legend: string;
+  value: boolean;
+  onChange: (next: boolean) => void;
+  /** 「あり」を押しても有効化できない（Pro 限定・非対応環境）ときに鍵を添える。 */
+  lockedOnEnable?: boolean;
+}
+
+/** 「あり / なし」の二択。fieldset の legend が項目名になるのでラベルの重複を避けられる。 */
+function ChoiceGroup({
+  legend,
+  value,
+  onChange,
+  lockedOnEnable = false,
+}: ChoiceGroupProps) {
+  return (
+    <fieldset>
+      <legend className="text-[13px] font-semibold text-zinc-400">
+        {legend}
+      </legend>
+      <div className="mt-2 flex gap-2">
+        {[
+          { label: "あり", enabled: true },
+          { label: "なし", enabled: false },
+        ].map((option) => {
+          const isActive = option.enabled === value;
+          const isLocked = lockedOnEnable && option.enabled;
+          return (
+            <button
+              key={option.label}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => onChange(option.enabled)}
+              className={`${OPTION_BASE_CLASS} ${
+                isActive ? "bg-[#d08000] text-white" : "bg-sub text-zinc-400"
+              } ${isLocked ? "opacity-50" : ""}`}
+            >
+              {option.label}
+              {isLocked ? (
+                <LockClosedIcon className="h-3 w-3 shrink-0" aria-hidden />
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/app/(app)/practice/shadow-swing/_components/ShadowSwingStatsCard.tsx
+++ b/app/(app)/practice/shadow-swing/_components/ShadowSwingStatsCard.tsx
@@ -1,0 +1,51 @@
+import type { FetchResult } from "@app/services/v2/requests";
+import type { ShadowSwingStats } from "@app/types/shadowSwing";
+import { STATS_ERROR_MESSAGE } from "./shadowSwingCopy";
+
+const NUMBER_LOCALE = "ja-JP";
+
+interface ShadowSwingStatsCardProps {
+  result: FetchResult<ShadowSwingStats>;
+  /** 完了直後の再取得中など、前回値を出したまま更新を待つときに立てる。 */
+  isRefreshing?: boolean;
+}
+
+const ROWS: ReadonlyArray<{ key: keyof ShadowSwingStats; label: string }> = [
+  { key: "today_count", label: "今日" },
+  { key: "month_count", label: "今月" },
+  { key: "total_count", label: "通算" },
+];
+
+/**
+ * 今日・今月・通算の素振り本数を表示する。
+ * 取得に失敗した場合は 0 本と区別できるよう、数値を出さずに失敗した旨を表示する
+ * （0 に丸めると「まだ振っていない」と誤解され、積み上げが消えたように見えてしまう）。
+ */
+export default function ShadowSwingStatsCard({
+  result,
+  isRefreshing = false,
+}: ShadowSwingStatsCardProps) {
+  if (result.status !== "ok") {
+    return (
+      <p className="rounded-[10px] bg-sub px-4 py-3 text-sm text-zinc-400">
+        {STATS_ERROR_MESSAGE}
+      </p>
+    );
+  }
+
+  return (
+    <dl
+      className="space-y-2.5 rounded-[10px] bg-sub px-4 py-3.5"
+      aria-busy={isRefreshing}
+    >
+      {ROWS.map((row) => (
+        <div key={row.key} className="flex items-center justify-between">
+          <dt className="text-sm text-zinc-400">{row.label}</dt>
+          <dd className="text-[15px] font-bold text-white tabular-nums">
+            {result.data[row.key].toLocaleString(NUMBER_LOCALE)}本
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/app/(app)/practice/shadow-swing/_components/shadowSwingCopy.ts
+++ b/app/(app)/practice/shadow-swing/_components/shadowSwingCopy.ts
@@ -1,0 +1,74 @@
+import {
+  FREE_INTERVAL_MAX_SECONDS,
+  FREE_INTERVAL_MIN_SECONDS,
+  PRO_INTERVAL_MAX_SECONDS,
+  PRO_INTERVAL_MIN_SECONDS,
+} from "../_utils/shadowSwingSettings";
+
+/**
+ * 素振りカウンターの文言。UI 実装から切り離し、
+ * ブラウザ制約についてユーザーに何を約束しているかを一箇所で読めるようにする。
+ */
+
+export const PAGE_TITLE = "素振りカウンター";
+
+export const PAGE_DESCRIPTION =
+  "設定したインターバルで自動的にカウントアップし、素振りの本数を練習記録に保存します。笛の音や読み上げでテンポを取りながら振れます。";
+
+export const FREE_INTERVAL_HINT = `無料プランはインターバル${FREE_INTERVAL_MIN_SECONDS}〜${FREE_INTERVAL_MAX_SECONDS}秒のみ選べます。Pro なら${PRO_INTERVAL_MIN_SECONDS}〜${PRO_INTERVAL_MAX_SECONDS}秒の全範囲を使えます。`;
+
+export const INTERVAL_PENDING_HINT =
+  "プランを確認しています。確認できるまではインターバルの選択範囲を無料プランと同じにしています。";
+
+export const CUE_EXCLUSIVE_HINT =
+  "「笛の音」と「カウント読み上げ」は同時に鳴らすと聞き分けられないため、どちらか一方だけを選べます。";
+
+export const VIBRATION_LOCKED_HINT =
+  "バイブレーションは Pro プラン限定の機能です。";
+
+/**
+ * `navigator.vibrate` 非対応環境（iOS Safari など）向けの説明。
+ * ここで黙ってトグルだけ無効にすると「なぜ押せないのか」が分からないため、
+ * 端末側の制約であることまで書く。
+ */
+export const VIBRATION_UNSUPPORTED_HINT =
+  "お使いのブラウザはバイブレーションに対応していないため設定できません（iOS の Safari など）。アプリ版では利用できます。";
+
+/**
+ * バックグラウンド継続実行（Pro: shadow_swing_background）の扱い。
+ * ブラウザは非アクティブタブのタイマーを間引き、音声や振動も止まるため
+ * Web では提供しない。トグルは出さず、代わりに何が起きるかを説明する。
+ */
+export const BACKGROUND_WEB_NOTICE =
+  "ブラウザでは、他のタブや別アプリに切り替えるとカウントを続けられません。切り替えを検知した時点で自動的に一時停止し、戻ってきたら「再開」から続けられます。バックグラウンドでの継続実行はアプリ版のみの機能です。";
+
+/** Screen Wake Lock 非対応環境（対応していれば表示しない）向けの注意書き。 */
+export const WAKE_LOCK_UNSUPPORTED_NOTICE =
+  "お使いのブラウザは画面の自動消灯を抑止できません。素振り中に画面が消えると一時停止するため、端末の自動ロックを長めに設定してください。";
+
+export const AUTO_PAUSED_BY_HIDDEN =
+  "画面が切り替わったため一時停止しました。「再開」で続けられます。";
+
+export const LEAVE_CONFIRM_MESSAGE =
+  "素振りをカウント中です。ページを離れると記録されません。";
+
+export const START_BUTTON_LABEL = "開始する";
+export const PAUSE_BUTTON_LABEL = "一時停止";
+export const RESUME_BUTTON_LABEL = "再開";
+export const FINISH_BUTTON_LABEL = "終了する";
+
+export const SAVE_FAILED_TITLE = "記録の保存に失敗しました";
+export const SAVE_FAILED_DESCRIPTION =
+  "カウントした本数はこの画面に残しています。通信状況を確認して「再試行」を押してください。";
+export const RETRY_BUTTON_LABEL = "再試行";
+
+export const SAVED_MESSAGE = "練習記録に保存しました";
+export const SAVING_MESSAGE = "練習記録に保存しています…";
+
+export const NO_SWING_MESSAGE =
+  "1本もカウントされていないため、記録は保存していません。";
+
+export const STATS_ERROR_MESSAGE =
+  "積み上げ本数を取得できませんでした。時間を置いて再度お試しください。";
+
+export const START_FAILED_MESSAGE = "素振りを開始できませんでした";

--- a/app/(app)/practice/shadow-swing/_utils/__tests__/browserSupport.test.ts
+++ b/app/(app)/practice/shadow-swing/_utils/__tests__/browserSupport.test.ts
@@ -1,0 +1,47 @@
+import {
+  supportsScreenWakeLock,
+  supportsVibration,
+  unsupportedOnServer,
+} from "../browserSupport";
+
+function defineOnNavigator(key: string) {
+  Object.defineProperty(navigator, key, {
+    value: jest.fn(),
+    configurable: true,
+    writable: true,
+  });
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(navigator, "vibrate");
+  Reflect.deleteProperty(navigator, "wakeLock");
+});
+
+describe("supportsVibration", () => {
+  it("navigator に vibrate が無い環境（iOS Safari など）では false", () => {
+    expect("vibrate" in navigator).toBe(false);
+    expect(supportsVibration()).toBe(false);
+  });
+
+  it("navigator が vibrate を持つ環境では true", () => {
+    defineOnNavigator("vibrate");
+    expect(supportsVibration()).toBe(true);
+  });
+});
+
+describe("supportsScreenWakeLock", () => {
+  it("navigator に wakeLock が無い環境では false", () => {
+    expect(supportsScreenWakeLock()).toBe(false);
+  });
+
+  it("navigator が wakeLock を持つ環境では true", () => {
+    defineOnNavigator("wakeLock");
+    expect(supportsScreenWakeLock()).toBe(true);
+  });
+});
+
+describe("unsupportedOnServer", () => {
+  it("SSR 時は常に非対応として描画する", () => {
+    expect(unsupportedOnServer()).toBe(false);
+  });
+});

--- a/app/(app)/practice/shadow-swing/_utils/__tests__/shadowSwingSettings.test.ts
+++ b/app/(app)/practice/shadow-swing/_utils/__tests__/shadowSwingSettings.test.ts
@@ -1,0 +1,209 @@
+import {
+  DEFAULT_CUE_SETTINGS,
+  DEFAULT_INTERVAL_SECONDS,
+  INTERVAL_OPTIONS,
+  applyCueSelection,
+  canEnableVibration,
+  clampIntervalToAccess,
+  intervalRange,
+  isIntervalAllowed,
+  resolveIntervalAccess,
+  resolveVibrationAvailability,
+  validateTargetCount,
+} from "../shadowSwingSettings";
+
+describe("resolveIntervalAccess", () => {
+  it("Pro 判定が未確定の間は pending（Pro 前提の値を使わない）", () => {
+    expect(
+      resolveIntervalAccess({
+        isEntitlementLoading: true,
+        hasCustomInterval: true,
+      }),
+    ).toBe("pending");
+  });
+
+  it("確定後は entitlement の有無で free / pro になる", () => {
+    expect(
+      resolveIntervalAccess({
+        isEntitlementLoading: false,
+        hasCustomInterval: false,
+      }),
+    ).toBe("free");
+    expect(
+      resolveIntervalAccess({
+        isEntitlementLoading: false,
+        hasCustomInterval: true,
+      }),
+    ).toBe("pro");
+  });
+});
+
+describe("intervalRange", () => {
+  it("無料は5〜10秒", () => {
+    expect(intervalRange("free")).toEqual({ min: 5, max: 10 });
+  });
+
+  it("Pro は1〜20秒", () => {
+    expect(intervalRange("pro")).toEqual({ min: 1, max: 20 });
+  });
+
+  it("判定未確定は無料と同じ範囲にする", () => {
+    expect(intervalRange("pending")).toEqual(intervalRange("free"));
+  });
+});
+
+describe("isIntervalAllowed", () => {
+  it("無料ユーザーは5〜10秒の外を選べない", () => {
+    expect(isIntervalAllowed(4.9, "free")).toBe(false);
+    expect(isIntervalAllowed(1, "free")).toBe(false);
+    expect(isIntervalAllowed(1.5, "free")).toBe(false);
+    expect(isIntervalAllowed(10.1, "free")).toBe(false);
+    expect(isIntervalAllowed(20, "free")).toBe(false);
+  });
+
+  it("無料ユーザーでも境界の5秒・10秒は選べる", () => {
+    expect(isIntervalAllowed(5, "free")).toBe(true);
+    expect(isIntervalAllowed(10, "free")).toBe(true);
+  });
+
+  it("Pro は1.0〜20秒を選べ、その外は選べない", () => {
+    expect(isIntervalAllowed(1, "pro")).toBe(true);
+    expect(isIntervalAllowed(1.5, "pro")).toBe(true);
+    expect(isIntervalAllowed(20, "pro")).toBe(true);
+    expect(isIntervalAllowed(0.9, "pro")).toBe(false);
+    expect(isIntervalAllowed(20.1, "pro")).toBe(false);
+  });
+
+  it("判定未確定の間は無料と同じ範囲しか選べない", () => {
+    expect(isIntervalAllowed(1, "pending")).toBe(false);
+    expect(isIntervalAllowed(20, "pending")).toBe(false);
+    expect(isIntervalAllowed(5, "pending")).toBe(true);
+  });
+
+  it("選択肢のうち無料で選べるのは5〜10秒の6つだけ", () => {
+    const allowed = INTERVAL_OPTIONS.filter((seconds) =>
+      isIntervalAllowed(seconds, "free"),
+    );
+    expect(allowed).toEqual([5, 6, 7, 8, 9, 10]);
+  });
+
+  it("既定のインターバルは無料でもそのまま開始できる", () => {
+    expect(isIntervalAllowed(DEFAULT_INTERVAL_SECONDS, "free")).toBe(true);
+  });
+});
+
+describe("clampIntervalToAccess", () => {
+  it("Pro 判定が確定して範囲が狭まったら、無料の範囲へ引き戻す", () => {
+    expect(clampIntervalToAccess(1, "free")).toBe(5);
+    expect(clampIntervalToAccess(20, "free")).toBe(10);
+  });
+
+  it("範囲内の値はそのまま返す", () => {
+    expect(clampIntervalToAccess(7, "free")).toBe(7);
+    expect(clampIntervalToAccess(1.5, "pro")).toBe(1.5);
+  });
+});
+
+describe("validateTargetCount", () => {
+  it("空欄・非数・小数を弾く", () => {
+    expect(validateTargetCount("").count).toBeNull();
+    expect(validateTargetCount("abc").count).toBeNull();
+    expect(validateTargetCount("1.5").count).toBeNull();
+  });
+
+  it("1本未満・上限超えを弾く", () => {
+    expect(validateTargetCount("0").count).toBeNull();
+    expect(validateTargetCount("-10").count).toBeNull();
+    expect(validateTargetCount("10000").count).toBeNull();
+  });
+
+  it("有効な値は数値として返す", () => {
+    expect(validateTargetCount("200")).toEqual({ count: 200, error: null });
+    expect(validateTargetCount(" 1 ")).toEqual({ count: 1, error: null });
+    expect(validateTargetCount("9999")).toEqual({ count: 9999, error: null });
+  });
+});
+
+describe("applyCueSelection", () => {
+  it("既定は笛の音のみ有効（読み上げと同時にはならない）", () => {
+    expect(DEFAULT_CUE_SETTINGS).toEqual({ whistle: true, speech: false });
+  });
+
+  it("読み上げを有効にすると笛が無効になる", () => {
+    expect(
+      applyCueSelection({ whistle: true, speech: false }, "speech", true),
+    ).toEqual({ whistle: false, speech: true });
+  });
+
+  it("笛を有効にすると読み上げが無効になる", () => {
+    expect(
+      applyCueSelection({ whistle: false, speech: true }, "whistle", true),
+    ).toEqual({ whistle: true, speech: false });
+  });
+
+  it("どんな順番で切り替えても両方 true にならない", () => {
+    let cue = DEFAULT_CUE_SETTINGS;
+    for (const kind of ["speech", "whistle", "speech", "speech"] as const) {
+      cue = applyCueSelection(cue, kind, true);
+      expect(cue.whistle && cue.speech).toBe(false);
+    }
+  });
+
+  it("無効化はもう一方に影響しない（両方なしにできる）", () => {
+    expect(
+      applyCueSelection({ whistle: true, speech: false }, "whistle", false),
+    ).toEqual({ whistle: false, speech: false });
+  });
+});
+
+describe("resolveVibrationAvailability", () => {
+  it("navigator.vibrate 非対応なら Pro でも unsupported", () => {
+    expect(
+      resolveVibrationAvailability({
+        isSupported: false,
+        isEntitlementLoading: false,
+        hasVibration: true,
+      }),
+    ).toBe("unsupported");
+  });
+
+  it("非対応の判定は Pro 判定の未確定より優先する", () => {
+    expect(
+      resolveVibrationAvailability({
+        isSupported: false,
+        isEntitlementLoading: true,
+        hasVibration: true,
+      }),
+    ).toBe("unsupported");
+  });
+
+  it("Pro 判定が未確定の間は有効化しない", () => {
+    const availability = resolveVibrationAvailability({
+      isSupported: true,
+      isEntitlementLoading: true,
+      hasVibration: true,
+    });
+    expect(availability).toBe("pending");
+    expect(canEnableVibration(availability)).toBe(false);
+  });
+
+  it("対応環境かつ Pro なら利用できる", () => {
+    const availability = resolveVibrationAvailability({
+      isSupported: true,
+      isEntitlementLoading: false,
+      hasVibration: true,
+    });
+    expect(availability).toBe("available");
+    expect(canEnableVibration(availability)).toBe(true);
+  });
+
+  it("対応環境でも無料プランは locked", () => {
+    const availability = resolveVibrationAvailability({
+      isSupported: true,
+      isEntitlementLoading: false,
+      hasVibration: false,
+    });
+    expect(availability).toBe("locked");
+    expect(canEnableVibration(availability)).toBe(false);
+  });
+});

--- a/app/(app)/practice/shadow-swing/_utils/__tests__/shadowSwingTimer.test.ts
+++ b/app/(app)/practice/shadow-swing/_utils/__tests__/shadowSwingTimer.test.ts
@@ -1,0 +1,140 @@
+import {
+  INITIAL_CLOCK,
+  cueForCountChange,
+  elapsedMsAt,
+  formatElapsed,
+  pauseClock,
+  startClock,
+  swingCountAtElapsed,
+  timerSnapshot,
+} from "../shadowSwingTimer";
+
+describe("swingCountAtElapsed", () => {
+  it("インターバル1つ分が経過して初めて1本目になる", () => {
+    expect(swingCountAtElapsed(0, 5000)).toBe(0);
+    expect(swingCountAtElapsed(4999, 5000)).toBe(0);
+    expect(swingCountAtElapsed(5000, 5000)).toBe(1);
+  });
+
+  it("境界のちょうど手前・ちょうど・直後で本数が1本ずつ進む", () => {
+    expect(swingCountAtElapsed(9999, 5000)).toBe(1);
+    expect(swingCountAtElapsed(10000, 5000)).toBe(2);
+    expect(swingCountAtElapsed(10001, 5000)).toBe(2);
+  });
+
+  it("小数のインターバル（1.5秒）でも取りこぼさない", () => {
+    expect(swingCountAtElapsed(1499, 1500)).toBe(0);
+    expect(swingCountAtElapsed(1500, 1500)).toBe(1);
+    expect(swingCountAtElapsed(15000, 1500)).toBe(10);
+  });
+
+  it("フレームが落ちて経過時間が飛んでも、実時間ぶんの本数になる（ドリフトしない）", () => {
+    // 5 秒間隔で 100 秒ぶん時間が飛んでも 20 本。刻んだ回数を数える実装だと少なくなる。
+    expect(swingCountAtElapsed(100_000, 5000)).toBe(20);
+  });
+
+  it("不正な入力は0本として扱う", () => {
+    expect(swingCountAtElapsed(-1, 5000)).toBe(0);
+    expect(swingCountAtElapsed(5000, 0)).toBe(0);
+    expect(swingCountAtElapsed(5000, -5000)).toBe(0);
+    expect(swingCountAtElapsed(Number.NaN, 5000)).toBe(0);
+  });
+});
+
+describe("timerSnapshot", () => {
+  it("インターバル内の進捗を0〜1で返す", () => {
+    expect(timerSnapshot(0, 4000, 100).sweep).toBe(0);
+    expect(timerSnapshot(2000, 4000, 100).sweep).toBe(0.5);
+    expect(timerSnapshot(3999, 4000, 100).sweep).toBeCloseTo(0.99975);
+    // 1 周し切った瞬間は次の周の先頭に戻る。
+    expect(timerSnapshot(4000, 4000, 100).sweep).toBe(0);
+  });
+
+  it("目標本数に到達したら完了として本数・針・経過時間を頭打ちにする", () => {
+    const snapshot = timerSnapshot(10_000, 5000, 2);
+    expect(snapshot).toEqual({
+      elapsedMs: 10_000,
+      count: 2,
+      sweep: 1,
+      isCompleted: true,
+    });
+  });
+
+  it("タブ復帰などで目標を大きく超えた時間が渡っても、目標本数を超えて表示しない", () => {
+    // 目標 10 本（50 秒）に対し 5 分ぶん時間が飛んだ状態。
+    const snapshot = timerSnapshot(300_000, 5000, 10);
+    expect(snapshot.count).toBe(10);
+    expect(snapshot.elapsedMs).toBe(50_000);
+    expect(snapshot.isCompleted).toBe(true);
+  });
+
+  it("目標本数が0以下なら完了扱いにしない", () => {
+    expect(timerSnapshot(30_000, 5000, 0).isCompleted).toBe(false);
+    expect(timerSnapshot(30_000, 5000, 0).count).toBe(6);
+  });
+});
+
+describe("TimerClock", () => {
+  it("停止中は時間が進まない", () => {
+    const paused = pauseClock(startClock(INITIAL_CLOCK, 1000), 6000);
+    expect(elapsedMsAt(paused, 6000)).toBe(5000);
+    // 停止したまま 1 分放置しても増えない。
+    expect(elapsedMsAt(paused, 66_000)).toBe(5000);
+  });
+
+  it("再開すると停止前の時間から続く（停止していた時間は含めない）", () => {
+    const paused = pauseClock(startClock(INITIAL_CLOCK, 1000), 6000);
+    const resumed = startClock(paused, 100_000);
+    expect(elapsedMsAt(resumed, 103_000)).toBe(8000);
+  });
+
+  it("実行中に再度 startClock しても開始時刻を巻き戻さない", () => {
+    const running = startClock(INITIAL_CLOCK, 1000);
+    expect(startClock(running, 50_000)).toBe(running);
+    expect(elapsedMsAt(running, 6000)).toBe(5000);
+  });
+
+  it("停止中に pauseClock しても累計が変わらない", () => {
+    const paused = pauseClock(startClock(INITIAL_CLOCK, 0), 3000);
+    expect(pauseClock(paused, 90_000)).toBe(paused);
+  });
+
+  it("タブが隠れて戻ってきても、隠れていた時間ぶん本数が飛ばない", () => {
+    const intervalMs = 5000;
+    // 12 秒カウント（2 本）した時点で非表示になり停止。
+    const hidden = pauseClock(startClock(INITIAL_CLOCK, 0), 12_000);
+    expect(swingCountAtElapsed(elapsedMsAt(hidden, 12_000), intervalMs)).toBe(
+      2,
+    );
+
+    // 10 分後に戻って再開。復帰直後は 2 本のままで、そこから積み上がる。
+    const resumed = startClock(hidden, 612_000);
+    expect(swingCountAtElapsed(elapsedMsAt(resumed, 612_000), intervalMs)).toBe(
+      2,
+    );
+    expect(swingCountAtElapsed(elapsedMsAt(resumed, 615_000), intervalMs)).toBe(
+      3,
+    );
+  });
+});
+
+describe("cueForCountChange", () => {
+  it("本数が増えたときだけ、増えた先の本数を返す", () => {
+    expect(cueForCountChange(0, 1)).toBe(1);
+    expect(cueForCountChange(5, 5)).toBeNull();
+    expect(cueForCountChange(5, 4)).toBeNull();
+  });
+
+  it("一度に複数本進んでも1回ぶんだけ返す（連打しない）", () => {
+    expect(cueForCountChange(3, 9)).toBe(9);
+  });
+});
+
+describe("formatElapsed", () => {
+  it("mm:ss に整形する", () => {
+    expect(formatElapsed(0)).toBe("00:00");
+    expect(formatElapsed(59_999)).toBe("00:59");
+    expect(formatElapsed(60_000)).toBe("01:00");
+    expect(formatElapsed(3_723_000)).toBe("62:03");
+  });
+});

--- a/app/(app)/practice/shadow-swing/_utils/__tests__/swingCuePlayer.test.ts
+++ b/app/(app)/practice/shadow-swing/_utils/__tests__/swingCuePlayer.test.ts
@@ -1,0 +1,220 @@
+/**
+ * ブラウザ API（Web Audio / SpeechSynthesis / navigator.vibrate）は jsdom に無いため、
+ * ここでは「どの API をどの順番で呼ぶか」だけを検証する。
+ * 実際に音が鳴るか・振動するかは実機でしか確認できない。
+ */
+
+import { SwingCuePlayer } from "../swingCuePlayer";
+
+interface MockOscillator {
+  type: string;
+  frequency: { setValueAtTime: jest.Mock };
+  connect: jest.Mock;
+  start: jest.Mock;
+  stop: jest.Mock;
+}
+
+interface MockGain {
+  gain: {
+    setValueAtTime: jest.Mock;
+    exponentialRampToValueAtTime: jest.Mock;
+  };
+  connect: jest.Mock;
+}
+
+function buildOscillator(): MockOscillator {
+  return {
+    type: "sine",
+    frequency: { setValueAtTime: jest.fn() },
+    connect: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+  };
+}
+
+function buildGain(): MockGain {
+  return {
+    gain: {
+      setValueAtTime: jest.fn(),
+      exponentialRampToValueAtTime: jest.fn(),
+    },
+    connect: jest.fn(),
+  };
+}
+
+const oscillators: MockOscillator[] = [];
+const resume = jest.fn();
+const close = jest.fn();
+
+class MockAudioContext {
+  state = "suspended";
+  currentTime = 0;
+  destination = { id: "destination" };
+
+  resume = async () => {
+    this.state = "running";
+    resume();
+  };
+
+  close = async () => {
+    close();
+  };
+
+  createOscillator = () => {
+    const oscillator = buildOscillator();
+    oscillators.push(oscillator);
+    return oscillator;
+  };
+
+  createGain = () => buildGain();
+}
+
+const speak = jest.fn();
+const cancel = jest.fn();
+
+class MockUtterance {
+  lang = "";
+  volume = 1;
+  constructor(public text: string) {}
+}
+
+function installBrowserApis({
+  audio = true,
+  speech = true,
+  vibrate = true,
+}: { audio?: boolean; speech?: boolean; vibrate?: boolean } = {}) {
+  if (audio) {
+    (window as unknown as Record<string, unknown>).AudioContext =
+      MockAudioContext;
+  }
+  if (speech) {
+    Object.defineProperty(window, "speechSynthesis", {
+      value: { speak, cancel },
+      configurable: true,
+      writable: true,
+    });
+    (window as unknown as Record<string, unknown>).SpeechSynthesisUtterance =
+      MockUtterance;
+  }
+  if (vibrate) {
+    Object.defineProperty(navigator, "vibrate", {
+      value: jest.fn(() => true),
+      configurable: true,
+      writable: true,
+    });
+  }
+}
+
+function removeBrowserApis() {
+  delete (window as unknown as Record<string, unknown>).AudioContext;
+  delete (window as unknown as Record<string, unknown>)
+    .SpeechSynthesisUtterance;
+  Reflect.deleteProperty(window, "speechSynthesis");
+  Reflect.deleteProperty(navigator, "vibrate");
+}
+
+beforeEach(() => {
+  oscillators.length = 0;
+  jest.clearAllMocks();
+  removeBrowserApis();
+});
+
+afterEach(() => {
+  removeBrowserApis();
+});
+
+describe("unlock", () => {
+  it("AudioContext を作って resume する（ユーザー操作起点で音声を解禁する）", async () => {
+    installBrowserApis();
+    const player = new SwingCuePlayer();
+
+    await player.unlock();
+
+    expect(resume).toHaveBeenCalledTimes(1);
+  });
+
+  it("解禁前に笛を鳴らそうとしても何も再生しない", () => {
+    installBrowserApis();
+    const player = new SwingCuePlayer();
+
+    player.playWhistle();
+
+    expect(oscillators).toHaveLength(0);
+  });
+
+  it("解禁後は笛が発振・停止まで組み立てられる", async () => {
+    installBrowserApis();
+    const player = new SwingCuePlayer();
+
+    await player.unlock();
+    player.playWhistle();
+
+    expect(oscillators).toHaveLength(1);
+    expect(oscillators[0].start).toHaveBeenCalledTimes(1);
+    expect(oscillators[0].stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("Web Audio 非対応でも例外を投げない", async () => {
+    installBrowserApis({ audio: false });
+    const player = new SwingCuePlayer();
+
+    await expect(player.unlock()).resolves.toBeUndefined();
+    expect(() => player.playWhistle()).not.toThrow();
+  });
+});
+
+describe("speakCount", () => {
+  it("日本語で本数を読み上げ、前の読み上げを打ち切る", () => {
+    installBrowserApis();
+    const player = new SwingCuePlayer();
+
+    player.speakCount(12);
+
+    expect(cancel).toHaveBeenCalled();
+    expect(speak).toHaveBeenCalledTimes(1);
+    const utterance = speak.mock.calls[0][0] as MockUtterance;
+    expect(utterance.text).toBe("12");
+    expect(utterance.lang).toBe("ja-JP");
+  });
+
+  it("読み上げ非対応の環境でも例外を投げない", () => {
+    installBrowserApis({ speech: false });
+    const player = new SwingCuePlayer();
+
+    expect(() => player.speakCount(1)).not.toThrow();
+    expect(speak).not.toHaveBeenCalled();
+  });
+});
+
+describe("vibrate", () => {
+  it("対応環境では1本ごとに振動させる", () => {
+    installBrowserApis();
+    const player = new SwingCuePlayer();
+
+    player.vibrateSwing();
+
+    expect(navigator.vibrate).toHaveBeenCalledWith(40);
+  });
+
+  it("非対応環境（iOS Safari など）では navigator.vibrate を呼ばない", () => {
+    installBrowserApis({ vibrate: false });
+    const player = new SwingCuePlayer();
+
+    expect("vibrate" in navigator).toBe(false);
+    expect(() => player.vibrateSwing()).not.toThrow();
+    expect(() => player.vibrateCompletion()).not.toThrow();
+  });
+});
+
+describe("dispose", () => {
+  it("読み上げを止めて AudioContext を閉じる", async () => {
+    installBrowserApis();
+    const player = new SwingCuePlayer();
+    await player.unlock();
+
+    player.dispose();
+
+    expect(cancel).toHaveBeenCalled();
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/(app)/practice/shadow-swing/_utils/browserSupport.ts
+++ b/app/(app)/practice/shadow-swing/_utils/browserSupport.ts
@@ -1,0 +1,31 @@
+/**
+ * 素振りカウンターが使うブラウザ API の対応可否。
+ * SSR では `navigator` が無いので必ず false を返し、クライアントで再判定する。
+ */
+
+/**
+ * `navigator.vibrate` を持つか。iOS Safari は非対応で、Android Chrome などは対応する。
+ * 呼んでも例外は出ずに何も起きないため、機能検出しないと
+ * 「設定できるのに一切振動しない」状態を作ってしまう。
+ */
+export function supportsVibration(): boolean {
+  return typeof navigator !== "undefined" && "vibrate" in navigator;
+}
+
+/**
+ * Screen Wake Lock API（画面の自動消灯抑止）を持つか。
+ * 非対応環境では素振り中に画面が消えるため、呼び出し側で注意書きを出す。
+ */
+export function supportsScreenWakeLock(): boolean {
+  return typeof navigator !== "undefined" && "wakeLock" in navigator;
+}
+
+/** `useSyncExternalStore` 用の購読関数。対応可否は実行中に変わらないので何も購読しない。 */
+export function subscribeToNothing(): () => void {
+  return () => {};
+}
+
+/** SSR 時のスナップショット。クライアントで判定するまでは「非対応」として描画する。 */
+export function unsupportedOnServer(): false {
+  return false;
+}

--- a/app/(app)/practice/shadow-swing/_utils/screenWakeLock.ts
+++ b/app/(app)/practice/shadow-swing/_utils/screenWakeLock.ts
@@ -1,0 +1,62 @@
+import { supportsScreenWakeLock } from "./browserSupport";
+
+/**
+ * 素振り中の画面消灯を抑止する Screen Wake Lock のラッパー。
+ *
+ * 非対応環境（Safari の一部バージョンなど）では取得に失敗するが、その場合も
+ * 素振り自体は続けられるため例外にはしない。呼び出し側は `supportsScreenWakeLock()` を見て
+ * 「端末の自動ロックが働く」旨の注意書きを出す。
+ */
+
+/** lib.dom の型に依らず、使う分だけを構造的に受ける。 */
+interface WakeLockSentinelLike {
+  released: boolean;
+  release(): Promise<void>;
+}
+
+interface WakeLockLike {
+  request(type: "screen"): Promise<WakeLockSentinelLike>;
+}
+
+function resolveWakeLock(): WakeLockLike | null {
+  if (!supportsScreenWakeLock()) return null;
+  return (
+    (navigator as Navigator & { wakeLock?: WakeLockLike }).wakeLock ?? null
+  );
+}
+
+export class ScreenWakeLock {
+  private sentinel: WakeLockSentinelLike | null = null;
+
+  /**
+   * ロックを取得する。
+   * タブが非表示の間はブラウザが必ず拒否するため、可視状態に戻ってから呼び直す必要がある。
+   *
+   * @return 取得できたか
+   */
+  async acquire(): Promise<boolean> {
+    const wakeLock = resolveWakeLock();
+    if (!wakeLock) return false;
+    if (this.sentinel && !this.sentinel.released) return true;
+
+    try {
+      this.sentinel = await wakeLock.request("screen");
+      return true;
+    } catch {
+      this.sentinel = null;
+      return false;
+    }
+  }
+
+  /** ロックを解放する。取得していなければ何もしない。 */
+  async release(): Promise<void> {
+    const sentinel = this.sentinel;
+    this.sentinel = null;
+    if (!sentinel || sentinel.released) return;
+    try {
+      await sentinel.release();
+    } catch {
+      // 解放に失敗しても、タブを閉じればブラウザ側で解放される。
+    }
+  }
+}

--- a/app/(app)/practice/shadow-swing/_utils/shadowSwingSettings.ts
+++ b/app/(app)/practice/shadow-swing/_utils/shadowSwingSettings.ts
@@ -1,0 +1,187 @@
+/**
+ * 素振りカウンターの設定値と、プラン（entitlement）による可否判定。
+ * ブラウザ API にも React にも依存しない純粋関数だけを置く。
+ */
+
+/**
+ * 無料プランで選べるインターバルの範囲（秒）。
+ * back/app/models/concerns/entitlement.rb の
+ * `shadow_swing_custom_interval`（無料は5〜10秒のみ）と一致させる。
+ */
+export const FREE_INTERVAL_MIN_SECONDS = 5;
+export const FREE_INTERVAL_MAX_SECONDS = 10;
+
+/** Pro プランで選べるインターバルの範囲（秒）。 */
+export const PRO_INTERVAL_MIN_SECONDS = 1;
+export const PRO_INTERVAL_MAX_SECONDS = 20;
+
+/** 無料でもそのまま開始できるよう、既定値は無料の範囲内に置く。 */
+export const DEFAULT_INTERVAL_SECONDS = 5;
+
+export const DEFAULT_TARGET_COUNT = 200;
+export const MIN_TARGET_COUNT = 1;
+/** 現実的に振り切れる上限。桁の打ち間違いで数時間のセッションが始まるのを防ぐ。 */
+export const MAX_TARGET_COUNT = 9999;
+
+/** 選択肢として並べるインターバル（秒）。mobile の設定画面と同じ刻みで揃える。 */
+export const INTERVAL_OPTIONS: readonly number[] = [
+  1, 1.5, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+];
+
+/**
+ * インターバル設定の解放状態。
+ * `pending` は Pro 判定がまだ確定していない状態で、可否の扱いは無料と同じにする
+ * （UI 上はロック表示ではなく「確認中」として見せる）。
+ */
+export type IntervalAccess = "pending" | "free" | "pro";
+
+/**
+ * Pro 判定の状態からインターバルの解放状態を決める。
+ * 判定中を `pro` に倒すと、無料ユーザーが 5〜10 秒の外を選べてしまい、
+ * 開始時にサーバー側とも食い違うため、判定中は必ず無料と同じ扱いにする。
+ */
+export function resolveIntervalAccess({
+  isEntitlementLoading,
+  hasCustomInterval,
+}: {
+  isEntitlementLoading: boolean;
+  hasCustomInterval: boolean;
+}): IntervalAccess {
+  if (isEntitlementLoading) return "pending";
+  return hasCustomInterval ? "pro" : "free";
+}
+
+/** 解放状態ごとに選べるインターバルの範囲（秒）。判定中は無料と同じ範囲。 */
+export function intervalRange(access: IntervalAccess): {
+  min: number;
+  max: number;
+} {
+  if (access === "pro") {
+    return { min: PRO_INTERVAL_MIN_SECONDS, max: PRO_INTERVAL_MAX_SECONDS };
+  }
+  return { min: FREE_INTERVAL_MIN_SECONDS, max: FREE_INTERVAL_MAX_SECONDS };
+}
+
+/** そのインターバルを選べるか。 */
+export function isIntervalAllowed(
+  seconds: number,
+  access: IntervalAccess,
+): boolean {
+  if (!Number.isFinite(seconds)) return false;
+  const { min, max } = intervalRange(access);
+  return seconds >= min && seconds <= max;
+}
+
+/**
+ * 選択済みのインターバルを解放状態の範囲へ引き戻す。
+ * Pro 判定が確定して範囲が狭まったときに、選べない値のまま開始されるのを防ぐ。
+ */
+export function clampIntervalToAccess(
+  seconds: number,
+  access: IntervalAccess,
+): number {
+  const { min, max } = intervalRange(access);
+  if (!Number.isFinite(seconds)) return DEFAULT_INTERVAL_SECONDS;
+  return Math.min(Math.max(seconds, min), max);
+}
+
+/** 目標本数の入力値を検証する。空欄・非数・範囲外はエラー文言を返す。 */
+export function validateTargetCount(value: string): {
+  count: number | null;
+  error: string | null;
+} {
+  const trimmed = value.trim();
+  if (trimmed === "")
+    return { count: null, error: "目標本数を入力してください" };
+
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed)) {
+    return { count: null, error: "目標本数は整数で入力してください" };
+  }
+  if (parsed < MIN_TARGET_COUNT || parsed > MAX_TARGET_COUNT) {
+    return {
+      count: null,
+      error: `目標本数は${MIN_TARGET_COUNT}〜${MAX_TARGET_COUNT.toLocaleString("ja-JP")}本で入力してください`,
+    };
+  }
+  return { count: parsed, error: null };
+}
+
+/** 合図の設定。笛の音とカウント読み上げは同時に有効にならない。 */
+export interface CueSettings {
+  whistle: boolean;
+  speech: boolean;
+}
+
+export type CueKind = "whistle" | "speech";
+
+export const DEFAULT_CUE_SETTINGS: CueSettings = {
+  whistle: true,
+  speech: false,
+};
+
+/**
+ * 笛の音・カウント読み上げの選択を反映する。
+ *
+ * 両方を同時に鳴らすと読み上げが笛にかき消され、どちらの合図としても機能しなくなるため、
+ * 片方を有効にしたらもう片方は必ず無効にする（＝排他）。
+ * 有効化の分岐をここに閉じ込め、呼び出し側が両方 true の状態を作れないようにしている。
+ */
+export function applyCueSelection(
+  current: CueSettings,
+  kind: CueKind,
+  enabled: boolean,
+): CueSettings {
+  if (!enabled) return { ...current, [kind]: false };
+  return kind === "whistle"
+    ? { whistle: true, speech: false }
+    : { whistle: false, speech: true };
+}
+
+/**
+ * バイブレーション設定の状態。
+ * - available: 使える
+ * - pending: Pro 判定が未確定（確定するまで有効化しない）
+ * - locked: Pro 未加入
+ * - unsupported: ブラウザが `navigator.vibrate` を持たない（iOS Safari など）
+ */
+export type VibrationAvailability =
+  | "available"
+  | "pending"
+  | "locked"
+  | "unsupported";
+
+/**
+ * バイブレーションの可否を決める。
+ *
+ * 非対応ブラウザの判定を最優先にする。Pro であっても `navigator.vibrate` が無い環境では
+ * 一切振動しないため、「Pro なので設定できる」と見せてしまうと機能しない設定が残る。
+ */
+export function resolveVibrationAvailability({
+  isSupported,
+  isEntitlementLoading,
+  hasVibration,
+}: {
+  isSupported: boolean;
+  isEntitlementLoading: boolean;
+  hasVibration: boolean;
+}): VibrationAvailability {
+  if (!isSupported) return "unsupported";
+  if (isEntitlementLoading) return "pending";
+  return hasVibration ? "available" : "locked";
+}
+
+/** バイブレーションを実際に有効化してよいか。 */
+export function canEnableVibration(
+  availability: VibrationAvailability,
+): boolean {
+  return availability === "available";
+}
+
+/** カウント画面へ引き渡す確定済みの設定。 */
+export interface ShadowSwingConfig {
+  targetCount: number;
+  intervalSeconds: number;
+  cue: CueSettings;
+  vibration: boolean;
+}

--- a/app/(app)/practice/shadow-swing/_utils/shadowSwingTimer.ts
+++ b/app/(app)/practice/shadow-swing/_utils/shadowSwingTimer.ts
@@ -1,0 +1,127 @@
+/**
+ * 素振りカウンターの時間計算。UI・ブラウザ API から独立した純粋関数だけを置く。
+ *
+ * `setInterval` で「発火した回数」を足し込む方式は採らない。ブラウザは非アクティブタブの
+ * タイマーを 1 秒以上まで間引くため、発火回数を数えると実時間より本数が少なくなり、
+ * さらに 1 回あたりの遅延が積み上がってドリフトする。
+ * ここでは常に「開始からの経過時間 ÷ インターバル」で本数を導出するため、
+ * フレームが何回落ちても本数は実時間とずれない。
+ */
+
+/**
+ * 実行時間の計測状態。一時停止をまたいで累計するため、
+ * 「停止までに積んだ時間」と「現在の実行区間の開始時刻」を分けて持つ。
+ */
+export interface TimerClock {
+  /** 直前までに実行した累計時間（ms）。一時停止していた時間は含まない。 */
+  accumulatedMs: number;
+  /** 現在の実行区間の開始時刻（`performance.now()` 相当の ms）。停止中は null。 */
+  startedAt: number | null;
+}
+
+export const INITIAL_CLOCK: TimerClock = { accumulatedMs: 0, startedAt: null };
+
+/**
+ * 現在時刻における実行済み時間（ms）を返す。
+ * 停止中は累計値をそのまま返すので、停止中に時間が進むことはない。
+ */
+export function elapsedMsAt(clock: TimerClock, now: number): number {
+  if (clock.startedAt === null) return Math.max(0, clock.accumulatedMs);
+  return Math.max(0, clock.accumulatedMs + (now - clock.startedAt));
+}
+
+/** 計測を開始・再開する。既に動いている場合は開始時刻を上書きしない（時間の巻き戻り防止）。 */
+export function startClock(clock: TimerClock, now: number): TimerClock {
+  if (clock.startedAt !== null) return clock;
+  return { accumulatedMs: clock.accumulatedMs, startedAt: now };
+}
+
+/** 計測を一時停止する。停止した瞬間までの時間を累計へ畳み込む。 */
+export function pauseClock(clock: TimerClock, now: number): TimerClock {
+  if (clock.startedAt === null) return clock;
+  return { accumulatedMs: elapsedMsAt(clock, now), startedAt: null };
+}
+
+/**
+ * 経過時間から「何本目まで振り終えたか」を返す。
+ * 1 本目はインターバル 1 つ分が経過した時点でカウントする（開始直後は 0 本）。
+ * 不正な入力（負の経過時間・0 以下のインターバル）は 0 本として扱う。
+ */
+export function swingCountAtElapsed(
+  elapsedMs: number,
+  intervalMs: number,
+): number {
+  if (!Number.isFinite(elapsedMs) || !Number.isFinite(intervalMs)) return 0;
+  if (intervalMs <= 0 || elapsedMs <= 0) return 0;
+  return Math.floor(elapsedMs / intervalMs);
+}
+
+/** カウント画面の表示に必要な値をまとめたもの。 */
+export interface TimerSnapshot {
+  /** 実行済み時間（ms）。目標到達後は到達時点で頭打ちにする。 */
+  elapsedMs: number;
+  /** 現在の本数。目標本数を超えない。 */
+  count: number;
+  /** 現在のインターバル内の進捗（0〜1）。円形タイマーの針の位置。 */
+  sweep: number;
+  /** 目標本数に到達したか。 */
+  isCompleted: boolean;
+}
+
+/**
+ * 経過時間から表示状態を導出する。
+ *
+ * タブ復帰時などで一気に時間が飛んでも、本数・針は「その時刻における正しい値」に落ち着く。
+ * 目標到達より先の時間は切り捨てるため、復帰直後に目標を超えた本数が表示されることはない。
+ *
+ * @param elapsedMs 実行済み時間（ms）
+ * @param intervalMs 1 本あたりのインターバル（ms）
+ * @param targetCount 目標本数。0 以下なら上限なしとして扱う
+ */
+export function timerSnapshot(
+  elapsedMs: number,
+  intervalMs: number,
+  targetCount: number,
+): TimerSnapshot {
+  const safeElapsed = Number.isFinite(elapsedMs) ? Math.max(0, elapsedMs) : 0;
+  const rawCount = swingCountAtElapsed(safeElapsed, intervalMs);
+  const isCompleted = targetCount > 0 && rawCount >= targetCount;
+
+  if (isCompleted) {
+    return {
+      elapsedMs: targetCount * intervalMs,
+      count: targetCount,
+      sweep: 1,
+      isCompleted: true,
+    };
+  }
+
+  return {
+    elapsedMs: safeElapsed,
+    count: rawCount,
+    sweep: intervalMs > 0 ? (safeElapsed % intervalMs) / intervalMs : 0,
+    isCompleted: false,
+  };
+}
+
+/**
+ * 直前のフレームからの本数の変化に対して鳴らすべき合図（読み上げる本数）を返す。
+ * 増えていなければ null。
+ *
+ * タブ復帰などで一度に複数本進んだ場合も 1 回だけ鳴らす。飛んだ本数ぶん連打すると
+ * 読み上げのキューが詰まり、実際の本数から遅れた数字を読み上げ続けてしまう。
+ */
+export function cueForCountChange(
+  previousCount: number,
+  nextCount: number,
+): number | null {
+  return nextCount > previousCount ? nextCount : null;
+}
+
+/** 実行時間を "mm:ss" に整形する。60 分を超えても分は繰り上げずに桁を増やす。 */
+export function formatElapsed(elapsedMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}

--- a/app/(app)/practice/shadow-swing/_utils/swingCuePlayer.ts
+++ b/app/(app)/practice/shadow-swing/_utils/swingCuePlayer.ts
@@ -1,0 +1,173 @@
+import { supportsVibration } from "./browserSupport";
+
+/**
+ * 素振り 1 本ごとの合図（笛の音・カウント読み上げ・バイブレーション）をまとめて扱う。
+ *
+ * ブラウザは自動再生を禁止しており、ユーザー操作のハンドラの中で AudioContext を作って
+ * `resume()` しない限り音が鳴らない。そのため `unlock()` を「開始」「再開」ボタンの
+ * クリックハンドラから呼ぶ前提の API にしている（未解禁の状態で再生要求が来ても無視する）。
+ *
+ * 笛は音源ファイルを持たずオシレータで合成する。数十 KB の音声を読み込む必要がなく、
+ * 1 本ごとに即時発音できる（ファイル読み込みの遅延がテンポを崩さない）。
+ */
+
+type AudioContextConstructor = new () => AudioContext;
+
+const WHISTLE_FREQUENCY_HZ = 2200;
+const WHISTLE_DURATION_SECONDS = 0.15;
+const WHISTLE_PEAK_GAIN = 0.22;
+/** 1 本ごとの短い振動。長いと次のインターバルにかぶる。 */
+const VIBRATION_DURATION_MS = 40;
+/** 完了時の達成演出。振動 → 間 → 少し長い振動の 2 拍。 */
+const COMPLETION_VIBRATION_PATTERN = [0, 80, 60, 140];
+
+function resolveAudioContextConstructor(): AudioContextConstructor | null {
+  if (typeof window === "undefined") return null;
+  // Safari は非標準の webkitAudioContext しか持たないバージョンがあるため両方を見る。
+  const scope = window as Window & {
+    AudioContext?: AudioContextConstructor;
+    webkitAudioContext?: AudioContextConstructor;
+  };
+  return scope.AudioContext ?? scope.webkitAudioContext ?? null;
+}
+
+function resolveSpeechSynthesis(): SpeechSynthesis | null {
+  if (typeof window === "undefined") return null;
+  return "speechSynthesis" in window ? window.speechSynthesis : null;
+}
+
+export class SwingCuePlayer {
+  private context: AudioContext | null = null;
+
+  /**
+   * 音声再生を解禁する。必ずユーザー操作（開始・再開ボタン）のハンドラから呼ぶ。
+   * AudioContext は作った直後 `suspended` で、`resume()` を通してからでないと発音しない。
+   */
+  async unlock(): Promise<void> {
+    const AudioContextCtor = resolveAudioContextConstructor();
+    if (AudioContextCtor && !this.context) {
+      try {
+        this.context = new AudioContextCtor();
+      } catch {
+        this.context = null;
+      }
+    }
+
+    if (this.context && this.context.state !== "running") {
+      try {
+        await this.context.resume();
+      } catch {
+        // 解禁に失敗しても素振り自体は続けられるため、握りつぶして無音で進める。
+      }
+    }
+
+    this.primeSpeech();
+  }
+
+  /**
+   * SpeechSynthesis もユーザー操作起点でしか話し始めない実装があるため、
+   * 解禁時に空の発話を一度通してキューを起こしておく。
+   */
+  private primeSpeech(): void {
+    const synthesis = resolveSpeechSynthesis();
+    if (!synthesis) return;
+    try {
+      synthesis.cancel();
+      const utterance = new SpeechSynthesisUtterance("");
+      utterance.volume = 0;
+      utterance.lang = "ja-JP";
+      synthesis.speak(utterance);
+    } catch {
+      // 読み上げ非対応でもカウント自体は継続する。
+    }
+  }
+
+  /** 笛を 1 回鳴らす。未解禁（`unlock()` 前）なら何もしない。 */
+  playWhistle(): void {
+    const context = this.context;
+    if (!context || context.state !== "running") return;
+
+    try {
+      const startAt = context.currentTime;
+      const oscillator = context.createOscillator();
+      const gain = context.createGain();
+
+      // 矩形波は倍音が多く、屋外でも抜ける笛らしい音になる。
+      oscillator.type = "square";
+      oscillator.frequency.setValueAtTime(WHISTLE_FREQUENCY_HZ, startAt);
+
+      // 立ち上がり・減衰を付けないとプツッというクリックノイズが乗る。
+      gain.gain.setValueAtTime(0.0001, startAt);
+      gain.gain.exponentialRampToValueAtTime(WHISTLE_PEAK_GAIN, startAt + 0.01);
+      gain.gain.exponentialRampToValueAtTime(
+        0.0001,
+        startAt + WHISTLE_DURATION_SECONDS,
+      );
+
+      oscillator.connect(gain);
+      gain.connect(context.destination);
+      oscillator.start(startAt);
+      oscillator.stop(startAt + WHISTLE_DURATION_SECONDS);
+    } catch {
+      // 音が出せなくてもカウントは止めない。
+    }
+  }
+
+  /** 本数を日本語で読み上げる。前の読み上げが残っていれば打ち切って最新の本数を優先する。 */
+  speakCount(count: number): void {
+    const synthesis = resolveSpeechSynthesis();
+    if (!synthesis) return;
+
+    try {
+      synthesis.cancel();
+      const utterance = new SpeechSynthesisUtterance(String(count));
+      utterance.lang = "ja-JP";
+      synthesis.speak(utterance);
+    } catch {
+      // 読み上げに失敗してもカウントは止めない。
+    }
+  }
+
+  /** 読み上げを打ち切る。一時停止・終了時に呼ぶ。 */
+  stopSpeaking(): void {
+    const synthesis = resolveSpeechSynthesis();
+    if (!synthesis) return;
+    try {
+      synthesis.cancel();
+    } catch {
+      // 何もしない。
+    }
+  }
+
+  /** 1 本ぶんの振動。非対応ブラウザでは何もしない。 */
+  vibrateSwing(): void {
+    this.vibrate(VIBRATION_DURATION_MS);
+  }
+
+  /** 完了時の達成演出としての振動。 */
+  vibrateCompletion(): void {
+    this.vibrate(COMPLETION_VIBRATION_PATTERN);
+  }
+
+  private vibrate(pattern: number | number[]): void {
+    if (!supportsVibration()) return;
+    try {
+      navigator.vibrate(pattern);
+    } catch {
+      // 非対応・拒否時は無視する。
+    }
+  }
+
+  /** 画面を離れるときに音声リソースを解放する。 */
+  dispose(): void {
+    this.stopSpeaking();
+    const context = this.context;
+    this.context = null;
+    if (!context) return;
+    try {
+      void context.close();
+    } catch {
+      // すでに閉じている場合は無視する。
+    }
+  }
+}

--- a/app/(app)/practice/shadow-swing/page.tsx
+++ b/app/(app)/practice/shadow-swing/page.tsx
@@ -1,0 +1,35 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Header from "@app/components/header/Header";
+import { getShadowSwingStats } from "@app/services/v2/shadowSwingService";
+import ShadowSwingContent from "./_components/ShadowSwingContent";
+import { PAGE_TITLE } from "./_components/shadowSwingCopy";
+
+export const metadata = {
+  title: "素振りカウンター",
+};
+
+export default async function ShadowSwingPage() {
+  const cookieStore = await cookies();
+  if (!cookieStore.get("access-token")) {
+    redirect("/signup?auth_required=true");
+  }
+
+  const statsResult = await getShadowSwingStats();
+
+  return (
+    <div className="buzz-dark flex flex-col w-full min-h-screen bg-main">
+      <Header />
+      <main className="h-full w-full max-w-[720px] mx-auto lg:m-[0_auto_0_28%]">
+        <div className="pb-32 relative lg:border-x-1 lg:border-b-1 lg:border-zinc-500 lg:pb-0 lg:mb-14">
+          <div className="pt-20 px-4 lg:px-6">
+            <h1 className="text-2xl font-bold">{PAGE_TITLE}</h1>
+            <div className="my-6">
+              <ShadowSwingContent initialStatsResult={statsResult} />
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/components/header/HeaderRight.tsx
+++ b/app/components/header/HeaderRight.tsx
@@ -98,6 +98,16 @@ export default function HeaderRight() {
                   目標
                 </DropdownItem>
                 <DropdownItem
+                  key="shadow-swing"
+                  as={Link}
+                  href="/practice/shadow-swing"
+                  startContent={
+                    <BallIcon fill="currentColor" width="18" height="18" />
+                  }
+                >
+                  素振りカウンター
+                </DropdownItem>
+                <DropdownItem
                   key="practice-menus"
                   as={Link}
                   href="/practice/menus"

--- a/app/components/pro/__tests__/proFeatureCatalog.test.ts
+++ b/app/components/pro/__tests__/proFeatureCatalog.test.ts
@@ -48,6 +48,7 @@ const WEB_DELIVERED_FEATURES: ProFeature[] = [
   "pitch_type_average",
   "pitcher_faceoff_average",
   "unlimited_media_uploads",
+  "shadow_swing_custom_interval",
 ];
 
 describe("FEATURE_COMPARISONS", () => {
@@ -79,7 +80,9 @@ describe("FEATURE_COMPARISONS", () => {
   });
 
   it("ブラウザで成立しない素振りカウンターの機能を Web 提供として扱わない", () => {
-    // バックグラウンド継続とバイブレーションはブラウザの制約で Web では実現できない。
+    // バックグラウンド継続はブラウザが非アクティブタブのタイマーを間引くため Web では成立しない。
+    // バイブレーションは iOS Safari が navigator.vibrate を持たず全ての Web 利用者には
+    // 届かないため、比較表では Web 提供として訴求しない（対応ブラウザでは機能検出のうえ提供する）。
     expect(FEATURE_COMPARISONS.shadow_swing_background.availability).toBe(
       "app_only",
     );

--- a/app/components/pro/proFeatureCatalog.ts
+++ b/app/components/pro/proFeatureCatalog.ts
@@ -91,7 +91,7 @@ export const FEATURE_COMPARISONS: Record<ProFeature, FeatureComparison> = {
   shadow_swing_custom_interval: {
     free: "5〜10秒",
     pro: "1〜20秒",
-    availability: "app_only",
+    availability: "web_and_app",
   },
   shadow_swing_vibration: { free: "✕", pro: "○", availability: "app_only" },
   shadow_swing_background: {

--- a/app/globals.css
+++ b/app/globals.css
@@ -70,3 +70,25 @@ label {
 .flex.flex-col.min-h-screen > .bg-main {
   flex-grow: 1;
 }
+
+/* 素振りカウンター完了画面の達成演出。
+   Tailwind v4 の @theme で --animate-* を定義すると animate-swing-pop が使える。
+   prefers-reduced-motion 環境では motion-safe: 修飾子側で外れる。 */
+@theme {
+  --animate-swing-pop: swing-pop 520ms cubic-bezier(0.22, 1.2, 0.36, 1) both;
+}
+
+@keyframes swing-pop {
+  0% {
+    transform: scale(0.4);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.12);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}

--- a/app/services/v2/__tests__/shadowSwingService.test.ts
+++ b/app/services/v2/__tests__/shadowSwingService.test.ts
@@ -1,0 +1,139 @@
+const mockGet = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(() => Promise.resolve({ get: mockGet })),
+}));
+
+jest.mock("@app/constants/api", () => ({
+  RAILS_API_URL: "http://back:3000",
+}));
+
+jest.mock("../../../../lib/sentry-helpers", () => ({
+  captureServerActionError: jest.fn(),
+}));
+
+import type { ShadowSwingSession } from "@app/types/shadowSwing";
+import {
+  completeShadowSwingSession,
+  getShadowSwingStats,
+  startShadowSwingSession,
+} from "../shadowSwingService";
+
+function setupAuthCookies() {
+  mockGet.mockImplementation((key: string) => {
+    const values: Record<string, { value: string }> = {
+      "access-token": { value: "test-access-token" },
+      client: { value: "test-client" },
+      uid: { value: "test-uid" },
+    };
+    return values[key];
+  });
+}
+
+function requestedUrl(callIndex = 0): string {
+  return (global.fetch as jest.Mock).mock.calls[callIndex][0] as string;
+}
+
+function requestedInit(callIndex = 0): RequestInit {
+  return (global.fetch as jest.Mock).mock.calls[callIndex][1] as RequestInit;
+}
+
+function sentBody(callIndex = 0): Record<string, unknown> {
+  return JSON.parse(requestedInit(callIndex).body as string) as Record<
+    string,
+    unknown
+  >;
+}
+
+function mockJsonResponse(body: unknown, status = 200) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+const session: ShadowSwingSession = {
+  id: 42,
+  logged_on: "2026-08-03",
+  target_count: 200,
+  swing_count: 0,
+  completed_at: null,
+  practice_log_id: null,
+};
+
+describe("v2 素振りカウンター Server Actions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    setupAuthCookies();
+  });
+
+  describe("startShadowSwingSession", () => {
+    it("目標本数を shadow_swing_session でラップして POST する", async () => {
+      mockJsonResponse(session, 201);
+
+      const result = await startShadowSwingSession(200);
+
+      expect(result).toEqual({ ok: true, data: session });
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/shadow_swing_sessions",
+      );
+      expect(requestedInit().method).toBe("POST");
+      expect(sentBody()).toEqual({
+        shadow_swing_session: { target_count: 200 },
+      });
+    });
+
+    it("失敗時は back のエラーメッセージを返す", async () => {
+      mockJsonResponse({ errors: ["目標本数を入力してください"] }, 422);
+
+      const result = await startShadowSwingSession(0);
+
+      expect(result).toEqual({
+        ok: false,
+        reason: "error",
+        errors: ["目標本数を入力してください"],
+      });
+    });
+  });
+
+  describe("completeShadowSwingSession", () => {
+    it("セッション id の complete へ本数を POST する", async () => {
+      mockJsonResponse({ ...session, swing_count: 180 });
+
+      const result = await completeShadowSwingSession(42, 180);
+
+      expect(result.ok).toBe(true);
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/shadow_swing_sessions/42/complete",
+      );
+      expect(requestedInit().method).toBe("POST");
+      expect(sentBody()).toEqual({
+        shadow_swing_session: { swing_count: 180 },
+      });
+    });
+  });
+
+  describe("getShadowSwingStats", () => {
+    it("stats を GET し、0件をそのまま 0 として返す", async () => {
+      mockJsonResponse({ today_count: 0, month_count: 0, total_count: 0 });
+
+      const result = await getShadowSwingStats();
+
+      expect(result).toEqual({
+        status: "ok",
+        data: { today_count: 0, month_count: 0, total_count: 0 },
+      });
+      expect(requestedUrl()).toBe(
+        "http://back:3000/api/v2/shadow_swing_sessions/stats",
+      );
+    });
+
+    it("取得に失敗したら 0 件へ丸めず error を返す", async () => {
+      mockJsonResponse({}, 500);
+
+      expect(await getShadowSwingStats()).toEqual({ status: "error" });
+    });
+  });
+});

--- a/app/services/v2/shadowSwingService.ts
+++ b/app/services/v2/shadowSwingService.ts
@@ -1,0 +1,65 @@
+"use server";
+
+import type {
+  ShadowSwingSession,
+  ShadowSwingStats,
+} from "@app/types/shadowSwing";
+import {
+  type FetchResult,
+  type MutationResult,
+  fetchV2,
+  mutateV2,
+} from "./requests";
+
+const BASE_PATH = "/api/v2/shadow_swing_sessions";
+
+/**
+ * 素振りセッションを開始する（POST /api/v2/shadow_swing_sessions）。
+ * 素振りカウンター自体は無料機能（entitlement: shadow_swing_basic）なので 403 は返らない。
+ * 作成したセッションは完了するまで practice_log を持たないため、
+ * 開始しただけで積み上げ本数（stats）は変化しない。
+ *
+ * @param targetCount 目標本数（back で 0 より大きいことを検証する）
+ */
+export async function startShadowSwingSession(
+  targetCount: number,
+): Promise<MutationResult<ShadowSwingSession>> {
+  return mutateV2<ShadowSwingSession>(BASE_PATH, {
+    method: "POST",
+    body: { shadow_swing_session: { target_count: targetCount } },
+    action: "startShadowSwingSession",
+    fallbackMessage: "素振りを開始できませんでした",
+  });
+}
+
+/**
+ * 素振りセッションを完了し、本数を練習ログへ保存する
+ * （POST /api/v2/shadow_swing_sessions/:id/complete）。
+ * back の complete! は completed_at があるセッションを素通りさせる冪等な実装なので、
+ * 通信失敗時にそのまま再送してよい（本数が二重計上されることはない）。
+ *
+ * @param id 開始時に受け取ったセッション id
+ * @param swingCount 実際に振った本数
+ */
+export async function completeShadowSwingSession(
+  id: number,
+  swingCount: number,
+): Promise<MutationResult<ShadowSwingSession>> {
+  return mutateV2<ShadowSwingSession>(`${BASE_PATH}/${id}/complete`, {
+    method: "POST",
+    body: { shadow_swing_session: { swing_count: swingCount } },
+    action: "completeShadowSwingSession",
+    fallbackMessage: "素振りの記録を保存できませんでした",
+  });
+}
+
+/**
+ * 今日・今月・通算の素振り本数を取得する（GET /api/v2/shadow_swing_sessions/stats）。
+ * 記録が無ければ 0 が返る（status:"ok"）。取得に失敗したときは status:"error" で、
+ * 「まだ0本」と「取得できなかった」を呼び出し側が取り違えないようにする。
+ */
+export async function getShadowSwingStats(): Promise<
+  FetchResult<ShadowSwingStats>
+> {
+  return fetchV2<ShadowSwingStats>(`${BASE_PATH}/stats`, "getShadowSwingStats");
+}

--- a/app/types/shadowSwing.ts
+++ b/app/types/shadowSwing.ts
@@ -1,0 +1,30 @@
+/**
+ * 素振りカウンターの型定義。
+ * back/app/serializers/v2/shadow_swing_session_serializer.rb と
+ * Api::V2::ShadowSwingSessionsController#stats のレスポンスに対応する。
+ * キー名は back の JSON をそのまま使う（snake_case のまま扱い、変換しない）。
+ */
+
+/**
+ * 素振りセッション1件。開始時に作成し、完了時に本数を確定させる。
+ * completed_at が null の間は未完了（練習ログもまだ作られていない）。
+ */
+export interface ShadowSwingSession {
+  id: number;
+  logged_on: string;
+  target_count: number;
+  swing_count: number;
+  completed_at: string | null;
+  /** 完了時に自動生成・加算された練習ログの id。未完了なら null。 */
+  practice_log_id: number | null;
+}
+
+/**
+ * 素振りの積み上げ本数。back は practice_logs（source: shadow_swing）から集計するため、
+ * 未完了セッションの本数は含まれない。
+ */
+export interface ShadowSwingStats {
+  today_count: number;
+  month_count: number;
+  total_count: number;
+}


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#485

## 概要

目標本数・インターバル・笛の音・カウント読み上げ・バイブレーションを設定し、自動カウントアップする素振りツールです。完了時に練習ログへ自動保存され、草／Streak にも反映されます。

## ブラウザ制約4点への判断（issue が「要判断」としていた点）

### (a) `shadow_swing_background` は Web で非提供

**トグルを出していません。** 代わりに設定画面に説明を常設しています。

> ブラウザでは、他のタブや別アプリに切り替えるとカウントを続けられません。切り替えを検知した時点で自動的に一時停止し、戻ってきたら「再開」から続けられます。バックグラウンドでの継続実行はアプリ版のみの機能です。

実装も**全ユーザー（Pro 含む）を非表示時に自動一時停止**します。「カウントだけ進んで笛・読み上げ・振動が鳴らない」状態は合図ツールとして無意味だからです。時間ごと止めるので復帰時に本数が飛びません。

テストで「設定可能な `role="group"` はちょうど4つ」を固定しているため、**トグルを足すとテストが落ちます**。

### (b) `navigator.vibrate` 非対応（iOS Safari）

`"vibrate" in navigator` で機能検出し、**非対応判定を Pro 判定より優先**しています。Pro でも非対応環境では有効化できず、**Pro 訴求モーダルも出しません**（課金しても直らないため）。

### (c) Screen Wake Lock 非対応 — 黙って何もしないのではなく注意を出す

> お使いのブラウザは画面の自動消灯を抑止できません。素振り中に画面が消えると一時停止するため、端末の自動ロックを長めに設定してください。

### (d) 音声のユーザー操作起点

`SwingCuePlayer.unlock()` を**「開始する」クリックハンドラ内で `await` より前に**呼びます。「再開」でも呼び直します（非表示中に Safari が context を suspend するため）。`SpeechSynthesis` も volume 0 の空発話でキューを起こします。

## タイマーのドリフト補正

**`setInterval` の発火回数を数える方式は採用していません。**

`requestAnimationFrame` のループが毎フレーム `performance.now()` から経過時間を求め、**本数 = `Math.floor(elapsed / interval)`** を導出します。フレームが何回落ちても本数は実時間と一致します。

タブ復帰などで一気に進んだ場合、**合図は1回だけ**鳴らします（連打すると読み上げが詰まって実際の本数から遅れるため）。目標到達後は本数・経過時間とも頭打ちにします。

純粋関数に切り出し、境界（4999/5000/9999/10000）、小数インターバル、100秒ぶんのフレーム落ち、10分間の非表示→復帰を直接テストしています。

## ⚠️ back に未完了セッションの掃除機構がありません

**開始したまま離脱すると `completed_at: nil` の行が永久に残ります**（TTL も cron もありません）。ただし `stats` も推移も `practice_logs` から集計するため**ユーザーに見える数値には影響しません**（行が溜まるだけ）。別途 issue を起票します。

front 側の緩和として、3画面を1ルート内の状態遷移にし、カウント中は `beforeunload` で離脱確認を出しています。

**また 0本で終了したときは complete を呼びません。** `swing_count: 0` で完了させると amount 0 の練習ログが作られ、その日が草・Streak 上「練習した日」になってしまうためです。代償として 0本離脱時はセッション行が未完了で残ります。

## mobile と意図的に変えた点

1. **Pro 判定未確定時の倒し方が逆です。** mobile は解放側（`isProLoading || hasEntitlement`）、front は**無料側**に倒します。ロック表示のちらつきを避けるため、`pending` では鍵アイコンではなく「プランを確認しています…」という別文言を出して区別しています。**front を正とするなら mobile 側にも同じ修正が必要**です
2. **笛の音源を Web Audio で合成**しています（mobile は `whistle.wav`）。バイナリ資産を増やさず、読み込み遅延でテンポが崩れないためです
3. **完了 API 失敗時にエラー表示＋再試行ボタン**を出します（mobile は「保存失敗でも完了画面は見せる」）。back の complete は `completed_at.present?` で即 return する**冪等**な実装なので、再送しても二重計上されません

## LP カタログの更新

`shadow_swing_custom_interval` を `app_only` → `web_and_app` に変更しました（Web で実際に提供したため）。

**`shadow_swing_vibration` は `app_only` のままにしています。** iOS Safari に届かない以上、比較表で「Web 提供」と訴求しない方が正確だからです。「対応ブラウザでは使えるのに LP はアプリ版限定と書く」というズレは残りますが、**過大訴求より過少訴求を選びました**。

## ⚠️ 検証できていないこと

- **実際に音が鳴るか。** OscillatorNode で合成した矩形波2200Hz が「笛らしく」聞こえるか、屋外で聞き取れる音量かは実機確認が必要です
- **`SpeechSynthesis` の `ja-JP` 音声が端末にあるか**（未インストールなら無音になりますが例外は出ません）
- **iOS Safari で `AudioContext.resume()` / 空発話プライミングが実際に解禁として機能するか**
- **Screen Wake Lock が実際に画面消灯を防ぐか**
- **実ブラウザのタイマー間引き下での長時間セッション**（200本 × 5秒 ≒ 17分）
- **`beforeunload` の確認ダイアログ**が各ブラウザで実際に出るか
- 実機のバイブレーションパターンの体感

## レビューで確認いただきたい点

1. **完了画面から `/practice/summary?source=shadow_swing` へリンクしていません。** #473（PR #433）が未マージで現時点では 404 になるためです。**マージ後は `href` 1行の差し替えで追加できます**
2. **3画面をルート分割せず1ページの状態遷移にしました。** 別ルートにすると App Router の遷移でコンポーネントが破棄され、経過時間と AudioContext を失うためです。結果としてカウント中の URL 直リンクはできません

## チェックリスト

- [x] `yarn typecheck` / `yarn lint` / `yarn format:check` が通る
- [x] `yarn test` が通る（**179 suites / 2100 tests**。新規 6ファイル / 111ケース）
- [x] `yarn build` が通る（ローカルで実行済み）
- [x] ミューテーションテスト **30 設計 / 30 KILLED / 0 SURVIVED**

### ルート表

base（`07770ce`）も同条件でビルドして比較しました。**追加は `/practice/shadow-swing`（動的）の1件のみ、静的 87 で不変、既存ルートの分類変更なし**。

<details>
<summary>ミューテーションテスト詳細</summary>

タイマー計算の境界4種 / ドリフト補正の除去2種 / 合図の連打2種 / 無料インターバル範囲の改変5種 / **Pro 判定未確定を Pro 扱い3種** / 笛と読み上げの排他解除 / **`vibrate` の機能検出削除2種** / `AudioContext.resume()` 削除 / タブ非表示の自動一時停止削除 / **`shadow_swing_background` のトグル追加** / 完了 API 失敗で結果を捨てる / 0本でも complete を叩く / 統計の0件と取得失敗の取り違え / API パス・メソッド・ボディ改変4種 / 目標本数の下限チェック削除 — 全 KILLED。

**初回に1件 SURVIVED**（`supportsVibration` を常に true）。`SwingCuePlayer` の try/catch が例外を飲むため素通りしていたため、**機能検出の単体テストと「非対応環境で理由を表示しトグルが `なし` のまま」の検証を追加**して KILL しました。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUPyNMG6QXYPKkWsncCCE7)_