### PR TITLE
Fix: 試合詳細画面でlocalStorageの古いgameResultIdを優先してしまう不具合を修正

### DIFF
--- a/app/(app)/game-result/summary/[slug]/page.tsx
+++ b/app/(app)/game-result/summary/[slug]/page.tsx
@@ -91,9 +91,6 @@ export default function ResultsSummary() {
   const [currentUserId, setCurrentUserId] = useState<number | null>(null);
   const [memo, setMemo] = useState<string | null>();
   const [currentUserPage, setCurrentUserPage] = useState(false);
-  const [localStorageGameResultId, setLocalStorageGameResultId] = useState<
-    number | null
-  >(null);
   const { isOpen, onOpen, onOpenChange } = useDisclosure();
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
@@ -129,7 +126,6 @@ export default function ResultsSummary() {
     // URLのidを常に正とする。localStorageの値は編集/削除継続フローに引き継ぐためのものであり、
     // 表示対象の特定に使うと前回訪問した別試合のidが残っていた場合に誤表示・所有者判定ズレが起きる。
     localStorage.setItem("gameResultId", JSON.stringify(id));
-    setLocalStorageGameResultId(id);
     fetchCurrentResultData(id);
   }, [pathname, id]);
 
@@ -142,7 +138,7 @@ export default function ResultsSummary() {
   }, [matchResult, isDetailDataFetched, currentUserId]);
 
   // 試合データ取得
-  const fetchCurrentResultData = async (localStorageGameResultId: number) => {
+  const fetchCurrentResultData = async (gameResultId: number) => {
     try {
       const [
         matchResultData,
@@ -152,11 +148,11 @@ export default function ResultsSummary() {
         plateAppearancesV2Data,
         currentUserIdData,
       ] = await Promise.all([
-        getUserMatchResult(localStorageGameResultId),
-        getUserBattingAverage(localStorageGameResultId),
-        getUserPitchingResult(localStorageGameResultId),
-        getUserPlateAppearance(localStorageGameResultId),
-        getPlateAppearancesByGame(localStorageGameResultId),
+        getUserMatchResult(gameResultId),
+        getUserBattingAverage(gameResultId),
+        getUserPitchingResult(gameResultId),
+        getUserPlateAppearance(gameResultId),
+        getPlateAppearancesByGame(gameResultId),
         getCurrentUserId(),
       ]);
       setPlateAppearancesV2(plateAppearancesV2Data);
@@ -615,9 +611,7 @@ export default function ResultsSummary() {
                         <Button
                           color="danger"
                           radius="sm"
-                          onPress={() =>
-                            handleDeleteGameResult(localStorageGameResultId)
-                          }
+                          onPress={() => handleDeleteGameResult(id)}
                         >
                           削除する
                         </Button>

--- a/app/(app)/game-result/summary/[slug]/page.tsx
+++ b/app/(app)/game-result/summary/[slug]/page.tsx
@@ -126,15 +126,11 @@ export default function ResultsSummary() {
   };
 
   useEffect(() => {
-    // ローカルストレージからid取得
-    const savedGameResultId = localStorage.getItem("gameResultId");
-    if (savedGameResultId) {
-      setLocalStorageGameResultId(JSON.parse(savedGameResultId));
-      fetchCurrentResultData(JSON.parse(savedGameResultId));
-    }
-    if (!savedGameResultId) {
-      localStorage.setItem("gameResultId", JSON.stringify(id));
-    }
+    // URLのidを常に正とする。localStorageの値は編集/削除継続フローに引き継ぐためのものであり、
+    // 表示対象の特定に使うと前回訪問した別試合のidが残っていた場合に誤表示・所有者判定ズレが起きる。
+    localStorage.setItem("gameResultId", JSON.stringify(id));
+    setLocalStorageGameResultId(id);
+    fetchCurrentResultData(id);
   }, [pathname, id]);
 
   useEffect(() => {

--- a/app/(app)/game-result/summary/[slug]/page.tsx
+++ b/app/(app)/game-result/summary/[slug]/page.tsx
@@ -123,9 +123,11 @@ export default function ResultsSummary() {
   };
 
   useEffect(() => {
-    // URLのidを常に正とする。localStorageの値は編集/削除継続フローに引き継ぐためのものであり、
-    // 表示対象の特定に使うと前回訪問した別試合のidが残っていた場合に誤表示・所有者判定ズレが起きる。
-    localStorage.setItem("gameResultId", JSON.stringify(id));
+    // 表示対象の特定は常にURLのidを正とする。localStorageは書き込まない
+    // （record/page.tsxは記録中の下書きIDとしてlocalStorageを信頼して送信時に
+    // 既存MatchResultの上書き判定をするため、単に閲覧しただけでここを書き換えると
+    // 進行中の別の記録セッションを巻き込んでしまう。書き込みは編集を選択した
+    // handleResultComplete内でのみ行う）。
     fetchCurrentResultData(id);
   }, [pathname, id]);
 
@@ -241,6 +243,9 @@ export default function ResultsSummary() {
 
   const handleResultComplete = () => {
     // 既存試合の編集として試合情報入力画面へ入ることを記録する。
+    // record/page.tsxはgameResultIdを送信対象の試合として信頼するため、ここで
+    // 明示的に「今表示している（＝自分の所有と確認済みの）試合」のidをセットする。
+    localStorage.setItem("gameResultId", JSON.stringify(id));
     localStorage.setItem(GAME_RECORD_EDIT_MODE_STORAGE_KEY, "true");
     router.push("/game-result/record");
   };


### PR DESCRIPTION
## 概要

試合詳細画面（`/game-result/summary/[slug]`）で、前回訪問した別試合の `gameResultId` が `localStorage` に残っている場合、URLのIDではなく `localStorage` の古いIDを優先してデータ取得・所有者判定を行ってしまう不具合を修正しました。

## 背景

ユーザーからの問い合わせで、「自分の試合結果なのに詳細画面に編集・削除ボタンが表示されず削除できない」という報告がありました。

原因は `useEffect` 内のロジックが `localStorage.getItem("gameResultId")` を優先し、値が存在する場合はURLの `id`（slug）を無視してそちらでデータ取得・所有者判定（`currentUserPage`）を行っていたためです。記録フロー全体（`record`/`batting`/`pitching`/`plate-appearances`）で単一の `gameResultId` キーを使い回す実装のため、別の記録セッション直後にこの画面へ来ると参照がズレ、以下のような問題が起きていました。

- URLとは異なる試合のデータが表示される
- 所有者判定がズレて、自分の試合なのに編集・削除ボタンが表示されない

## 修正内容

`useEffect` 内で、常にURLの `id` を正としてデータ取得・`localStorage` への書き戻しを行うように変更しました。`localStorage` への書き込みは、編集継続フロー（`handleResultComplete` → `/game-result/record`）や削除処理が参照する値を最新化するために残しています。

## テスト

- [x] `yarn typecheck`（対象ファイルにエラーなし。既存の `.next` 生成物起因の無関係なエラーのみ残存）
- [x] `yarn lint`（対象ファイルは差分なし）
- [ ] 実機での動作確認（別試合を閲覧した直後に自分の試合詳細画面を開き、編集・削除ボタンが表示されることを確認）
