### PR TITLE
Update: front の試合記録フォームで自チーム名にもサジェストを表示する

### DIFF
--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -358,8 +358,19 @@ export default function GameRecord() {
   // 未確定(null)に戻して保存時に新規作成させる。
   const handleMyTeamInputChange = (value: string) => {
     setMyTeam(value);
-    const matched = teamsData.find((team) => team.name === value);
-    setMyTeamId(matched ? Number(matched.id) : null);
+    setMyTeamId((prev) => {
+      // 候補選択の直後は同じテキストで onInputChange が続けて発火する。名前だけで
+      // 引き直すと同名チームがあるとき先頭の id にすり替わるため、確定済み id の
+      // 名前と一致する間はその id を維持する。
+      const confirmed = teamsData.find(
+        (team) => String(team.id) === String(prev),
+      );
+      if (confirmed && confirmed.name === value) {
+        return prev;
+      }
+      const matched = teamsData.find((team) => team.name === value);
+      return matched ? Number(matched.id) : null;
+    });
   };
   // 候補の選択。allowsCustomValue では打ち替え時に null が飛びうるため、null は
   // 無視して入力中の文字列を消さない（id の解除は onInputChange 側が担う）。

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -98,7 +98,8 @@ export default function GameRecord() {
   const [userData, setUserData] = useState<userData | null>(null);
   const [existingGameDate, setExistingGameDate] = useState<string>("");
   const [myTeam, setMyTeam] = useState("");
-  const [existingMyTeam, setExistingMyTeam] = useState("");
+  // 自チームの id。既存チームが確定しているときだけ入り、手入力中は null。
+  const [myTeamId, setMyTeamId] = useState<number | null>(null);
   const [teamsData, setTeamsData] = useState<Team[]>([]);
   const [positionData, setPositionData] = useState<Position[]>([]);
   const [tournamentData, setTournamentData] = useState<TournamentData[]>([]);
@@ -220,7 +221,7 @@ export default function GameRecord() {
         setExistingGameDate(formattedDate);
         setMatchType(existingMatchResult.match_type);
         setTournament(existingMatchResult.tournament_id);
-        setExistingMyTeam(existingMatchResult.my_team_id);
+        setMyTeamId(existingMatchResult.my_team_id);
         setMyTeamScore(existingMatchResult.my_team_score);
         setOpponentTeamScore(existingMatchResult.opponent_team_score);
         setExistingMatchBattingOrder(existingMatchResult.batting_order);
@@ -314,15 +315,18 @@ export default function GameRecord() {
     }
   }, [userData, positionData]);
 
-  // チーム名検索(編集時)
+  // 編集時は my_team_id だけ先に確定し、チーム一覧の到着タイミングは不定なので
+  // 一覧が揃ってから id を表示名へ解決する。
   useEffect(() => {
-    if (existingMyTeam) {
-      const foundTeam = teamsData.find((team) => team.id === existingMyTeam);
+    if (myTeamId) {
+      const foundTeam = teamsData.find(
+        (team) => String(team.id) === String(myTeamId),
+      );
       if (foundTeam) {
         setMyTeam(foundTeam.name);
       }
     }
-  }, [existingMyTeam, teamsData]);
+  }, [myTeamId, teamsData]);
 
   // 今日の日付
   const [gameDate, setGameDate] = useState(() => {
@@ -347,10 +351,13 @@ export default function GameRecord() {
     setMatchType(event.target.value);
   };
 
-  // 自チーム名設定
+  // 自チーム名設定。入力名が既存チームと完全一致すれば id を確定し、
+  // そうでなければ未確定(null)に戻して保存時に新規作成させる。
   const handleMyTeamChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setExistingMyTeam(event.target.value);
-    setMyTeam(event.target.value);
+    const value = event.target.value;
+    setMyTeam(value);
+    const matched = teamsData.find((team) => team.name === value);
+    setMyTeamId(matched ? Number(matched.id) : null);
   };
 
   // 相手チーム設定
@@ -541,9 +548,11 @@ export default function GameRecord() {
           ]);
         }
       }
