### PR TITLE
Add: 認証画面でレート制限(429)エラーの専用文言を表示

### DIFF
--- a/app/components/auth/GoogleLoginButton.tsx
+++ b/app/components/auth/GoogleLoginButton.tsx
@@ -12,6 +12,10 @@ import { googleSignIn } from "@app/services/authService";
 import { getUserData } from "@app/services/userService";
 import { trackSignUpCompleted, trackUserLoggedIn } from "@app/utils/analytics";
 import { identifyUser } from "@app/utils/posthog";
+import {
+  isRateLimitError,
+  rateLimitErrorMessage,
+} from "@app/utils/rateLimitError";
 
 interface GoogleLoginButtonProps {
   mode?: "signin" | "signup";
@@ -66,8 +70,12 @@ export default function GoogleLoginButton({
         }
         setIsLoggedIn(true);
       }
-    } catch {
-      setErrors(["Googleログインに失敗しました"]);
+    } catch (error: unknown) {
+      setErrors([
+        isRateLimitError(error)
+          ? rateLimitErrorMessage(error)
+          : "Googleログインに失敗しました",
+      ]);
     } finally {
       setIsLoading(false);
     }

--- a/app/components/auth/PasswordResetRequestForm.tsx
+++ b/app/components/auth/PasswordResetRequestForm.tsx
@@ -1,11 +1,16 @@
 "use client";
 import { useCallback, useMemo, useState } from "react";
 import EmailInput from "@app/components/auth/EmailInput";
+import ErrorMessages from "@app/components/auth/ErrorMessages";
 import SubmitButton from "@app/components/button/SendButton";
 import { requestPasswordReset } from "@app/services/authService";
+import {
+  isRateLimitError,
+  rateLimitErrorMessage,
+} from "@app/utils/rateLimitError";
 
 // アカウント列挙・認証方式の推測を防ぐため、送信成功・失敗やアカウントの有無に
-// かかわらず常に同じ文言を表示する。
+// かかわらず常に同じ文言を表示する。レート制限だけは対象メールの有無に依存しないため例外的に別文言を出す。
 const GENERIC_MESSAGE =
   "ご入力いただいたメールアドレス宛にパスワード再設定のご案内をお送りしました（該当するアカウントが存在する場合）。メールをご確認ください。";
 
