### PR TITLE
Update: Pro課金CTAボタンのトライアル出し分け・プラン未選択デザイン改善

### DIFF
--- a/app/components/pro/ProUpgradeModal.tsx
+++ b/app/components/pro/ProUpgradeModal.tsx
@@ -108,8 +108,11 @@ export default function ProUpgradeModal({
   const proFeatures = useFeatureFlag("pro_features", { skip: !isOpen });
   // back の trial_days_calculator と同じ判定（has_used_trial）。既に使い切ったユーザーに
   // 「7日間無料」と誤案内しないため、CTA まわりの文言はここで出し分ける。
-  const { proStatus } = useProStatus();
-  const isTrialEligible = !proStatus.subscription.has_used_trial;
+  // 判定確定前（isLoading）は DEFAULT_PRO_STATUS（has_used_trial: false）にフォールバックし
+  // isTrialEligible が常に true になるため、確定するまではトライアル訴求を一切出さない。
+  const { proStatus, isLoading: isProStatusLoading } = useProStatus();
+  const isTrialEligible =
+    !isProStatusLoading && !proStatus.subscription.has_used_trial;
 
   const copy = (trigger && PRO_PAYWALL_COPY[trigger]) ?? DEFAULT_PAYWALL_COPY;
   // ハイライトカードで既に訴求している機能を比較表でも繰り返さない。
@@ -365,7 +368,11 @@ export default function ProUpgradeModal({
                 className="font-bold"
                 data-testid="pro-upgrade-cta"
               >
-                {isTrialEligible ? "7日間無料で試す" : "Proに加入する"}
+                {isProStatusLoading
+                  ? "PROを始める"
+                  : isTrialEligible
+                    ? "7日間無料で試す"
+                    : "Proに加入する"}
               </Button>
             </>
           )}

--- a/app/components/pro/ProUpgradeModal.tsx
+++ b/app/components/pro/ProUpgradeModal.tsx
@@ -272,7 +272,7 @@ export default function ProUpgradeModal({
                     className={`flex items-center gap-3 rounded-xl border p-3.5 text-left ${
                       isSelected
                         ? "border-[#d08000] bg-[#d08000]/10"
-                        : "border-transparent bg-[#424242]"
+                        : "border-zinc-600 bg-[#424242]"
                     }`}
                   >
                     <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 border-[#d08000]">

--- a/app/components/pro/ProUpgradeModal.tsx
+++ b/app/components/pro/ProUpgradeModal.tsx
@@ -365,7 +365,7 @@ export default function ProUpgradeModal({
                 className="font-bold"
                 data-testid="pro-upgrade-cta"
               >
-                PROを始める
+                {isTrialEligible ? "7日間無料で試す" : "Proに加入する"}
               </Button>
             </>
           )}

--- a/app/components/pro/ProUpgradeModal.tsx
+++ b/app/components/pro/ProUpgradeModal.tsx
@@ -275,7 +275,7 @@ export default function ProUpgradeModal({
                     className={`flex items-center gap-3 rounded-xl border p-3.5 text-left ${
                       isSelected
                         ? "border-[#d08000] bg-[#d08000]/10"
-                        : "border-zinc-600 bg-[#424242]"
+                        : "border-zinc-500 bg-[#424242]"
                     }`}
                   >
                     <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 border-[#d08000]">

--- a/app/components/pro/__tests__/ProUpgradeModal.test.tsx
+++ b/app/components/pro/__tests__/ProUpgradeModal.test.tsx
@@ -17,8 +17,14 @@ jest.mock("@app/hooks/featureFlags/useFeatureFlag", () => ({
     mockUseFeatureFlag(key, options),
 }));
 
+const mockUseProStatus = jest.fn();
+jest.mock("@app/hooks/pro/useProStatus", () => ({
+  useProStatus: () => mockUseProStatus(),
+}));
+
 import { fireEvent, render, screen } from "@testing-library/react";
 import { APP_ONLY_LABEL } from "@app/components/pro/proFeatureCatalog";
+import { DEFAULT_PRO_STATUS } from "@app/types/pro";
 import ProUpgradeModal from "../ProUpgradeModal";
 
 const SUSPENDED_MESSAGE =
@@ -28,6 +34,41 @@ describe("ProUpgradeModal", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseFeatureFlag.mockReturnValue("enabled");
+    mockUseProStatus.mockReturnValue({
+      proStatus: DEFAULT_PRO_STATUS,
+      isPro: false,
+      isLoading: false,
+      isRefreshing: false,
+      refresh: jest.fn(),
+    });
+  });
+
+  it("トライアル未利用なら CTA ボタンに「7日間無料で試す」を表示する", () => {
+    render(<ProUpgradeModal isOpen onClose={jest.fn()} />);
+    expect(screen.getByTestId("pro-upgrade-cta")).toHaveTextContent(
+      "7日間無料で試す",
+    );
+  });
+
+  it("トライアル利用済みなら CTA ボタンに「Proに加入する」を表示する", () => {
+    mockUseProStatus.mockReturnValue({
+      proStatus: {
+        ...DEFAULT_PRO_STATUS,
+        subscription: {
+          ...DEFAULT_PRO_STATUS.subscription,
+          has_used_trial: true,
+        },
+      },
+      isPro: false,
+      isLoading: false,
+      isRefreshing: false,
+      refresh: jest.fn(),
+    });
+
+    render(<ProUpgradeModal isOpen onClose={jest.fn()} />);
+    expect(screen.getByTestId("pro-upgrade-cta")).toHaveTextContent(
+      "Proに加入する",
+    );
   });
 
   it("isOpen が false のときは何も描画しない", () => {

--- a/app/components/pro/__tests__/ProUpgradeModal.test.tsx
+++ b/app/components/pro/__tests__/ProUpgradeModal.test.tsx
@@ -71,6 +71,44 @@ describe("ProUpgradeModal", () => {
     );
   });
 
+  it("Pro状態の判定確定前は、実際はトライアル利用済みでもCTAボタンに中立文言を表示する", () => {
+    mockUseProStatus.mockReturnValue({
+      proStatus: {
+        ...DEFAULT_PRO_STATUS,
+        subscription: {
+          ...DEFAULT_PRO_STATUS.subscription,
+          has_used_trial: true,
+        },
+      },
+      isPro: false,
+      isLoading: true,
+      isRefreshing: false,
+      refresh: jest.fn(),
+    });
+
+    render(<ProUpgradeModal isOpen onClose={jest.fn()} />);
+    expect(screen.getByTestId("pro-upgrade-cta")).toHaveTextContent(
+      "PROを始める",
+    );
+  });
+
+  it("Pro状態の判定確定前はトライアル案内文を表示しない", () => {
+    mockUseProStatus.mockReturnValue({
+      proStatus: DEFAULT_PRO_STATUS,
+      isPro: false,
+      isLoading: true,
+      isRefreshing: false,
+      refresh: jest.fn(),
+    });
+
+    render(<ProUpgradeModal isOpen onClose={jest.fn()} />);
+    expect(
+      screen.queryByText(
+        "7 日間の無料トライアル期間中に解約すれば料金はかかりません",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it("isOpen が false のときは何も描画しない", () => {
     render(<ProUpgradeModal isOpen={false} onClose={jest.fn()} />);
     expect(screen.queryByText("BUZZ BASE Pro")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- `ippei-shimizu/buzzbase#527`: Pro課金CTAボタンのテキストを、ユーザーのトライアル利用状況に応じて出し分ける
  - トライアル対象（未使用）: 「7日間無料で試す」
  - トライアル対象外（利用済み）: 「Proに加入する」
  - 既存の`isTrialEligible`判定（`proStatus.subscription.has_used_trial`）をそのまま利用
- `ippei-shimizu/buzzbase#528`: Pro料金プラン選択で未選択カードの枠線を追加し、ボタンだとわかるデザインにする
  - `border-transparent` → `border-zinc-600`（選択時の`border-[#d08000]`ほど強調しない範囲）

## 変更内容

- `app/components/pro/ProUpgradeModal.tsx`
  - プラン選択カード（未選択時）に`border-zinc-600`を追加
  - CTAボタンのテキストを`isTrialEligible`で出し分け
- `app/components/pro/__tests__/ProUpgradeModal.test.tsx`
  - トライアル未利用/利用済みそれぞれでCTA文言が変わることを検証するテストを追加

## Test plan

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn format:check`
- [x] `yarn build`
- [x] `yarn test ProUpgradeModal`（16件成功）

なお、このPRは対応するmobile側のPR（buzzbase_mobile側の#527）と対にしてください。