+      // 自チーム保存。既存チームが確定済み（myTeamId あり）なら新規作成せず id を
+      // そのまま使い、手入力で新しいチーム名を入れた場合のみ作成する。
+      let resolvedMyTeamId = myTeamId;
       const trimmedMyTeam = myTeam.trim();
-      let myTeamId = teamsData.find((team) => team.name === trimmedMyTeam)?.id;
-      if (!myTeamId) {
+      if (!resolvedMyTeamId && trimmedMyTeam !== "") {
         const newTeam = await createOrUpdateTeam({
           team: {
             name: trimmedMyTeam,
@@ -551,7 +560,12 @@ export default function GameRecord() {
             prefecture_id: undefined,
           },
         });
-        myTeamId = newTeam.data.id;
+        resolvedMyTeamId = Number(newTeam.data.id);
+      }
+      // 球場と違い自チームは必須項目なので、id を確定できなければ保存を中断する。
+      if (!resolvedMyTeamId) {
+        setErrorsWithTimeout(["自チームの登録に失敗しました。"]);
+        return;
       }
 
       // 大会保存
@@ -615,9 +629,7 @@ export default function GameRecord() {
           user_id: Number(userId),
           date_and_time: existingGameDate ? existingGameDate : gameDate,
           match_type: matchType,
-          my_team_id: Number(existingMyTeam)
-            ? Number(existingMyTeam)
-            : Number(myTeamId),
+          my_team_id: resolvedMyTeamId,
           opponent_team_id: existingOpponentTeam
             ? existingOpponentTeam
             : Number(opponentTeamId),

--- a/app/(app)/game-result/record/page.tsx
+++ b/app/(app)/game-result/record/page.tsx
@@ -186,6 +186,9 @@ export default function GameRecord() {
       );
       if (userTeam) {
         setMyTeam(userTeam.name);
+        // 編集時は既存試合の my_team_id が先に入りうるので、未確定のときだけ
+        // プロフィールの所属チームで補う。
+        setMyTeamId((prev) => prev ?? Number(userTeam.id));
       }
       setPositionData(positionDataList);
       setTournamentData(getTournamentList);
@@ -351,13 +354,24 @@ export default function GameRecord() {
     setMatchType(event.target.value);
   };
 
-  // 自チーム名設定。入力名が既存チームと完全一致すれば id を確定し、
-  // そうでなければ未確定(null)に戻して保存時に新規作成させる。
-  const handleMyTeamChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
+  // 自チーム名の入力。入力名が候補と完全一致すれば id を確定し、そうでなければ
+  // 未確定(null)に戻して保存時に新規作成させる。
+  const handleMyTeamInputChange = (value: string) => {
     setMyTeam(value);
     const matched = teamsData.find((team) => team.name === value);
     setMyTeamId(matched ? Number(matched.id) : null);
+  };
+  // 候補の選択。allowsCustomValue では打ち替え時に null が飛びうるため、null は
+  // 無視して入力中の文字列を消さない（id の解除は onInputChange 側が担う）。
+  const handleMyTeamSelectionChange = (teamKey: React.Key | null) => {
+    if (teamKey == null) return;
+    const selectedTeam = teamsData.find(
+      (team) => String(team.id) === String(teamKey),
+    );
+    if (selectedTeam) {
+      setMyTeamId(Number(selectedTeam.id));
+      setMyTeam(selectedTeam.name);
+    }
   };
 
   // 相手チーム設定
@@ -862,19 +876,27 @@ export default function GameRecord() {
                   onSelectionChange={handleSeasonSelectionChange}
                 />
                 <Divider className="my-4" />
-                <Input
+                <Autocomplete
                   isRequired
-                  type="text"
-                  size="sm"
-                  variant="bordered"
+                  allowsCustomValue
                   label="自チーム"
-                  labelPlacement="outside-left"
+                  variant="bordered"
                   placeholder="自分のチーム名を入力"
-                  className="flex justify-between items-center [&>div>div>div>input]:py-2"
+                  labelPlacement="outside-left"
+                  className="[&>div]:justify-between"
+                  size="sm"
                   color={isMyTeamValid ? "default" : "danger"}
-                  value={myTeam}
-                  onChange={handleMyTeamChange}
-                />
+                  inputValue={myTeam}
+                  selectedKey={myTeamId ? myTeamId.toString() : null}
+                  onInputChange={handleMyTeamInputChange}
+                  onSelectionChange={handleMyTeamSelectionChange}
+                >
+                  {teamsData.map((data) => (
+                    <AutocompleteItem key={data.id} textValue={data.name}>
+                      {data.name}
+                    </AutocompleteItem>
+                  ))}
+                </Autocomplete>
                 <Divider className="my-4" />
                 <Autocomplete
                   isRequired


### PR DESCRIPTION
## 概要

ippei-shimizu/buzzbase#548 の対応。試合記録フォームの自チーム名欄を `Input` から `Autocomplete` に置き換え、相手チーム欄と同様に既存チームをサジェスト表示するようにした。

自チーム名は保存時に名前の完全一致でしか id を引けていなかったため、表記ゆれ（全角/半角、スペース有無など）で同一チームが重複登録されうる状態だった。入力段階で既存チームを選べるようにして重複を防ぐ。

## 変更内容

### 1. 自チームの state を id 専用にする

`existingMyTeam` は「既存試合の `my_team_id`」と「ユーザーが入力した生テキスト」の両方が入る二重用途になっていて、保存時の `my_team_id` 決定が `Number("チーム名")` が NaN になることに依存していた。

- `existingMyTeam: string` を `myTeamId: number | null` に置き換え（球場欄の `stadiumId` と同じ形）
- 保存処理を「id が確定済みなら新規作成しない、未確定かつ名前があるときだけ作成する」に統一（相手チーム欄と同じ考え方）
- 自チームは必須項目なので、id を確定できなかった場合はエラー表示して保存を中断する

### 2. 自チーム欄を Autocomplete にする

実装は同ファイル内の球場欄を手本にしている。自チーム欄はプロフィールの所属チーム名が初期表示される＝常に選択済みの状態から始まるため、`inputValue` を制御しつつ `onSelectionChange` の `null` を無視する形にしないと、打ち替え時に入力中の文字列が消えるリスクがある。

- `onInputChange`: 入力名が候補と完全一致すれば id を確定、一致しなければ未確定(null)に戻す
- `onSelectionChange`: `null` は無視（id の解除は `onInputChange` 側が担う）
- プロフィールの所属チームを初期表示する際、未確定のときだけ id も入れる（編集時に既存試合の `my_team_id` を壊さないよう関数形式で更新）

## 動作確認

`docker compose up` + ローカル DB で以下を実測済み。

| ケース | 結果 |
| ---- | ---- |
| 候補から既存チームを選んで保存 | `my_team_id` が既存 id になり、新規チームは作られない |
| 既存にない名前を手入力して保存 | 新規チームが 1 件だけ作成され、その id が入る |
| 編集フローで自チーム名が復元される | 保存済みチーム名が初期表示される（id→名前の解決が効いている） |
| 編集フローで別の既存チームに変更して保存 | `my_team_id` が変更後の id に更新され、新規チームは作られない |
| 既存チーム確定済みの状態から名前を打ち替えて保存 | 打ち替え後の名前で新規作成され、古い id は残らない |

`yarn lint` / `yarn typecheck` / `yarn format:check` はいずれも通過。

## 補足（このPRのスコープ外）

- プロフィールの所属チーム名が自チーム欄に初期表示されるはずだが、ローカルで確認した限り初期表示は空だった。`GET /api/v1/user/` のレスポンスに `team_id` が含まれていない可能性があり、本PRの変更以前からの挙動。別途調査が必要
- 相手チーム欄は `onInputChange` で `existingOpponentTeam` をクリアしていないため、既存チームを選んだ後に名前を打ち替えると古い id のまま保存されうる。今回は自チーム側のみ修正しているため、必要なら別issueで対応
