### PR TITLE
Perf: 二次的なナビゲーションリンクのprefetchを無効化しEdge Requestsを削減

### DIFF
--- a/app/components/auth/HeaderLoginAndSignUp.tsx
+++ b/app/components/auth/HeaderLoginAndSignUp.tsx
@@ -4,7 +4,11 @@ import { UserIcon } from "@app/components/icon/UserIcon";
 export default function HeaderLoginAndSignUp() {
   return (
     <>
-      <Link href="/signin" className="text-sm text-white font-medium">
+      <Link
+        href="/signin"
+        prefetch={false}
+        className="text-sm text-white font-medium"
+      >
         ログイン
       </Link>
       <Link

--- a/app/components/footer/Footer.tsx
+++ b/app/components/footer/Footer.tsx
@@ -17,7 +17,7 @@ export default function Footer() {
         <footer className="border-t border-t-zinc-500 pt-12 px-4 pb-24 bg-main lg:pb-12 lg:relative lg:z-100 lg:pl-[8%] lg:pr-auto">
           <div className="lg:max-w-[900px] lg:mx-auto lg:flex lg:items-center lg:gap-x-8 lg:justify-center">
             <div className="max-w-[692px] mx-auto mb-6 lg:mb-0 lg:mx-0 lg:m-[0_0_0_32%] lg:max-w-full">
-              <Link href={isLoggedIn ? "/dashboard" : "/"}>
+              <Link href={isLoggedIn ? "/dashboard" : "/"} prefetch={false}>
                 <Image
                   src="/images/buzz-logo-v2.png"
                   width="184"
@@ -38,27 +38,35 @@ export default function Footer() {
                 )}
               </li>
               <li>
-                <Link href="/calculation-of-grades" className="text-sm">
+                <Link
+                  href="/calculation-of-grades"
+                  prefetch={false}
+                  className="text-sm"
+                >
                   成績の算出方法
                 </Link>
               </li>
               <li>
-                <Link href="/tools" className="text-sm">
+                <Link href="/tools" prefetch={false} className="text-sm">
                   計算ツール
                 </Link>
               </li>
               <li>
-                <Link href="/column" className="text-sm">
+                <Link href="/column" prefetch={false} className="text-sm">
                   コラム
                 </Link>
               </li>
               <li>
-                <Link href="/contact" className="text-sm">
+                <Link href="/contact" prefetch={false} className="text-sm">
                   お問い合わせ
                 </Link>
               </li>
               <li>
-                <Link href="/notice-from-management" className="text-sm">
+                <Link
+                  href="/notice-from-management"
+                  prefetch={false}
+                  className="text-sm"
+                >
                   運営からのお知らせ
                 </Link>
               </li>
@@ -76,17 +84,29 @@ export default function Footer() {
                 </Link>
               </li>
               <li>
-                <Link href="/privacypolicy" className="text-sm">
+                <Link
+                  href="/privacypolicy"
+                  prefetch={false}
+                  className="text-sm"
+                >
                   プライバシーポリシー
                 </Link>
               </li>
               <li>
-                <Link href="/termsofservice" className="text-sm">
+                <Link
+                  href="/termsofservice"
+                  prefetch={false}
+                  className="text-sm"
+                >
                   利用規約
                 </Link>
               </li>
               <li>
-                <Link href="/account-deletion" className="text-sm">
+                <Link
+                  href="/account-deletion"
+                  prefetch={false}
+                  className="text-sm"
+                >
                   アカウント削除について
                 </Link>
               </li>

--- a/app/components/user/UserSearch.tsx
+++ b/app/components/user/UserSearch.tsx
@@ -4,7 +4,7 @@ import { SearchIcon } from "@app/components/icon/SearchIcon";
 export default function UserSearch() {
   return (
     <>
-      <Link href="/users/search">
+      <Link href="/users/search" prefetch={false}>
         <SearchIcon width="22" height="22" stroke="#f4f4f4" />
       </Link>
     </>


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#519

## 実装概要
Footer・ユーザー検索アイコン・ヘッダーの「ログイン」リンクに `prefetch={false}` を設定し、`next/link` のデフォルトprefetchによる不要なEdge Requestsを削減する。

## 背景
Vercelの無料枠(Edge Requests: 月100万件)を使い切り、超過状態が続くとプロジェクトが自動pauseされるリスクが発生した。調査の結果、共通ヘッダー・フッター等のリンクに`prefetch` propが未指定（デフォルトtrue）で、ページ表示のたびにビューポート内の全リンク先がsegment単位（tree/head/page/paramごと）で自動先読みフェッチされ、実際のページビュー数（GA計測: 1日400〜700件程度）に対して桁違いに多いリクエストが発生していた。

## やらなかったこと
- `NavigationMenu.tsx`（ボトムタブバー/PCサイドバー）・`HeaderUserMenu.tsx`（マイページタブ）はアプリの主要動線でUX影響のトレードオフが大きいため対象外（別issueで検討）
- `/api/blog` `/api/generate` `/api/demo` `/blog/1〜3` 等、実装されていないパスへの外部bot/スキャナー由来のアクセスへの対処（Vercel Firewall側での検討事項）

## 受入基準
- [ ] Footer内の二次的リンク（成績算出方法・計算ツール・コラム・お問い合わせ・お知らせ・プラポリ・利用規約・アカウント削除・ロゴ）でprefetchが発火しない
- [ ] ヘッダーの検索アイコン(`/users/search`)でprefetchが発火しない
- [ ] 未ログイン時ヘッダーの「ログイン」リンク(`/signin`)でprefetchが発火しない（「新規登録」は現状維持）

## 実装詳細
- `app/components/footer/Footer.tsx`: ロゴLinkおよび8つの二次リンクすべてに `prefetch={false}` を追加
- `app/components/user/UserSearch.tsx`: `/users/search` へのLinkに `prefetch={false}` を追加
- `app/components/auth/HeaderLoginAndSignUp.tsx`: `/signin` のLinkのみ `prefetch={false}` を追加（`/signup`はCVR上重要なため維持）

## スクリーンショット
なし（見た目の変更なし）

## 確認手順
1. ブラウザのNetworkタブを開き、トップページ等を表示
2. フッターがビューポートに入っても `.segment` 系のリクエストが発火しないことを確認
3. ヘッダーの検索アイコン・ログインリンクについても同様にhover/表示時にprefetchリクエストが飛ばないことを確認
4. 各リンクをクリックし、遷移自体は問題なく行われることを確認（初回のみ体感速度がわずかに変わる可能性はあるが許容範囲）

## 影響範囲
Footer・ユーザー検索・未ログイン時ヘッダーの表示範囲全体（見た目の変更はなし、prefetchタイミングのみ変更）

## コード上の懸念点
特になし

## その他
特になし
