### PR TITLE
Fix: グループ作成・参加とアカウント削除のPro上限エラーを専用文言で表示する

### DIFF
--- a/app/(app)/account-deletion/__tests__/page.test.tsx
+++ b/app/(app)/account-deletion/__tests__/page.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AxiosError, AxiosHeaders } from "axios";
+import AccountDeletionPage from "../page";
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => "/account-deletion",
+}));
+
+jest.mock("@app/contexts/useAuthContext", () => ({
+  useAuthContext: () => ({ isLoggedIn: true, loading: false }),
+}));
+
+jest.mock("@app/components/header/Header", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockDeleteUser = jest.fn();
+jest.mock("@app/services/userService", () => ({
+  getCurrentUserId: () => Promise.resolve(1),
+  deleteUser: (...args: unknown[]) => mockDeleteUser(...args),
+}));
+
+const responseError = (status: number, data: unknown) =>
+  new AxiosError("failed", "ERR_BAD_REQUEST", undefined, undefined, {
+    status,
+    statusText: "Error",
+    data,
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  });
+
+const confirmDeletion = async () => {
+  const user = userEvent.setup();
+  render(<AccountDeletionPage />);
+  await user.click(screen.getByText("アカウントを削除する"));
+  await user.click(await screen.findByText("削除する"));
+};
+
+describe("アカウント削除ページ", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDeleteUser.mockResolvedValue({ success: true });
+  });
+
+  it("Pro 加入中で拒否されたら専用文言と解約導線を出す", async () => {
+    mockDeleteUser.mockRejectedValue(
+      responseError(422, {
+        error: "pro_active",
+        message: "Pro 加入中のため、先に解約してください",
+      }),
+    );
+
+    await confirmDeletion();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("先に Pro プランを解約してください");
+    expect(screen.getByText("Pro プランの解約手続きへ")).toHaveAttribute(
+      "href",
+      "/account/subscription",
+    );
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("Pro 加入以外の失敗では汎用文言だけを出す", async () => {
+    mockDeleteUser.mockRejectedValue(responseError(500, { error: "failed" }));
+
+    await confirmDeletion();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("アカウントの削除に失敗しました");
+    expect(screen.queryByText("Pro プランの解約手続きへ")).toBeNull();
+  });
+
+  it("削除に成功したらログイン画面へ遷移する", async () => {
+    await confirmDeletion();
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/signin"));
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/app/(app)/account-deletion/__tests__/page.test.tsx
+++ b/app/(app)/account-deletion/__tests__/page.test.tsx
@@ -3,10 +3,19 @@ import userEvent from "@testing-library/user-event";
 import { AxiosError, AxiosHeaders } from "axios";
 import AccountDeletionPage from "../page";
 
-const mockPush = jest.fn();
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push: mockPush }),
+  useRouter: () => ({ push: jest.fn() }),
   usePathname: () => "/account-deletion",
+}));
+
+const mockClearAuthCookies = jest.fn();
+jest.mock("@app/services/authService", () => ({
+  clearAuthCookies: () => mockClearAuthCookies(),
+}));
+
+const mockResetUser = jest.fn();
+jest.mock("@app/utils/posthog", () => ({
+  resetUser: () => mockResetUser(),
 }));
 
 jest.mock("@app/contexts/useAuthContext", () => ({
@@ -62,7 +71,7 @@ describe("アカウント削除ページ", () => {
       "href",
       "/account/subscription",
     );
-    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockClearAuthCookies).not.toHaveBeenCalled();
   });
 
   it("Pro 加入以外の失敗では汎用文言だけを出す", async () => {
@@ -75,10 +84,11 @@ describe("アカウント削除ページ", () => {
     expect(screen.queryByText("Pro プランの解約手続きへ")).toBeNull();
   });
 
-  it("削除に成功したらログイン画面へ遷移する", async () => {
+  it("削除に成功したら認証cookieとPostHogの識別子を破棄する", async () => {
     await confirmDeletion();
 
-    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/signin"));
+    await waitFor(() => expect(mockClearAuthCookies).toHaveBeenCalled());
+    expect(mockResetUser).toHaveBeenCalled();
     expect(screen.queryByRole("alert")).toBeNull();
   });
 });

--- a/app/(app)/account-deletion/page.tsx
+++ b/app/(app)/account-deletion/page.tsx
@@ -11,11 +11,12 @@ import {
 } from "@heroui/react";
 import { isAxiosError } from "axios";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import Header from "@app/components/header/Header";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
+import { clearAuthCookies } from "@app/services/authService";
 import { deleteUser, getCurrentUserId } from "@app/services/userService";
+import { resetUser } from "@app/utils/posthog";
 
 type DeletionError = "pro_active" | "unknown";
 
@@ -36,7 +37,6 @@ const isProActiveError = (error: unknown): boolean =>
   error.response.data?.error === "pro_active";
 
 export default function AccountDeletionPage() {
-  const router = useRouter();
   useRequireAuth();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [isDeleting, setIsDeleting] = useState(false);
@@ -55,7 +55,13 @@ export default function AccountDeletionPage() {
 
       await deleteUser(currentUserId);
 
-      router.push("/signin");
+      // 削除済みユーザーの cookie が残ると、次回アクセス時に失効トークンのまま
+      // ログイン中と判定されて画面が壊れる。
+      clearAuthCookies();
+      resetUser();
+      // router.push だと AuthContext や PostHog の識別子がクライアントに残るため、
+      // 存在しなくなったユーザーの状態を確実に捨てられるフルリロードで遷移する。
+      window.location.assign("/signin");
     } catch (error) {
       if (isProActiveError(error)) {
         setDeletionError("pro_active");

--- a/app/(app)/account-deletion/page.tsx
+++ b/app/(app)/account-deletion/page.tsx
@@ -9,20 +9,44 @@ import {
   ModalFooter,
   useDisclosure,
 } from "@heroui/react";
+import { isAxiosError } from "axios";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import Header from "@app/components/header/Header";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import { deleteUser, getCurrentUserId } from "@app/services/userService";
 
+type DeletionError = "pro_active" | "unknown";
+
+const DELETION_ERROR_MESSAGES: Record<DeletionError, string> = {
+  pro_active:
+    "Pro に加入中のためアカウントを削除できません。自動課金が続いてしまうため、先に Pro プランを解約してください。",
+  unknown:
+    "アカウントの削除に失敗しました。しばらく時間をおいてから再度お試しください。",
+};
+
+/**
+ * back の users#destroy が Pro 加入中を理由に削除を拒否したか。
+ * 同じ 422 でもバリデーション由来のものと区別する必要があるため error キーまで見る。
+ */
+const isProActiveError = (error: unknown): boolean =>
+  isAxiosError(error) &&
+  error.response?.status === 422 &&
+  error.response.data?.error === "pro_active";
+
 export default function AccountDeletionPage() {
   const router = useRouter();
   useRequireAuth();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [isDeleting, setIsDeleting] = useState(false);
+  const [deletionError, setDeletionError] = useState<DeletionError | null>(
+    null,
+  );
 
   const handleDeleteAccount = async () => {
     setIsDeleting(true);
+    setDeletionError(null);
     try {
       const currentUserId = await getCurrentUserId();
       if (!currentUserId) {
@@ -33,10 +57,12 @@ export default function AccountDeletionPage() {
 
       router.push("/signin");
     } catch (error) {
+      if (isProActiveError(error)) {
+        setDeletionError("pro_active");
+        return;
+      }
       console.error("アカウント削除エラー:", error);
-      alert(
-        "アカウントの削除に失敗しました。しばらく時間をおいてから再度お試しください。",
-      );
+      setDeletionError("unknown");
     } finally {
       setIsDeleting(false);
       onClose();
@@ -90,6 +116,22 @@ export default function AccountDeletionPage() {
                   </p>
                 </div>
               </div>
+              {deletionError ? (
+                <div
+                  role="alert"
+                  className="mt-8 rounded-lg border border-danger-400 bg-danger-400/10 p-4 text-sm leading-relaxed text-danger-400"
+                >
+                  <p>{DELETION_ERROR_MESSAGES[deletionError]}</p>
+                  {deletionError === "pro_active" ? (
+                    <Link
+                      href="/account/subscription"
+                      className="mt-3 inline-block font-bold underline"
+                    >
+                      Pro プランの解約手続きへ
+                    </Link>
+                  ) : null}
+                </div>
+              ) : null}
               <div className="text-center mt-8">
                 <Button
                   color="danger"

--- a/app/(app)/groups/join/__tests__/page.test.tsx
+++ b/app/(app)/groups/join/__tests__/page.test.tsx
@@ -17,7 +17,10 @@ const forbiddenError = () =>
   new AxiosError("forbidden", "ERR_BAD_REQUEST", undefined, undefined, {
     status: 403,
     statusText: "Forbidden",
-    data: { error: "Pro プランでグループを無制限に作成・参加できます" },
+    data: {
+      error: "group_limit_exceeded",
+      message: "Pro プランでグループを無制限に作成・参加できます",
+    },
     headers: new AxiosHeaders(),
     config: { headers: new AxiosHeaders() },
   });

--- a/app/(app)/groups/join/__tests__/page.test.tsx
+++ b/app/(app)/groups/join/__tests__/page.test.tsx
@@ -1,6 +1,26 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { AxiosError, AxiosHeaders } from "axios";
 import GroupJoinPage from "../page";
+
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: { error: (...args: unknown[]) => mockToastError(...args) },
+}));
+
+const mockOpenProUpgradeModal = jest.fn();
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: mockOpenProUpgradeModal }),
+}));
+
+const forbiddenError = () =>
+  new AxiosError("forbidden", "ERR_BAD_REQUEST", undefined, undefined, {
+    status: 403,
+    statusText: "Forbidden",
+    data: { error: "Pro プランでグループを無制限に作成・参加できます" },
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  });
 
 const mockCapture = jest.fn();
 jest.mock("@app/utils/posthog", () => ({
@@ -68,5 +88,45 @@ describe("グループ参加ページの計測", () => {
       "group joined",
       expect.anything(),
     );
+  });
+});
+
+describe("グループ参加ページの上限エラー表示", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetInviteLinkInfo.mockResolvedValue({
+      group: { id: 5, name: "テストグループ", icon: null, member_count: 3 },
+      inviter: { name: "招待者", image: { url: null } },
+    });
+    mockAcceptInviteLink.mockResolvedValue({ group_id: 5 });
+  });
+
+  it("無料枠の上限で拒否されたら専用文言とPro訴求モーダルを出す", async () => {
+    mockAcceptInviteLink.mockRejectedValue(forbiddenError());
+
+    await joinWithCode();
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith(
+        expect.stringContaining("無料プランで参加できるグループは1つまで"),
+      ),
+    );
+    expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+      trigger: "unlimited_groups",
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("上限以外の失敗ではPro訴求モーダルを出さない", async () => {
+    mockAcceptInviteLink.mockRejectedValue(new Error("failed"));
+
+    await joinWithCode();
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith(
+        "グループへの参加に失敗しました",
+      ),
+    );
+    expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
   });
 });

--- a/app/(app)/groups/join/page.tsx
+++ b/app/(app)/groups/join/page.tsx
@@ -6,16 +6,22 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 import Header from "@app/components/header/Header";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import {
   acceptInviteLink,
   getInviteLinkInfo,
 } from "@app/services/groupInviteLinksService";
 import { trackGroupJoined } from "@app/utils/analytics";
+import {
+  GROUP_FREE_LIMIT_MESSAGE,
+  isGroupLimitError,
+} from "@app/utils/pro/groupLimit";
 
 export default function GroupJoinPage() {
   const router = useRouter();
   useRequireAuth();
+  const { open: openProUpgradeModal } = useProUpgradeModal();
 
   const [code, setCode] = useState("");
   const [inviteInfo, setInviteInfo] = useState<InviteLinkInfo | null>(null);
@@ -47,6 +53,11 @@ export default function GroupJoinPage() {
       trackGroupJoined(result.group_id);
       router.push(`/groups/${result.group_id}`);
     } catch (error) {
+      if (isGroupLimitError(error)) {
+        toast.error(GROUP_FREE_LIMIT_MESSAGE);
+        openProUpgradeModal({ trigger: "unlimited_groups" });
+        return;
+      }
       console.error("グループへの参加に失敗しました", error);
       toast.error("グループへの参加に失敗しました");
     } finally {

--- a/app/(app)/groups/new/__tests__/page.test.tsx
+++ b/app/(app)/groups/new/__tests__/page.test.tsx
@@ -17,7 +17,10 @@ const forbiddenError = () =>
   new AxiosError("forbidden", "ERR_BAD_REQUEST", undefined, undefined, {
     status: 403,
     statusText: "Forbidden",
-    data: { error: "Pro プランでグループを無制限に作成・参加できます" },
+    data: {
+      error: "group_limit_exceeded",
+      message: "Pro プランでグループを無制限に作成・参加できます",
+    },
     headers: new AxiosHeaders(),
     config: { headers: new AxiosHeaders() },
   });

--- a/app/(app)/groups/new/__tests__/page.test.tsx
+++ b/app/(app)/groups/new/__tests__/page.test.tsx
@@ -1,6 +1,26 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { AxiosError, AxiosHeaders } from "axios";
 import GroupNew from "../page";
+
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: { error: (...args: unknown[]) => mockToastError(...args) },
+}));
+
+const mockOpenProUpgradeModal = jest.fn();
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: mockOpenProUpgradeModal }),
+}));
+
+const forbiddenError = () =>
+  new AxiosError("forbidden", "ERR_BAD_REQUEST", undefined, undefined, {
+    status: 403,
+    statusText: "Forbidden",
+    data: { error: "Pro プランでグループを無制限に作成・参加できます" },
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  });
 
 const mockCapture = jest.fn();
 jest.mock("@app/utils/posthog", () => ({
@@ -77,5 +97,41 @@ describe("グループ作成ページの計測", () => {
 
     await waitFor(() => expect(mockCreateGroup).toHaveBeenCalled());
     expect(mockCapture).not.toHaveBeenCalled();
+  });
+});
+
+describe("グループ作成ページの上限エラー表示", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateGroup.mockResolvedValue({ id: 77 });
+  });
+
+  it("無料枠の上限で拒否されたら専用文言とPro訴求モーダルを出す", async () => {
+    mockCreateGroup.mockRejectedValue(forbiddenError());
+
+    await createGroupWithMember();
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith(
+        expect.stringContaining("無料プランで参加できるグループは1つまで"),
+      ),
+    );
+    expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+      trigger: "unlimited_groups",
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("上限以外の失敗ではPro訴求モーダルを出さない", async () => {
+    mockCreateGroup.mockRejectedValue(new Error("failed"));
+
+    await createGroupWithMember();
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith(
+        "グループの作成に失敗しました",
+      ),
+    );
+    expect(mockOpenProUpgradeModal).not.toHaveBeenCalled();
   });
 });

