### PR TITLE
Chore: Vercelのビルド対象をmain・stgブランチのみに制限

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "stg": true,
+      "**": false
+    }
+  }
+}


### PR DESCRIPTION
## 概要

- 作業ブランチ・PRへのpushのたびにVercelのプレビュービルドが走り、Build CPU Minutesの従量課金が発生していた
- `vercel.json`の`git.deploymentEnabled`で、本番ブランチ`main`とリリース前確認用の`stg`のみビルド対象にし、それ以外の作業ブランチ・PRのビルドを止める

## 変更内容

- `vercel.json`を追加し、`main`・`stg`以外の全ブランチのVercel自動ビルドを無効化

## 影響

- 作業ブランチ・PRでのVercelプレビューデプロイ・プレビューURLは今後生成されない
- `stg`・`main`へのpush時の挙動は変わらない（従来通りビルドされる）

## テスト計画

- [ ] マージ後、作業ブランチにpushしてもVercelのビルドが発生しないことを確認
- [ ] `stg`へのpush（マージ）でビルドが発生することを確認