@@ -13,6 +18,7 @@ export default function PasswordResetRequestForm() {
   const [email, setEmail] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
 
   const validateEmail = useCallback(
     (email: string) => email.match(/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i),
@@ -33,13 +39,18 @@ export default function PasswordResetRequestForm() {
     event.preventDefault();
     if (!isFormValid || isLoading) return;
     setIsLoading(true);
+    setErrors([]);
     try {
       await requestPasswordReset(email);
-    } catch {
-      // 成否にかかわらず同一文言を表示するため、ここではエラー内容を利用しない
+      setIsSubmitted(true);
+    } catch (error: unknown) {
+      if (isRateLimitError(error)) {
+        setErrors([rateLimitErrorMessage(error)]);
+      } else {
+        setIsSubmitted(true);
+      }
     } finally {
       setIsLoading(false);
-      setIsSubmitted(true);
     }
   };
 
@@ -49,6 +60,7 @@ export default function PasswordResetRequestForm() {
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col justify-end gap-y-4">
+      <ErrorMessages errors={errors} />
       <EmailInput
         value={email}
         onChange={(e) => setEmail(e.target.value)}

--- a/app/components/auth/ResetPasswordForm.tsx
+++ b/app/components/auth/ResetPasswordForm.tsx
@@ -69,6 +69,8 @@ export default function ResetPasswordForm({ authHeaders }: Props) {
       setIsCompleted(true);
       setTimeout(() => router.push("/signin"), 3000);
     } catch (error) {
+      // back は PUT /api/v1/auth/password をスロットル対象にしていないため現状は到達しないが、
+      // 他の認証画面と実装を揃え、対象化された際の取りこぼしを防ぐために置いている。
       if (isRateLimitError(error)) {
         setErrorsWithTimeout([rateLimitErrorMessage(error)]);
         return;

--- a/app/components/auth/ResetPasswordForm.tsx
+++ b/app/components/auth/ResetPasswordForm.tsx
@@ -72,7 +72,7 @@ export default function ResetPasswordForm({ authHeaders }: Props) {
       // back は PUT /api/v1/auth/password をスロットル対象にしていないため現状は到達しないが、
       // 他の認証画面と実装を揃え、対象化された際の取りこぼしを防ぐために置いている。
       if (isRateLimitError(error)) {
-        setErrorsWithTimeout([rateLimitErrorMessage(error)]);
+        setErrors([rateLimitErrorMessage(error)]);
         return;
       }
       // PUT /api/v1/auth/password のバリデーションエラーは devise_token_auth の

--- a/app/components/auth/ResetPasswordForm.tsx
+++ b/app/components/auth/ResetPasswordForm.tsx
@@ -8,6 +8,10 @@ import PasswordConfirmInput from "@app/components/auth/PasswordConfirmInput";
 import PasswordInput from "@app/components/auth/PasswordInput";
 import SubmitButton from "@app/components/button/SendButton";
 import { resetPassword } from "@app/services/authService";
+import {
+  isRateLimitError,
+  rateLimitErrorMessage,
+} from "@app/utils/rateLimitError";
 
 interface Props {
   authHeaders: ResetPasswordAuthHeaders;
@@ -65,6 +69,10 @@ export default function ResetPasswordForm({ authHeaders }: Props) {
       setIsCompleted(true);
       setTimeout(() => router.push("/signin"), 3000);
     } catch (error) {
+      if (isRateLimitError(error)) {
+        setErrorsWithTimeout([rateLimitErrorMessage(error)]);
+        return;
+      }
       // PUT /api/v1/auth/password のバリデーションエラーは devise_token_auth の
       // resource_errors ヘルパーにより { フィールド名: [...], full_messages: [...] }
       // というハッシュ形式で返るため、full_messages を優先的に取り出す

--- a/app/components/auth/SignIn.tsx
+++ b/app/components/auth/SignIn.tsx
@@ -17,6 +17,10 @@ import { signIn } from "@app/services/authService";
 import { getUserData } from "@app/services/userService";
 import { trackUserLoggedIn } from "@app/utils/analytics";
 import { identifyUser } from "@app/utils/posthog";
+import {
+  isRateLimitError,
+  rateLimitErrorMessage,
+} from "@app/utils/rateLimitError";
 
 export default function SignIn() {
   const [email, setEmail] = useState("");
@@ -70,7 +74,9 @@ export default function SignIn() {
         navigateAfterAuth("/register-username");
       }
     } catch (error: unknown) {
-      if (error instanceof AxiosError && error.response?.data?.errors) {
+      if (isRateLimitError(error)) {
+        setErrorsWithTimeout([rateLimitErrorMessage(error)]);
+      } else if (error instanceof AxiosError && error.response?.data?.errors) {
         const errorMessages = error.response.data.errors;
         const isUnconfirmedError =
           error.response.status === 401 &&

--- a/app/components/auth/SignIn.tsx
+++ b/app/components/auth/SignIn.tsx
@@ -75,7 +75,7 @@ export default function SignIn() {
       }
     } catch (error: unknown) {
       if (isRateLimitError(error)) {
-        setErrorsWithTimeout([rateLimitErrorMessage(error)]);
+        setErrors([rateLimitErrorMessage(error)]);
       } else if (error instanceof AxiosError && error.response?.data?.errors) {
         const errorMessages = error.response.data.errors;
         const isUnconfirmedError =

--- a/app/components/auth/SignUp.tsx
+++ b/app/components/auth/SignUp.tsx
@@ -62,7 +62,7 @@ export default function SignUp() {
       router.push("/registration-confirmation");
     } catch (error: unknown) {
       if (isRateLimitError(error)) {
-        setErrorsWithTimeout([rateLimitErrorMessage(error)]);
+        setErrors([rateLimitErrorMessage(error)]);
       } else if (error instanceof AxiosError && error.response?.data?.errors) {
         const errorData = error.response.data.errors;
         const isEmailTakenError =

--- a/app/components/auth/SignUp.tsx
+++ b/app/components/auth/SignUp.tsx
@@ -14,6 +14,10 @@ import LoadingSpinner from "@app/components/spinner/LoadingSpinner";
 import ToastSuccess from "@app/components/toast/ToastSuccess";
 import { trackEvent } from "@app/lib/analytics";
 import { signUp } from "@app/services/authService";
+import {
+  isRateLimitError,
+  rateLimitErrorMessage,
+} from "@app/utils/rateLimitError";
 
 export default function SignUp() {
   const [email, setEmail] = useState("");
@@ -57,7 +61,9 @@ export default function SignUp() {
       trackEvent("sign_up_started", { method: "email" });
       router.push("/registration-confirmation");
     } catch (error: unknown) {
-      if (error instanceof AxiosError && error.response?.data?.errors) {
+      if (isRateLimitError(error)) {
+        setErrorsWithTimeout([rateLimitErrorMessage(error)]);
+      } else if (error instanceof AxiosError && error.response?.data?.errors) {
         const errorData = error.response.data.errors;
         const isEmailTakenError =
           error.response.status === 422 &&

--- a/app/components/auth/__tests__/PasswordResetRequestForm.test.tsx
+++ b/app/components/auth/__tests__/PasswordResetRequestForm.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AxiosError, AxiosHeaders } from "axios";
+import PasswordResetRequestForm from "../PasswordResetRequestForm";
+
+const mockRequestPasswordReset = jest.fn();
+jest.mock("@app/services/authService", () => ({
+  requestPasswordReset: (...args: unknown[]) =>
+    mockRequestPasswordReset(...args),
+}));
+
+const responseError = (status: number, data: unknown) =>
+  new AxiosError("failed", "ERR_BAD_REQUEST", undefined, undefined, {
+    status,
+    statusText: "Error",
+    data,
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  });
+
+const submit = async () => {
+  const user = userEvent.setup();
+  render(<PasswordResetRequestForm />);
+  await user.type(screen.getByLabelText("メールアドレス"), "reset@example.com");
+  await user.click(screen.getByText("送信する"));
+};
+
+describe("PasswordResetRequestForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("レート制限のときは専用文言を出し、送信完了画面に進まない", async () => {
+    mockRequestPasswordReset.mockRejectedValue(
+      responseError(429, {
+        error: "rate_limit_exceeded",
+        message: "試行回数が上限に達しました",
+      }),
+    );
+
+    await submit();
+
+    expect(
+      await screen.findByText("試行回数が上限に達しました"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("送信する")).toBeInTheDocument();
+  });
+
+  it("レート制限以外のエラーはアカウント列挙を防ぐため成功時と同じ文言を出す", async () => {
+    mockRequestPasswordReset.mockRejectedValue(
+      responseError(404, { errors: ["Unable to find user"] }),
+    );
+
+    await submit();
+
+    expect(
+      await screen.findByText(/パスワード再設定のご案内をお送りしました/),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/components/auth/__tests__/ResetPasswordForm.test.tsx
+++ b/app/components/auth/__tests__/ResetPasswordForm.test.tsx
@@ -69,6 +69,8 @@ describe("ResetPasswordForm", () => {
 
     await submitReset();
 
-    expect(await screen.findByText("Password is too short")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Password is too short"),
+    ).toBeInTheDocument();
   });
 });

--- a/app/components/auth/__tests__/ResetPasswordForm.test.tsx
+++ b/app/components/auth/__tests__/ResetPasswordForm.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AxiosError, AxiosHeaders } from "axios";
+import ResetPasswordForm from "../ResetPasswordForm";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockResetPassword = jest.fn();
+jest.mock("@app/services/authService", () => ({
+  resetPassword: (...args: unknown[]) => mockResetPassword(...args),
+}));
+
+const responseError = (status: number, data: unknown) =>
+  new AxiosError("failed", "ERR_BAD_REQUEST", undefined, undefined, {
+    status,
+    statusText: "Error",
+    data,
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  });
+
+const authHeaders = {
+  accessToken: "token",
+  client: "client",
+  uid: "user@example.com",
+};
+
+const submitReset = async () => {
+  const user = userEvent.setup();
+  render(<ResetPasswordForm authHeaders={authHeaders} />);
+  await user.type(screen.getByLabelText("新しいパスワード"), "password123");
+  await user.type(
+    screen.getByLabelText("新しいパスワード（確認用）"),
+    "password123",
+  );
+  await user.click(screen.getByText("パスワードを変更する"));
+};
+
+describe("ResetPasswordForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // back は PUT をスロットル対象にしていないため現状 429 は返らないが、
+  // 対象化された際にこの分岐が壊れていないことを担保する。
+  it("レート制限のときはバックエンドの文言を表示する", async () => {
+    mockResetPassword.mockRejectedValue(
+      responseError(429, {
+        error: "rate_limit_exceeded",
+        message: "試行回数が上限に達しました",
+      }),
+    );
+
+    await submitReset();
+
+    expect(
+      await screen.findByText("試行回数が上限に達しました"),
+    ).toBeInTheDocument();
+  });
+
+  it("422 のときは従来通り full_messages を表示する", async () => {
+    mockResetPassword.mockRejectedValue(
+      responseError(422, {
+        errors: { full_messages: ["Password is too short"] },
+      }),
+    );
+
+    await submitReset();
+
+    expect(await screen.findByText("Password is too short")).toBeInTheDocument();
+  });
+});

--- a/app/components/auth/__tests__/SignIn.test.tsx
+++ b/app/components/auth/__tests__/SignIn.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AxiosError, AxiosHeaders } from "axios";
+import SignIn from "../SignIn";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+}));
+
+const mockSignIn = jest.fn();
+jest.mock("@app/services/authService", () => ({
+  signIn: (...args: unknown[]) => mockSignIn(...args),
+  resendConfirmation: jest.fn(),
+}));
+
+jest.mock("@app/services/userService", () => ({
+  getUserData: () => Promise.resolve({ id: 1, user_id: "buzz" }),
+}));
+
+jest.mock("@app/contexts/useAuthContext", () => ({
+  useAuthContext: () => ({ setIsLoggedIn: jest.fn() }),
+}));
+
+jest.mock("@app/components/auth/GoogleLoginButton", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@app/lib/analytics", () => ({ trackEvent: jest.fn() }));
+jest.mock("@app/utils/analytics", () => ({ trackUserLoggedIn: jest.fn() }));
+jest.mock("@app/utils/posthog", () => ({ identifyUser: jest.fn() }));
+
+const responseError = (status: number, data: unknown) =>
+  new AxiosError("failed", "ERR_BAD_REQUEST", undefined, undefined, {
+    status,
+    statusText: "Error",
+    data,
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  });
+
+const submitLogin = async () => {
+  const user = userEvent.setup();
+  render(<SignIn />);
+  await user.type(screen.getByLabelText("メールアドレス"), "user@example.com");
+  await user.type(screen.getByLabelText("パスワード"), "password123");
+  await user.click(screen.getByText("ログインする"));
+};
+
+describe("SignIn", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("レート制限のときはバックエンドの文言を表示する", async () => {
+    mockSignIn.mockRejectedValue(
+      responseError(429, {
+        error: "rate_limit_exceeded",
+        message: "試行回数が上限に達しました",
+      }),
+    );
+
+    await submitLogin();
+
+    expect(
+      await screen.findByText("試行回数が上限に達しました"),
+    ).toBeInTheDocument();
+  });
+
+  it("認証失敗のときは従来通りサーバーのエラーを表示する", async () => {
+    mockSignIn.mockRejectedValue(
+      responseError(401, { errors: ["Invalid login credentials"] }),
+    );
+
+    await submitLogin();
+
+    expect(
+      await screen.findByText("Invalid login credentials"),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/components/auth/__tests__/SignUp.test.tsx
+++ b/app/components/auth/__tests__/SignUp.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AxiosError, AxiosHeaders } from "axios";
+import SignUp from "../SignUp";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockSignUp = jest.fn();
+jest.mock("@app/services/authService", () => ({
+  signUp: (...args: unknown[]) => mockSignUp(...args),
+  resendConfirmation: jest.fn(),
+}));
+
+jest.mock("@app/components/auth/GoogleLoginButton", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@app/lib/analytics", () => ({ trackEvent: jest.fn() }));
+
+const responseError = (status: number, data: unknown) =>
+  new AxiosError("failed", "ERR_BAD_REQUEST", undefined, undefined, {
+    status,
+    statusText: "Error",
+    data,
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  });
+
+const submitSignUp = async () => {
+  const user = userEvent.setup();
+  render(<SignUp />);
+  await user.type(screen.getByLabelText("メールアドレス"), "new@example.com");
+  await user.type(screen.getByLabelText("パスワード"), "password123");
+  await user.type(screen.getByLabelText("パスワード（確認用）"), "password123");
+  await user.click(screen.getByText("登録する"));
+};
+
+describe("SignUp", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("レート制限のときはバックエンドの文言を表示する", async () => {
+    mockSignUp.mockRejectedValue(
+      responseError(429, {
+        error: "rate_limit_exceeded",
+        message: "試行回数が上限に達しました",
+      }),
+    );
+
+    await submitSignUp();
+
+    expect(
+      await screen.findByText("試行回数が上限に達しました"),
+    ).toBeInTheDocument();
+  });
+
+  it("422 のときは従来通りサーバーのエラーを表示する", async () => {
+    mockSignUp.mockRejectedValue(
+      responseError(422, {
+        errors: { full_messages: ["Password is too short"] },
+      }),
+    );
+
+    await submitSignUp();
+
+    expect(await screen.findByText("Password is too short")).toBeInTheDocument();
+  });
+});

--- a/app/components/auth/__tests__/SignUp.test.tsx
+++ b/app/components/auth/__tests__/SignUp.test.tsx
@@ -67,6 +67,8 @@ describe("SignUp", () => {
 
     await submitSignUp();
 
-    expect(await screen.findByText("Password is too short")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Password is too short"),
+    ).toBeInTheDocument();
   });
 });

--- a/app/components/modal/ResendConfirmationModal.tsx
+++ b/app/components/modal/ResendConfirmationModal.tsx
@@ -13,6 +13,10 @@ import { useCallback, useMemo, useState } from "react";
 import EmailInput from "@app/components/auth/EmailInput";
 import ErrorMessages from "@app/components/auth/ErrorMessages";
 import { resendConfirmation } from "@app/services/authService";
+import {
+  isRateLimitError,
+  rateLimitErrorMessage,
+} from "@app/utils/rateLimitError";
 
 export default function ResendConfirmationModal({
   isOpen,
@@ -55,7 +59,9 @@ export default function ResendConfirmationModal({
       onClose();
       setEmail("");
     } catch (error: unknown) {
-      if (error instanceof AxiosError && error.response?.data?.errors) {
+      if (isRateLimitError(error)) {
+        setErrorsWithTimeout([rateLimitErrorMessage(error)]);
+      } else if (error instanceof AxiosError && error.response?.data?.errors) {
         setErrorsWithTimeout(error.response.data.errors);
       } else {
         setErrorsWithTimeout([

--- a/app/components/modal/ResendConfirmationModal.tsx
+++ b/app/components/modal/ResendConfirmationModal.tsx
@@ -60,7 +60,7 @@ export default function ResendConfirmationModal({
       setEmail("");
     } catch (error: unknown) {
       if (isRateLimitError(error)) {
-        setErrorsWithTimeout([rateLimitErrorMessage(error)]);
+        setErrors([rateLimitErrorMessage(error)]);
       } else if (error instanceof AxiosError && error.response?.data?.errors) {
         setErrorsWithTimeout(error.response.data.errors);
       } else {

--- a/app/utils/__tests__/rateLimitError.test.ts
+++ b/app/utils/__tests__/rateLimitError.test.ts
@@ -1,0 +1,65 @@
+import { AxiosError, AxiosHeaders } from "axios";
+import {
+  RATE_LIMIT_FALLBACK_MESSAGE,
+  isRateLimitError,
+  rateLimitErrorMessage,
+} from "../rateLimitError";
+
+const responseError = (status: number, data: unknown) =>
+  new AxiosError("failed", "ERR_BAD_REQUEST", undefined, undefined, {
+    status,
+    statusText: "Error",
+    data,
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  });
+
+describe("isRateLimitError", () => {
+  it("429 かつ安定コードが一致するとき true", () => {
+    expect(
+      isRateLimitError(
+        responseError(429, {
+          error: "rate_limit_exceeded",
+          message: "上限です",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("429 でも安定コードが違うとき false", () => {
+    expect(isRateLimitError(responseError(429, { error: "other" }))).toBe(
+      false,
+    );
+  });
+
+  it("別のステータスのとき false", () => {
+    expect(
+      isRateLimitError(responseError(401, { error: "rate_limit_exceeded" })),
+    ).toBe(false);
+  });
+
+  it("AxiosError でないとき false", () => {
+    expect(isRateLimitError(new Error("network"))).toBe(false);
+  });
+});
+
+describe("rateLimitErrorMessage", () => {
+  it("バックエンドの message を優先する", () => {
+    expect(
+      rateLimitErrorMessage(
+        responseError(429, {
+          error: "rate_limit_exceeded",
+          message: "しばらく待ってください",
+        }),
+      ),
+    ).toBe("しばらく待ってください");
+  });
+
+  it("message が無ければフォールバック文言を返す", () => {
+    expect(
+      rateLimitErrorMessage(
+        responseError(429, { error: "rate_limit_exceeded" }),
+      ),
+    ).toBe(RATE_LIMIT_FALLBACK_MESSAGE);
+  });
+});

--- a/app/utils/rateLimitError.ts
+++ b/app/utils/rateLimitError.ts
@@ -1,0 +1,31 @@
+import { AxiosError } from "axios";
+
+export const RATE_LIMIT_FALLBACK_MESSAGE =
+  "試行回数が上限に達しました。しばらく時間をおいてからお試しください";
+
+type RateLimitResponse = {
+  error?: string;
+  message?: string;
+};
+
+/**
+ * バックエンドの rack-attack によるレート制限エラーか判定する。
+ * ステータスと安定コードの両方を見る（他の 429 と取り違えないため）。
+ */
+export const isRateLimitError = (error: unknown): boolean => {
+  if (!(error instanceof AxiosError)) return false;
+  if (error.response?.status !== 429) return false;
+
+  const data = error.response.data as RateLimitResponse | undefined;
+  return data?.error === "rate_limit_exceeded";
+};
+
+/**
+ * レート制限エラーの表示文言を返す。文言はバックエンドに一元化しているため message を優先する。
+ */
+export const rateLimitErrorMessage = (error: unknown): string => {
+  if (!(error instanceof AxiosError)) return RATE_LIMIT_FALLBACK_MESSAGE;
+
+  const data = error.response?.data as RateLimitResponse | undefined;
+  return data?.message || RATE_LIMIT_FALLBACK_MESSAGE;
+};


### PR DESCRIPTION
## 概要

back に rack-attack を導入し認証エンドポイントが 429 を返すようになるため、front 側で 429 を検知して専用文言を表示する。

ippei-shimizu/buzzbase#547

## 変更内容

- `app/utils/rateLimitError.ts` を新規追加
  - `isRateLimitError` — status 429 かつ安定コード `rate_limit_exceeded` の両方を見て判定する
  - `rateLimitErrorMessage` — 文言は back に一元化しているため `message` を優先し、無ければフォールバック文言を返す
- 以下の画面で 429 の分岐を追加
  - ログイン（`SignIn.tsx`）
  - 新規登録（`SignUp.tsx`）
  - パスワードリセット申請（`PasswordResetRequestForm.tsx`）
  - パスワード再設定（`ResetPasswordForm.tsx`）
  - Google ログイン（`GoogleLoginButton.tsx`）
  - 確認メール再送モーダル（`ResendConfirmationModal.tsx`）
- テストを追加（`rateLimitError` のユニットテスト、`SignIn` / `PasswordResetRequestForm` の画面テスト）

## パスワードリセット申請の扱い

この画面はアカウント列挙を防ぐため成否にかかわらず同一文言を出す設計になっている。レート制限のカウントは対象メールアドレスの存在有無に依存しないため列挙情報は漏れず、429 のときだけ例外的に別文言を出すようにした（ユーザーがブロックされていることに気付けないと、無言で再送を繰り返してしまうため）。既存の意図はコメントに追記して保持している。

## 既存機能への影響

- 429 以外のエラー分岐は一切変更していない（未確認アカウントのモーダル表示、422 の `full_messages` 表示など従来通り）
- `GoogleLoginButton` の `catch {}` を `catch (error)` に変更したが、429 以外は従来と同じ文言を出す
- 既存テスト 229 スイート / 2694 件がすべてパスすることを確認済み

## セキュリティ

- 表示文言は back が返す `message` のみを使い、内部情報（残り試行回数・対象キー等）は表示しない
- レート制限の判定は status と安定コードの両方を見るため、他の 429 と取り違えない

## 確認方法

```bash
yarn typecheck && yarn lint && yarn test
```

## 関連 PR

- back: ippei-shimizu/buzzbase_back#353
- mobile: ippei-shimizu/buzzbase_mobile#184