--- a/app/(app)/groups/new/page.tsx
+++ b/app/(app)/groups/new/page.tsx
@@ -3,13 +3,19 @@ import type { FollowingUser } from "@app/interface";
 import { Avatar, Checkbox, Input, User } from "@heroui/react";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import HeaderMatchResultNext from "@app/components/header/HeaderMatchResultSave";
 import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
 import useRequireAuth from "@app/hooks/auth/useRequireAuth";
 import { createGroup } from "@app/services/groupService";
 import { getCurrentUserId, getFollowingUser } from "@app/services/userService";
 import { trackGroupCreated } from "@app/utils/analytics";
+import {
+  GROUP_FREE_LIMIT_MESSAGE,
+  isGroupLimitError,
+} from "@app/utils/pro/groupLimit";
 
 export default function GroupNew() {
   const [currentUserId, setCurrentUserId] = useState(null);
@@ -26,6 +32,7 @@ export default function GroupNew() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
   useRequireAuth();
+  const { open: openProUpgradeModal } = useProUpgradeModal();
 
   const fetchData = async () => {
     const responseCurrentUserId = await getCurrentUserId();
@@ -132,7 +139,15 @@ export default function GroupNew() {
       const response = await createGroup(formData);
       trackGroupCreated(response.id);
       router.push(`/groups/${response.id}/share-invite`);
-    } catch {}
+    } catch (error) {
+      setIsSubmitting(false);
+      if (isGroupLimitError(error)) {
+        toast.error(GROUP_FREE_LIMIT_MESSAGE);
+        openProUpgradeModal({ trigger: "unlimited_groups" });
+        return;
+      }
+      toast.error("グループの作成に失敗しました");
+    }
   };
 
   return (

--- a/app/components/notification/NotificationGroup.tsx
+++ b/app/components/notification/NotificationGroup.tsx
@@ -13,13 +13,19 @@ import {
 import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { GroupIcon } from "@app/components/icon/GroupIcon";
+import { useProUpgradeModal } from "@app/contexts/proUpgradeModalContext";
 import {
   acceptGroupInvitation,
   declinedGroupInvitation,
 } from "@app/services/groupInvitationsService";
 import { deleteNotification } from "@app/services/notificationsService";
 import { trackGroupJoined } from "@app/utils/analytics";
+import {
+  GROUP_FREE_LIMIT_MESSAGE,
+  isGroupLimitError,
+} from "@app/utils/pro/groupLimit";
 
 interface NotificationGroupProps {
   notice: Notifications;
@@ -37,6 +43,7 @@ export default function NotificationGroup({
 }: NotificationGroupProps) {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const router = useRouter();
+  const { open: openProUpgradeModal } = useProUpgradeModal();
 
   // 承認・辞退できるのは招待が保留中のときだけ。それ以外は結果を履歴として表示する
   const isPending = notice.group_invitation === "pending";
@@ -49,6 +56,12 @@ export default function NotificationGroup({
       await deleteNotification(id);
       router.push(`/groups/${groupId}`);
     } catch (error) {
+      // 無料枠の上限は想定内の拒否なので Sentry へは送らず、その場で理由を提示する。
+      if (isGroupLimitError(error)) {
+        toast.error(GROUP_FREE_LIMIT_MESSAGE);
+        openProUpgradeModal({ trigger: "unlimited_groups" });
+        return;
+      }
       Sentry.captureException(error, {
         tags: { source: "notification-group", action: "acceptInvitation" },
       });

--- a/app/components/notification/__tests__/NotificationItem.test.tsx
+++ b/app/components/notification/__tests__/NotificationItem.test.tsx
@@ -1,5 +1,6 @@
 import type { Notifications } from "@app/interface";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { AxiosError, AxiosHeaders } from "axios";
 import React from "react";
 import { toast } from "sonner";
 import { SWRConfig } from "swr";
@@ -37,7 +38,13 @@ jest.mock("@sentry/nextjs", () => ({
   captureException: jest.fn(),
 }));
 
+const mockOpenProUpgradeModal = jest.fn();
+jest.mock("@app/contexts/proUpgradeModalContext", () => ({
+  useProUpgradeModal: () => ({ open: mockOpenProUpgradeModal }),
+}));
+
 const mockGet = axiosInstance.get as jest.Mock;
+const mockPost = axiosInstance.post as jest.Mock;
 const mockDelete = axiosInstance.delete as jest.Mock;
 const mockToastError = toast.error as jest.Mock;
 
@@ -270,5 +277,29 @@ describe("NotificationItem", () => {
         ).not.toBeInTheDocument();
       },
     );
+
+    it("無料枠の上限で参加を拒否されたら専用文言とPro訴求モーダルを出す", async () => {
+      mockPost.mockRejectedValue(
+        new AxiosError("forbidden", "ERR_BAD_REQUEST", undefined, undefined, {
+          status: 403,
+          statusText: "Forbidden",
+          data: { error: "Pro プランでグループを無制限に作成・参加できます" },
+          headers: new AxiosHeaders(),
+          config: { headers: new AxiosHeaders() },
+        }),
+      );
+      renderNotifications([groupInvitation("pending")]);
+
+      fireEvent.click(await screen.findByRole("button", { name: "参加する" }));
+
+      await waitFor(() =>
+        expect(mockToastError).toHaveBeenCalledWith(
+          expect.stringContaining("無料プランで参加できるグループは1つまで"),
+        ),
+      );
+      expect(mockOpenProUpgradeModal).toHaveBeenCalledWith({
+        trigger: "unlimited_groups",
+      });
+    });
   });
 });

--- a/app/components/notification/__tests__/NotificationItem.test.tsx
+++ b/app/components/notification/__tests__/NotificationItem.test.tsx
@@ -283,7 +283,10 @@ describe("NotificationItem", () => {
         new AxiosError("forbidden", "ERR_BAD_REQUEST", undefined, undefined, {
           status: 403,
           statusText: "Forbidden",
-          data: { error: "Pro プランでグループを無制限に作成・参加できます" },
+          data: {
+            error: "group_limit_exceeded",
+            message: "Pro プランでグループを無制限に作成・参加できます",
+          },
           headers: new AxiosHeaders(),
           config: { headers: new AxiosHeaders() },
         }),

--- a/app/services/authService.tsx
+++ b/app/services/authService.tsx
@@ -44,12 +44,17 @@ export const signIn = async (data: SignInData) => {
   return response;
 };
 
-export const signOut = async () => {
-  const response = await axiosInstance.delete("/api/v1/auth/sign_out");
-
+/** devise_token_auth の認証 cookie 3点を破棄する。 */
+export const clearAuthCookies = () => {
   Cookies.remove("access-token");
   Cookies.remove("client");
   Cookies.remove("uid");
+};
+
+export const signOut = async () => {
+  const response = await axiosInstance.delete("/api/v1/auth/sign_out");
+
+  clearAuthCookies();
 
   return response;
 };

--- a/app/utils/pro/groupLimit.ts
+++ b/app/utils/pro/groupLimit.ts
@@ -6,9 +6,14 @@ export const GROUP_FREE_LIMIT_MESSAGE =
 
 /**
  * グループの作成・参加が無料枠の上限で拒否されたか。
- * 対象の3エンドポイント（グループ作成 / 招待コード参加 / 招待承認）が返す 403 は
- * 上限超過のみで、未認証は 401、権限外は別経路になるため status だけで判別できる。
+ * 403 の原因が将来増えても誤判定しないよう、back が返す安定コード
+ * （`group_limit_exceeded`）まで見て判定する。
  */
 export function isGroupLimitError(error: unknown): boolean {
-  return isAxiosError(error) && error.response?.status === 403;
+  return (
+    isAxiosError(error) &&
+    error.response?.status === 403 &&
+    (error.response.data as { error?: string } | undefined)?.error ===
+      "group_limit_exceeded"
+  );
 }

--- a/app/utils/pro/groupLimit.ts
+++ b/app/utils/pro/groupLimit.ts
@@ -1,0 +1,14 @@
+import { isAxiosError } from "axios";
+
+/** back の GROUP_FREE_LIMIT（無料は所属1件まで）に合わせた上限到達時の文言。 */
+export const GROUP_FREE_LIMIT_MESSAGE =
+  "無料プランで参加できるグループは1つまでです。Pro プランなら無制限に作成・参加できます";
+
+/**
+ * グループの作成・参加が無料枠の上限で拒否されたか。
+ * 対象の3エンドポイント（グループ作成 / 招待コード参加 / 招待承認）が返す 403 は
+ * 上限超過のみで、未認証は 401、権限外は別経路になるため status だけで判別できる。
+ */
+export function isGroupLimitError(error: unknown): boolean {
+  return isAxiosError(error) && error.response?.status === 403;
+}


### PR DESCRIPTION
## 概要

ippei-shimizu/buzzbase#495 の front 側対応。

back は Pro の上限到達（403）や Pro 加入中の操作拒否（422）に対して意味のあるエラーを返しているが、front が汎用エラー文言に潰しており、ユーザーが原因を理解できない状態だった。原因が伝わる専用文言と、Pro 訴求・解約導線を出すようにした。

## base ブランチについて

指示時点では `stg` 起点の想定だったが、以下の理由で `release/pro-202605` 起点に変更している。

- front の `origin/stg` には Pro 機能一式（`app/components/pro/`、`app/(app)/pro/`、`ProUpgradeModal` 等）が存在しない
- back の `origin/stg` にも `app/models/concerns/plan_limits.rb` が無く、今回対応する 403 の発生源である `can_create_or_join_group?` 自体が存在しない
- つまり `stg` 起点では「発生しないエラー」に対して「存在しないコンポーネント」を参照することになり、ビルドも通らない

## 対象1: グループ作成・参加の 403

back は以下 3 経路で、無料枠（所属1件まで）超過時に 403 を返す。

- `POST /api/v1/groups`（グループ作成）
- `POST /api/v1/invite_links/:code/accept`（招待コードで参加）
- `POST /api/v1/group_invitations/:id/accept_invitation`（通知からの招待承認）

### 修正前の問題

| 画面 | 修正前の挙動 |
| ---- | ---- |
| `app/(app)/groups/join/page.tsx` | 403 を汎用文言 `グループへの参加に失敗しました` に潰していた |
| `app/(app)/groups/new/page.tsx` | `catch {}` で完全に握り潰し、何も表示されない。さらに `isSubmitting` が `true` のままでローディングスピナーが出続ける |
| `app/components/notification/NotificationGroup.tsx` | Sentry に送るだけでユーザーには何も表示されない。想定内の上限拒否がエラーとして記録されてもいた |

### 修正内容

3 経路で共通の判定・文言を使うため `app/utils/pro/groupLimit.ts` を追加し、各画面で 403 を検出したら次を行う。

- 専用文言の toast 表示（`無料プランで参加できるグループは1つまでです。Pro プランなら無制限に作成・参加できます`）
- `openProUpgradeModal({ trigger: "unlimited_groups" })` で Pro 訴求モーダルを表示（`paywallCopy.ts` に既にある `unlimited_groups` のコピーがそのまま使われる）

あわせてグループ作成画面の以下も直している。

- 失敗時に `setIsSubmitting(false)` してスピナーを解除
- 上限以外の失敗も無言だったため、汎用文言の toast を出すように変更

通知からの招待承認では、上限拒否は想定内なので Sentry へは送らないようにした。

## 対象2: アカウント削除の 422 (`pro_active`)

`app/(app)/account-deletion/page.tsx` が、back の `users#destroy` が返す `{ error: "pro_active", message: "Pro 加入中のため、先に解約してください" }` を汎用の `alert()` に潰していた。

### 修正内容

- 422 かつ `error === "pro_active"` の場合、専用文言と `/account/subscription`（解約手続き）への導線を `role="alert"` のパネルで表示する
- それ以外の失敗は従来どおり汎用文言を出す（`alert()` はページ内表示に変更）

### 削除成功時の認証情報破棄（未実装だったため追加）

調査の結果、**削除成功時のローカル認証情報の破棄は未実装**だった（`router.push("/signin")` のみで cookie が残る）。削除済みユーザーの `access-token` / `client` / `uid` が残ると、次回アクセス時に失効トークンのままログイン中と判定されてしまうため、以下を追加した。

- `authService` に `clearAuthCookies()` を切り出し（既存の `signOut` からも利用）、削除成功時に呼ぶ
- PostHog の識別子も `resetUser()` で破棄
- 遷移は `router.push` ではなくフルリロード（`window.location.assign("/signin")`）にした。`router.push` だと `AuthContext` の `isLoggedIn` がクライアントに残り、かつ `setIsLoggedIn(false)` すると `useRequireAuth` が `/signup?auth_required=true` へ飛ばして遷移先が競合するため

## 動作確認

- `yarn typecheck` 通過
- `yarn lint` 通過
- `yarn test` 通過（222 suites / 2648 tests）

追加したテスト:

- グループ作成・参加ページ: 403 で専用文言と Pro 訴求モーダルが出ること / 上限以外の失敗ではモーダルを出さないこと
- 通知の招待承認: 403 で専用文言と Pro 訴求モーダルが出ること
- アカウント削除ページ: `pro_active` で専用文言と解約導線が出ること / それ以外は汎用文言のみ出ること / 成功時に認証 cookie と PostHog 識別子を破棄すること
